### PR TITLE
feat: add song length guidance to prevent overly long lyrics

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": {
     "name": "bitwize-music"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-01-31
+
+### Added
+- **Song length guidance for lyric writer** — word count targets by genre (150–250 pop, 200–350 rock/folk, 300–500 hip-hop), default structure (2 verses + chorus + bridge), and hard limits to prevent 800+ word songs that cause Suno to rush or skip sections
+- **Length check added to lyric reviewer** — 9-point checklist (was 8-point) now includes word count validation with warning/critical severity levels
+- **Suno best practices updated** — "Keep Lyrics Concise" note in Lyric Formatting section explaining shorter lyrics generate better results
+
 ## [0.22.0] - 2026-01-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,7 +412,7 @@ Specialized skills are available as slash commands. Type `/` to see the menu.
 | `/bitwize-music:suno-engineer` | Technical Suno prompting, genre selection |
 | `/bitwize-music:explicit-checker` | Scan lyrics for explicit content, verify flags match content |
 | `/bitwize-music:pronunciation-specialist` | Scan lyrics for risky words, prevent Suno mispronunciations |
-| `/bitwize-music:lyric-reviewer` | QC gate before Suno generation - 8-point checklist, auto-fix pronunciation |
+| `/bitwize-music:lyric-reviewer` | QC gate before Suno generation - 9-point checklist, auto-fix pronunciation |
 | `/bitwize-music:mastering-engineer` | Audio mastering guidance, loudness optimization, platform delivery |
 | `/bitwize-music:promo-director` | Generate promo videos for social media from mastered audio |
 | `/bitwize-music:cloud-uploader` | Upload promo videos to Cloudflare R2 or AWS S3 |

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ For documentary or true-story albums:
 
 | Skill | Description |
 |-------|-------------|
-| `/bitwize-music:lyric-reviewer` | QC gate before Suno - 8-point checklist |
+| `/bitwize-music:lyric-reviewer` | QC gate before Suno - 9-point checklist |
 | `/bitwize-music:explicit-checker` | Scan lyrics for explicit content |
 
 ### Release

--- a/reference/SKILL_INDEX.md
+++ b/reference/SKILL_INDEX.md
@@ -98,7 +98,7 @@ Quick-reference guide for finding the right skill for any task.
 | [`import-art`](/skills/import-art/SKILL.md) | Place album art in audio and content locations | Copying artwork to correct paths after creation |
 | [`import-audio`](/skills/import-audio/SKILL.md) | Move audio files to correct album location | Importing WAV files from Suno downloads |
 | [`import-track`](/skills/import-track/SKILL.md) | Move track .md files to correct album location | Importing track files from external sources |
-| [`lyric-reviewer`](/skills/lyric-reviewer/SKILL.md) | QC gate before Suno generation (8-point checklist) | Final quality check before generating |
+| [`lyric-reviewer`](/skills/lyric-reviewer/SKILL.md) | QC gate before Suno generation (9-point checklist) | Final quality check before generating |
 | [`lyric-writer`](/skills/lyric-writer/SKILL.md) | Write or review lyrics with prosody and rhyme craft | Writing new lyrics or fixing existing ones |
 | [`mastering-engineer`](/skills/mastering-engineer/SKILL.md) | Audio mastering guidance, loudness optimization | Mastering tracks to -14 LUFS for streaming |
 | [`new-album`](/skills/new-album/SKILL.md) | Create album directory structure with templates | Starting a brand new album project |

--- a/reference/suno/pronunciation-guide.md
+++ b/reference/suno/pronunciation-guide.md
@@ -331,7 +331,7 @@ When in doubt:
   - Applies rules from this guide during review process
 
 - **`/bitwize-music:lyric-reviewer`** - Pre-generation QC gate
-  - 8-point checklist includes pronunciation check
+  - 9-point checklist includes pronunciation check
   - Auto-fixes pronunciation issues before Suno generation
 
 ## See Also

--- a/reference/suno/v5-best-practices.md
+++ b/reference/suno/v5-best-practices.md
@@ -135,6 +135,10 @@ Male baritone, gravelly, introspective, folk storyteller
 
 ## Lyric Formatting
 
