### PR TITLE
fix: correct model counts, lyric-reviewer checklist, contributing checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ When adding a new skill, you MUST update all of these files:
 - [ ] Update workflow diagram in `CLAUDE.md` (if part of main workflow)
 - [ ] Add to Album Completion Checklist in `CLAUDE.md` (if part of release)
 - [ ] Add reference docs in `/reference/` if complex
-- [ ] Update `README.md` if user-facing feature
+- [ ] Update `README.md` Skills Reference tables (add to appropriate section: Core Production, Research, Quality Control, Release, or Setup & Maintenance)
 
 **Testing:**
 - [ ] Run `/bitwize-music:test all` to ensure no regressions

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ For documentary or true-story albums:
 
 | Skill | Description |
 |-------|-------------|
-| `/bitwize-music:lyric-reviewer` | QC gate before Suno - 12-point checklist |
+| `/bitwize-music:lyric-reviewer` | QC gate before Suno - 9-point checklist |
 | `/bitwize-music:explicit-checker` | Scan lyrics for explicit content |
 | `/bitwize-music:validate-album` | Validate album structure, file locations, content integrity |
 

--- a/reference/model-strategy.md
+++ b/reference/model-strategy.md
@@ -210,7 +210,7 @@ Is it purely pattern matching, file operations, or static info?
 | Tier | Count | Percentage | Purpose |
 |------|-------|------------|---------|
 | Opus 4.5 | 6 | 15.8% | Music-defining output, high error cost |
-| Sonnet 4.5 | 21 | 55.3% | Reasoning, coordination, moderate creativity |
-| Haiku 4.5 | 11 | 28.9% | Rule-based operations, no judgment |
+| Sonnet 4.5 | 22 | 57.9% | Reasoning, coordination, moderate creativity |
+| Haiku 4.5 | 10 | 26.3% | Rule-based operations, no judgment |
 
 The plugin reserves Opus for skills where quality directly impacts the music or where errors have significant consequences. Most work happens at Sonnet tier. Haiku handles mechanical operations where speed matters more than nuance.


### PR DESCRIPTION
## Summary
- **model-strategy.md**: Fixed distribution summary counts (21→22 Sonnet, 11→10 Haiku) and percentages (55.3%→57.9%, 28.9%→26.3%)
- **README.md**: Reverted lyric-reviewer from "12-point" back to "9-point" checklist. The lyric-reviewer has its own 9-point QC gate (separate from the lyric-writer's 12 automatic quality checks). The earlier change in PR #24 was incorrect.
- **CONTRIBUTING.md**: "Adding a New Skill" checklist now explicitly requires updating README.md Skills Reference tables (with section names)

## Test plan
- [ ] model-strategy.md shows Sonnet 22/57.9%, Haiku 10/26.3%
- [ ] README.md lyric-reviewer says "9-point checklist"
- [ ] CONTRIBUTING.md new skill checklist mentions Skills Reference tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)