### PR TITLE
chore: release 0.37.0 — security hardening and prompt quality improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": {
     "name": "bitwize-music"
   },

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -95,6 +95,26 @@ jobs:
           validate_model_date "$SONNET" "Sonnet" && \
           validate_model_date "$HAIKU" "Haiku" || exit 1
 
+          # Validate model IDs contain only safe characters (a-z, 0-9, hyphens)
+          validate_model_chars() {
+            local MODEL_ID="$1"
+            local LABEL="$2"
+            if ! echo "$MODEL_ID" | grep -qE '^[a-z0-9-]+$'; then
+              echo "::error::$LABEL model ID contains unexpected characters: $MODEL_ID"
+              return 1
+            fi
+            local LEN=${#MODEL_ID}
+            if [ "$LEN" -lt 20 ] || [ "$LEN" -gt 50 ]; then
+              echo "::error::$LABEL model ID has unexpected length ($LEN): $MODEL_ID"
+              return 1
+            fi
+            return 0
+          }
+
+          validate_model_chars "$OPUS" "Opus" && \
+          validate_model_chars "$SONNET" "Sonnet" && \
+          validate_model_chars "$HAIKU" "Haiku" || exit 1
+
           echo "opus=$OPUS" >> $GITHUB_OUTPUT
           echo "sonnet=$SONNET" >> $GITHUB_OUTPUT
           echo "haiku=$HAIKU" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-02-04
+
+### Added
+- **Security: temp file cleanup** — atexit handlers and `0o600` permissions on temp files in promo video generators
+- **Security: path traversal validation** — `Path.relative_to()` containment checks in mastering tools
+- **Security: state cache permissions** — `0o700` on cache directory, `0o600` on temp files in indexer
+- **Security: album name validation** — character validation before `rglob` in cloud uploader prevents glob injection
+- **Security: CI model-updater hardening** — character whitelist and length validation on fetched model IDs
+- **Security: session input validation** — length limits, null byte checks, action count cap in state indexer
+- **Mastering: pre-flight check** — new Step 1 verifies WAV files exist before mastering workflow
+- **Album-conceptualizer: type decision criteria** — guidance for choosing between Documentary, Character Study, Thematic
+- **Album-conceptualizer: energy mapping example** — concrete visual example and pacing problems checklist
+- **Resume: Research Phase** — suggests `/researcher` and `/document-hunter` for documentary albums
+- **Checkpoint scripts: required actions** — action checklists before each checkpoint message template
+- **Source verification: human checklist** — 6 concrete items for verifying sources (URL, quotes, dates, context, etc.)
+- **Pronunciation guide: enforcement workflow** — full table enforcement process, verification format, rules
+- **Researcher: evidence chain format** — example documentation format for connecting sources
+
+### Changed
+- **Lyric-reviewer: homograph handling unified** — now verifies decisions from lyric-writer instead of independently re-determining pronunciation (fixes contradiction)
+- **Lyric-reviewer: 13-point checklist** — added section length, rhyme scheme, density/pacing, verse-chorus echo checks (was 9)
+- **Suno-engineer: parenthetical contradictions fixed** — removed instructions to use parentheticals in lyrics box (Suno sings them)
+- **Suno-engineer: genre specificity guidance** — added 2-3 descriptor limit with "too much" anti-pattern example
+- **Suno-engineer: album context lookup** — explicit instructions for finding album README from track path
+- **Bass homograph standardized** — `bayss` (music) across lyric-writer, lyric-reviewer, pronunciation-specialist
+- **New-album: documentary parsing** — documents both 2-arg and 3-arg formats, always asks about true-story status
+- **Pronunciation-specialist: standard Override Support section** — restructured to match pattern used by other skills
+- **Researcher: state cache + Glob approach** — replaced `find`/`cat` commands with state cache lookup per CLAUDE.md
+- **Researcher: smart album detection** — checks for single in-progress album before asking user
+- **Mastering-engineer: version-safe plugin detection** — `[0-9]*` pattern replaces `0.*` (works post-1.0)
+- **Mastering-engineer: step renumbering** — 6 steps with new pre-flight check
+- **Lyric-writer: trim strategy** — specific guidance on what to cut when sections exceed limits
+- **Lyric-writer: pronunciation check split** — table enforcement elevated from parenthetical to explicit sub-item
+- **Lyric-writer: twin verses example** — concrete before/after showing reworded vs developing V2
+- **Track template: pronunciation enforcement note** — bold warning that table is mandatory checklist, not documentation
+- **Track template: keeper marker documented** — explains ✓ in Generation Log Rating column
+- **Album template: verification deduplication** — removed per-track table, points to track files as single source of truth
+- **Album template: art filename convention** — documents expected filenames and locations for album art
+- **Suno LUFS targets clarified** — renamed section, added note these are Suno outputs not mastering targets
+- **Style Prompt terminology standardized** — consistent "Style Prompt" (content) vs "Style Box" (UI) across Suno docs
+- **Test skill: section renumbering** — fixed duplicate section 9, renumbered 10-14
+- **Resume: plugin root resolution** — explains how to find plugin directory when state cache needs rebuild
+- **Clipboard: shell-safe example** — `printf '%s'` replaces `echo` for lyrics with special characters
+- **Cross-references added** — release-procedures→distribution.md, error-recovery→mastering-workflow.md
+- **Homograph drift prevention** — canonical source notes added to all 3 skills with homograph tables
+- **Researcher sub-skills: override inheritance** — all 10 sub-skills now reference parent override preferences
+
 ## [0.36.0] - 2026-02-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 | Version | Highlights |
 |---------|------------|
+| **0.37** | Security hardening (6 fixes), prompt quality improvements across 30+ skill/reference files |
 | **0.34** | Python 3.9–3.12 CI matrix, bandit/pip-audit security scanning, path traversal fixes |
 | **0.33** | Pronunciation table enforcement — table entries must be applied to Suno lyrics |
 | **0.29** | Suno verse length limits by genre and BPM across all 67 genres |
@@ -41,7 +42,6 @@ See [CHANGELOG.md](CHANGELOG.md) for full history.
 | **0.20** | Python logging, progress bars, concurrent processing, 180 tests at 91% coverage |
 | **0.18** | State cache layer — fast session startup (2-3 file reads vs 50-220) |
 | **0.17** | Test automation, genre INDEX, model strategy docs, 64 quick-start guides |
-| **0.16** | All 64 genre docs enhanced to Gold standard |
 
 ---
 

--- a/reference/suno/pronunciation-guide.md
+++ b/reference/suno/pronunciation-guide.md
@@ -258,6 +258,37 @@ Add words that make the pronunciation obvious.
 
 Sometimes the mispronunciation isn't jarring enough to matter, or there's no good fix. Document the risk and move on.
 
+## Pronunciation Table Enforcement Workflow
+
+The Pronunciation Notes table in each track file is a **mandatory checklist**, not passive documentation. Every entry MUST be applied as phonetic spelling in the Suno Lyrics Box.
+
+### Process
+
+1. **Before finalizing any track**: Read the Pronunciation Notes table top to bottom
+2. **For each entry**: Search the Suno Lyrics Box for the standard spelling
+3. **Replace** with the phonetic version from the table
+4. **Verify** every occurrence is fixed — check all verses, choruses, bridges, and outros
+5. **Common failure**: Word added to table but never applied to lyrics, or phonetic in one verse but missed in chorus/bridge
+
+### Verification Format
+
+After applying all phonetics, document verification:
+
+```markdown
+| Word | Standard | Phonetic | Applied? |
+|------|----------|----------|----------|
+| Ramos | Ramos | Rah-mohs | ✓ All 4 occurrences |
+| live | live | lyve | ✓ V1, V2, Chorus |
+| FBI | FBI | F-B-I | ✓ Bridge |
+```
+
+### Rules
+
+- The table is the source of truth — if it says phonetic, the Suno lyrics MUST use phonetic
+- Streaming/distributor lyrics always keep standard English spelling
+- When adding a new word to the table, immediately apply it to all Suno lyrics
+- Run this check as the final step before generation, after all other edits are complete
+
 ## Quick Reference Card
 
 ```
@@ -331,8 +362,8 @@ When in doubt:
   - Applies rules from this guide during review process
 
 - **`/bitwize-music:lyric-reviewer`** - Pre-generation QC gate
-  - 9-point checklist includes pronunciation check
-  - Auto-fixes pronunciation issues before Suno generation
+  - 13-point checklist includes pronunciation verification
+  - Verifies homograph decisions and phonetic spelling application before Suno generation
 
 ## See Also
 

--- a/reference/suno/v5-best-practices.md
+++ b/reference/suno/v5-best-practices.md
@@ -176,7 +176,7 @@ Then suddenly [laughter] breaks the silence
 
 ### Atmospheric Effects
 
-For environmental sounds (rain, wind, fire), mention in **both** lyrics and style box:
+For environmental sounds (rain, wind, fire), mention in **both** the Lyrics Box and Style Prompt:
 
 **Lyrics Box**:
 ```
@@ -185,7 +185,7 @@ Rain falling on the window
 Thunder in the distance
 ```
 
-**Style Box**:
+**Style Prompt**:
 ```
 lofi effects rain, ambient thunder
 ```
@@ -193,10 +193,10 @@ lofi effects rain, ambient thunder
 **Why Both?**: Repetition strengthens AI recognition of desired atmosphere
 
 **Common Atmospheres**:
-- `rain` + "lofi effects rain" (style box)
-- `wind` + "ambient wind textures" (style box)
-- `fire` + "crackling fire ambience" (style box)
-- `ocean` + "ocean waves background" (style box)
+- `rain` + "lofi effects rain" (style prompt)
+- `wind` + "ambient wind textures" (style prompt)
+- `fire` + "crackling fire ambience" (style prompt)
+- `ocean` + "ocean waves background" (style prompt)
 
 ### Syllable Control
 
@@ -246,13 +246,15 @@ V5 handles exclusions reliably.
 
 ---
 
-## Mix & Master Targets
+## Suno Output Loudness (Pre-Mastering)
 
-| Genre | LUFS Target |
-|-------|-------------|
-| Pop/EDM | -9 to -7 |
-| Lo-Fi | -12 to -11 |
-| Podcast/Spoken | -16 to -14 |
+These are typical loudness levels Suno generates — **not** final mastering targets. For streaming platform delivery, master all tracks to **-14 LUFS / -1.0 dBTP** regardless of genre. See `/reference/mastering/mastering-workflow.md` for mastering procedures.
+
+| Genre | Typical Suno Output |
+|-------|---------------------|
+| Pop/EDM | -9 to -7 LUFS |
+| Lo-Fi | -12 to -11 LUFS |
+| Podcast/Spoken | -16 to -14 LUFS |
 
 ---
 
@@ -373,7 +375,7 @@ crisp, warm, bright, deep, spacious
 
 - **`/bitwize-music:suno-engineer`** - Technical Suno V5 prompting expert
   - Uses this guide as reference
-  - Constructs style boxes and genre tags
+  - Constructs style prompts and genre tags
   - Optimizes prompts for best generation results
 
 - **`/bitwize-music:lyric-writer`** - Lyric writing with Suno formatting

--- a/reference/suno/voice-tags.md
+++ b/reference/suno/voice-tags.md
@@ -144,7 +144,7 @@ Creating alien, robot, or creature voices requires **overloading the style promp
 
 ### Robot/Synthetic Voices
 
-**Style Box**:
+**Style Prompt**:
 ```
 metallic, autotuned, monotone, robotic, synthetic voice
 ```

--- a/reference/workflows/checkpoint-scripts.md
+++ b/reference/workflows/checkpoint-scripts.md
@@ -9,6 +9,13 @@ This document contains the detailed example messages for workflow checkpoints. C
 
 **Trigger**: When all track lyrics are written for an album
 
+**Required Actions (before presenting to user):**
+1. Review all track statuses — confirm every track has lyrics written
+2. Verify Suno Style Box and Lyrics Box are filled in each track
+3. Run `/bitwize-music:explicit-checker` on all tracks
+4. Verify phonetic review: pronunciation tables complete, phonetic spellings applied in Suno lyrics
+5. For source-based albums: confirm all sources are `✅ Verified`
+
 **Say to user:**
 ```
 ✅ ALL LYRICS COMPLETE
@@ -31,6 +38,12 @@ Proceed to generation?
 ## Album Generation Complete Checkpoint
 
 **Trigger**: When all tracks marked `Generated` with Suno Links
+
+**Required Actions (before presenting to user):**
+1. Verify every track has status `Generated`
+2. Confirm Suno Links are present in each track file
+3. Check Generation Log in each track — at least one keeper (✓) per track
+4. List all tracks with their status and links for the user
 
 **Say to user:**
 ```
@@ -61,6 +74,11 @@ After QA, tell me:
 
 **Trigger**: User says "album approved" after QA review
 
+**Required Actions (before presenting to user):**
+1. Update all track statuses from `Generated` to `Final`
+2. Update album status to `Complete`
+3. Verify WAV files are downloaded from Suno (ask user if not confirmed)
+
 **Say to user:**
 ```
 ✅ ALBUM APPROVED FOR MASTERING
@@ -79,6 +97,13 @@ I'll set up mastering workflow once files are ready.
 ## Ready to Release Checkpoint
 
 **Trigger**: After mastering complete and album art generated
+
+**Required Actions (before presenting to user):**
+1. Review full Album Completion Checklist (see CLAUDE.md) — verify all items checked
+2. Confirm mastered audio meets targets (-14 LUFS, -1.0 dBTP)
+3. Confirm album art is generated and saved
+4. Verify streaming lyrics are filled in each track (if using distributor)
+5. For source-based albums: confirm RESEARCH.md, SOURCES.md complete, all sources verified
 
 **Say to user:**
 ```

--- a/reference/workflows/error-recovery.md
+++ b/reference/workflows/error-recovery.md
@@ -42,7 +42,7 @@ This document covers edge cases and recovery procedures for common workflow issu
 
 **Symptoms**: Audio sounds distorted, clipped, wrong loudness, or different from expected.
 
-**Prevention**: Always run preview (dry-run) before mastering. Check LUFS/dBTP after mastering.
+**Prevention**: Always run preview (dry-run) before mastering. Check LUFS/dBTP after mastering. See [mastering-workflow.md](../mastering/mastering-workflow.md) for dry-run procedures and settings.
 
 **Recovery Steps**:
 1. Rename bad masters: `track.wav` → `track-BAD.wav`

--- a/reference/workflows/release-procedures.md
+++ b/reference/workflows/release-procedures.md
@@ -76,7 +76,7 @@ Ensure all items in Album Completion Checklist are done:
 - All tracks Final with Suno Links
 - Album art generated and saved
 - Audio mastered
-- Streaming Lyrics filled in each track (if using distributor)
+- Streaming Lyrics filled in each track (if using distributor — see [distribution.md](../distribution.md) for format rules)
 
 ### 2. Update Album README
 

--- a/reference/workflows/source-verification-handoff.md
+++ b/reference/workflows/source-verification-handoff.md
@@ -2,6 +2,19 @@
 
 This document contains detailed procedures for handling human verification of source material in documentary/true-story albums.
 
+## What to Verify (Checklist for Humans)
+
+For each source cited in a track, verify:
+
+1. **URL is accessible** — the link loads and points to the claimed source (not a 404 or paywall-only page)
+2. **Quotes are accurate** — any quoted text appears verbatim in the source (not paraphrased, truncated, or taken out of context)
+3. **Dates match** — dates, years, and timelines cited in the track match the source
+4. **Names and facts match** — names, places, dollar amounts, and other specific claims are correct per the source
+5. **Context is preserved** — the source material is not misrepresented (e.g., a quote isn't attributed to the wrong person, a conditional statement isn't presented as definitive)
+6. **No fabrication** — nothing in the track's "Quotes & Attribution" section is invented or conflated from multiple sources without notation
+
+If any item fails, note the specific issue and report it for correction before marking as verified.
+
 ## When to Stop and Request Verification
 
 ### Trigger 1: After Adding Sources to Track

--- a/skills/album-conceptualizer/SKILL.md
+++ b/skills/album-conceptualizer/SKILL.md
@@ -120,6 +120,15 @@ See [album-types.md](album-types.md) for detailed planning approaches.
 | **Character Study** | Deep dive into a person | Aspects, time periods, through-line |
 | **Collection** | Standalone songs, loose connection | Unifying element, flow |
 
+### Choosing Between Similar Types
+
+When a concept could fit multiple types, use these criteria:
+
+- **Documentary vs Character Study**: Does the album focus on **events and timeline** (Documentary) or on **a person's inner life, growth, and contradictions** (Character Study)? An album about a hacker's arrest → Documentary. An album exploring what made them who they are → Character Study.
+- **Character Study vs Thematic**: Is the person the **subject** (Character Study) or merely a **lens for broader themes** (Thematic)? An album about Snowden's choices → Character Study. An album about surveillance using Snowden as one example → Thematic.
+- **Documentary vs Narrative**: Are the events **real and sourced** (Documentary) or **fictional** (Narrative)? Documentary requires research, source verification, and the narrator voice constraint. Narrative has creative freedom.
+- **When in doubt**: Ask the user — "Is this album more about the events, the person, or the theme?" Their answer determines the type.
+
 ---
 
 ## Tracklist Architecture
@@ -149,10 +158,31 @@ See [album-types.md](album-types.md) for detailed planning approaches.
 ## Pacing & Dynamics
 
 ### Energy Mapping
-Map album energy as a curve with peaks and valleys.
+Map album energy as a curve with peaks and valleys. Present to user for review.
 
-**Avoid**: Flatline energy (all medium)
-**Aim for**: Builds and releases
+**Example** (10-track album):
+```
+01 (Intro):  ▂▂▂ Low, atmospheric
+02:          ▅▅▅ Building
+03:          ▇▇▇ Peak (first single)
+04:          ▄▄▄ Mid-energy
+05:          ▂▂▂ Valley (breather)
+06:          ▆▆▆ Building again
+07:          ████ Peak (centerpiece)
+08:          ▅▅▅ Sustained
+09:          ▃▃▃ Wind down
+10 (Outro):  ▂▂▂ Resolution
+```
+
+**Avoid**: Flatline energy (all medium), all peaks clustered at start/end, three slow songs in a row, no contrast between adjacent tracks
+**Aim for**: Build → Peak → Valley → Build → Peak → Resolution
+
+### Pacing Problems Checklist
+- Three or more songs at the same energy level in a row
+- Adjacent tracks within 10 BPM of each other (no contrast)
+- All high-energy tracks clustered together
+- Emotional tone doesn't evolve across the album
+- Fix: swap track positions, suggest tempo changes, identify which track needs rewriting for contrast
 
 ### Tempo Variation
 Don't cluster all fast or all slow songs.

--- a/skills/clipboard/SKILL.md
+++ b/skills/clipboard/SKILL.md
@@ -149,10 +149,10 @@ Use the detected platform's clipboard command:
 | Linux (xclip) | `xclip -selection clipboard` |
 | Linux (xsel) | `xsel --clipboard --input` |
 
-Example:
+Example (use `printf '%s'` to safely handle special characters in lyrics):
 ```bash
-echo "content" | pbcopy  # macOS
-echo "content" | xclip -selection clipboard  # Linux
+printf '%s' "$content" | pbcopy  # macOS
+printf '%s' "$content" | xclip -selection clipboard  # Linux
 ```
 
 ## Step 7: Confirm

--- a/skills/lyric-reviewer/SKILL.md
+++ b/skills/lyric-reviewer/SKILL.md
@@ -57,7 +57,7 @@ lyric-writer → lyric-reviewer → suno-engineer
 
 ---
 
-## The 9-Point Checklist
+## The 13-Point Checklist
 
 ### 1. Rhyme Check
 - Repeated end words, self-rhymes, predictable patterns
@@ -98,6 +98,26 @@ lyric-writer → lyric-reviewer → suno-engineer
 - **Warning**: Over genre target range, or more than 3 verses without explicit request
 - **Critical**: Over 500 words (non-hip-hop) or 700 words (hip-hop)
 
+### 10. Section Length Check
+- Count lines per section, compare against genre limits (see lyric-writer Section Length Limits)
+- **Hard fail**: Any section exceeding its genre max must be flagged for trimming
+
+### 11. Rhyme Scheme Check
+- Verify rhyme scheme matches the genre (see lyric-writer Default Rhyme Schemes by Genre)
+- No orphan lines, no random scheme switches mid-verse
+- **Warning**: Inconsistent scheme within a section, orphan unrhymed line
+
+### 12. Density/Pacing Check
+- Verse line count vs genre README's `Density/pacing (Suno)` default
+- Cross-reference BPM/mood from Musical Direction
+- **Hard fail**: Any verse exceeding the genre's max line count
+
+### 13. Verse-Chorus Echo Check
+- Compare last 2 lines of every verse against first 2 lines of the following chorus
+- Flag exact phrases, shared rhyme words, restated hooks, or shared signature imagery
+- Check ALL verse-to-chorus and bridge-to-chorus transitions
+- **Warning**: Shared phrases or rhyme words bleeding across section boundaries
+
 See [checklist-reference.md](checklist-reference.md) for detailed criteria.
 
 ---
@@ -122,21 +142,22 @@ See [checklist-reference.md](checklist-reference.md) for detailed criteria.
 - Documentary issues
 - Flow/phrasing
 
-### Homograph Detection & Auto-Fix (MANDATORY)
+### Homograph Verification (MANDATORY)
+
+The lyric-writer asks the user to resolve homographs during writing. Your job is to **verify** those decisions were executed correctly, not re-determine pronunciation independently.
 
 When you detect a homograph (live, read, lead, wind, tear, bass, bow, etc.):
 
-1. **DO NOT** ask the user which option they prefer
-2. **DO NOT** offer to change the lyric to avoid the word
-3. Determine correct pronunciation from context
-4. Create phonetic spelling (e.g., "live" → "liv" for verb)
-5. Apply to Suno Lyrics Box ONLY (streaming lyrics keep standard spelling)
-6. Add to Pronunciation Notes table
-7. Report as "Auto-Fix Applied"
+1. **Check** if the word has an entry in the Pronunciation Notes table
+2. **If resolved**: Verify the phonetic spelling from the table is applied in the Suno Lyrics Box (not just documented)
+3. **If missing**: Flag as "Unresolved homograph — needs user decision" (do NOT guess the pronunciation)
+4. Verify streaming lyrics keep standard spelling (phonetics are Suno-only)
+5. Report each homograph as "Verified ✓" or "Unresolved — ask user"
 
-**Anti-pattern**: Offering the user "Option A: keep it, Option B: change the lyric" is WRONG. The answer is ALWAYS phonetic spelling.
+**Anti-pattern**: Determining pronunciation from context is WRONG. Suno cannot infer from context. Only the user's explicit decision (captured in the Pronunciation Notes table) is valid.
 
 #### Common Homograph Fixes
+*(Canonical reference: `/reference/suno/pronunciation-guide.md`. Keep this table in sync.)*
 
 | Word | Context A | Spelling | Context B | Spelling |
 |------|-----------|----------|-----------|----------|
@@ -145,7 +166,7 @@ When you detect a homograph (live, read, lead, wind, tear, bass, bow, etc.):
 | lead | verb (to lead) | leed | noun (metal) | led |
 | wind | noun (air) | wind | verb (to wind) | wynd |
 | tear | noun (crying) | teer | verb (to rip) | tare |
-| bass | noun (fish) | bass | noun (music) | base |
+| bass | noun (fish) | bass | noun (music) | bayss |
 | bow | noun (ribbon) | boh | verb (to bow) | bow |
 | close | verb (to close) | cloze | adjective (near) | close |
 

--- a/skills/lyric-writer/SKILL.md
+++ b/skills/lyric-writer/SKILL.md
@@ -51,14 +51,14 @@ You are a professional lyric writer with expertise in prosody, rhyme craft, and 
 **After writing or revising any lyrics**, automatically run through:
 1. **Rhyme check**: Repeated end words, self-rhymes, lazy patterns
 2. **Prosody check**: Stressed syllables align with strong beats
-3. **Pronunciation check**: Proper nouns, homographs, acronyms, tech terms, invented contractions (no noun'd/brand'd), pronunciation table enforcement (every table entry must be phonetic in Suno lyrics)
+3. **Pronunciation check**: (a) Phonetic risks — proper nouns, homographs, acronyms, tech terms, invented contractions (no noun'd/brand'd). (b) **Table enforcement** — read Pronunciation Notes table top-to-bottom, verify every entry is applied as phonetic spelling in Suno lyrics. See `/reference/suno/pronunciation-guide.md` for full enforcement workflow.
 4. **POV/Tense check**: Consistent throughout
 5. **Source verification**: If source-based, match captured material
 6. **Structure check**: Section tags, verse/chorus contrast, V2 develops
-7. **Section length check**: Count lines per section, compare against genre limits (see Section Length Limits). **Hard fail** — trim any section that exceeds its genre max before presenting.
+7. **Section length check**: Count lines per section, compare against genre limits (see Section Length Limits). **Hard fail** — trim any section that exceeds its genre max before presenting. Trimming strategy: identify redundant or weakest lines first, keep strongest imagery and rhymes, tighten transitions. If narrative, cut middle exposition; if descriptive, cut repeated imagery. Never cut the hook or opening line.
 8. **Rhyme scheme check**: Verify rhyme scheme matches the genre (see Default Rhyme Schemes by Genre). No orphan lines, no random scheme switches mid-verse. Read each rhyming pair aloud.
 9. **Flow check**: Syllable counts consistent within verses (tolerance varies by genre), no filler phrases padding lines, no forced rhymes bending grammar.
-10. **Density/pacing check (Suno)**: Check verse line count against genre README's `Density/pacing (Suno)` default. Flag any verse exceeding the genre's max. Cross-reference BPM/mood from Musical Direction. **Hard fail** — trim or split any verse over the limit.
+10. **Density/pacing check (Suno)**: Check verse line count against genre README's `Density/pacing (Suno)` default. Cross-reference BPM/mood from Musical Direction. **Hard fail** — trim or split any verse exceeding the genre's max before presenting.
 11. **Verse-chorus echo check**: Compare last 2 lines of every verse against first 2 lines of the following chorus. Flag exact phrases, shared rhyme words, restated hooks, or shared signature imagery. Check ALL verse-to-chorus and bridge-to-chorus transitions.
 12. **Pitfalls check**: Run through checklist
 
@@ -547,7 +547,7 @@ Before finalizing:
 - [ ] Tense jumping without reason
 - [ ] Too specific (alienating names/places)
 - [ ] Too vague (abstractions without imagery)
-- [ ] Twin verses (V2 = V1 reworded)
+- [ ] Twin verses (V2 = V1 reworded — V2 must advance the story, deepen emotion, or shift perspective, not just rephrase V1. Example: V1 "Streets are cold, I walk alone" → bad V2 "Roads are freezing, I'm by myself" (same idea reworded) → good V2 "Found your old coat in the closet / Still smells like smoke and home" (new detail, emotional shift))
 - [ ] No hook
 - [ ] Disingenuous voice
 - [ ] Section too long for genre (check Section Length Limits table)
@@ -588,6 +588,7 @@ Suno CANNOT infer pronunciation from context. **"Context is clear" is NEVER an a
 4. **Document**: Add to track pronunciation table with reason
 
 **Common homographs — ALWAYS ask, NEVER guess:**
+*(Canonical homograph reference: `/reference/suno/pronunciation-guide.md`. Keep this table in sync.)*
 
 | Word | Pronunciation A | Phonetic | Pronunciation B | Phonetic |
 |------|----------------|----------|-----------------|----------|

--- a/skills/mastering-engineer/SKILL.md
+++ b/skills/mastering-engineer/SKILL.md
@@ -120,17 +120,25 @@ genres:
 
 **Find plugin directory** (version-independent):
 ```bash
-PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "0.*" | sort -V | tail -1)
+PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "[0-9]*" | sort -V | tail -1)
 MASTERING_DIR="$PLUGIN_DIR/tools/mastering"
 ```
 
 This finds the latest installed version automatically.
 
-### Step 1: Analyze Tracks
+### Step 1: Pre-Flight Check
+
+Before mastering, verify:
+1. **Audio folder exists** — confirm the path is valid
+2. **WAV files present** — check for at least one `.wav` file in the folder
+3. If no WAV files found, report: "No WAV files in [path]. Download tracks from Suno as WAV (highest quality) first."
+4. If folder contains only MP3s, warn: "MP3 files found but mastering requires WAV. Re-download from Suno as WAV."
+
+### Step 2: Analyze Tracks
 
 ```bash
 # Find plugin directory
-PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "0.*" | sort -V | tail -1)
+PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "[0-9]*" | sort -V | tail -1)
 
 # Analyze tracks in audio folder
 python3 "$PLUGIN_DIR/tools/mastering/analyze_tracks.py" /path/to/audio/folder
@@ -152,7 +160,7 @@ python3 "$PLUGIN_DIR/tools/mastering/analyze_tracks.py" ~/bitwize-music/audio/bi
 - True peak >0.0 dBTP (clipping)
 - LUFS <-20 or >-8 (too quiet or too loud)
 
-### Step 2: Choose Settings
+### Step 3: Choose Settings
 
 **Standard (most cases)**:
 ```bash
@@ -169,7 +177,7 @@ python3 "$PLUGIN_DIR/tools/mastering/master_tracks.py" /path/to/audio/folder --g
 python3 "$PLUGIN_DIR/tools/mastering/reference_master.py" /path/to/audio/folder --reference reference_track.wav
 ```
 
-### Step 3: Dry Run (Preview)
+### Step 4: Dry Run (Preview)
 
 ```bash
 python3 "$PLUGIN_DIR/tools/mastering/master_tracks.py" /path/to/audio/folder --dry-run --cut-highmid -2
@@ -177,7 +185,7 @@ python3 "$PLUGIN_DIR/tools/mastering/master_tracks.py" /path/to/audio/folder --d
 
 Shows what will happen without modifying files.
 
-### Step 4: Master
+### Step 5: Master
 
 ```bash
 python3 "$PLUGIN_DIR/tools/mastering/master_tracks.py" /path/to/audio/folder --cut-highmid -2
