### PR TITLE
feat: validation improvements — CLAUDE.md trim, CI checks, pattern-based model validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "author": {
     "name": "bitwize-music"
   },

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,27 +89,91 @@ jobs:
         print('[OK] Versions match')
         "
 
-    - name: Check SKILL.md structure
+    - name: Check SKILL.md structure and frontmatter
       run: |
         python -c "
         import os
         import sys
+        import yaml
+        import re
+
+        REQUIRED_FIELDS = ['name', 'description', 'model']
+        # Pattern: claude-{tier}-{major}-{minor}-{date} e.g. claude-opus-4-5-20251101
+        MODEL_PATTERN = r'^claude-(opus|sonnet|haiku)-\d+-\d+-\d{8}$'
 
         skill_dirs = [d for d in os.listdir('skills') if os.path.isdir(f'skills/{d}')]
 
         missing_skill_md = []
+        frontmatter_errors = []
+
         for skill_dir in skill_dirs:
             skill_md_path = f'skills/{skill_dir}/SKILL.md'
             if not os.path.exists(skill_md_path):
                 missing_skill_md.append(skill_md_path)
+                continue
+
+            # Check frontmatter
+            with open(skill_md_path, 'r') as f:
+                content = f.read()
+
+            # Extract YAML frontmatter
+            match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+            if not match:
+                frontmatter_errors.append(f'{skill_md_path}: missing YAML frontmatter')
+                continue
+
+            try:
+                frontmatter = yaml.safe_load(match.group(1))
+            except yaml.YAMLError as e:
+                frontmatter_errors.append(f'{skill_md_path}: invalid YAML - {e}')
+                continue
+
+            # Check required fields
+            for field in REQUIRED_FIELDS:
+                if field not in frontmatter:
+                    frontmatter_errors.append(f'{skill_md_path}: missing required field \"{field}\"')
+
+            # Validate model format (allows new versions without updating check)
+            if 'model' in frontmatter and not re.match(MODEL_PATTERN, frontmatter['model']):
+                frontmatter_errors.append(f'{skill_md_path}: invalid model format \"{frontmatter[\"model\"]}\"')
 
         if missing_skill_md:
             print('[FAIL] Missing SKILL.md files:')
             for path in missing_skill_md:
                 print(f'  - {path}')
+
+        if frontmatter_errors:
+            print('[FAIL] Frontmatter errors:')
+            for error in frontmatter_errors:
+                print(f'  - {error}')
+
+        if missing_skill_md or frontmatter_errors:
             sys.exit(1)
 
-        print(f'[OK] All {len(skill_dirs)} skills have SKILL.md')
+        print(f'[OK] All {len(skill_dirs)} skills have valid SKILL.md with required frontmatter')
+        "
+
+    - name: Check CLAUDE.md size
+      run: |
+        python -c "
+        import sys
+
+        MAX_CHARS = 40000
+
+        with open('CLAUDE.md', 'r', encoding='utf-8') as f:
+            content = f.read()
+            char_count = len(content)
+
+        size_k = char_count / 1000
+        print(f'CLAUDE.md: {size_k:.1f}K chars (max {MAX_CHARS // 1000}K)')
+
+        if char_count > MAX_CHARS:
+            print(f'[FAIL] CLAUDE.md exceeds {MAX_CHARS // 1000}K character limit')
+            print(f'  Current: {char_count} chars')
+            print(f'  Over by: {char_count - MAX_CHARS} chars')
+            sys.exit(1)
+
+        print('[OK] CLAUDE.md size within limit')
         "
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-02-03
+
+### Added
+- **CI: CLAUDE.md size check** — validates CLAUDE.md stays under 40K characters (matches pre-commit hook)
+- **CI: Skill frontmatter validation** — validates required fields (name, description, model) and model ID format pattern
+- **Reference: status-tracking.md** — new reference doc for track/album status workflows (split from CLAUDE.md)
+
+### Changed
+- **CLAUDE.md trimmed** — reduced from 40.2K to 33.2K chars by moving skills table to SKILL_INDEX.md, lyrics checklist to lyric-writer SKILL.md, and status tracking to reference file
+- **Model validation uses pattern** — skill frontmatter check now uses regex `^claude-(opus|sonnet|haiku)-\d+-\d+-\d{8}$` instead of hardcoded model IDs, allowing new model versions without updating checks
+- **Plugin tests check SKILL_INDEX.md** — skill documentation test now checks SKILL_INDEX.md instead of CLAUDE.md (since skills table was moved there)
+
 ## [0.35.0] - 2026-02-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,24 +181,9 @@ Documents: ~/bitwize-music/documents/bitwize/sample-album/     ← includes arti
 
 ## Music Generation Service
 
