### PR TITLE
feat: Suno verse length limits by genre and BPM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ You are a co-producer, editor, and creative partner. Push back when ideas don't 
 7. **Section length check**: Count lines per section, compare against genre limits in `/skills/lyric-writer/SKILL.md`. **Hard fail** — trim any section exceeding its genre max before presenting.
 8. **Rhyme scheme check**: Verify rhyme scheme matches the genre (see `/skills/lyric-writer/SKILL.md` Default Rhyme Schemes by Genre). No orphan lines, no random scheme switches mid-verse.
 9. **Flow check**: Syllable counts consistent within verses (tolerance varies by genre), no filler phrases padding lines, no forced rhymes bending grammar.
-10. **Density/pacing check**: Count topics per verse, check against genre README's `Density/pacing` norms (syl/line, topics/verse). Cross-reference against BPM/mood from Musical Direction. Flag verses that read like lists or feel too dense for the genre/tempo.
+10. **Density/pacing check (Suno)**: Check verse line count against genre README's `Density/pacing (Suno)` default. Flag any verse exceeding the genre's max lines/verse. Cross-reference BPM/mood from Musical Direction. **Hard fail** — trim or split any verse over the limit before presenting.
 11. **Chorus lead-in check**: Compare the last line before each chorus against the chorus opening. Flag if they share key phrases, rhyme words, or restate the hook. The chorus is the payoff — the lead-in should set it up, not pre-deliver it.
 12. **Pitfalls check**: Run through Lyric Pitfalls Checklist (see `/skills/lyric-writer/SKILL.md`)
 

--- a/genres/afrobeats/README.md
+++ b/genres/afrobeats/README.md
@@ -46,7 +46,7 @@ Beyond Nigeria, Afrobeats has catalyzed a pan-African musical movement. Ghanaian
 - **Verse structure**: Call-and-response structure. Short repeated phrases as hooks. Code-switching between English, Pidgin, and local languages.
 - **Key rule**: Audience participation is a design principle. Catchy chorus designed for immediate sing-along. Multilingual flow (English, Pidgin, Yoruba, Igbo, etc.).
 - **Avoid**: Overcomplicating lyrics. Forcing standard English rhythms onto Pidgin phrasing. Missing call-and-response opportunities.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 1-2 topics/verse · typical BPM 100-120. Rhythmic, call-and-response. Repetitive hooks. Dance-oriented — groove determines density. Pidgin/multilingual delivery common.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 100-120 BPM. Rhythmic, call-and-response. Repetitive hooks. Groove determines density. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/alternative/README.md
+++ b/genres/alternative/README.md
@@ -48,7 +48,7 @@ Today, alternative rock encompasses an extraordinary range of sounds united by a
 - **Verse structure**: Standard 4–8 line verses, but unconventional structures welcomed.
 - **Key rule**: Rejection of mainstream norms. Introspective, thought-provoking. Flexibility for both straightforward storytelling and abstract, image-driven approaches.
 - **Avoid**: Generic rock cliches. Overly conventional structures when the genre invites experimentation.
-- **Density/pacing**: moderate-high density · 7-11 syl/line · max 2-4 topics/verse · typical BPM 100-140. Emotional dynamics drive density — quiet verses, loud choruses. Variable pacing acceptable.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-130 BPM. Slower (<110): up to 8 lines. Faster (130-140): 4 lines. Emotional dynamics drive density — quiet verses, loud choruses. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/ambient/README.md
+++ b/genres/ambient/README.md
@@ -25,7 +25,7 @@ Contemporary ambient has fractured into numerous subgenres while maintaining rem
 - **Verse structure**: No traditional structure. Sparse, impressionistic lines (2–4 words floating through the track). Spoken word or breathy phrases.
 - **Key rule**: Atmosphere first. Vocals are texture, not focal point. Most ambient is instrumental.
 - **Avoid**: Dense lyrics. Narrative structure. Anything that demands listener attention over the soundscape.
-- **Density/pacing**: very low density · 2-6 syl/line · max 1 topics/verse · typical BPM 60-100. Often instrumental. When vocals appear, whispered/processed. Texture over content. Fewer words is always better.
+- **Density/pacing (Suno)**: Default **0-2 lines** at 60-100 BPM. Often instrumental. Vocals whispered/processed when present. Texture over content. Topics: 1/verse or none.
 
 ## Subgenres & Styles
 

--- a/genres/americana/README.md
+++ b/genres/americana/README.md
@@ -23,7 +23,7 @@ Contemporary Americana has evolved into a remarkably diverse tent. At one end st
 - **Verse structure**: Verses 4–8 lines. Emphasis on verse progression over chorus dominance.
 - **Key rule**: Place-based imagery — dusty roads, front porches, wide-open landscapes. Symbolism and layered interpretation. Transport the listener to a specific location and era.
 - **Avoid**: Generic Americana cliches without specific detail. Abstract emotion without sensory grounding.
-- **Density/pacing**: moderate-high density · 10-14 syl/line · max 2-3 topics/verse · typical BPM 85-120. Literary tradition allows complex imagery. Can weave 2-3 related topics if thematically unified. Most density-tolerant in the country family.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 85-120 BPM. Most density-tolerant in the country family — literary tradition allows complex imagery. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/black-metal/README.md
+++ b/genres/black-metal/README.md
@@ -60,7 +60,7 @@ Beyond Norway, black metal rapidly globalized while fragmenting into diverse sub
 - **Verse structure**: Variable — through-composed structures common. No pop conventions required.
 - **Key rule**: Nature imagery (forests, mountains, winter), mythology, paganism, anti-religious themes. Archaic or folkloric vocabulary. Transporting the listener to another world.
 - **Avoid**: Modern/mundane imagery. Pop song structures. Literal or prosaic language.
-- **Density/pacing**: moderate-high density · 8-14 syl/line · max 2-4 topics/verse · typical BPM 130-200. Atmospheric passages alternate with blasts. Shrieked vocals obscure syllables — keep imagery vivid despite delivery.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 130-200 BPM. Atmospheric passages alternate with blasts. Shrieked vocals obscure syllables — vivid imagery despite delivery. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/bluegrass/README.md
+++ b/genres/bluegrass/README.md
@@ -24,7 +24,7 @@ The genre experienced significant evolution starting in the 1970s when New Grass
 - **Verse structure**: 4-line quatrains typical. Verse-chorus with strong verse progression.
 - **Key rule**: Simplicity of language — powerful emotions without flourish or fluff. Universal human experiences: heartbreak, loss, longing, faith. Gospel influence (Methodist, Holiness, Baptist traditions).
 - **Avoid**: Over-complicating language. Straying from universal human experiences. Ignoring gospel/moral traditions.
-- **Density/pacing**: low-moderate density · 7-10 syl/line · max 1 topics/verse · typical BPM 120-180. Fast picking tempo but sparse lyrics. Instrumental breaks dominate. One clear topic per verse for comprehension at speed.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 120-160 BPM. Fast picking tempo but sparse lyrics. Instrumental breaks dominate. One clear topic per verse. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/blues/README.md
+++ b/genres/blues/README.md
@@ -24,7 +24,7 @@ By the 1960s, British musicians had absorbed blues records and reflected them ba
 - **Verse structure**: 12-bar blues — each line occupies 4 bars. No separate chorus section. Each verse stands alone while building thematic continuity.
 - **Key rule**: Call-and-response — vocal line followed by instrumental answer. Question-question-answer format. Emotional directness, first-person perspective.
 - **Avoid**: Breaking the AAB structure in traditional blues. Forgetting the instrumental "answer" space. Making the two A lines too different.
-- **Density/pacing**: low density · 6-10 syl/line · max 1 topics/verse · typical BPM 60-90. 12-bar AAB structure demands repetition. Topic stated then restated. Extreme clarity — one vivid image per verse.
+- **Density/pacing (Suno)**: Default **3 lines/verse** (AAB structure) at any BPM. Blues form is rigid: line 1 stated, line 2 repeats, line 3 resolves. Never break AAB. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/bossa-nova/README.md
+++ b/genres/bossa-nova/README.md
@@ -23,7 +23,7 @@ The international breakthrough came in 1962-1964 through collaborations with Ame
 - **Verse structure**: Short, concrete phrases — objects, places, images over abstract emotion. Keep sections brief.
 - **Key rule**: Wistful mood (saudade — gentle longing mixed with love). Natural speech rhythm. Less is more.
 - **Avoid**: Abstract emotion words without concrete images. Forcing rhythms onto Portuguese-influenced phrasing. Lyric density that overwhelms the gentle groove.
-- **Density/pacing**: low-moderate density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 70-100. Whispered, intimate delivery. Guitar patterns need space. Portuguese-influenced phrasing even in English. Understated elegance.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 70-100 BPM. Whispered, intimate delivery. Guitar patterns need space. Understated elegance. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/celtic-punk/README.md
+++ b/genres/celtic-punk/README.md
@@ -56,7 +56,7 @@ Celtic punk's themes reflect its working-class roots and immigrant heritage: Iri
 - **Verse structure**: 4–8 lines. Story-driven, often character-based. Blends folk narrative with punk directness.
 - **Key rule**: Heritage, history, rebellion, and identity. Folk storytelling meets punk urgency.
 - **Avoid**: Stereotypical Irish cliches (drunken brawler tropes). Appropriating culture without understanding.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 1-2 topics/verse · typical BPM 130-170. Folk storytelling at punk tempo. Singalong choruses need clear syllables. Instrumental breaks (tin whistle, mandolin) need space.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 130-160 BPM. At 150+: 4 lines. Singalong choruses need clear syllables. Instrumental breaks (tin whistle) need space. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/chillwave/README.md