@@ -185,7 +193,7 @@ python3 "$PLUGIN_DIR/tools/mastering/master_tracks.py" /path/to/audio/folder --c
 
 Creates `mastered/` subdirectory in audio folder with processed files.
 
-### Step 5: Verify
+### Step 6: Verify
 
 ```bash
 # Analyze the mastered output
@@ -230,7 +238,7 @@ pip install matchering pyloudnorm scipy numpy soundfile
 source ~/.bitwize-music/mastering-env/bin/activate
 
 # Find plugin directory (version-independent)
-PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "0.*" | sort -V | tail -1)
+PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "[0-9]*" | sort -V | tail -1)
 
 # Set audio path
 AUDIO_DIR="/path/to/audio/folder"
@@ -308,7 +316,7 @@ python3 analyze_tracks.py
 
 **Right:**
 ```bash
-PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "0.*" | sort -V | tail -1)
+PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "[0-9]*" | sort -V | tail -1)
 python3 "$PLUGIN_DIR/tools/mastering/analyze_tracks.py" ~/audio/my-album
 ```
 
@@ -326,7 +334,7 @@ cd ~/.claude/plugins/cache/bitwize-music/bitwize-music/0.12.0/tools/mastering
 
 **Right:**
 ```bash
-PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "0.*" | sort -V | tail -1)
+PLUGIN_DIR=$(find ~/.claude/plugins/cache/bitwize-music/bitwize-music -maxdepth 1 -type d -name "[0-9]*" | sort -V | tail -1)
 cd "$PLUGIN_DIR/tools/mastering"
 ```
 

--- a/skills/new-album/SKILL.md
+++ b/skills/new-album/SKILL.md
@@ -23,12 +23,15 @@ You create the complete album directory structure based on config.
 
 ## Step 1: Parse Arguments
 
-Expected format: `<album-name> <genre>`
+Expected formats:
+- `<album-name> <genre>` — standard album
+- `<album-name> documentary <genre>` — true-story/documentary album (creates RESEARCH.md + SOURCES.md)
 
 Examples:
 - `sample-album electronic`
 - `my-new-album hip-hop`
 - `protest-songs folk`
+- `the-heist documentary hip-hop`
 
 Valid genres (primary categories):
 - `hip-hop`
@@ -37,11 +40,22 @@ Valid genres (primary categories):
 - `folk`
 - `rock`
 
+**Parsing logic:**
+1. If 3 arguments and second is `documentary`: album = arg1, genre = arg3, documentary = true
+2. If 2 arguments: album = arg1, genre = arg2, documentary = false
+3. If 2 arguments and neither matches a valid genre: ask for clarification
+4. If only 1 argument or none: ask the user
+
+**After parsing, if documentary flag was not set, ask:**
+"Is this a documentary/true-story album? (This adds research and sources templates.)"
+
 If arguments are missing, ask:
 ```
 Usage: /new-album <album-name> <genre>
