### PR TITLE
feat: add Lessons Learned Protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,38 @@ See `/skills/resume/SKILL.md` for full documentation.
 
 **The rule**: Changes to workflow files take effect immediately. Re-read the relevant section after any edit to ensure you're following the updated process.
 
+## Lessons Learned Protocol
+
+**When you discover a technical issue during production** (pronunciation error, rhyme violation, formatting problem, wrong assumption), don't just fix it — propose a rule to prevent it from happening again.
+
+### Process
+
+1. **Fix the immediate issue** in the current track/file
+2. **Sweep the album** for the same issue in other tracks
+3. **Draft a rule** — specific, actionable, with examples
+4. **Present to user**: "I found [issue]. Here's a rule to prevent this: [rule]. Should I add it to [location]?"
+5. **Log the lesson** — add the rule to the appropriate file (SKILL.md, CLAUDE.md, genre README, or reference doc)
+
+### What Qualifies
+
+- Pronunciation errors Suno got wrong (add to pronunciation guide)
+- Rhyme pattern violations that slipped through review
+- Formatting issues that caused generation problems
+- Assumptions that turned out wrong for a genre/style
+- Manual corrections that should be automated checks
+
+### Rule Format
+
+When proposing a rule, include:
+- **What went wrong**: The specific issue encountered
+- **Why it matters**: Impact on output quality
+- **The rule**: Clear, actionable instruction
+- **Examples**: Before/after showing the fix
+
+### Key Principle
+
+**Be proactive.** When you correct something manually, ask yourself: "Should this be a rule?" If the answer is yes, propose it immediately. Don't wait to be asked.
+
 ---
 
 ## Core Principles


### PR DESCRIPTION
## Summary
- Adds a Lessons Learned Protocol section to CLAUDE.md (after Mid-Session Workflow Updates)
- 5-step process: fix issue → sweep album → draft rule → present to user → log the lesson
- Covers what qualifies (pronunciation errors, rhyme violations, formatting, assumptions, manual corrections)
- Includes rule format template (what went wrong, why it matters, the rule, examples)
- Key principle: proactively propose rules when issues are corrected, don't wait to be asked

## Test plan
- [ ] Verify section appears after "Mid-Session Workflow Updates" and before "Core Principles"
- [ ] Verify markdown renders correctly
- [ ] Verify no existing content was altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)