+++ b/genres/chillwave/README.md
@@ -23,7 +23,7 @@ By 2012, critics declared chillwave "dead," but its influence proved enduring. T
 - **Verse structure**: Sparse — short phrases with reverb and delay. Retro synths dominate.
 - **Key rule**: Nostalgia and haze. Dreamy, blissed-out. Vocals are part of the texture.
 - **Avoid**: Clear vocal delivery. Dense wordplay. Narratives that fight the dreamy wash.
-- **Density/pacing**: low density · 4-8 syl/line · max 1 topics/verse · typical BPM 80-110. Hazy, nostalgic. Vocals heavily processed. Simple phrases, dreamy imagery. Let the wash of sound dominate.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 80-110 BPM. Hazy, nostalgic. Heavily processed vocals. Simple phrases, dreamy imagery. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/cinematic/README.md
+++ b/genres/cinematic/README.md
@@ -44,7 +44,7 @@ The democratization of orchestral sample libraries and digital production has ex
 - **Verse structure**: No standard — follows the visual narrative or emotional arc of the scene.
 - **Key rule**: Music serves the image/emotion. Vocals (if present) are atmospheric texture or emotional punctuation.
 - **Avoid**: Dense lyrics that compete with orchestration. Pop song structure. Lyrics that distract from the visual narrative.
-- **Density/pacing**: low-moderate density · 6-12 syl/line · max 1-2 topics/verse · typical BPM 60-120. Orchestral arrangements need vocal space. Dramatic dynamics. Words are sparse but weighty. Film-score pacing.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** (or instrumental) at variable BPM. Orchestral arrangements need vocal space. Words sparse but weighty. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/classical/README.md
+++ b/genres/classical/README.md
@@ -45,7 +45,7 @@ Classical music's influence extends far beyond the concert hall. Its harmonic la
 - **Verse structure**: Through-composed or strophic depending on form. Text serves the musical composition.
 - **Key rule**: Words serve the music, not vice versa. Text painting (musical expression of word meaning) is paramount.
 - **Avoid**: Pop song conventions. Simple repetitive structures. Ignoring classical prosody.
-- **Density/pacing**: low density · varies syl/line · max 1-2 topics/verse · typical BPM 40-120. Instrument-dominated. Vocal pieces (art song, opera) follow strict prosody. Libretto conventions apply. Space for musical expression.
+- **Density/pacing (Suno)**: Default **4-6 lines** (when vocal) at variable BPM. Instrument-dominated. Vocal pieces follow strict prosody. Space for musical expression. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/country/README.md
+++ b/genres/country/README.md
@@ -20,7 +20,7 @@ Country music is a quintessentially American genre rooted in folk, blues, and go
 - **Verse structure**: Verses 4–8 lines. Chorus-dominant structure. 74% of recent hits use 2 verses total.
 - **Key rule**: Storytelling is paramount. Show, don't tell. Conversational tone — write like you'd tell a friend. Emotional authenticity over polish.
 - **Avoid**: Overused cliches (trucks, tailgates, generic party imagery). Forced drawl in spelling. Telling instead of showing. Inverted word order for rhyme.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 1-2 topics/verse · typical BPM 80-140. Storytelling determines density. Narrative verses can be denser than emotional ones. Conversational pace — write like you'd tell a friend.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 90-120 BPM. Ballads (60-80): 4 lines. Uptempo (130+): 6-8 lines but prioritize chorus. Storytelling verses can push to 8 at mid-tempo. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/dancehall/README.md
+++ b/genres/dancehall/README.md
@@ -23,7 +23,7 @@ Contemporary dancehall continues to evolve through fusion and experimentation wh
 - **Verse structure**: Variable — riddim-driven. Repetitive chanted hooks for crowd participation. Fast-chat sections with rapid delivery.
 - **Key rule**: Toasting (DJ-style vocal delivery) is the foundation. Heavy Patois use. Syncopated phrasing locks into riddim groove.
 - **Avoid**: Standard English delivery without Patois flavor. Slow pacing. Lyrics that don't match the riddim energy.
-- **Density/pacing**: moderate-high density · 8-13 syl/line · max 1-2 topics/verse · typical BPM 90-110. Faster than reggae. DJ-style rapid delivery (singjay). Danceable riddim patterns. Higher density than roots reggae.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 90-110 BPM. Faster than reggae. DJ-style rapid delivery (singjay). More density than roots reggae. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/disco/README.md
+++ b/genres/disco/README.md
@@ -47,7 +47,7 @@ Nu-disco emerged in the early 2000s as producers like Lindstrom, Todd Terje, and
 - **Verse structure**: Verse-chorus with extended dance breaks. Chorus is king — repetitive and singable.
 - **Key rule**: Dance floor energy. Love, celebration, freedom, nightlife. Lyrics serve the groove.
 - **Avoid**: Heavy themes. Complex structures. Anything that kills the party.
-- **Density/pacing**: low-moderate density · 6-9 syl/line · max 1 topics/verse · typical BPM 110-130. Four-on-the-floor demands dancefloor clarity. Repetitive hooks. Verse-to-chorus energy builds. Simple, euphoric.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 110-130 BPM. Four-on-the-floor demands dancefloor clarity. Repetitive hooks. Simple, euphoric. Topics: 1/verse.
 
 ## Subgenres and Styles
 

--- a/genres/doom-metal/README.md
+++ b/genres/doom-metal/README.md
@@ -23,7 +23,7 @@ The late 1980s and 1990s witnessed doom metal's divergence into increasingly ext
 - **Verse structure**: Longer, theatrical lines with space between phrases. Ritualistic repetition of short phrases.
 - **Key rule**: Suffering, mortality, grief, occult, existential dread. Personal and specific — not generic despair. Concrete imagery (landscapes, occult symbols, myth as mirror for grief).
 - **Avoid**: Generic despair cliches. Overwriting — space and repetition are the point. Fast delivery.
-- **Density/pacing**: low-moderate density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 60-100. Slowest metal. Crushing, deliberate delivery. Each word carries weight. Sparse lyrics, heavy imagery.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 60-100 BPM. Funeral doom (<60): 2-4 lines. Slowest metal — each word carries crushing weight. Never exceed 6 lines. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/drill/README.md
+++ b/genres/drill/README.md
@@ -54,7 +54,7 @@ The genre has since spread globally: Australian drill (ONEFOUR, HP Boyz) emerged
 - **Verse structure**: 8–16 bars. UK drill: 138–151 BPM with expressive delivery. Chicago: ~60–70 BPM, deadpan.
 - **Key rule**: Pauses are punctuation — silence makes the listener lean in. No auto-tune (UK/Brooklyn drill).
 - **Avoid**: Generic imagery without street specificity. Melodic singing where deadpan is expected.
-- **Density/pacing**: moderate density · 9-13 syl/line · max 2-3 topics/verse · typical BPM 140-150. Aggressive but staccato delivery. Sliding 808s need vocal space. Repetitive hooks balance verse density.
+- **Density/pacing (Suno)**: Default **8 lines/verse** (4 couplets) at 140-145 BPM. Aggressive but staccato — sliding 808s need vocal space. Never exceed 8 lines. Topics: 1-2/verse. UK drill: rapid wordplay stays within 8 lines.
 
 ## Subgenres & Styles
 

--- a/genres/drum-and-bass/README.md
+++ b/genres/drum-and-bass/README.md
@@ -23,7 +23,7 @@ The 2000s and 2010s saw drum and bass mature into a global phenomenon while rema
 - **Verse structure**: Short vocal hooks or MC bars over 170+ BPM breakbeats. Jungle/DnB MC style: rapid, rhythmic.
 - **Key rule**: Energy and speed. Vocals must cut through heavy bass and fast drums. Short, punchy, repeatable.
 - **Avoid**: Slow, drawn-out vocal passages. Dense lyrics that can't match the tempo.
-- **Density/pacing**: high density · 8-14 syl/line · max 2-3 topics/verse · typical BPM 160-180. Fastest electronic genre. MC delivery allows high density despite tempo. Jungle tradition of rapid-fire toasting.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 160-180 BPM. Fastest electronic genre. MC delivery allows brief bursts of density. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/dubstep/README.md
+++ b/genres/dubstep/README.md
@@ -75,7 +75,7 @@ Today, dubstep encompasses a vast spectrum from introspective, atmospheric compo
 - **Verse structure**: No traditional verses. Pre-drop hype vocals, post-drop hooks. Build-drop-build.
 - **Key rule**: Phrases must work when effected, twisted, and transformed. Short and punchy.
 - **Avoid**: Long vocal passages. Complex narratives. Lyrics that don't survive heavy processing.