+       /new-album <album-name> documentary <genre>
 
 Example: /new-album sample-album electronic
+         /new-album the-heist documentary hip-hop
 
 Valid genres: hip-hop, electronic, country, folk, rock
 ```

--- a/skills/pronunciation-specialist/SKILL.md
+++ b/skills/pronunciation-specialist/SKILL.md
@@ -56,6 +56,7 @@ See [word-lists.md](word-lists.md) for complete tables. Summary:
 
 ### 1. Homographs (CRITICAL)
 Same spelling, different pronunciation. **ALWAYS require clarification.**
+*(Canonical reference: `/reference/suno/pronunciation-guide.md`. Keep this summary in sync.)*
 
 | Word | Options | Fix |
 |------|---------|-----|
@@ -64,7 +65,7 @@ Same spelling, different pronunciation. **ALWAYS require clarification.**
 | lead | LEED (guide) / LED (metal) | "leed" or "led" |
 | wind | WYND (air) / WINED (coil) | "wynd" or "wined" |
 | tear | TEER (cry) / TARE (rip) | "teer" or "tare" |
-| bass | BASE (music) / BASS (fish) | context |
+| bass | BAYSS (music) / BASS (fish) | "bayss" or "bass" |
 
 ### 2. Tech Terms
 Suno often mispronounces tech words:
@@ -97,28 +98,38 @@ You reference TWO pronunciation guides:
 - **Contains**: Universal pronunciation rules, common homographs, tech terms
 - **Updated**: By plugin maintainers when new issues are discovered
 
-### Override Guide (User-Maintained)
-- **Location**: Read from `~/.bitwize-music/config.yaml` → `paths.overrides`
-- **File**: `{overrides}/pronunciation-guide.md`
-- **Default**: `{content_root}/overrides/pronunciation-guide.md` if not set in config
-- **Contains**: Artist names, album-specific terms, genre-specific jargon
-- **Optional**: Skip silently if file doesn't exist
+## Override Support
 
-### Loading Behavior
+Check for custom pronunciation entries:
 
-At session start or when invoked:
-1. Load base guide from `/reference/suno/pronunciation-guide.md`
-2. Read config to get `paths.overrides`
-3. Check for `{overrides}/pronunciation-guide.md`
-4. If override guide exists, load and merge with base guide
-5. **Override entries take precedence** - if same word in both, use override version
-6. If override guide doesn't exist, continue with base guide only
+### Loading Override
+1. Read `~/.bitwize-music/config.yaml` → `paths.overrides`
+2. Check for `{overrides}/pronunciation-guide.md`
+3. If exists: load and merge with base guide (override entries take precedence)
+4. If not exists: use base guide only (skip silently)
 
-**Why two guides:**
+### Override File Format
+
+**`{overrides}/pronunciation-guide.md`:**
+```markdown
+# Pronunciation Guide (Override)
+
+## Artist Names
+| Name | Pronunciation | Notes |
+|------|---------------|-------|
+| Ramos | Rah-mohs | Character name |
+
+## Album-Specific Terms
+| Term | Pronunciation | Notes |
+|------|---------------|-------|
+| Sinaloa | Sin-ah-lo-ah | Location |
+```
+
+### How to Use Override
+- Add artist names, album-specific terms, and genre-specific jargon
+- Override entries take precedence over base guide entries for the same word
 - Base guide updates via plugin updates without conflicts
-- Override guide version-controlled with your music content
-- Your artist-specific pronunciations don't get overwritten
-- Part of unified overrides system (all customizations in one directory)
+- Override guide is version-controlled with your music content
 
 ---
 

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -23,7 +23,13 @@ When invoked for research:
 1. **Read primary sources in full** - Not summaries, the actual documents
 2. **Cross-verify every key fact** across 3+ independent sources
 3. **Extract verbatim quotes** with page numbers and context
-4. **Build evidence chains** - Connect sources, follow the money, map relationships
+4. **Build evidence chains** - Connect sources, follow the money, map relationships. Use this format:
+   ```
+   ## Evidence Chain: [Topic]
+   1. [Claim] (Date) — Source: [Name](URL), p.X → [key fact]
+   2. [Connected claim] (Date) — Source: [Name](URL) → [key fact]
+   3. [Discrepancy]: $X unaccounted → Source: [Name](URL)
+   ```
 5. **Document methodology** - Show how each fact was verified
 6. **Anticipate challenges** - Know the counter-evidence, document discrepancies
 
@@ -257,20 +263,21 @@ These specialists have `user-invocable: false` - you coordinate them, users don'
 
 **Before creating any files, you MUST:**
 
-1. **Read config to get paths:**
-   ```bash
-   cat ~/.bitwize-music/config.yaml
-   ```
-   Extract: `paths.content_root` and `artist.name`
+1. **Check state cache first:**
+   - Read `~/.bitwize-music/cache/state.json`
+   - Search `state.albums` keys for the album name (case-insensitive)
+   - If found: use the album's `path` directly
 
 2. **Determine album from context:**
-   - If working on an album, you should know its name from the conversation
-   - If unclear, ask: "Which album is this research for?"
+   - If state cache has albums, check for exactly 1 album with status "Concept", "Research Complete", or "In Progress" — if so, use it
+   - If multiple match or none, ask: "Which album is this research for?"
 
-3. **Find album directory:**
-   ```bash
-   find {content_root}/artists/{artist}/albums -type d -name "{album-name}" 2>/dev/null
-   ```
+3. **If state cache is missing or stale:**
+   - Try rebuilding: `python3 {plugin_root}/tools/state/indexer.py rebuild`
+   - If rebuild fails, fall back to config + Glob:
+     - Read `~/.bitwize-music/config.yaml` — extract `paths.content_root` and `artist.name`
+     - Glob: `{content_root}/artists/{artist}/albums/*/*/README.md`
+     - Filter results for the album name (case-insensitive)
 
 4. **Save files to album directory:**
    ```

