### PR TITLE
fix: move @bitwizemusic to end of tweet text

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "bitwize-music"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-01-31
+
+### Fixed
+- **Tweet copy-paste text no longer starts with @bitwizemusic** — tweets starting with @ are treated as replies on X/Twitter, not public posts. Moved @ mention to end of tweet text in release templates, about skill, and README
+
 ## [0.22.0] - 2026-01-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://www.bitwizemusic.com/behind-the-music/
 
 Not required, but I'd love to hear what you create with this. Drop a tweet with your album:
 
-**[@bitwizemusic](https://x.com/bitwizemusic) #ClaudeCode #SunoAI #AIMusic**
+**#ClaudeCode #SunoAI #AIMusic [@bitwizemusic](https://x.com/bitwizemusic)**
 
 ---
 

--- a/reference/workflows/checkpoint-scripts.md
+++ b/reference/workflows/checkpoint-scripts.md
@@ -130,7 +130,7 @@ If you used this plugin to make your album, I'd love to hear about it.
 
 [Click to tweet about your release](https://twitter.com/intent/tweet?text=Just%20released%20%22{URL_ENCODED_NAME}%22%20🎵%20Made%20with%20%40bitwizemusic%27s%20Claude%20AI%20Music%20Skills%20%23ClaudeCode%20%23SunoAI%20%23AIMusic)
 
-Or manually: @bitwizemusic #ClaudeCode #SunoAI #AIMusic
+Or manually: Just released my new album! #ClaudeCode #SunoAI #AIMusic @bitwizemusic
 
 Not required, just curious what people create with this. 🎵
 ```

--- a/skills/about/SKILL.md
+++ b/skills/about/SKILL.md
@@ -15,7 +15,7 @@ I'm bitwize—a hacker who loves music and experimenting with new technology. Wh
 
 **Behind the Music:** https://www.bitwizemusic.com/behind-the-music/
 
-**Share What You Make:** Tag [@bitwizemusic](https://x.com/bitwizemusic) on X/Twitter with anything interesting you create!
+**Share What You Make:** Share what you create on X/Twitter and tag [@bitwizemusic](https://x.com/bitwizemusic)!
 
 ---
 

--- a/skills/release-director/SKILL.md
+++ b/skills/release-director/SKILL.md
@@ -276,7 +276,7 @@ If you used this plugin to make your album, I'd love to hear about it.
 
 [Click to tweet about your release](https://twitter.com/intent/tweet?text=Just%20released%20%22{URL_ENCODED_NAME}%22%20🎵%20Made%20with%20%40bitwizemusic%27s%20Claude%20AI%20Music%20Skills%20%23ClaudeCode%20%23SunoAI%20%23AIMusic)
 
-Or manually: @bitwizemusic #ClaudeCode #SunoAI #AIMusic
+Or manually: Just released my new album! #ClaudeCode #SunoAI #AIMusic @bitwizemusic
 
 Not required, just curious what people create with this. 🎵
 ```
@@ -293,7 +293,7 @@ If you used this plugin to make your album, I'd love to hear about it.
 
 [Click to tweet about your release](https://twitter.com/intent/tweet?text=Just%20released%20%22Your%20Album%22%20🎵%20Made%20with%20%40bitwizemusic%27s%20Claude%20AI%20Music%20Skills%20%23ClaudeCode%20%23SunoAI%20%23AIMusic)
 
-Or manually: @bitwizemusic #ClaudeCode #SunoAI #AIMusic
+Or manually: Just released my new album! #ClaudeCode #SunoAI #AIMusic @bitwizemusic
 
 Not required, just curious what people create with this. 🎵
 ```


### PR DESCRIPTION
## Summary
- Tweets starting with `@` on X/Twitter are treated as replies, not public posts
- Moved `@bitwizemusic` mention to the end of all copy-paste tweet templates
- Updated: release templates (checkpoint-scripts, release-director), about skill, README
- Version bump: 0.22.0 → 0.22.1

## Test plan
- [ ] Verify tweet intent URLs still render correctly
- [ ] Verify manual copy-paste text no longer starts with @

🤖 Generated with [Claude Code](https://claude.com/claude-code)