-- **Density/pacing**: low density · 5-9 syl/line · max 1-2 topics/verse · typical BPM 140 (half-time 70). Bass drops need clear vocal space. Half-time feel. MC-style vocals can be denser, sung vocals stay sparse.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 140 BPM (half-time 70). Bass drops need clear vocal space. MC-style can be denser, sung vocals stay sparse. Topics: 1/verse.
 
 ## Subgenres and Styles
 

--- a/genres/edm/README.md
+++ b/genres/edm/README.md
@@ -23,7 +23,7 @@ From intimate underground warehouse parties to massive festival stages accommoda
 - **Verse structure**: Short vocal hooks (4–8 words) designed for build-up and drop sections. No traditional verse structure.
 - **Key rule**: Energy and singability. Hooks must work in a festival/club context. Build-drop-build structure.
 - **Avoid**: Dense lyrics. Complex narratives. Anything that competes with the production.
-- **Density/pacing**: low density · 5-8 syl/line · max 1 topics/verse · typical BPM 126-132. Festival-oriented. Big vocal hooks, minimal verses. Build-drop structure governs everything. Anthemic simplicity.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 126-132 BPM. Festival-oriented — big vocal hooks, minimal verses. Build-drop structure governs. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/electronic/README.md
+++ b/genres/electronic/README.md
@@ -46,7 +46,7 @@ Today, electronic music production tools are democratized through affordable sof
 - **Verse structure**: Minimal vocals. Short phrases (2–8 words) repeated as loops or hooks. Space between phrases.
 - **Key rule**: Less is more. Repetition is the defining characteristic — same phrase repeating creates hypnotic effect. Too many words ruin the track.
 - **Avoid**: Dense lyrics. Narrative complexity. Traditional verse-chorus structure (unless synthwave). Over-rhyming.
-- **Density/pacing**: low density · 6-9 syl/line · max 1-2 topics/verse · typical BPM 120-140. Production is the star. Vocals are texture, not focus. Fewer syllables, more space for drops and builds.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 120-140 BPM. Production is the star — vocals are texture. Fewer syllables, more space for drops and builds. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/emo/README.md
+++ b/genres/emo/README.md
@@ -61,7 +61,7 @@ After a brief period of mainstream retreat, emo experienced a revival driven by 
 - **Verse structure**: 4–8 lines per section. Quiet verses, explosive choruses (dynamic contrast).
 - **Key rule**: Introspective and confessional. Vivid sensory imagery essential — sights, sounds, smells, textures. Vulnerability and authenticity paramount.
 - **Avoid**: Generic emotional cliches without specific detail. Telling emotions instead of showing through imagery. Twin verses.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 2-3 topics/verse · typical BPM 90-140. Emotional intensity over speed. Confessional lyrics need breathing room. Quiet/loud dynamics.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-140 BPM. Slower emo (<115): up to 8 lines. Fast emo-punk (140-160): 4 lines. Confessional lyrics need breathing room. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/folk/README.md
+++ b/genres/folk/README.md
@@ -23,7 +23,7 @@ Contemporary folk spans a vast spectrum: from traditionalists preserving centuri
 - **Verse structure**: 4-line quatrains (ballad meter: 8/6/8/6 syllables). Verse-only (strophic) form common — same melody, different lyrics each verse, with refrain line.
 - **Key rule**: Linear narrative progression. Each verse develops the story. Character-focused, historical events, travel, lost love. Simplicity of language paramount.
 - **Avoid**: Flowery or complex vocabulary. Abstract lyrics without grounding. Breaking the ballad meter inconsistently.
-- **Density/pacing**: high density · 10-16 syl/line · max 2-4 topics/verse · typical BPM 80-110. Traditional folk storytelling handles topic-dense verses. Listeners expect narrative complexity. Acoustic setting makes every word audible.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 80-110 BPM. Traditional folk storytelling handles longer verses. Acoustic setting makes every word audible. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/funk/README.md
+++ b/genres/funk/README.md
@@ -44,7 +44,7 @@ The defining element of funk is "the one"—the heavy emphasis on the first beat
 - **Verse structure**: Short, punchy phrases that lock into the rhythm. Non-conventional structure prioritizing groove.
 - **Key rule**: Lyrics accent the downbeat ("on the one"). Groove over narrative. Double entendres and innuendo are genre tradition.
 - **Avoid**: Conventional song structure forced onto funk grooves. Overwriting. Ignoring the "one" (downbeat emphasis).
-- **Density/pacing**: moderate density · 7-10 syl/line · max 1-2 topics/verse · typical BPM 100-130. Rhythmic, groove-locked. Syllables on the one. Call-and-response patterns. Keep it tight and danceable.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 100-130 BPM. Rhythmic, groove-locked. Syllables on the one. Call-and-response patterns. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/garage-rock/README.md
+++ b/genres/garage-rock/README.md
@@ -52,7 +52,7 @@ Garage rock emerged in the mid-1960s as the raw, unpolished response to the Brit
 - **Verse structure**: Short verses (4–6 lines), punchy choruses. Straightforward delivery.
 - **Key rule**: Energy and attitude first. Keep it simple, keep it raw.
 - **Avoid**: Overwritten lyrics. Complex metaphors. Anything that sounds too polished.
-- **Density/pacing**: low density · 5-8 syl/line · max 1-2 topics/verse · typical BPM 120-160. Raw energy, simple phrasing. Repetition over variety. Lo-fi production means fewer syllables cut through.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 120-140 BPM. At 140-160: 3-4 lines. Raw energy, simple phrasing. Repetition over variety. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/gospel/README.md
+++ b/genres/gospel/README.md
@@ -28,7 +28,7 @@ Today, gospel encompasses a remarkable range of expressions: from traditional qu
 - **Verse structure**: Call-and-response between lead and congregation/choir. Lines designed for repetition and group singing.
 - **Key rule**: Repetition builds intensity — this is the engine of gospel. Faith, belief, passion conveyed through delivery as much as words.
 - **Avoid**: Lyrics too complex for congregation participation. Insufficient repetition. Missing call-and-response structure.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 1-2 topics/verse · typical BPM 70-120. Spiritual themes need room to breathe. Melismatic delivery. Building emotional intensity through repetition, not word count.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 70-120 BPM. Melismatic delivery — building emotional intensity through repetition, not word count. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/grime/README.md
+++ b/genres/grime/README.md
@@ -23,7 +23,7 @@ The mid-2000s saw grime struggle against industry skepticism and a UK garage sce
 - **Verse structure**: 8-bar, 16-bar, or 32-bar patterns ("nu shape"). Drums/lyrics/melody change every 8 bars.
 - **Key rule**: 8-bar changes are the heartbeat of grime. Regional British accents and slang are essential.
 - **Avoid**: Slow delivery, American slang, ignoring the 8-bar structure.
-- **Density/pacing**: high density · 10-14 syl/line · max 2-3 topics/verse · typical BPM 140. UK tempo locked at ~140 BPM. Rapid-fire delivery expected. Syllable density similar to battle rap but with melodic hooks.
+- **Density/pacing (Suno)**: Default **8 lines/verse** (4 couplets) at 140 BPM. Rapid-fire delivery but respect 8-bar change structure — don't write one 16-line verse, write two 8-line verses. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/grunge/README.md
+++ b/genres/grunge/README.md
@@ -30,7 +30,7 @@ The movement's tragic dimension—Kurt Cobain's 1994 suicide, Layne Staley's 200
 - **Verse structure**: Quiet verses, loud choruses (quiet-loud-quiet dynamic). 4–8 lines per section.
 - **Key rule**: Images that make the listener feel seen, sorry, or amused simultaneously. First verse sets emotion, chorus releases dissatisfaction.
 - **Avoid**: Straightforward, literal lyrics. Polished delivery. Happy-sounding choruses.
-- **Density/pacing**: low-moderate density · 6-10 syl/line · max 1-3 topics/verse · typical BPM 90-130. Mumbled delivery makes dense lyrics unintelligible. Keep it raw, emotionally direct, sparse. Dynamics (quiet-loud) matter more than word count.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-120 BPM. Slow grunge (<100): up to 8 lines. Mumbled delivery makes dense lyrics unintelligible. Keep raw and sparse. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/hardcore-punk/README.md
+++ b/genres/hardcore-punk/README.md
@@ -23,7 +23,7 @@ Hardcore punk's evolution throughout the 1980s and beyond spawned numerous subge
 - **Verse structure**: Ultra-short — 4–8 bars max. 5-syllable chants common. Songs often under 2 minutes.
 - **Key rule**: Gang vocals must be simple and shoutable. Political anger, social confrontation, direct message.
 - **Avoid**: Complex vocabulary. Long narrative verses. Melodic singing. Lines too long for breath at 300+ BPM.