--- a/skills/researchers-biographical/SKILL.md
+++ b/skills/researchers-biographical/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a biographical research specialist for documentary music projects. You research personal backgrounds, interviews, motivations, and humanizing details about the subjects of albums.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-financial/SKILL.md
+++ b/skills/researchers-financial/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a financial documents specialist for documentary music projects. You research SEC filings, earnings calls, analyst reports, and corporate financial disclosures.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-gov/SKILL.md
+++ b/skills/researchers-gov/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a government source specialist for documentary music projects. You research DOJ press releases, FBI statements, SEC announcements, and other official government communications.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-historical/SKILL.md
+++ b/skills/researchers-historical/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a historical research specialist for documentary music projects. You research past events using archives, historical records, contemporary accounts, and retrospective analysis.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-journalism/SKILL.md
+++ b/skills/researchers-journalism/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are an investigative journalism specialist for documentary music projects. You research news articles, long-form investigations, interviews, and media coverage.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-legal/SKILL.md
+++ b/skills/researchers-legal/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a legal document specialist for documentary music projects. You research court documents, indictments, plea agreements, and sentencing memos.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-primary-source/SKILL.md
+++ b/skills/researchers-primary-source/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a primary source specialist for documentary music projects. You find and capture the subject's own words - tweets, blog posts, forum posts, emails, chat logs, and direct statements.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-security/SKILL.md
+++ b/skills/researchers-security/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a cybersecurity specialist for documentary music projects. You research malware analysis, hacking incidents, threat intelligence, and security community sources.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-tech/SKILL.md
+++ b/skills/researchers-tech/SKILL.md
@@ -31,6 +31,7 @@ When invoked:
 You are a technical documentation specialist for documentary music projects. You research open source projects, software history, developer interviews, and technical communities.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/researchers-verifier/SKILL.md