+### Keep Lyrics Concise
+
+Shorter lyrics generate better results. Dense or long lyrics cause Suno to rush, compress sections, or skip content entirely. Target **200–350 words** for most genres (up to 500 for hip-hop/rap). Two verses plus chorus plus bridge is the sweet spot — avoid 4–5 verse songs.
+
 ### Use Explicit Section Tags
 
 ```

--- a/reference/workflows/error-recovery.md
+++ b/reference/workflows/error-recovery.md
@@ -267,7 +267,7 @@ Verify before each phase to avoid recovery scenarios:
 
 ### Before Generation
 - [ ] Pronunciation check complete on all tracks
-- [ ] Lyric review complete (8-point checklist)
+- [ ] Lyric review complete (9-point checklist)
 - [ ] Style prompts filled in all track files
 - [ ] Explicit content flags set correctly
 

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -47,7 +47,7 @@ Display this help information to the user in a clear, organized format.
 - `/bitwize-music:researchers-verifier` - Quality control, citation validation
 
 **Quality Control**
-- `/bitwize-music:lyric-reviewer` - Pre-generation QC gate (8-point checklist)
+- `/bitwize-music:lyric-reviewer` - Pre-generation QC gate (9-point checklist)
 - `/bitwize-music:pronunciation-specialist` - Scan for pronunciation risks
 - `/bitwize-music:explicit-checker` - Verify explicit content flags
 - `/bitwize-music:validate-album` - Validate album structure and paths

--- a/skills/lyric-reviewer/SKILL.md
+++ b/skills/lyric-reviewer/SKILL.md
@@ -18,12 +18,12 @@ Based on the argument provided:
 
 **Single track path** (`tracks/01-song.md`):
 - Read the track file
-- Run 8-point checklist
+- Run 9-point checklist
 - Generate verification report
 
 **Album path** (`artists/[artist]/albums/[genre]/album-name/`):
 - Glob all track files in `tracks/`
-- Run 8-point checklist on each
+- Run 9-point checklist on each
 - Generate consolidated album report
 
 **Default behavior**:
@@ -39,7 +39,7 @@ Based on the argument provided:
 
 ## Supporting Files
 
-- **[checklist-reference.md](checklist-reference.md)** - Detailed 8-point checklist criteria
+- **[checklist-reference.md](checklist-reference.md)** - Detailed 9-point checklist criteria
 
 ---
 
@@ -57,7 +57,7 @@ lyric-writer → lyric-reviewer → suno-engineer
 
 ---
 
-## The 8-Point Checklist
+## The 9-Point Checklist
 
 ### 1. Rhyme Check
 - Repeated end words, self-rhymes, predictable patterns
@@ -92,6 +92,11 @@ lyric-writer → lyric-reviewer → suno-engineer
 - Only if RESEARCH.md exists
 - Names, dates, numbers, events match sources
 - **Critical**: Wrong date/name/major fact
+
+### 9. Length Check
+- Word count vs genre target (see lyric-writer Song Length table)
+- **Warning**: Over genre target range, or more than 3 verses without explicit request
+- **Critical**: Over 500 words (non-hip-hop) or 700 words (hip-hop)
 
 See [checklist-reference.md](checklist-reference.md) for detailed criteria.
 
@@ -217,6 +222,7 @@ Before marking "Ready for Suno":
 - [ ] Zero critical issues
 - [ ] All pronunciation notes applied to Lyrics Box
 - [ ] No unresolved homographs
+- [ ] Word count within genre target range
 - [ ] For documentary: No internal state claims, no fabricated quotes
 - [ ] Warnings documented (can proceed with caution)
 

--- a/skills/lyric-reviewer/checklist-reference.md
+++ b/skills/lyric-reviewer/checklist-reference.md
@@ -1,4 +1,4 @@
-# 8-Point Checklist Reference
+# 9-Point Checklist Reference
 
 Detailed criteria for each lyric review checkpoint.
 
@@ -236,6 +236,41 @@ Detailed criteria for each lyric review checkpoint.
 - [✗] CRITICAL: V1 says "1943" but RESEARCH.md says "1942"
 - [⚠] Bridge: "seventeen convicted" - actually 17 of 22, context unclear
 - [✓] Names: All match sources
+```
+
+---
+
+## 9. Length Check
+
+**What to scan:**
+- Total word count (count all lyrics excluding section tags)
+- Number of verses
+- Whether user explicitly requested extra verses
+
+**Genre targets:**
+
+| Genre | Target Words | Max Verses |
+|-------|-------------|------------|
+| Pop / Dance-Pop / Synth-Pop | 150–250 | 2 |
+| Punk / Pop-Punk | 150–250 | 2 |
+| Rock / Alt-Rock | 200–350 | 2–3 |
+| Folk / Country / Americana | 200–350 | 2–3 |
+| Hip-Hop / Rap | 300–500 | 2–3 |
+| Ballad (any genre) | 200–300 | 2–3 |
+
+**Severity:**
+- **Critical**: Over 500 words (non-hip-hop) or over 700 words (hip-hop) — Suno will rush or skip content
+- **Warning**: Over genre target range
+- **Warning**: More than 3 verses without explicit user request
+- **Info**: At upper end of range, could trim
+
+**Output format:**
+```
+### Length Check
+- [✗] CRITICAL: 720 words (pop) - far over 150-250 target, Suno will skip sections
+- [✗] V1, V2, V3, V4 - 4 verses, user did not request extra
+- [⚠] 360 words (rock) - slightly over 200-350 target
+- [✓] 280 words (folk) - within 200-350 range
 ```
 
 ---