-- **Density/pacing**: high density · 8-14 syl/line · max 1-2 topics/verse · typical BPM 160-220. Fastest delivery in punk. Shouted vocals allow high syllable density despite speed. Aggressive, direct.
+- **Density/pacing (Suno)**: Default **2-3 lines/verse** at 180-220+ BPM. Extreme tempo — shouted vocals, barely intelligible at peak speed. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/hip-hop/README.md
+++ b/genres/hip-hop/README.md
@@ -26,7 +26,7 @@ The genre's production has evolved from simple breakbeat loops to sophisticated 
 - **Key rule**: Internal rhymes are mandatory in modern hip-hop — rhyme density and placement throughout the bar separates good from amateur.
 - **No orphan lines**: If line 1 rhymes with line 2, line 3 MUST rhyme with line 4.
 - **Avoid**: Filler words (uh, um, like), cramming too many thoughts into one bar, sacrificing meaning for forced rhymes.
-- **Density/pacing**: moderate-high density · 10-14 syl/line · max 2-3 topics/verse · typical BPM 80-100. 16-bar verses at head-nod tempo; internal rhyme density adds perceived syllables. Trap/drill BPMs (130-150) use half-time feel — treat as 65-75 BPM for density.
+- **Density/pacing (Suno)**: Default **8 lines/verse** (4 couplets) at 85-95 BPM. At 80-85 BPM: max 6 lines. Never exceed 8 lines — Suno rushes past this. Topics: 2-3/verse. Half-time trap BPMs (130-150) = treat as 65-75 effective BPM.
 
 ## Subgenres & Styles
 

--- a/genres/house/README.md
+++ b/genres/house/README.md
@@ -23,7 +23,7 @@ Today, house music stands as the foundational genre of global dance culture, wit
 - **Verse structure**: No traditional verses. Single repeated phrases or very short vocal sections (4–12 words).
 - **Key rule**: Groove lock — vocals must serve the rhythm, not compete with it. Uplifting, soulful, or funky tone.
 - **Avoid**: Walls of lyrics. Complex rhyme schemes. Anything that breaks the groove.
-- **Density/pacing**: low density · 5-8 syl/line · max 1 topics/verse · typical BPM 120-130. Repetitive vocal phrases over groove. Single ideas looped. Dancefloor clarity — simple, catchy, memorable.
+- **Density/pacing (Suno)**: Default **2 lines/verse** (or repeated phrases) at 120-130 BPM. Groove-driven — single ideas looped. Dancefloor clarity. Topics: 1/verse max.
 
 ## Subgenres & Styles
 

--- a/genres/hyperpop/README.md
+++ b/genres/hyperpop/README.md
@@ -29,7 +29,7 @@ Hyperpop thrives on digital manipulation, unconventional song structures, and a 
 - **Verse structure**: Short, punchy sections. Heavy vocal processing (pitch-shifting, distortion) affects how lyrics land.
 - **Key rule**: Maximalist and genre-bending. Lyrics can be absurdist, ironic, or hyper-emotional. Vocal processing is part of the writing.
 - **Avoid**: Conventional pop sincerity without ironic edge. Writing for unprocessed vocals when heavy effects are expected.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 1-2 topics/verse · typical BPM 140-170. Chaotic energy but simple lyrical content. Distortion and pitch-shifting obscure dense lyrics. Keep words clear despite production chaos.
+- **Density/pacing (Suno)**: Default **3 lines/verse** at 140-170 BPM. At 160+: 2-3 lines. Frenetic energy — minimal verses, hook-dominant. Fragment ideas; hyperpop is impressionistic. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/indie-folk/README.md
+++ b/genres/indie-folk/README.md
@@ -24,7 +24,7 @@ Indie folk's aesthetic centers on warmth and imperfection. Where mainstream pop 
 - **Verse structure**: 4–8 lines. Often verse-heavy. Acoustic-driven arrangements influence sparse phrasing.
 - **Key rule**: Intimate, personal, and specific. Quiet observation over grand statements. Nature imagery and small domestic details.
 - **Avoid**: Overwrought emotion. Arena-scale lyrics in an intimate genre. Cliched folk imagery.
-- **Density/pacing**: moderate-high density · 10-14 syl/line · max 2-3 topics/verse · typical BPM 85-120. Literary lyrics tolerated. Abstract topic shifts OK if mood/theme unifies. Intimate production demands clear enunciation.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 85-120 BPM. Literary lyrics tolerated. Intimate production demands clear enunciation. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/indie-rock/README.md
+++ b/genres/indie-rock/README.md
@@ -27,7 +27,7 @@ The 2000s brought a significant indie rock revival that pushed the genre into ma
 - **Verse structure**: Varies — standard verse-chorus or unconventional forms. 4–8 lines per section.
 - **Key rule**: Personal, quirky, and specific. Indie lyrics favor the particular over the universal. Conversational delivery.
 - **Avoid**: Arena-rock bombast. Generic emotional statements. Polished-sounding lyrics that feel manufactured.
-- **Density/pacing**: moderate density · 6-9 syl/line · max 2-3 topics/verse · typical BPM 90-130. Conversational, trim excess syllables. Name specific objects/places for authenticity.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-120 BPM. Conversational — trim excess syllables. At 100-110: up to 8 lines. At 120-130: 4-6 lines. Topics: 2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/industrial/README.md
+++ b/genres/industrial/README.md
@@ -56,7 +56,7 @@ Today, industrial's influence pervades contemporary music far beyond its scene b
 - **Verse structure**: Short lines — chant-like repetition. Concrete industrial imagery (machines, soot, conveyor belts, grease).
 - **Key rule**: Alienation, technology, corporate oppression, existential anger. Technical language flipped into emotional context. Small human details amid machine imagery.
 - **Avoid**: Long, flowery lines. Abstract machine metaphors without concrete details. Unexplained jargon.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 1-2 topics/verse · typical BPM 100-140. Mechanical, repetitive. Syllables lock to machine rhythms. Distorted vocals limit comprehensible density.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 100-130 BPM. Mechanical, repetitive — syllables lock to machine rhythms. Distorted vocals limit comprehensible density. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/jazz/README.md
+++ b/genres/jazz/README.md
@@ -25,7 +25,7 @@ What unifies all jazz is the centrality of improvisation—the spontaneous creat
 - **Verse structure**: 8-bar sections in AABA form. A sections repeat melodically but lyrics differ each time.
 - **Key rule**: Conversational yet musical phrasing. Swing feel requires phrasing behind or ahead of the beat — lyrics must allow flexibility. Scat sections marked as [Scat] or with written syllables.
 - **Avoid**: Simple, predictable end rhymes (too basic for jazz). Stiff, on-the-beat phrasing. Overly narrative lyrics.
-- **Density/pacing**: moderate-high density · 8-14 syl/line · max 2-4 topics/verse · typical BPM 60-200. Highly variable by style. Bebop phrasing can be dense; ballads are sparse. Match density to the rhythm section's energy.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** (AABA 32-bar form) at variable BPM. Bebop (120-200): 2-4 lines. Ballads: 6-8 lines. Match density to rhythm section energy. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/k-pop/README.md
+++ b/genres/k-pop/README.md
@@ -51,7 +51,7 @@ K-Pop (Korean Pop) is a global entertainment phenomenon rooted in South Korean p
 - **Verse structure**: Faster tempo, shorter sections, more phrase repetition than Western pop. Tight 8–16 bar sections.
 - **Key rule**: Title/hook always in English. Simple, chantable English choruses. Korean verses for emotional detail.
 - **Avoid**: Complex English vocabulary in hooks. Ignoring code-switching conventions.
-- **Density/pacing**: high density · 8-12 syl/line · max 2-3 topics/verse · typical BPM 120-140. Shorter sections with more repetition. Rhythmic delivery, often bilingual. Rapid section changes keep density feeling lighter.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 120-140 BPM. Rapid verse-chorus cycling with pre-choruses. Shorter sections feel lighter despite high density. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/latin/README.md
+++ b/genres/latin/README.md
@@ -57,7 +57,7 @@ The 21st century has seen Latin music achieve unprecedented global reach. Reggae
 - **Verse structure**: Verse-chorus with emphasis on rhythmic delivery. Bilingual (Spanish/English) hooks common in crossover tracks.
 - **Key rule**: Rhythm drives everything — lyrics must lock into the specific Latin rhythm (reggaeton, cumbia, bachata, etc.). Passion and emotional directness.
 - **Avoid**: Rhythmically stiff phrasing. Ignoring the specific Latin subgenre's rhythmic pattern. Awkward bilingual mixing.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 1-2 topics/verse · typical BPM 90-140. Rhythmic patterns (clave, tresillo) govern syllable placement. Dance-oriented — clarity for movement.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 90-140 BPM. Clave/tresillo rhythms govern syllable placement. Dance-oriented — clarity for movement. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/lo-fi/README.md
+++ b/genres/lo-fi/README.md
@@ -94,7 +94,7 @@ Lo-fi production treats degradation as enhancement. Where conventional recording
 - **Verse structure**: Sparse — 2–4 lines floating through the track. Often instrumental or with sampled vocal snippets.
 - **Key rule**: Mood over narrative. Nostalgia, warmth, chill. Vocals blend into the texture.
 - **Avoid**: Clear, polished vocal delivery. Dense lyrics. Demanding attention from the listener.