+++ b/skills/researchers-verifier/SKILL.md
@@ -39,6 +39,7 @@ When invoked:
 You are a fact-checking specialist for documentary music projects. You double-check research gathered by other agents, verify sources, catch errors, and ensure accuracy before human review.
 
 **Parent agent**: See `/skills/researcher/SKILL.md` for core principles and standards.
+**Override preferences**: If `{overrides}/research-preferences.md` exists, apply those standards (minimum sources, depth, etc.) to your domain-specific research.
 
 ---
 

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -33,7 +33,9 @@ When this skill is invoked with an album name:
 Read `~/.bitwize-music/cache/state.json` to get album and track data.
 
 **If state.json is missing or corrupted**:
+- Resolve `{plugin_root}`: find the plugin installation directory (typically the repo root containing `tools/state/indexer.py`, or search `~/.claude/plugins/cache/bitwize-music/bitwize-music` for latest version directory)
 - Run: `python3 {plugin_root}/tools/state/indexer.py rebuild`
+- If rebuild fails, fall back to manual Glob scan: read config, glob `{content_root}/artists/{artist}/albums/*/*/README.md`
 - Then read the newly created state.json
 
 **If state.json exists**: Use it directly (much faster than scanning files).
@@ -135,6 +137,11 @@ Based on the phase, suggest concrete next steps:
 **Planning Phase**:
 - "Let's fill in the album concept and tracklist"
 - "Run the 7 Planning Phases to finalize details"