--- a/skills/lyric-writer/SKILL.md
+++ b/skills/lyric-writer/SKILL.md
@@ -191,6 +191,35 @@ Prosody is matching stressed syllables to strong musical beats.
 
 ---
 
+## Song Length
+
+Songs that are too long (800+ words) cause Suno to rush, compress sections, or skip lyrics. Keep songs concise.
+
+### Word Count Targets by Genre
+
+| Genre | Words | Verses | Lines/Verse |
+|-------|-------|--------|-------------|
+| Pop / Dance-Pop / Synth-Pop | 150–250 | 2 | 4–6 |
+| Punk / Pop-Punk | 150–250 | 2 | 4–6 |
+| Rock / Alt-Rock | 200–350 | 2–3 | 4–8 |
+| Folk / Country / Americana | 200–350 | 2–3 | 4–8 |
+| Hip-Hop / Rap | 300–500 | 2–3 | 8–16 |
+| Ballad (any genre) | 200–300 | 2–3 | 4–6 |
+
+### Structure Defaults
+
+- **Default**: 2 verses + chorus + bridge. 3 verses max unless user explicitly requests more.
+- **Chorus**: 4–6 lines, repeated verbatim — not rewritten each time.
+- **Bridge**: 2–4 lines.
+- **Outro**: Optional, 2–4 lines max. Not a new verse.
+
+### Length Limits
+
+- **If draft exceeds 350 words (non-hip-hop) or 500 words (hip-hop)**: Cut it down before presenting.
+- Count words after drafting. If over target, remove a verse or trim sections — don't just shorten lines.
+
+---
+
 ## Point of View & Tense
 
 **POV**: Choose one and maintain it


### PR DESCRIPTION
## Summary
- Added word count targets by genre to lyric writer (150–250 pop, 200–350 rock/folk, 300–500 hip-hop) with default structure of 2 verses + chorus + bridge
- Added Check 9 (Length Check) to lyric reviewer's checklist (now 9-point) with warning/critical severity for oversized songs
- Added "Keep Lyrics Concise" note to Suno V5 best practices explaining dense lyrics cause Suno to rush or skip sections
- Updated all 8-point → 9-point references across 7 additional files (CLAUDE.md, README, help, SKILL_INDEX, error-recovery, pronunciation-guide)

## Test plan
- [x] `test all` passes (302/303, 1 pre-existing false positive)
- [ ] Write lyrics for a pop track — verify output stays under 250 words
- [ ] Run lyric-reviewer on a long song — verify length check triggers warning/critical

🤖 Generated with [Claude Code](https://claude.com/claude-code)