-- **Density/pacing**: low density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 60-90. Chill, study-music aesthetic. Muted, warm. When vocal, laid-back and spacious. Jazz-influenced phrasing.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 60-90 BPM. Chill, study-music aesthetic. When vocal, laid-back and spacious. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/metal/README.md
+++ b/genres/metal/README.md
@@ -53,7 +53,7 @@ The 2000s saw metal fragment further: metalcore merged hardcore breakdowns with 
 - **Verse structure**: Variable — lyrics must fit the riff. Rhythmic alignment with the music is the priority.
 - **Key rule**: Concrete imagery over everything. A skull, a factory, a blizzard — specific images beat vague concepts. Conflict is mandatory.
 - **Avoid**: Forced rhymes over meaning. Vague abstractions. Ignoring the riff's rhythm.
-- **Density/pacing**: moderate-high density · 8-12 syl/line · max 2-3 topics/verse · typical BPM 100-140. Vocal delivery style (clean, growl, scream) compresses syllables efficiently. Riff alignment matters — land words on riff accents.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 100-140 BPM. Vocal delivery (clean/growl/scream) compresses syllables — metal handles more density than tempo alone suggests. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/metalcore/README.md
+++ b/genres/metalcore/README.md
@@ -31,7 +31,7 @@ The breakdown remains metalcore's most distinctive structural element---a sectio
 - **Verse structure**: Verse-chorus-verse-chorus-bridge-chorus (most traditional of metal subgenres). Breakdown sections essential.
 - **Key rule**: Clean chorus / screamed verse contrast is the defining characteristic. Choruses must be singable and melodic. Screamed sections carry aggression.
 - **Avoid**: No vocal contrast (clean/screamed dynamic defines the genre). Ignoring melody in choruses. Missing the breakdown.
-- **Density/pacing**: moderate-high density · 8-13 syl/line · max 2-3 topics/verse · typical BPM 100-150. Screamed verses / clean choruses. Breakdown sections need chant-friendly phrases. Syllable density varies by section.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 120-140 BPM. Screamed verses / clean choruses. Breakdown sections need chant-friendly phrases (2-4 lines). Topics: 2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/nerdcore/README.md
+++ b/genres/nerdcore/README.md
@@ -26,7 +26,7 @@ The modern nerdcore scene has expanded well beyond its original boundaries, infl
 - **Verse structure**: 85–100 BPM (story-driven) or 120–150 BPM (electro/trap energy). Standard 16-bar verses.
 - **Key rule**: Vocals must be forward and clear — dense references must be understood by the listener.
 - **Avoid**: Obscure references without context. Sacrificing flow for niche in-jokes.
-- **Density/pacing**: moderate-high density · 10-15 syl/line · max 2-4 topics/verse · typical BPM 80-110. Technical wordplay and reference density. Similar to boom-bap but with geek-culture subject matter. Avoid cramming too many references per bar.
+- **Density/pacing (Suno)**: Default **8 lines/verse** (4 couplets) at 85-100 BPM. Electro/trap nerdcore (120-150 BPM): 6 lines. Reference density is high — avoid cramming too many per bar. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/new-wave/README.md
+++ b/genres/new-wave/README.md
@@ -53,7 +53,7 @@ The genre's influence extends far beyond its commercial heyday. Post-punk reviva
 - **Verse structure**: Verses 4–6 lines, choruses 4–6 lines. Synth-driven arrangements influence phrasing.
 - **Key rule**: Wit, irony, and art-school intelligence. Post-punk sensibility with pop accessibility.
 - **Avoid**: Earnest rock sincerity without ironic distance. Overly complex vocals fighting synth textures.
-- **Density/pacing**: moderate density · 7-10 syl/line · max 1-2 topics/verse · typical BPM 100-140. Synth-driven, quirky phrasing. Catchy over complex. Angular melodies prefer clean syllable placement.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 110-130 BPM. At 130-140: 4 lines. Synth-driven, quirky phrasing — catchy over complex. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/opera/README.md
+++ b/genres/opera/README.md
@@ -24,7 +24,7 @@ Opera demands extraordinary performers: singers who combine the projection to fi
 - **Verse structure**: Recitative (speech-like) and aria (melodic) sections alternate. Dramatic arc drives structure.
 - **Key rule**: Dramatic narrative — characters, conflict, emotional arc. Vocal range and power determine phrasing. Libretto serves the story.
 - **Avoid**: Pop conventions. Casual language. Ignoring the dramatic structure of opera.
-- **Density/pacing**: low density · varies syl/line · max 1-2 topics/verse · typical BPM 40-120. Vocal technique demands elongated syllables. Libretto economy — fewer words, more expression. Dramatic pauses essential.
+- **Density/pacing (Suno)**: Default **4-6 lines** (aria form) at variable BPM. Vocal technique demands elongated syllables. Libretto economy — fewer words, more expression. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/phonk/README.md
+++ b/genres/phonk/README.md
@@ -24,7 +24,7 @@ Modern phonk has exploded into mainstream consciousness, becoming the dominant s
 - **Verse structure**: Short — repetitive, hypnotic, and subtle. Mood first, then detail.
 - **Key rule**: Dark, atmospheric mood drives everything. Night drives, nostalgia, graveyard shift.
 - **Avoid**: Overwriting. Dense wordplay that fights the hypnotic groove.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 1-2 topics/verse · typical BPM 60-80 (drift phonk 130-170). Memphis-style chopped vocals. Lo-fi aesthetic demands space. Drift phonk variant is often instrumental.
+- **Density/pacing (Suno)**: Default **4 lines/verse** (2 couplets) at 60-80 BPM. Memphis phonk is slow — Suno has very little time per line. Drift phonk (130-170 BPM): 4-6 lines but often instrumental. Topics: 1/verse max.
 
 ## Subgenres & Styles
 

--- a/genres/piano-pop/README.md
+++ b/genres/piano-pop/README.md
@@ -51,7 +51,7 @@ The 2010s and 2020s saw piano pop proliferate further. Sam Smith's ballad-heavy 
 - **Verse structure**: Verses 4–8 lines. Choruses 4–6 lines. Slower tempo allows more syllables per line.
 - **Key rule**: Story-driven, emotionally sentimental. First or third person POV. Melody carries the emotion.
 - **Avoid**: Forced upbeat energy. Complex rhythmic patterns that fight the piano-led arrangement.
-- **Density/pacing**: moderate density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 90-120. Piano-driven arrangements need vocal space. Emotional delivery over syllable density. Let the instrument breathe.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 100-120 BPM. Ballad tempo (90-100): up to 8 lines. Piano arrangements need vocal space. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/piano-rock/README.md
+++ b/genres/piano-rock/README.md
@@ -49,7 +49,7 @@ Piano rock's enduring appeal lies in its paradox: the piano is simultaneously on
 - **Verse structure**: Verses 4–8 lines. Choruses 4–6 lines. Storytelling and character sketches common.
 - **Key rule**: Piano drives the harmonic and rhythmic foundation — lyrics should complement, not fight the piano's role. Wit, storytelling, and emotional range.
 - **Avoid**: Generic rock imagery that ignores the piano-centric arrangement. Overly simple lyrics beneath the genre's musicality.
-- **Density/pacing**: moderate density · 7-10 syl/line · max 2-3 topics/verse · typical BPM 100-130. Piano-driven rock balances instrumental showcasing with vocal narrative. Similar density to mainstream rock.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 100-120 BPM. Ballad tempo (<100): up to 8 lines. Piano showcasing needs vocal space. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/pop/README.md
+++ b/genres/pop/README.md
@@ -23,7 +23,7 @@ From the British Invasion of the 1960s through the MTV revolution of the 1980s, 
 - **Syllable range**: 6–10 syllables per line. Conversational phrasing — lyrics should sound natural when spoken as prose.
 - **Key rule**: If it sounds "carefully crafted," it breaks immersion. Conversational beats poetic.
 - **Avoid**: Lyric cliches ("cold as ice," "by my side," "set me free"), forced perfect rhymes, complex/abstract choruses.
-- **Density/pacing**: moderate density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 100-130. Syllable matching between verses is critical (Max Martin method). Hook repetition > verse density. Conversational phrasing.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 110-120 BPM. At 100-110: up to 6 lines. At 120-130: stick to 4. Pop is chorus-first — longer verses bury the hook. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/post-rock/README.md
+++ b/genres/post-rock/README.md
@@ -25,7 +25,7 @@ Post-rock's evolution has taken it from underground art-rock circles to mainstre
 - **Verse structure**: No verse-chorus structure. Vocals (if any) float over long instrumental passages.
 - **Key rule**: Mood and atmosphere over lyrics. Vocals are texture, not the focal point.
 - **Avoid**: Conventional song structures. Narrative lyrics. Treating vocals as the primary element.
-- **Density/pacing**: low density · 4-8 syl/line · max 1-2 topics/verse · typical BPM 80-140. Primarily instrumental. When vocals appear, sparse and atmospheric. Let the build-ups speak.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** (or fully instrumental). Sparse, atmospheric — let the build-ups speak. Topics: 1/verse or abstract fragments.
 
 ## Subgenres & Styles
 