+
+**Research Phase** (documentary/true-story albums):
+- "This is a documentary album — let's gather sources before writing"
+- "Use `/bitwize-music:researcher` to coordinate research across domains"
+- "Use `/bitwize-music:document-hunter` for automated free source searching"
 
 **Writing Phase**:
 - "Which track should we write next?"

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -17,9 +17,10 @@ allowed-tools:
 **Input**: $ARGUMENTS
 
 When invoked with a track file:
-1. Read the track file and any related album/artist context
-2. Construct optimal Suno V5 style prompt and settings
-3. Update the track file's Suno Inputs section
+1. Read the track file
+2. Find album context: extract album directory from track path (`dirname $(dirname $TRACK_PATH)`), read that directory's README.md for album-level genre/theme/style. If README missing, use only track-level context.
+3. Construct optimal Suno V5 style prompt and settings
+4. Update the track file's Suno Inputs section
 
 When invoked with a concept:
 1. Design complete Suno prompting strategy
@@ -143,7 +144,7 @@ Chorus lyrics here
 
 **Rules**:
 - Use section tags for every section
-- Parenthetical directions for instrumental parts
+- Section tags only for instrumental parts (no parentheticals — Suno sings them)
 - Clean lyrics only (no vocalist names, no extra instructions)
 - Phonetic spelling for pronunciation issues
 
@@ -161,11 +162,14 @@ clean electric guitar, driving bassline, tight drums. Modern production, dynamic
 
 ## Genre Selection
 
-More specific = better results.
+More specific = better results, but stop at 2-3 genre descriptors. Over-specification (5+ genre terms) dilutes rather than clarifies.
+
+**Pattern**: `[Primary genre] + [1-2 subgenre modifiers] + [1 key instrument/technique]`
 
 **Generic**: "Rock"
 **Better**: "Alternative rock"
-**Best**: "Midwest emo, math rock influences, clean guitar, intricate picking"
+**Best**: "Midwest emo, math rock influences, clean guitar"
+**Too much**: "Midwest emo, math rock, post-rock, shoegaze, ambient, clean guitar, intricate picking, reverb-heavy" — Suno can't honor all of these simultaneously
 
 ### Genre Mixing
 Combine up to 3 genres for unique sound:
@@ -207,10 +211,11 @@ Combine up to 3 genres for unique sound:
 4. Max total length: 8 minutes
 
 ### Instrumental Sections
-Use parenthetical directions:
+Use descriptive section tags only (no parentheticals — Suno will sing them as words):
 ```
+[Guitar Solo]
 [Instrumental Break]
-(Guitar solo, 16 bars)
+[Drum Break]
 ```
 
 ### Voice Switching

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -959,7 +959,7 @@ Verify it documents:
 
 ---
 
-## 9. CONSISTENCY TESTS (`/test consistency`)
+## 10. CONSISTENCY TESTS (`/test consistency`)
 
 Cross-reference and consistency checks.
 
@@ -1036,7 +1036,7 @@ This test was added after an accidental skill.json was found in the resume skill
 
 ---
 
-## 10. TERMINOLOGY TESTS (`/test terminology`)
+## 11. TERMINOLOGY TESTS (`/test terminology`)
 
 Consistent language across docs.
 
@@ -1068,7 +1068,7 @@ Brand should always be "bitwize-music" (lowercase with hyphen).
 
 ---
 
-## 11. BEHAVIOR TESTS (`/test behavior`)
+## 12. BEHAVIOR TESTS (`/test behavior`)
 
 Scenario-based tests verifying correct instructions.
 
@@ -1104,7 +1104,7 @@ Verify it lists all check types:
 
 ---
 
-## 12. QUALITY TESTS (`/test quality`)
+## 13. QUALITY TESTS (`/test quality`)
 
 Code quality and best practices.
 
@@ -1204,7 +1204,7 @@ Read CLAUDE.md and verify these sections exist:
 
 ---
 
-## 13. E2E TESTS (`/test e2e`)
+## 14. E2E TESTS (`/test e2e`)
 
 End-to-end integration test that creates a test album and exercises the full workflow.
 

--- a/templates/album.md
+++ b/templates/album.md
@@ -128,10 +128,7 @@ spotify_url: ""  # Fill in when released (optional)
 
 ### Source Verification Status
 
-| Track | Sources Captured | Human Verified | Legal Cleared |
-|-------|------------------|----------------|---------------|
-| 01 - [Title] | ☐ | ☐ | ☐ |
-| 02 - [Title] | ☐ | ☐ | ☐ |
+Source verification is tracked per-track in each track file's `Sources Verified` field (single source of truth). Use `/bitwize-music:resume` or `/bitwize-music:validate-album` to see verification status across all tracks.
 
 ### Legal Notes
 
