### PR TITLE
ci: add test count badge validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,28 @@ jobs:
       run: |
         python -m pytest tests/ -v --tb=short --cov=tools --cov=servers --cov-report=term-missing --cov-report=html:coverage-html
 
+    - name: Verify test count badge
+      if: matrix.python-version == '3.11'
+      run: |
+        ACTUAL_COUNT=$(python -m pytest tests/ --co -q 2>/dev/null | tail -1 | grep -oP '^\d+')
+        BADGE_COUNT=$(grep -oP 'badge/tests-\K\d+' README.md)
+
+        echo "Actual test count:  $ACTUAL_COUNT"
+        echo "README badge count: $BADGE_COUNT"
+
+        if [ "$ACTUAL_COUNT" != "$BADGE_COUNT" ]; then
+          echo ""
+          echo "[FAIL] Test count badge is out of date!"
+          echo "  README says: $BADGE_COUNT tests"
+          echo "  Actual:      $ACTUAL_COUNT tests"
+          echo ""
+          echo "Update README.md badge to:"
+          echo "  ![Tests](https://img.shields.io/badge/tests-${ACTUAL_COUNT}-brightgreen)"
+          exit 1
+        fi
+
+        echo "[OK] Test count badge matches: $ACTUAL_COUNT"
+
     - name: Upload coverage report
       if: matrix.python-version == '3.11'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -7,6 +7,7 @@ on:
       - '.claude-plugin/marketplace.json'
       - 'README.md'
       - 'skills/*/SKILL.md'
+      - 'tests/**'
 
 permissions:
   contents: read
@@ -65,6 +66,16 @@ jobs:
           README_SKILLS=$(grep -oP 'badge/skills-\K[0-9]+' README.md || echo "not found")
           echo "[FAIL] Skills badge ($README_SKILLS) does not match actual count ($SKILL_COUNT)"
           echo "  Update README.md: badge/skills-${SKILL_COUNT}-green"
+          ERRORS=$((ERRORS + 1))
+        fi
+
+        # Check test badge exists and has a numeric value
+        if grep -qP 'badge/tests-\d+-brightgreen' README.md; then
+          TEST_COUNT=$(grep -oP 'badge/tests-\K\d+' README.md)
+          echo "[OK] Test badge present: $TEST_COUNT"
+        else
+          echo "[FAIL] Test count badge missing or malformed in README.md"
+          echo "  Expected: ![Tests](https://img.shields.io/badge/tests-COUNT-brightgreen)"
           ERRORS=$((ERRORS + 1))
         fi
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,11 +4,11 @@
 
 set -e
 
-echo "=== Pre-commit checks ==="
+echo "=== Pre-commit checks (11) ==="
 echo ""
 
 # 1. Ruff linter
-echo "[1/10] Running ruff linter..."
+echo "[1/11] Running ruff linter..."
 if command -v ruff &> /dev/null; then
     ruff check tools/
     echo "      ✓ Lint passed"
@@ -18,7 +18,7 @@ fi
 echo ""
 
 # 2. JSON/YAML validation
-echo "[2/10] Validating JSON/YAML configs..."
+echo "[2/11] Validating JSON/YAML configs..."
 python3 -c "
 import json
 import sys
@@ -60,7 +60,7 @@ print('      ✓ Config files valid')
 echo ""
 
 # 3. CLAUDE.md size check (characters, not bytes - better approximates tokens)
-echo "[3/10] Checking CLAUDE.md size..."
+echo "[3/11] Checking CLAUDE.md size..."
 MAX_CHARS=40000  # 40K characters
 CLAUDE_CHARS=$(wc -m < CLAUDE.md 2>/dev/null || echo 0)
 if [ "$CLAUDE_CHARS" -gt "$MAX_CHARS" ]; then
@@ -74,7 +74,7 @@ fi
 echo ""
 
 # 4. Version sync check
-echo "[4/10] Checking version sync..."
+echo "[4/11] Checking version sync..."
 python3 -c "
 import json
 import sys
@@ -96,7 +96,7 @@ print(f'      ✓ Versions match ({plugin_version})')
 echo ""
 
 # 5. Skill frontmatter validation