-The workflow currently supports:
-- **Suno** (default) - Full support
+Currently supports **Suno** (default). To configure: Set `generation.service` in `~/.bitwize-music/config.yaml`.
 
-Future services (not yet implemented):
-- Udio
-- (others as added)
-
-To configure: Set `generation.service` in `~/.bitwize-music/config.yaml`. If unset, defaults to `suno`.
-
-**Service-specific content:**
-- Skills: `/bitwize-music:suno-engineer` (Suno), future: `/bitwize-music:udio-engineer`, etc.
-- Reference docs: `/reference/suno/` (Suno), future: `/reference/udio/`, etc.
-- Template sections: Marked with `<!-- SERVICE: suno -->` comments
-
-**Finding service-specific sections:**
-```bash
-grep -r "<!-- SERVICE:" templates/
-```
+**Service-specific content:** Skills (`/bitwize-music:suno-engineer`), reference docs (`/reference/suno/`), template sections (marked with `<!-- SERVICE: suno -->`).
 
 ## Session Start
 
@@ -297,21 +282,7 @@ You are a co-producer, editor, and creative partner. Push back when ideas don't 
 
 ### Automatic Lyrics Review
 
-**After writing or revising any lyrics**, automatically run through:
-1. **Rhyme check**: Repeated end words, self-rhymes, lazy/predictable patterns
-2. **Prosody check**: Stressed syllables align with strong beats (see `/skills/lyric-writer/SKILL.md`)
-3. **Pronunciation check**: Apply all rules from the Pronunciation section below (proper nouns, homographs, phonetic spelling, acronyms, tech terms, numbers, no invented contractions, pronunciation table enforcement)
-4. **POV/Tense check**: Consistent point of view and tense throughout
-5. **Source verification**: If source-based, verify lyrics match captured source material
-6. **Structure check**: Section tags present, verse/chorus contrast, V2 develops (not twins V1)
-7. **Section length check**: Count lines per section, compare against genre limits in `/skills/lyric-writer/SKILL.md`. **Hard fail** — trim any section exceeding its genre max before presenting.
-8. **Rhyme scheme check**: Verify rhyme scheme matches the genre (see `/skills/lyric-writer/SKILL.md` Default Rhyme Schemes by Genre). No orphan lines, no random scheme switches mid-verse.
-9. **Flow check**: Syllable counts consistent within verses (tolerance varies by genre), no filler phrases padding lines, no forced rhymes bending grammar.
-10. **Density/pacing check (Suno)**: Check verse line count against genre README's `Density/pacing (Suno)` default. Flag any verse exceeding the genre's max lines/verse. Cross-reference BPM/mood from Musical Direction. **Hard fail** — trim or split any verse over the limit before presenting.
-11. **Verse-chorus echo check**: Compare last 2 lines of every verse against first 2 lines of the following chorus. Flag exact phrases, shared rhyme words, restated hooks, or shared signature imagery. Check ALL verse-to-chorus and bridge-to-chorus transitions. The chorus is the payoff — the verse should set it up, not pre-deliver it.
-12. **Pitfalls check**: Run through Lyric Pitfalls Checklist (see `/skills/lyric-writer/SKILL.md`)
-
-Report any violations found. Don't wait to be asked.
+**After writing or revising any lyrics**, run the 12-point quality checklist in `/skills/lyric-writer/SKILL.md` (Automatic Quality Check section). Covers: rhyme, prosody, pronunciation, POV/tense, sources, structure, section length, rhyme scheme, flow, density, verse-chorus echo, pitfalls. Report violations without being asked.
 
 ### Working On a Track
 
@@ -362,55 +333,13 @@ See `/skills/lyric-writer/SKILL.md` for full homograph table and process.
 
 ## Skills (Slash Commands)
 
-Specialized skills are available as slash commands. Type `/` to see the menu.
+Specialized skills are available as slash commands. Type `/` to see the menu, or see `/reference/SKILL_INDEX.md` for:
+- Decision tree ("I need to..." → skill)
+- Alphabetical reference (38 skills)
+- Skill prerequisites and sequences
+- Model assignments (Opus/Sonnet/Haiku)
 