--- a/genres/progressive-rock/README.md
+++ b/genres/progressive-rock/README.md
@@ -48,7 +48,7 @@ Today, progressive rock continues to evolve through artists who blend its compos
 - **Verse structure**: No constraints — extended narratives, asymmetric sections, concept-driven passages. Songs can be 10+ minutes.
 - **Key rule**: Ambitious subjects — philosophy, fantasy, science, epic narratives. Concept albums that tell unified stories.
 - **Avoid**: Simplistic lyrics beneath the genre's intellectual ambition. Standard 3-minute song structures.
-- **Density/pacing**: high density · 9-13 syl/line · max 3-5 topics/verse · typical BPM 70-150. Longest acceptable verses in rock. Complex narratives, variable time signatures. Careful phrasing required — density must serve the composition.
+- **Density/pacing (Suno)**: Default **8-10 lines/verse** — prog is the exception. At 90-110: up to 12 lines. At 130+: 6-8 lines. Complex narratives, variable time signatures. Test carefully with Suno. Topics: 3-4/verse.
 
 ## Subgenres & Styles
 

--- a/genres/psychedelic-rock/README.md
+++ b/genres/psychedelic-rock/README.md
@@ -48,7 +48,7 @@ Neo-psychedelia emerged in the 1980s and continues thriving today, reinterpretin
 - **Verse structure**: Flexible — can be extended, non-linear, or through-composed. No strict limits.
 - **Key rule**: Surreal imagery, altered states, cosmic themes. Lyrics can be impressionistic sound-paintings.
 - **Avoid**: Literal, grounded narratives. Conventional pop structure unless intentionally subverted.
-- **Density/pacing**: moderate-high density · 6-11 syl/line · max 3-5 topics/verse · typical BPM 80-130. Surreal imagery allows topic shifts. Stream-of-consciousness acceptable if mood-unified. Space for instrumental passages.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 100-120 BPM. Slow psych (<100): up to 8 lines. Surreal imagery allows topic shifts if mood-unified. Topics: 2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/punk/README.md
+++ b/genres/punk/README.md
@@ -54,7 +54,7 @@ Punk rock exploded in the mid-1970s as a visceral rejection of the bloated exces
 - **Verse structure**: Short — 4–6 lines. Songs under 3 minutes. Lines must work at 150–200 BPM.
 - **Key rule**: Directness over poetry. Simple, punchy, shoutable. Authenticity is punk's cardinal virtue.
 - **Avoid**: Pretentious vocabulary. Flowery descriptions. Complex sentence structures. Anything that sounds "carefully written."
-- **Density/pacing**: moderate density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 150-200. Fast and furious. Short songs, short verses. Energy over complexity. Every word must punch.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 150-180 BPM. At 160+: 2-3 lines. Fast and furious — every word must punch. Never exceed 4 lines. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/reggae/README.md
+++ b/genres/reggae/README.md
@@ -56,7 +56,7 @@ The 1980s saw reggae evolve into dancehall, shifting from live instrumentation t
 - **Verse structure**: 4–8 lines per section. Riddim determines section lengths. Heavy repetition of hooks.
 - **Key rule**: Groove lock — lyrics must fit the riddim. Call-and-response, chanted hooks for crowd participation. One love, social justice, spiritual themes.
 - **Avoid**: Fighting the riddim groove. Incorrect Patois use. Ignoring call-and-response conventions.
-- **Density/pacing**: low-moderate density · 6-10 syl/line · max 1-2 topics/verse · typical BPM 65-90. Offbeat skank rhythm creates natural spaces. Laid-back delivery. Message-focused but never rushed. One love, one topic.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 65-90 BPM. Offbeat skank rhythm creates natural spaces. Laid-back, never rushed. Topics: 1/verse.
 
 ## Subgenres and Styles
 

--- a/genres/rnb/README.md
+++ b/genres/rnb/README.md
@@ -28,7 +28,7 @@ Throughout its evolution, R&B has remained the voice of Black American experienc
 - **Verse structure**: Verses 6–8 lines. Chorus-dominant structure — chorus gets most time allocation.
 - **Key rule**: Leave space for vocal runs and melisma. Don't overload lines with dense wordplay — singers need room for ornamentation. Intimate, specific details over generic emotion.
 - **Avoid**: Dense wordplay that fights vocal interpretation. Greeting card sentiments. Technique overshadowing emotion.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 2-3 topics/verse · typical BPM 60-100. Melisma spreads syllables across beats. Leave room for vocal runs and ad-libs. Groove > density.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 60-100 BPM. Ballads (<80): 4-6 lines. Melisma stretches syllables — leave room for vocal runs and ad-libs. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/rock/README.md
+++ b/genres/rock/README.md
@@ -24,7 +24,7 @@ At its core, rock remains defined by the interplay of electric guitar, bass, and
 - **Verse structure**: Verses 4–8 lines. Choruses 4–6 lines. 6–10 syllables per line typical.
 - **Key rule**: Specific imagery ("coffee gone cold on the counter") beats abstract statements ("I felt so sad"). Show, don't tell.
 - **Avoid**: Forced perfect rhymes. Generic emotion words without grounding imagery. Cliches ("cold as ice," "learning to fly").
-- **Density/pacing**: moderate density · 7-10 syl/line · max 2-3 topics/verse · typical BPM 110-140. 120 BPM is the rock sweet spot. Balance between vocal and instrumental energy. Guitar riffs need space.
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-130 BPM. At 130-140: 4 lines. Guitar riffs need space. 120 BPM is the sweet spot. Topics: 2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/shoegaze/README.md
+++ b/genres/shoegaze/README.md
@@ -73,7 +73,7 @@ The revival gained further momentum when original acts reformed: Slowdive return
 - **Verse structure**: Sparse lines buried beneath layers of guitar effects. No strong verse-chorus distinction.
 - **Key rule**: Vocals are another instrument in the wall of sound. Choose words for their sonic quality (vowels, sibilance) not just meaning.
 - **Avoid**: Clear, upfront vocal delivery. Dense wordplay. Lyrics that demand to be heard over the guitars.
-- **Density/pacing**: low density · 4-8 syl/line · max 1-2 topics/verse · typical BPM 80-120. Vocals are another texture, not the focus. Heavy reverb/distortion obscures words. Fewer syllables, dream-like imagery.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 80-110 BPM. Vocals are texture, not focus — fewer syllables cut through reverb/distortion. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/singer-songwriter/README.md
+++ b/genres/singer-songwriter/README.md
@@ -50,7 +50,7 @@ The genre's relationship with other styles is fluid. Singer-songwriter overlaps 
 - **Verse structure**: Varies — verse-heavy, with chorus as emotional anchor rather than dominant element.
 - **Key rule**: Conversational tone essential. Write like you'd speak to friends. Personal anecdote adds depth. Confessional, intimate lyrical approach.
 - **Avoid**: Inauthenticity. Generic statements. Hiding behind abstraction instead of personal specificity.
-- **Density/pacing**: high density · 10-16 syl/line · max 2-4 topics/verse · typical BPM 70-105. Confessional mode allows stream-of-consciousness. Listeners expect dense personal detail. Stripped-back production carries every word.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 70-105 BPM. Confessional mode — listeners expect dense personal detail. Stripped-back production carries every word. Topics: 2-3/verse.
 
 ## Subgenres & Styles
 

--- a/genres/ska-punk/README.md
+++ b/genres/ska-punk/README.md
@@ -52,7 +52,7 @@ Ska punk is a high-energy fusion genre that marries the upbeat, offbeat rhythms 
 - **Verse structure**: 4–6 lines. Lines must work with offbeat ska rhythm patterns.
 - **Key rule**: Lyrical dissonance — upbeat music paired with cynical/sarcastic/political lyrics. Pick a voice persona and maintain it.
 - **Avoid**: Pure sincerity without sarcasm/irony. Lines that don't lock into the offbeat groove.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 1-2 topics/verse · typical BPM 140-180. Upstroke rhythm creates natural spaces. Call-and-response with horns. Keep verses tight for skank groove.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 140-170 BPM. Upstroke rhythm creates natural spaces. Horn sections need room. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/surf-rock/README.md
+++ b/genres/surf-rock/README.md
@@ -23,7 +23,7 @@ The surf rock revival beginning in the 1980s and continuing through today has pr
 - **Verse structure**: Short verses (4–6 lines). Many tracks are instrumental.
 - **Key rule**: Carefree energy. Summer, waves, cars, fun. When lyrics exist, keep them light and rhythmic.
 - **Avoid**: Heavy themes. Complex structures. Overwriting for an instrumental-first genre.
-- **Density/pacing**: low density · 4-7 syl/line · max 1-2 topics/verse · typical BPM 130-170. Often instrumental. When vocal, simple themes. Fast tempo but sparse lyrics. Guitar leads take priority.
+- **Density/pacing (Suno)**: Default **4 lines/verse** (when vocal) at 130-160 BPM. Often instrumental — guitar leads take priority. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/swing/README.md
+++ b/genres/swing/README.md
@@ -45,7 +45,7 @@ The 2000s-2010s saw electro-swing emerge, primarily from European producers. Aus
 - **Verse structure**: 32-bar form typical. Phrasing matters more than range — anticipation and lag in delivery.
 - **Key rule**: Conversational feel, like telling a bold secret. Dynamic shading and tiny articulations. Lyrics must breathe — room for syncopation.
 - **Avoid**: Stiff, metronomic delivery. Lyrics that don't allow phrasing flexibility. Simple predictable patterns.
