### PR TITLE
feat: add automated release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,117 @@
+name: Auto Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.claude-plugin/plugin.json'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Full history for tagging
+
+    - name: Extract version
+      id: version
+      run: |
+        VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+        echo "Detected version: $VERSION"
+
+    - name: Check if tag exists
+      id: check_tag
+      run: |
+        if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "Tag v${{ steps.version.outputs.version }} already exists, skipping release"
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "Tag v${{ steps.version.outputs.version }} does not exist, proceeding with release"
+        fi
+
+    - name: Extract release notes from CHANGELOG
+      id: changelog
+      if: steps.check_tag.outputs.exists == 'false'
+      run: |
+        # Extract everything between [Unreleased] and the next ## heading
+        NOTES=$(awk '/## \[Unreleased\]/,/^## \[/ {
+          if (/^## \[Unreleased\]/) next
+          if (/^## \[/) exit
+          print
+        }' CHANGELOG.md | sed '/^$/d' | head -c 65000)
+
+        # If empty, use default message
+        if [ -z "$NOTES" ]; then
+          NOTES="Release ${{ steps.version.outputs.version }}"
+        fi
+
+        # Save to file to preserve formatting
+        echo "$NOTES" > /tmp/release_notes.md
+        echo "Release notes extracted"
+
+    - name: Create GitHub Release
+      if: steps.check_tag.outputs.exists == 'false'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Determine if pre-release (0.x.x versions)
+        if [[ "${{ steps.version.outputs.version }}" =~ ^0\. ]]; then
+          PRERELEASE="--prerelease"
+        else
+          PRERELEASE=""
+        fi
+
+        gh release create \
+          "${{ steps.version.outputs.tag }}" \
+          --title "${{ steps.version.outputs.version }}" \
+          --notes-file /tmp/release_notes.md \
+          $PRERELEASE
+
+    - name: Update CHANGELOG
+      if: steps.check_tag.outputs.exists == 'false'
+      run: |
+        VERSION="${{ steps.version.outputs.version }}"
+        DATE=$(date +%Y-%m-%d)
+
+        python3 << 'PYTHON_SCRIPT'
+        import os
+        import re
+        from datetime import date
+
+        version = os.environ['VERSION']
+        release_date = os.environ['DATE']
+
+        with open('CHANGELOG.md', 'r') as f:
+            content = f.read()
+
+        # Replace [Unreleased] with [X.Y.Z] - DATE
+        content = content.replace('## [Unreleased]', f'## [{version}] - {release_date}')
+
+        # Add new [Unreleased] section
+        new_section = "## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n\n"
+        # Insert new section before the versioned release
+        content = content.replace(f'## [{version}] - {release_date}', new_section + f'## [{version}] - {release_date}')
+
+        with open('CHANGELOG.md', 'w') as f:
+            f.write(content)
+
+        print("CHANGELOG.md updated")
+        PYTHON_SCRIPT
+
+    - name: Commit CHANGELOG update
+      if: steps.check_tag.outputs.exists == 'false'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add CHANGELOG.md
+        git commit -m "chore: update CHANGELOG for ${{ steps.version.outputs.version }} release [skip ci]"
+        git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Added
+- Automated release workflow - GitHub Actions automatically creates tags and releases when version files are updated on main
 - `/sheet-music-publisher` skill - Convert audio to sheet music, create KDP-ready songbooks
   - AnthemScore CLI integration for automated transcription
   - MuseScore integration for polishing and PDF export

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,16 +37,21 @@ This plugin uses [Semantic Versioning](https://semver.org/) with [Conventional C
 | `docs:` | `docs: update README` | None |
 | `chore:` | `chore: cleanup tests` | None |
 
-**Manual release process:**
-1. Update version in `.claude-plugin/plugin.json`
-2. Update version in `marketplace.json` (must match plugin.json)
-3. Update `CHANGELOG.md` with changes
-4. Commit: `chore: release 0.x.0`
-5. Create GitHub Release with tag `v0.x.0`
+**Release process:**
+1. Update entries in `CHANGELOG.md` under `[Unreleased]` as you work
+2. When ready to release:
+   - Update version in `.claude-plugin/plugin.json`
+   - Update version in `.claude-plugin/marketplace.json` (must match plugin.json)
+3. Commit: `chore: release 0.x.0`
+4. Push to main → **Automated workflow**:
+   - Creates git tag `v0.x.0`
+   - Creates GitHub release with CHANGELOG notes
+   - Updates CHANGELOG.md (renames [Unreleased] → [0.x.0] with date)
+   - Commits CHANGELOG update back to main
 
 **Version files (must stay in sync):**
 - `.claude-plugin/plugin.json` - Plugin manifest
-- `marketplace.json` - Marketplace listing
+- `.claude-plugin/marketplace.json` - Marketplace listing
 
 **Pre-1.0 note:** While version is 0.x.x, the plugin is in early development.
 


### PR DESCRIPTION
## Summary

Automates the release process using GitHub Actions. When version files are updated and pushed to main, the workflow automatically:

1. Creates git tag (e.g., `v0.5.0`)
2. Creates GitHub Release with CHANGELOG notes
3. Updates CHANGELOG.md (renames [Unreleased] → [version] with date)
4. Commits CHANGELOG update back to main

## Changes

- Added `.github/workflows/auto-release.yml` - Automated release workflow
- Updated `CLAUDE.md` - New release process documentation
- Updated `CHANGELOG.md` - Added workflow to feature list

## Benefits

- Eliminates manual tag/release creation
- Ensures consistent release process
- Automatically maintains CHANGELOG.md
- Marks 0.x.x versions as pre-release

## Testing Plan

After merge, test by:
1. Bumping version to 0.5.0 in both version files
2. Committing with `chore: release 0.5.0`
3. Pushing to main
4. Verifying tag and release are created automatically

## Checklist

- [x] Workflow YAML syntax validated
- [x] CLAUDE.md updated
- [x] CHANGELOG.md updated
- [x] Conventional commit message used
- [x] Co-author line included

🤖 Generated with [Claude Code](https://claude.com/claude-code)