-| Skill | When to Use |
-|-------|-------------|
-| `/bitwize-music:resume` | Find an album and resume work where you left off - shows status and next steps |
-| `/bitwize-music:tutorial` | Interactive guided album creation, session resume, getting started |
-| `/bitwize-music:album-ideas` | Track and manage album ideas - brainstorming, planning, status tracking |
-| `/bitwize-music:lyric-writer` | Writing/reviewing lyrics, fixing prosody issues |
-| `/bitwize-music:researcher` | Source verification, fact-checking, coordinates specialized researchers |
-| `/bitwize-music:document-hunter` | Automated document search/download from free public archives (Playwright) |
-| `/bitwize-music:album-conceptualizer` | Album concepts, tracklist architecture |
-| `/bitwize-music:album-art-director` | Album artwork concepts, visual prompts for AI art generation |
-| `/bitwize-music:suno-engineer` | Technical Suno prompting, genre selection |
-| `/bitwize-music:explicit-checker` | Scan lyrics for explicit content, verify flags match content |
-| `/bitwize-music:pronunciation-specialist` | Scan lyrics for risky words, prevent Suno mispronunciations |
-| `/bitwize-music:lyric-reviewer` | QC gate before Suno generation - 9-point checklist, auto-fix pronunciation |
-| `/bitwize-music:mastering-engineer` | Audio mastering guidance, loudness optimization, platform delivery |
-| `/bitwize-music:promo-director` | Generate promo videos for social media from mastered audio |
-| `/bitwize-music:cloud-uploader` | Upload promo videos to Cloudflare R2 or AWS S3 |
-| `/bitwize-music:sheet-music-publisher` | Convert audio to sheet music, create songbooks |
-| `/bitwize-music:import-audio` | Move audio files to correct album location (always reads config) |
-| `/bitwize-music:import-track` | Move track .md files to correct album location (always reads config) |
-| `/bitwize-music:import-art` | Place album art in both audio and content locations (always reads config) |
-| `/bitwize-music:clipboard` | Copy track content (lyrics, style prompts) to system clipboard - works on macOS/Linux/WSL |
-| `/bitwize-music:new-album` | Create album directory structure with templates (always reads config) |
-| `/bitwize-music:release-director` | Album release coordination, QA, distribution, platform uploads |
-| `/bitwize-music:validate-album` | Validate album structure, file locations, catch path issues |
-| `/bitwize-music:configure` | Set up or edit plugin configuration (~/.bitwize-music/config.yaml) |
-| `/bitwize-music:test` | Run automated tests to validate plugin integrity (`/bitwize-music:test e2e` for full E2E test) |
-| `/bitwize-music:skill-model-updater` | Update model references in skills when new Claude models are released |
-| `/bitwize-music:help` | Show available skills, common workflows, and quick reference |
-| `/bitwize-music:about` | About bitwize and this plugin |
-
-### Specialized Researchers
-
-For deep research, `/bitwize-music:researcher` coordinates specialists:
-
-| Skill | Domain |
-|-------|--------|
-| `/bitwize-music:researchers-legal` | Court documents, indictments, plea agreements, sentencing |
-| `/bitwize-music:researchers-gov` | DOJ/FBI/SEC press releases, agency statements |
-| `/bitwize-music:researchers-tech` | Project histories, changelogs, developer interviews |
-| `/bitwize-music:researchers-journalism` | Investigative articles, interviews, coverage |
-| `/bitwize-music:researchers-security` | Malware analysis, CVEs, attribution reports, hacker communities |
-| `/bitwize-music:researchers-financial` | SEC filings, earnings calls, analyst reports, market data |
-| `/bitwize-music:researchers-historical` | Archives, contemporary accounts, timeline reconstruction |
-| `/bitwize-music:researchers-biographical` | Personal backgrounds, interviews, motivations, humanizing details |
-| `/bitwize-music:researchers-primary-source` | Subject's own words: tweets, blogs, forums, chat logs |
-| `/bitwize-music:researchers-verifier` | Quality control, citation validation, fact-checking before human review |
+**Key skills**: `/resume` (continue work), `/lyric-writer` (write lyrics), `/suno-engineer` (prompts), `/researcher` (sources), `/mastering-engineer` (audio), `/release-director` (publish).
 
 ### How to Invoke
 