-- **Density/pacing**: moderate density · 7-11 syl/line · max 1-2 topics/verse · typical BPM 120-180. Swung rhythm affects syllable placement. Conversational, witty phrasing. Singable melodies over jazz harmonies.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 120-180 BPM. Swung rhythm affects syllable placement. Conversational, witty phrasing. Singable melodies. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/synthwave/README.md
+++ b/genres/synthwave/README.md
@@ -24,7 +24,7 @@ Today, synthwave has matured into a diverse ecosystem with distinct regional sce
 - **Verse structure**: Verse-chorus when vocals present. Concise verses (4–8 lines), catchy chorus.
 - **Key rule**: Themes of technology, futurism, nostalgia, retrofuturism. Combine vintage references with modern ideas. Many tracks are purely instrumental.
 - **Avoid**: Lyrics that don't fit the 80s aesthetic. Overly modern references. Excessive lyrics in an instrumental-first genre.
-- **Density/pacing**: low-moderate density · 6-9 syl/line · max 1-2 topics/verse · typical BPM 90-120. Retro aesthetic. Clean vocal lines over synth pads. Cinematic imagery but sparse delivery. 80s movie soundtrack feel.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 90-120 BPM. Retro aesthetic — clean vocal lines over synth pads. 80s movie soundtrack feel. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/techno/README.md
+++ b/genres/techno/README.md
@@ -24,7 +24,7 @@ By the 2000s and 2010s, techno had fragmented into numerous subgenres while simu
 - **Verse structure**: Minimal — short commands, single words, even counts. 1–2 bar loops at most.
 - **Key rule**: Mechanical, hypnotic pulse. Vocals are texture, not content. Repetition drives the track.
 - **Avoid**: Meaningful lyrics in minimal techno. Traditional song structure. Fighting the repetition.
-- **Density/pacing**: very low density · 4-7 syl/line · max 1 topics/verse · typical BPM 125-150. Minimal or no vocals. When present, fragmented samples or single phrases. Let the machines talk.
+- **Density/pacing (Suno)**: Default **1-2 lines** (or none) at 125-150 BPM. Minimal or no vocals. Fragmented samples or single phrases. Topics: 1/verse or none.
 
 ## Subgenres & Styles
 

--- a/genres/thrash-metal/README.md
+++ b/genres/thrash-metal/README.md
@@ -25,7 +25,7 @@ After a commercial decline in the mid-1990s due to grunge's dominance and intern
 - **Verse structure**: Fast-paced delivery matching riff speed. Standard verse-chorus-verse with solo sections.
 - **Key rule**: Social commentary — war, corruption, abuse of power, addiction, political dissent. Aggressive, direct language.
 - **Avoid**: Slow delivery. Ignoring real-world issues. Lyrics that can't keep pace with the riffs.
-- **Density/pacing**: high density · 10-16 syl/line · max 2-3 topics/verse · typical BPM 150-220. Rapid-fire delivery at extreme tempo. Technical precision. Words must cut through wall of guitar.
+- **Density/pacing (Suno)**: Default **8-10 lines/verse** at 150-200+ BPM. Rapid-fire delivery at extreme tempo. Thrash can handle high density but test with Suno — may rush past 10 lines. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/trance/README.md
+++ b/genres/trance/README.md
@@ -63,7 +63,7 @@ After a commercial decline in the mid-2000s as electro-house dominated, trance e
 - **Verse structure**: Single hook phrase repeated at intervals. Often mezzo-soprano to soprano female vocals drenched in delay/reverb.
 - **Key rule**: Themes of love, hope, transcendence. Dreamy vocal tones. No verse/chorus — one central hook repeated.
 - **Avoid**: Dense lyrics. Grounded/mundane themes. Verse-chorus structure.
-- **Density/pacing**: low density · 5-8 syl/line · max 1 topics/verse · typical BPM 128-150. Euphoric build-up needs vocal space. Simple, uplifting phrases. Syllables timed to build/drop structure.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 128-150 BPM. Euphoric build-up needs vocal space. Simple, uplifting phrases timed to build/drop. Topics: 1/verse.
 
 ## Subgenres & Styles
 

--- a/genres/trap/README.md
+++ b/genres/trap/README.md
@@ -56,7 +56,7 @@ The genre's influence extended far beyond hip-hop. EDM producers like Flosstrada
 - **Verse structure**: 8–16 bars. Lower syllable counts (8–10 per bar) with more space and pauses.
 - **Key rule**: Melodic delivery and attitude matter more than lyrical complexity. Snare on 3rd beat.
 - **Avoid**: Overly dense wordplay that fights the beat's spacious feel.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 2-3 topics/verse · typical BPM 130-150 (half-time 65-75). Half-time feel makes high BPM spacious. Leave room for ad-libs and 808 slides. Sparse vocal placement.
+- **Density/pacing (Suno)**: Default **8 lines/verse** (4 couplets). Half-time feel (130-170 BPM = 65-85 effective). At 65-70 effective: max 6 lines. Sparse vocal placement — leave room for ad-libs and 808 slides. Topics: 1-2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/trip-hop/README.md
+++ b/genres/trip-hop/README.md
@@ -23,7 +23,7 @@ Beyond Bristol, trip-hop's influence spread globally and evolved through various
 - **Verse structure**: Full verses with laid-back, spoken-word delivery. Often without traditional choruses. 4–8 lines.
 - **Key rule**: Urban life, introspection, social commentary. Whispered, abstract, remote from braggadocio. Moody atmospheres.
 - **Avoid**: Upbeat energy. Conventional pop structures. Literal or surface-level lyrics.
-- **Density/pacing**: moderate density · 8-12 syl/line · max 2-3 topics/verse · typical BPM 80-100. Cinematic, moody. More lyrical space than other electronic genres. Storytelling over dark, atmospheric beats.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 80-100 BPM. More lyrical space than other electronic genres. Storytelling over dark, atmospheric beats. Topics: 2/verse.
 
 ## Subgenres & Styles
 

--- a/genres/vaporwave/README.md
+++ b/genres/vaporwave/README.md
@@ -23,7 +23,7 @@ Vaporwave quickly transcended music to become a broader aesthetic movement encom
 - **Verse structure**: Short, slowed-down phrases continuously repeated as ghostly loops.
 - **Key rule**: If writing original vocals: keep it short, dreamy, and designed to be slowed/chopped. Consumer culture critique through aesthetic.
 - **Avoid**: Original dense lyrics. Conventional delivery. Fighting the sample-based aesthetic.
-- **Density/pacing**: very low density · 2-6 syl/line · max 1 topics/verse · typical BPM 60-90. Slowed, chopped samples. Often instrumental. When vocal, fragmented consumer culture phrases. Anti-density.
+- **Density/pacing (Suno)**: Default **0-2 lines** at 60-90 BPM. Slowed, chopped samples. Often instrumental. Fragmented phrases when vocal. Topics: 1/verse or none.
 
 ## Subgenres & Styles
 

--- a/skills/lyric-writer/SKILL.md
+++ b/skills/lyric-writer/SKILL.md
@@ -58,7 +58,7 @@ You are a professional lyric writer with expertise in prosody, rhyme craft, and 
 7. **Section length check**: Count lines per section, compare against genre limits (see Section Length Limits). **Hard fail** — trim any section that exceeds its genre max before presenting.
 8. **Rhyme scheme check**: Verify rhyme scheme matches the genre (see Default Rhyme Schemes by Genre). No orphan lines, no random scheme switches mid-verse. Read each rhyming pair aloud.
 9. **Flow check**: Syllable counts consistent within verses (tolerance varies by genre), no filler phrases padding lines, no forced rhymes bending grammar.
-10. **Density/pacing check**: Count topics per verse (max 2-3 per 8 lines). Cross-reference syllable density against BPM/mood from Musical Direction. Flag verses that read like lists.
+10. **Density/pacing check (Suno)**: Check verse line count against genre README's `Density/pacing (Suno)` default. Flag any verse exceeding the genre's max. Cross-reference BPM/mood from Musical Direction. **Hard fail** — trim or split any verse over the limit.
 11. **Chorus lead-in check**: Compare the last line before each chorus against the chorus opening. Flag if they share key phrases, rhyme words, or restate the hook.
 12. **Pitfalls check**: Run through checklist
 
@@ -432,6 +432,7 @@ Songs that are too long (800+ words) cause Suno to rush, compress sections, or s
 5. **Electronic verse over 6 lines**: Cut. Electronic tracks need space, not walls of text.
 6. **Punk sections over limits**: Punk is short and fast. If it's long, it's not punk.
 7. **When unsure about genre**: Use the Pop/Rock defaults (6–8 verse, 4–6 chorus, 4 bridge).
+8. **Also check BPM-aware limits** in the Lyric Density & Pacing section below — a genre may allow 8-line verses at fast tempo but only 4 at slow tempo.
 
 **Suno-specific reasoning**: Long sections cause:
 - Vocal rushing (cramming words into fixed musical time)