-echo "[5/10] Validating skill frontmatter..."
+echo "[5/11] Validating skill frontmatter..."
 python3 -c "
 import os
 import sys
@@ -153,7 +153,7 @@ print(f'      ✓ All {skill_count} skills have valid frontmatter')
 echo ""
 
 # 6. CHANGELOG format check
-echo "[6/10] Checking CHANGELOG format..."
+echo "[6/11] Checking CHANGELOG format..."
 if [ -f "CHANGELOG.md" ]; then
     if grep -q "\[Unreleased\]" CHANGELOG.md; then
         echo "      ✓ CHANGELOG has [Unreleased] section"
@@ -168,7 +168,7 @@ fi
 echo ""
 
 # 7. Merge conflict markers check
-echo "[7/10] Checking for merge conflict markers..."
+echo "[7/11] Checking for merge conflict markers..."
 CONFLICT_FILES=$(git diff --cached --name-only | xargs grep -l "^<<<<<<< \|^=======$\|^>>>>>>> " 2>/dev/null || true)
 if [ -n "$CONFLICT_FILES" ]; then
     echo "      ✗ Merge conflict markers found in:"
@@ -182,7 +182,7 @@ fi
 echo ""
 
 # 8. Large file check
-echo "[8/10] Checking for large files..."
+echo "[8/11] Checking for large files..."
 MAX_SIZE=500000  # 500KB
 LARGE_FILES=""
 for file in $(git diff --cached --name-only); do
@@ -205,7 +205,7 @@ fi
 echo ""
 
 # 9. Security scan (bandit + pip-audit)
-echo "[9/10] Running security scan..."
+echo "[9/11] Running security scan..."
 
 # Check code with bandit
 if command -v bandit &> /dev/null; then
@@ -243,7 +243,7 @@ fi
 echo ""
 
 # 10. All tests (plugin + unit)
-echo "[10/10] Running tests..."
+echo "[10/11] Running tests..."
 if command -v pytest &> /dev/null || python3 -c "import pytest" 2>/dev/null; then
     if python3 -m pytest tests/ -q --tb=line 2>/dev/null; then
         echo "      ✓ Tests passed"
@@ -254,6 +254,28 @@ if command -v pytest &> /dev/null || python3 -c "import pytest" 2>/dev/null; the
     fi
 else
     echo "      ⚠ pytest not installed, skipping (pip install pytest)"
+fi
+echo ""
+
+# 11. Test count badge sync
+echo "[11/11] Checking test count badge..."
+if command -v pytest &> /dev/null || python3 -c "import pytest" 2>/dev/null; then
+    ACTUAL_COUNT=$(python3 -m pytest tests/ --co -q 2>/dev/null | tail -1 | grep -oP '^\d+')
+    BADGE_COUNT=$(grep -oP 'badge/tests-\K\d+' README.md 2>/dev/null)
+
+    if [ -z "$ACTUAL_COUNT" ] || [ -z "$BADGE_COUNT" ]; then
+        echo "      ⚠ Could not determine test count or badge, skipping"
+    elif [ "$ACTUAL_COUNT" != "$BADGE_COUNT" ]; then
+        echo "      ✗ Test badge out of date!"
+        echo "        README badge: $BADGE_COUNT tests"
+        echo "        Actual count: $ACTUAL_COUNT tests"
+        echo "        Update: ![Tests](https://img.shields.io/badge/tests-${ACTUAL_COUNT}-brightgreen)"
+        exit 1
+    else
+        echo "      ✓ Test badge matches ($ACTUAL_COUNT)"
+    fi
+else
+    echo "      ⚠ pytest not installed, skipping"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary
- Adds pytest test count validation to CI (`test.yml`) — fails if README badge doesn't match actual count
- Adds test badge presence check to `version-sync.yml` badge verification
- Adds pre-commit hook check 11/11 for local test badge sync validation

## Test plan
- [x] Pre-commit hook passes locally (11/11 checks green)
- [x] Verified badge count matches actual (843)
- [x] Simulated mismatch detection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)