@@ -484,12 +413,9 @@ claude-ai-music-skills/           # {plugin_root}
 │       └── artists/              # Artist deep-dive reference files
 │           ├── INDEX.md          # Quick-reference: Suno keywords + links to deep-dives
 │           └── [artist].md
-├── reference/                    # Reference documentation
-│   ├── suno/
-│   └── mastering/
-└── config/                       # User config (gitignored)
-    ├── paths.yaml
-    └── artist.md
+└── reference/                    # Reference documentation
+    ├── suno/
+    └── mastering/
 ```
 
 ### Content Files (`{content_root}`)
@@ -666,40 +592,11 @@ All checkpoint message templates: See `/reference/workflows/checkpoint-scripts.m
 
 ## Status Tracking
 
-### Track Statuses
+Track statuses: `Not Started` → `Sources Pending` → `Sources Verified` → `In Progress` → `Generated` → `Final`
 
-| Status | Meaning |
-|--------|---------|
-| `Not Started` | Concept only |
-| `Sources Pending` | Has sources, awaiting human verification |
-| `Sources Verified` | Ready for production |
-| `In Progress` | Currently generating |
-| `Generated` | Has acceptable output |
-| `Final` | Complete, locked |
+Album statuses: `Concept` → `Research Complete` → `Sources Verified` → `In Progress` → `Complete` → `Released`
 
-### Album Statuses
-
-| Status | Meaning |
-|--------|---------|
-| `Concept` | Planning phase |
-| `Research Complete` | Sources gathered, awaiting verification |
-| `Sources Verified` | All sources verified |
-| `In Progress` | Tracks being created |
-| `Complete` | All tracks Final |
-| `Released` | Live on platforms (`release_date` set in frontmatter) |
-
----
-
-## Generation Log
-
-Every track file includes:
-
-| # | Date | Model | Result | Notes | Rating |
-|---|------|-------|--------|-------|--------|
-| 1 | 2025-12-03 | V5 | [Listen](url) | First attempt | — |
-| 2 | 2025-12-03 | V5 | [Listen](url) | Boosted vocals | ✓ |
-
-When you find a keeper: Set Status to `Generated`, add Suno Link.
+**Full details**: See `/reference/workflows/status-tracking.md`
 
 ---
 
@@ -836,15 +733,7 @@ All Suno-specific documentation in `/reference/suno/`:
 
 ## Distribution Guidelines
 
-### Streaming Lyrics Format
+**Streaming Lyrics**: Just lyrics (no section labels), capitalize first letter, no end punctuation, write out repeats.
 
-Fill in "Streaming Lyrics" section in each track file before distributor upload. Format: just lyrics (no section labels/vocalist names), capitalize first letter of lines, no end punctuation, write out repeats fully.
-
-### Explicit Content
-
-Use explicit flag when lyrics contain: fuck, shit, bitch, cunt, cock, dick, pussy, asshole, whore, slut, goddamn, or variations. Clean words (no flag needed): damn, hell, crap, ass, bastard, piss.
-
-**Check with Grep**: Use pattern `\b(fuck|shit|bitch|cunt|cock|dick|pussy|asshole|whore|slut)\b` on track files.
-
-**Full guidelines**: See `/reference/distribution.md` for complete formatting rules and explicit word lists.
+**Explicit Content**: Use `/bitwize-music:explicit-checker` or see `/reference/distribution.md` for word lists and rules.
 