@@ -441,53 +442,74 @@ Songs that are too long (800+ words) cause Suno to rush, compress sections, or s
 
 ---
 
-## Lyric Density & Pacing
+## Lyric Density & Pacing (Suno)
 
-Lyrics must match the track's intended energy and tempo. A slow, laid-back track cannot have verses crammed with 6+ topics in 8 lines.
+Suno rushes through dense verse blocks. Verse length must match tempo and feel. **The slower the BPM, the fewer lines Suno can handle** without rushing, compressing, or skipping.
 
-**Genre-specific density/pacing norms are in each genre's README** under "Lyric Conventions → Density/pacing". Always check the genre README for the track you're writing.
+**Genre-specific Suno verse limits are in each genre's README** under "Lyric Conventions → Density/pacing (Suno)". Always check the genre README for the track you're writing.
 
-### Density Check (per verse)
+### Suno Verse Length Defaults
 
-1. **Count the topics** — how many distinct subjects/scenes does the verse cover?
-2. **Check genre limits** — read the genre README's `Density/pacing` line for max topics/verse
-3. **If a verse exceeds its genre's topic limit**, split the verse or cut topics
-
-### Quick Reference: Density by Genre Family
-
-| Genre Family | Density | Syl/Line | Topics/Verse | Key Difference |
+| Genre Family | Default Lines/Verse | Max Safe | Topics/Verse | Key Rule |
 |---|---|---|---|---|
-| **Hip-Hop / Rap** | moderate-high | 10-14 | 2-3 | Internal rhyme adds perceived density; half-time trap feels spacious |
-| **Pop** | moderate | 6-10 | 1-2 | Syllable matching between verses; hook repetition > verse density |
-| **Rock** | moderate | 7-10 | 2-3 | Guitar riffs need space; 120 BPM sweet spot |
-| **Punk** | moderate-high | 6-14 | 1-2 | Fast and short; energy over complexity |
-| **Metal** | moderate-high | 8-16 | 2-3 | Vocal delivery compresses syllables; riff alignment critical |
-| **Country / Folk** | moderate | 8-14 | 1-3 | Storytelling pace; conversational delivery |
-| **Blues** | low | 6-10 | 1 | AAB repetition; one image per verse |
-| **Electronic / EDM** | low-very low | 4-9 | 1 | Production is the star; vocals are texture |
-| **R&B / Soul** | moderate | 8-12 | 2-3 | Melisma spreads syllables; groove > density |
-| **Jazz** | moderate-high | 8-14 | 2-4 | Highly variable; match rhythm section energy |
-| **Singer-Songwriter** | high | 10-16 | 2-4 | Confessional mode; listeners expect dense detail |
-| **Ambient / Shoegaze** | very low | 2-8 | 1 | Vocals are texture; fewer words always better |
+| **Hip-Hop / Rap** | 8 (4 couplets) | 8 | 2-3 | Never exceed 8; half-time trap = treat as 65-75 BPM |
+| **Pop** | 4 | 6-8 | 1-2 | Chorus-first — longer verses bury the hook |
+| **Rock** | 6 | 8 | 2 | 120 BPM sweet spot; guitar riffs need space |
+| **Punk** | 4 | 4 | 1 | Fast, short, every word punches |
+| **Hardcore Punk** | 2-3 | 3 | 1 | Extreme tempo; shouted, minimal |
+| **Metal** | 6-8 | 10 | 2-3 | Vocal delivery compresses syllables; thrash handles most |
+| **Doom Metal** | 4 | 6 | 1 | Slowest metal; each word carries crushing weight |
+| **Country / Folk** | 6 | 8 | 1-2 | Storytelling pace; ballads drop to 4 |
+| **Blues** | 3 (AAB) | 3 | 1 | Rigid structure — never break AAB |
+| **Electronic / EDM** | 2-4 | 4 | 1 | Production is the star; vocals are texture |
+| **Ambient / Shoegaze** | 0-2 | 4 | 1 | Often instrumental; vocals are texture |
+| **R&B / Soul** | 6 | 8 | 1-2 | Melisma stretches syllables; groove > density |
+| **Jazz** | 6-8 | 8 | 1-2 | Bebop: 2-4 lines; ballads: 6-8 |
+| **Singer-Songwriter** | 6-8 | 8 | 2-3 | Confessional; stripped-back production carries words |
+| **Progressive Rock** | 8-10 | 12 | 3-4 | The exception — handles long verses |
+
+### BPM-Aware Limits (Universal Fallback)
+
+When a genre README doesn't specify, use this table:
+
+| BPM Range | Max Lines/Verse | Topics/Verse | Feel |
+|-----------|----------------|-------------|------|
+| < 80 | 4 | 1-2 | Slow, heavy — fewer lines needed |
+| 80-94 | 4-6 | 1-2 | Laid back, mid-tempo |
+| 94-110 | 6 | 2-3 | Energetic, driving |
+| 110-140 | 6-8 | 2-3 | Standard rock/pop range |
+| 140+ | 4 | 1 | Fast — short verses, energy over density |
+
+**Default: 4 lines per verse** unless the genre and tempo justify more.
+
+### Topic Density
+
+- Max **1-2 topics per 4-line verse**, **2-3 per 6-8 line verse**
+- If a verse covers 3+ topics in 4 lines, split it
+- **Prefer more short verses over fewer dense verses** — two 4-line verses beat one 8-line verse
 
 ### Red Flags
 
-- Verse reads like a list of names/shows/facts with no room to breathe
-- Track concept says "laid back" or "slow" but verses are wall-to-wall syllables
+- 8-line verse at any BPM under 100 — too dense for Suno
+- Verse reads like a list of names/facts — it's a Wikipedia entry, not a verse
+- Track concept says "laid back" but verses are wall-to-wall syllables
 - More than 3 proper nouns introduced in a single verse
-- No verse has fewer than 2 topics (every verse is dense = track feels rushed)
-- Syllable count exceeds genre's typical range (check genre README)
+- Every verse in the song is dense (no breathing room anywhere)
 
 ### Fix
 
 When a verse is too dense:
 1. **Prefer adding a verse** over cutting content (spread, don't compress)
 2. Let each topic have at least a full couplet (2 lines) to land
-3. Re-read with the BPM in mind — can you actually rap/sing this at tempo without rushing?
+3. Re-read with the BPM in mind — can you actually sing/rap this at tempo without rushing?
+
+### Streaming Exception
+
+Streaming lyrics (distributor text) can have longer verse blocks since they aren't generated by Suno. But verse BREAKS should still align with the Suno structure so the text matches what's actually sung.
 
 ### Process
 
-Before finalizing any track, ASK: "Does the line density match the BPM and mood described in Musical Direction?" If not, flag it to the user. Cross-reference the genre README's density/pacing norms.
+Before finalizing any track, ASK: "Does the verse length match the BPM and mood described in Musical Direction?" Check the genre README's `Density/pacing (Suno)` line. If the verse exceeds the default, flag it to the user.
 
 ---
 
@@ -522,7 +544,8 @@ Before finalizing:
 - [ ] Wrong rhyme scheme for genre (e.g., AABB couplets in a folk ballad)
 - [ ] Filler phrases padding lines for rhyme or quote setup
 - [ ] Inconsistent syllable counts within a verse (tolerance varies by genre)
-- [ ] Verse too dense for BPM/mood (4+ topics in 8 lines, or wall-to-wall syllables on a slow track)
+- [ ] Verse exceeds Suno line limit for genre (check genre README's Density/pacing default)
+- [ ] 8-line verse at BPM under 100 (too dense for Suno — split or trim)
 - [ ] Too many proper nouns in a single verse (max 3 introductions per verse)
 - [ ] Density mismatch (Musical Direction says "laid back" but verses are packed)
 - [ ] Chorus lead-in repeats chorus (last line before chorus duplicates hook phrase or rhyme word)


### PR DESCRIPTION
## Summary
- **Reframes density/pacing as Suno-specific verse length limits** — practical line counts instead of abstract syllable-density metrics
- All 67 genre READMEs updated: `Density/pacing (Suno)` with default lines/verse, max safe limit, BPM guidance, and topics/verse
- SKILL.md rewritten with:
  - Suno Verse Length Defaults table (15 genre families with default, max, topics)
  - BPM-Aware Limits fallback table (universal, for unlisted genres)
  - Topic density rules (1-2 per 4-line, 2-3 per 6-8 line)
  - Streaming lyrics exception (distributor text can be longer but breaks must match Suno)
  - Red flag: 8-line verse at BPM <100
- Quality check #10 updated to hard fail on verse length violations
- New pitfalls: verse exceeds Suno limit, 8-line verse at slow BPM
- Cross-reference added between Section Length Enforcement and Density/Pacing sections

## Test plan
- [ ] Verify all 67 genre READMEs have `Density/pacing (Suno)` line
- [ ] Verify SKILL.md has both Suno defaults table and BPM fallback table
- [ ] Verify quality check #10 says "Hard fail" in both SKILL.md and CLAUDE.md
- [ ] Verify streaming exception is documented
- [ ] Spot-check genre limits make sense (blues=3 AAB, hip-hop=8, ambient=0-2, punk=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)