@@ -159,6 +156,14 @@ Dialogue and internal thoughts are dramatized for artistic purposes."]
 ```
 
 **Note**: Artist name should always appear in the bottom right. Preserve the artist's preferred casing/spelling.
+
+### File Naming Convention
+
+Save generated album art using `/bitwize-music:import-art` or manually to these locations:
+- **Audio directory**: `{audio_root}/{artist}/{album}/album.png` (used by promo videos, SoundCloud)
+- **Content directory**: `{content_root}/artists/{artist}/albums/{genre}/{album}/album-art.png` (tracked in git)
+
+Format: PNG preferred, JPEG acceptable. Resolution: at least 3000x3000 for distribution, 1500x1500 minimum.
 
 ## SoundCloud
 

--- a/templates/track.md
+++ b/templates/track.md
@@ -162,6 +162,8 @@ Blank lines between sections only]
 
 ## Pronunciation Notes
 
+**This table is a mandatory checklist, not passive documentation.** Every entry below MUST be applied as phonetic spelling in the Suno Lyrics Box. Before finalizing: read each row, search the Suno lyrics for the standard spelling, and confirm the phonetic version is used.
+
 | Word/Phrase | Pronunciation | Reason |
 |-------------|---------------|--------|
 | — | — | — |
@@ -185,6 +187,8 @@ Blank lines between sections only]
 <!-- /SERVICE: suno -->
 
 ## Generation Log
+
+Mark keepers with ✓ in the Rating column. Checkpoint verification looks for at least one ✓ per track.
 
 | # | Date | Model | Result | Notes | Rating |
 |---|------|-------|--------|-------|--------|

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -31,6 +31,7 @@ Usage:
     python upload_to_cloud.py my-album --audio-root /path/to/audio
 """
 
+import os
 import sys
 import argparse
 import time
@@ -180,6 +181,11 @@ def find_album_path(config: Dict[str, Any], album_name: str, audio_root_override
     checked.append(str(album_path_direct))
     if album_path_direct.exists() and _is_within(album_path_direct, audio_root):
         return album_path_direct
+
+    # Validate album_name before glob search (prevent path traversal and glob injection)
+    if os.sep in album_name or '/' in album_name or any(c in album_name for c in '*?[]'):
+        logger.error("Album name '%s' contains invalid characters (path separators or glob patterns)", album_name)
+        sys.exit(1)
 
     # Glob search as fallback (handles genre folders, mirrored structures)
     matches = sorted(audio_root.rglob(album_name))

--- a/tools/mastering/fix_dynamic_track.py
+++ b/tools/mastering/fix_dynamic_track.py
@@ -63,6 +63,17 @@ def main():
     input_file = sys.argv[1]
     output_file = sys.argv[2] if len(sys.argv) > 2 else f"mastered/{Path(input_file).name}"
 
+    # Prevent path traversal: output must stay within input file's parent directory
+    input_dir = Path(input_file).resolve().parent
+    output_path = Path(output_file).resolve()
+    try:
+        output_path.relative_to(input_dir)
+    except ValueError:
+        logger.error("Output path must be within input directory")
+        logger.error("  Output: %s", output_path)
+        logger.error("  Input dir: %s", input_dir)
+        sys.exit(1)
+
     logger.info("Processing %s...", input_file)
 
     # Ensure output directory exists

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -406,7 +406,16 @@ Examples:
         logger.error("Directory not found: %s", input_dir)
         sys.exit(1)
 
-    output_dir = input_dir / args.output_dir
+    output_dir = (input_dir / args.output_dir).resolve()
+
+    # Prevent path traversal: output must stay within input directory
+    try:
+        output_dir.relative_to(input_dir)
+    except ValueError:
+        logger.error("Output directory must be within input directory")
+        logger.error("  Output: %s", output_dir)
+        logger.error("  Input:  %s", input_dir)
+        sys.exit(1)
 
     if not args.dry_run:
         output_dir.mkdir(exist_ok=True)

--- a/tools/promotion/generate_album_sampler.py
+++ b/tools/promotion/generate_album_sampler.py
@@ -14,6 +14,7 @@ Usage:
     python generate_album_sampler.py /path/to/mastered --clip-duration 10
 """
 
+import atexit
 import os
 import sys
 import argparse
@@ -45,6 +46,21 @@ from tools.shared.media_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Safety-net cleanup for temp files left behind on abnormal exit
+_temp_files_to_cleanup: list = []
+
+
+def _cleanup_temp_files():
+    for path in _temp_files_to_cleanup:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    _temp_files_to_cleanup.clear()
+
+
+atexit.register(_cleanup_temp_files)
 
 _DEFAULT_CONFIG = {"artist": {"name": "bitwize"}}
 
@@ -98,14 +114,18 @@ def generate_clip(
     # This avoids all escaping issues with drawtext's text= parameter,
     # preventing injection of ffmpeg filter directives through track titles.
     title_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+    os.chmod(title_file.name, 0o600)
     title_file.write(title)
     title_file.close()
     title_file_path = title_file.name
+    _temp_files_to_cleanup.append(title_file_path)
 
     artist_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)
+    os.chmod(artist_file.name, 0o600)
     artist_file.write(artist_name)
     artist_file.close()
     artist_file_path = artist_file.name
+    _temp_files_to_cleanup.append(artist_file_path)
 
     viz_height = 600
 
@@ -175,11 +195,15 @@ def generate_clip(
     except Exception:
         return False
     finally:
-        # Clean up temp text files
+        # Clean up temp text files (also remove from atexit list)
         for tmp in (title_file_path, artist_file_path):
             try:
                 os.unlink(tmp)
             except OSError:
+                pass
+            try:
+                _temp_files_to_cleanup.remove(tmp)
+            except ValueError:
                 pass
 
 


### PR DESCRIPTION
## Summary

- 6 low-severity security fixes across Python tools and CI workflows
- 36 prompt/skill quality improvements across 30+ files
- 41 files changed, 464 insertions, 105 deletions
- All 252 unit tests passing, all 11 pre-commit checks green

### Security Fixes
- Temp file cleanup with atexit handlers and `0o600` permissions in promo generators
- Path traversal validation (`Path.relative_to()`) in mastering tools
- State cache permissions (`0o700` dir, `0o600` files)
- Album name validation before `rglob` (glob injection prevention)
- CI model-updater character whitelist and length validation
- Session input validation (length limits, null bytes, action cap)

### Prompt/Skill Quality
- **Critical**: Fixed contradictory homograph handling between lyric-writer and lyric-reviewer
- **Critical**: Fixed self-contradictory parenthetical guidance in suno-engineer (Suno sings parentheticals)
- **Critical**: Standardized `bass` homograph to `bayss` (music) across 3 skills
- Expanded lyric-reviewer from 9-point to 13-point checklist
- Added concrete examples: energy mapping, twin verses, evidence chains, trim strategy
- Added missing workflow phases: research phase, pre-flight WAV check, checkpoint actions
- Unified Style Prompt/Style Box terminology across Suno docs
- Added canonical source references to prevent homograph table drift across skills
- Updated all 10 researcher sub-skills with override preference inheritance
- Fixed test skill duplicate section numbering (9→10-14)
- Added pronunciation table enforcement workflow to reference guide
- Added human verification checklist (6 concrete items) to source verification handoff

### Verification Checklist
- [x] All 252 unit tests passing
- [x] All 11 pre-commit checks passing (ruff, JSON/YAML, version sync, CHANGELOG, security scan, plugin tests)
- [x] No broken file references across project
- [x] Run `/bitwize-music:test skills` locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)