--- a/reference/workflows/status-tracking.md
+++ b/reference/workflows/status-tracking.md
@@ -1,0 +1,74 @@
+# Status Tracking
+
+Track and album statuses indicate workflow progress.
+
+---
+
+## Track Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `Not Started` | Concept only |
+| `Sources Pending` | Has sources, awaiting human verification |
+| `Sources Verified` | Ready for production |
+| `In Progress` | Currently generating |
+| `Generated` | Has acceptable output |
+| `Final` | Complete, locked |
+
+### Track Status Flow
+
+```
+Not Started → Sources Pending → Sources Verified → In Progress → Generated → Final
+                    ↑                                              ↓
+                    └──────────── (regenerate if needed) ──────────┘
+```
+
+---
+
+## Album Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `Concept` | Planning phase |
+| `Research Complete` | Sources gathered, awaiting verification |
+| `Sources Verified` | All sources verified |
+| `In Progress` | Tracks being created |
+| `Complete` | All tracks Final |
+| `Released` | Live on platforms (`release_date` set in frontmatter) |
+
+### Album Status Flow
+
+```
+Concept → Research Complete → Sources Verified → In Progress → Complete → Released
+```
+
+---
+
+## Generation Log
+
+Every track file includes a generation log table:
+
+| # | Date | Model | Result | Notes | Rating |
+|---|------|-------|--------|-------|--------|
+| 1 | 2025-12-03 | V5 | [Listen](url) | First attempt | — |
+| 2 | 2025-12-03 | V5 | [Listen](url) | Boosted vocals | ✓ |
+
+**When you find a keeper**: Set Status to `Generated`, add Suno Link.
+
+---
+
+## Status Update Rules
+
+1. **Track status changes require action**:
+   - `Not Started` → `Sources Pending`: After adding sources
+   - `Sources Pending` → `Sources Verified`: After human verification
+   - `Sources Verified` → `In Progress`: When starting generation
+   - `In Progress` → `Generated`: When keeper found
+   - `Generated` → `Final`: After user approval
+
+2. **Album status follows tracks**:
+   - Album is `In Progress` when any track is being worked on
+   - Album is `Complete` when ALL tracks are `Final`
+   - Album is `Released` when uploaded to platforms
+
+3. **Never skip statuses** - Each represents a workflow gate

--- a/tools/tests/run_tests.py
+++ b/tools/tests/run_tests.py
@@ -431,25 +431,28 @@ class PluginTestRunner:
                     fix_hint="Add requirements: section listing external dependencies"
                 )
 
-        # Test: All skills documented in CLAUDE.md
-        self.log("Checking CLAUDE.md skill documentation...")
-        claude_content = self.get_claude_md()
+        # Test: All skills documented in SKILL_INDEX.md
+        self.log("Checking SKILL_INDEX.md skill documentation...")
+        skill_index_file = self.plugin_root / "reference" / "SKILL_INDEX.md"
+        skill_index_content = ""
+        if skill_index_file.exists():
+            skill_index_content = skill_index_file.read_text()
         skip_skills = {'help', 'about', 'configure', 'test'}  # System skills
 
         for skill_name in skills:
             if skill_name in skip_skills:
                 continue
-            skill_pattern = f"/bitwize-music:{skill_name}"
-            if skill_pattern in claude_content:
-                self._add_test(category, f"Documented in CLAUDE.md: {skill_name}", TestResult.OK)
+            # Check for skill in SKILL_INDEX.md (format: `skill-name` or /skill-name)
+            if f"`{skill_name}`" in skill_index_content or f"/{skill_name}" in skill_index_content:
+                self._add_test(category, f"Documented in SKILL_INDEX.md: {skill_name}", TestResult.OK)
             else:
                 self._add_test(
                     category,
-                    f"Documented in CLAUDE.md: {skill_name}",
+                    f"Documented in SKILL_INDEX.md: {skill_name}",
                     TestResult.FAIL,
-                    "Skill not found in CLAUDE.md",
-                    "CLAUDE.md",
-                    fix_hint=f"Add {skill_pattern} to the skills table in CLAUDE.md"
+                    "Skill not found in SKILL_INDEX.md",
+                    "reference/SKILL_INDEX.md",
+                    fix_hint=f"Add {skill_name} to the skill index in reference/SKILL_INDEX.md"
                 )
 
         # Print results


### PR DESCRIPTION
## Summary
- Trim CLAUDE.md from 40.2K to 33.2K chars by moving content to reference files
- Add CI validation for CLAUDE.md size (40K char limit) and skill frontmatter
- Use pattern-based model validation (`^claude-(opus|sonnet|haiku)-\d+-\d+-\d{8}$`) instead of hardcoded IDs

## Changes
- **CLAUDE.md** — moved skills table to SKILL_INDEX.md, status tracking to new reference file
- **CI workflow** — added CLAUDE.md size check, improved skill frontmatter validation
- **Plugin tests** — now check SKILL_INDEX.md for skill documentation
- **New file** — `reference/workflows/status-tracking.md`

## Pre-commit hook (local, not tracked)
11 checks: ruff, JSON/YAML, CLAUDE.md size, version sync, skill frontmatter, CHANGELOG format, merge conflicts, large files, bandit, pytest, plugin tests

## Test plan
- [x] Pre-commit hook passes all 11 checks
- [x] Plugin tests pass (305 tests)
- [x] Unit tests pass (252 tests)
- [ ] CI workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)