### PR TITLE
feat: add Schlager genre and genre-creator skill

### DIFF
--- a/genres/INDEX.md
+++ b/genres/INDEX.md
@@ -1,6 +1,6 @@
 # Genre Index
 
-A searchable, categorized guide to all 67 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
+A searchable, categorized guide to all 68 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
 
 ---
 
@@ -17,6 +17,7 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 - [Classical and Opera](#classical-and-opera)
 - [Reggae and Caribbean](#reggae-and-caribbean)
 - [Latin](#latin)
+- [European Pop](#european-pop)
 - [Other Genres](#other-genres)
 - [Quick Reference: Find by Characteristic](#quick-reference-find-by-characteristic)
 - [Genre Combinations](#genre-combinations)
@@ -145,6 +146,12 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 |-------|-------------|------|
 | **Latin** | Clave-based rhythms from salsa to reggaeton; pan-American scope | [README](latin/README.md) |
 
+## European Pop
+
+| Genre | Description | Link |
+|-------|-------------|------|
+| **Schlager** | German-language popular music with catchy melodies, sentimental lyrics, and singalong choruses; from post-war ballads to EDM-infused party hits | [README](schlager/README.md) |
+
 ---
 
 ## Quick Reference: Find by Characteristic
@@ -154,9 +161,9 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 | Speed | Genres |
 |-------|--------|
 | **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads |
-| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time) |
-| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Synthwave](synthwave/README.md) |
-| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md) |
+| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads) |
+| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md) |
+| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md), [Schlager](schlager/README.md) (party) |
 | **Very Fast (140-180+ BPM)** | [Drum and Bass](drum-and-bass/README.md), [Thrash Metal](thrash-metal/README.md), [Hardcore Punk](hardcore-punk/README.md), [Black Metal](black-metal/README.md) |
 
 ### By Energy Level
@@ -165,9 +172,9 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 |--------|--------|
 | **Chill/Relaxed** | [Ambient](ambient/README.md), [Lo-Fi](lo-fi/README.md), [Bossa Nova](bossa-nova/README.md), [Chillwave](chillwave/README.md), [Trip-Hop](trip-hop/README.md), [Indie Folk](indie-folk/README.md) |
 | **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md) |
-| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md) |
+| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party) |
 | **Aggressive** | [Metal](metal/README.md), [Punk](punk/README.md), [Drill](drill/README.md), [Dubstep](dubstep/README.md), [Industrial](industrial/README.md), [Grime](grime/README.md) |
-| **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Disco](disco/README.md) |
+| **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Disco](disco/README.md), [Schlager](schlager/README.md) |
 
 ### By Instrumentation
 
@@ -175,7 +182,7 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 |---------------|--------|
 | **Acoustic Guitar** | [Folk](folk/README.md), [Country](country/README.md), [Americana](americana/README.md), [Indie Folk](indie-folk/README.md), [Blues](blues/README.md) (acoustic), [Singer-Songwriter](singer-songwriter/README.md) |
 | **Electric Guitar** | [Rock](rock/README.md), [Metal](metal/README.md), [Blues](blues/README.md), [Punk](punk/README.md), [Grunge](grunge/README.md), [Shoegaze](shoegaze/README.md) |
-| **Synthesizers** | [Electronic](electronic/README.md), [Synthwave](synthwave/README.md), [Trance](trance/README.md), [House](house/README.md), [Ambient](ambient/README.md), [Hyperpop](hyperpop/README.md) |
+| **Synthesizers** | [Electronic](electronic/README.md), [Synthwave](synthwave/README.md), [Trance](trance/README.md), [House](house/README.md), [Ambient](ambient/README.md), [Hyperpop](hyperpop/README.md), [Schlager](schlager/README.md) |
 | **808/Drum Machines** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Phonk](phonk/README.md), [House](house/README.md), [Techno](techno/README.md) |
 | **Orchestra** | [Classical](classical/README.md), [Opera](opera/README.md), [Cinematic](cinematic/README.md), [Disco](disco/README.md) (strings) |
 | **Piano** | [Classical](classical/README.md), [Jazz](jazz/README.md), [Gospel](gospel/README.md), [Blues](blues/README.md), [Pop](pop/README.md) ballads, [Piano Rock](piano-rock/README.md), [Piano Pop](piano-pop/README.md) |
@@ -186,7 +193,7 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 
 | Vocal Approach | Genres |
 |----------------|--------|
-| **Powerful/Belted** | [Gospel](gospel/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Pop](pop/README.md), [Rock](rock/README.md) |
+| **Powerful/Belted** | [Gospel](gospel/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Pop](pop/README.md), [Rock](rock/README.md), [Schlager](schlager/README.md) |
 | **Rapped/Spoken** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Grime](grime/README.md), [Nerdcore](nerdcore/README.md) |
 | **Screamed/Harsh** | [Metal](metal/README.md), [Punk](punk/README.md), [Metalcore](metalcore/README.md), [Emo](emo/README.md), [Industrial](industrial/README.md) |
 | **Intimate/Whispered** | [Folk](folk/README.md), [Indie Folk](indie-folk/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Singer-Songwriter](singer-songwriter/README.md) |
@@ -198,18 +205,18 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 | Mood | Genres |
 |------|--------|
 | **Dark/Brooding** | [Black Metal](black-metal/README.md), [Doom Metal](doom-metal/README.md), [Industrial](industrial/README.md), [Drill](drill/README.md), [Grunge](grunge/README.md), [Trip-Hop](trip-hop/README.md) |
-| **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md) |
+| **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md), [Schlager](schlager/README.md) |
 | **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md) |
 | **Rebellious/Defiant** | [Punk](punk/README.md), [Hip-Hop](hip-hop/README.md), [Metal](metal/README.md), [Grime](grime/README.md) |
 | **Spiritual/Transcendent** | [Gospel](gospel/README.md), [Ambient](ambient/README.md), [Trance](trance/README.md), [Reggae](reggae/README.md), [Classical](classical/README.md) |
-| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md) |
+| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md) |
 
 ### By Era/Aesthetic
 
 | Era | Genres |
 |-----|--------|
 | **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md) |
-| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md) |
+| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md) |
 | **1990s** | [Grunge](grunge/README.md), [Hip-Hop](hip-hop/README.md), [Trip-Hop](trip-hop/README.md), [Trance](trance/README.md), [House](house/README.md) |
 | **2000s-2010s** | [EDM](edm/README.md), [Trap](trap/README.md), [Dubstep](dubstep/README.md), [Hyperpop](hyperpop/README.md), [Lo-Fi](lo-fi/README.md) |
 | **Internet/Modern** | [Vaporwave](vaporwave/README.md), [Hyperpop](hyperpop/README.md), [Phonk](phonk/README.md), [Drill](drill/README.md), [Lo-Fi](lo-fi/README.md) |
@@ -323,6 +330,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Reggae | Caribbean | [README](reggae/README.md) |
 | R&B | Soul | [README](rnb/README.md) |
 | Rock | Rock | [README](rock/README.md) |
+| Schlager | European Pop | [README](schlager/README.md) |
 | Shoegaze | Rock | [README](shoegaze/README.md) |
 | Singer-Songwriter | Folk/Pop | [README](singer-songwriter/README.md) |
 | Ska Punk | Rock | [README](ska-punk/README.md) |
@@ -350,4 +358,4 @@ These genres commonly blend well together or have natural crossover potential:
    - Reference artists and albums
    - Suno prompt keywords for AI generation
 
-**Total genres documented: 67**
+**Total genres documented: 68**

--- a/genres/schlager/README.md
+++ b/genres/schlager/README.md
@@ -1,0 +1,105 @@
+# Schlager
+
+## Genre Overview
+
+Schlager is a genre of popular music rooted in German-speaking Europe, with origins traceable to Viennese operetta and light entertainment music of the late 19th century. The term itself was first applied to music in an 1867 review of Johann Strauss II's *The Blue Danube* in the Wiener Fremden-Blatt. The genre took its modern form in the 1920s and 1930s through acts like the Comedian Harmonists and Rudi Schuricke, who established the template of catchy melodies with sentimental German-language lyrics. Post-war pioneers including Freddy Quinn, Caterina Valente, and Lale Andersen brought Schlager to mass audiences, with Quinn's "Die Gitarre und das Meer" (1959) becoming one of the first genre-defining chart-toppers.
+
+Schlager reached peak cultural dominance in the 1960s and early 1970s through artists like Peter Alexander, Roy Black, Udo Jürgens, and Heintje. Udo Jürgens elevated the genre with sophisticated compositions and won the Eurovision Song Contest in 1966 with "Merci, Chérie." Nicole repeated this feat in 1982 with "Ein bisschen Frieden," making Germany a Eurovision winner for the first time. Between 1975 and 1981, Schlager absorbed disco influences, blurring boundaries with mainstream dance music. The late 1980s and 1990s saw a split: Volkstümliche Musik catered to older rural audiences, while a revival wave led by Guildo Horn and Dieter Thomas Kuhn reintroduced Schlager to younger listeners with ironic appreciation. Andrea Berg's crossover success from the late 1990s onward attracted a genuinely new, younger fanbase.
+
+The 2010s brought Schlager's biggest commercial peak since the 1970s, driven almost entirely by Helene Fischer, whose 2013 album *Farbenspiel* became the most downloaded album ever by a German artist. Her single "Atemlos durch die Nacht" transcended the genre, becoming the fifth most successful song in German chart history. Today, Schlager remains a dominant force in German-language media with dedicated TV shows (Schlagerboom, Schlagerchampions), festivals (Schlagermove Hamburg), and streaming playlists. Modern acts like Vanessa Mai, Ben Zucker, and Beatrice Egli blend Schlager with EDM, pop, and Latin influences, while Roland Kaiser and Andrea Berg continue to fill arenas. The genre has also influenced Scandinavian schlager (dansband) and the broader Eurovision aesthetic.
+
+## Characteristics
+
+- **Instrumentation**: Keyboards/synthesizers (dominant since the 1980s), acoustic and electric guitar, accordion (especially in Volkstümliche variants), brass sections, string arrangements (often orchestral or sampled), drum machines and programmed beats in modern productions; live bands for arena shows
+- **Vocals**: Clean, powerful, emotionally expressive singing; emphasis on clarity and diction; vibrato common; duets frequent; male and female voices equally represented; German-language lyrics standard with occasional bilingual tracks; belted choruses designed for audience singalong
+- **Production**: Polished and radio-ready; heavy reverb on vocals; lush arrangements with layered synths and strings; modern productions incorporate EDM elements (sidechain compression, build-ups, drops); backing tracks often keyboard-driven; mixing prioritizes vocal intelligibility above all
+- **Energy/Mood**: Predominantly upbeat and feel-good; themes of love, longing, summer, travel, celebration, and nostalgia; emotional range from bittersweet melancholy (Herzschmerz) to euphoric party energy; optimistic tone even in sad songs; escapist and comforting
+- **Structure**: Verse-chorus-verse with prominent, highly singable choruses; bridges common; instrumental breaks often feature accordion or keyboard solos; key changes in final chorus frequent; intros typically 4-8 bars; songs designed for immediate hook recognition
+- **Tempo**: Ballads 60-80 BPM, mid-tempo 90-110 BPM, uptempo/party 120-140 BPM; most hits cluster around 100-130 BPM; straight 4/4 time signature nearly universal; occasional waltz (3/4) in Volkstümliche variants
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB (couplet) dominant, also ABAB and ABCB. Choruses often use AABB for maximum singability.
+- **Rhyme quality**: Clean end rhymes preferred; exact rhymes valued over slant rhymes; occasional internal rhyme but not required; simplicity over cleverness; rhymes should feel natural and effortless, never forced
+- **Verse structure**: 4-8 lines per verse; 4-line choruses most common; pre-chorus (Strophe → Refrain bridge) frequent in modern Schlager; repetition of chorus lyrics expected
+- **Key rule**: The chorus must be instantly memorable and singable by a crowd — if a drunk audience at Schlagermove can't sing along after one listen, the hook fails.
+- **Avoid**: Irony or cynicism (unless deliberately parodic like Guildo Horn); complex metaphors; English lyrics in traditional Schlager (modern hybrid acts excepted); profanity; political content; abstract poetry — Schlager lyrics are direct and emotionally transparent
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-120 BPM. At ballad tempo (70-80 BPM): max 4 lines. Chorus: 4 lines, repeated. Topics: 1/verse max — Schlager lyrics are thematically simple and focused.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Traditional Schlager** | Classic post-war style with orchestral arrangements, clean vocals, and sentimental lyrics about love and longing; the foundation of the genre from the 1950s through 1970s | Freddy Quinn, Peter Alexander, Roy Black, Caterina Valente |
+| **Discoschlager** | Late 1970s-early 1980s fusion of Schlager melodies with disco beats, synthesizers, and dance-floor energy; blurred the line between Schlager and mainstream pop | Boney M. (crossover), Dschinghis Khan, Ireen Sheer, Mary Roos |
+| **Volkstümliche Musik** | Rural-oriented variant emphasizing accordion, brass, and Alpine folk elements; slower tempos, traditional dress aesthetics; strong TV presence (Musikantenstadl) | Hansi Hinterseer, Die Kastelruther Spatzen, Stefanie Hertel, Die Amigos |
+| **Partyschlager** | High-energy party variant with EDM influences, crowd-chant choruses, and often comedic or provocative lyrics; Ballermann/Mallorca culture; heavy bass and synth drops | Mickie Krause, Ikke Hüftgold, Lorenz Büffel, Tim Toupet |
+| **Pop-Schlager** | Modern mainstream Schlager blending contemporary pop production (EDM builds, electronic beats) with traditional Schlager vocal delivery and German lyrics; the dominant commercial form since 2010 | Helene Fischer, Vanessa Mai, Beatrice Egli, Ben Zucker |
+| **Herzschmerz-Schlager** | Ballad-heavy emotional Schlager focusing on heartbreak, longing, and romantic pain; lush string arrangements, dramatic vocal delivery, slower tempos | Andrea Berg, Semino Rossi, Claudia Jung, Michelle |
+| **Schlager-Rock** | Guitar-driven Schlager incorporating rock instrumentation and energy while maintaining German-language lyrics and Schlager melodic sensibility | Ben Zucker, Andreas Gabalier (crossover), Matthias Reim |
+| **Euro-Schlager** | Eurovision-adjacent style with multilingual hooks, key changes, and anthemic choruses; polished production designed for international contest appeal | Nicole, Udo Jürgens, Lena (crossover), Wind |
+| **Neue Deutsche Welle** | Early 1980s German-language new wave/synth-pop that briefly overlapped with Schlager; angular synths, ironic lyrics, punk-influenced attitude — technically separate but historically intertwined | Nena, Trio, Falco, Ideal |
+
+## Artists
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| Udo Jürgens | *Merci, Chérie*, *Griechischer Wein*, *Aber bitte mit Sahne* | 1960s-2014 | Sophisticated piano Schlager; Eurovision winner 1966; socially aware lyrics |
+| Helene Fischer | *Farbenspiel*, *Helene Fischer*, *Rausch* | 2006-present | Pop-Schlager queen; EDM-infused productions; arena spectacles |
+| Andrea Berg | *Machtlos*, *Abenteuer*, *Seelenbeben* | 1992-present | Herzschmerz ballads; emotional powerhouse; revitalized genre for younger audience |
+| Roland Kaiser | *Santa Maria*, *Alles oder Dich*, *Perspektiven* | 1980-present | Romantic mid-tempo Schlager; warm baritone; enduring live act |
+| Freddy Quinn | *Freddy*, *Heimweh*, *Die Gitarre und das Meer* | 1956-1990s | Pioneer; sailor/wanderer themes; post-war Schlager foundation |
+| Peter Alexander | *Hier ist ein Mensch*, *Verliebte Musik* | 1950s-1990s | Entertainer; operetta-influenced; comedic and romantic |
+| Nicole | *Ein bißchen Frieden*, *Alles fließt* | 1982-present | Eurovision 1982 winner; peace anthem; gentle delivery |
+| Roy Black | *Ganz in Weiß*, *Frag nur dein Herz* | 1960s-1991 | Classic romantic Schlager; warm tenor; teenage idol |
+| Howard Carpendale | *Hello Again*, *Dann geh doch* | 1970s-present | South African-born German Schlager star; polished pop-Schlager |
+| Matthias Reim | *Verdammt, ich lieb' dich*, *Unendlich* | 1990-present | Rock-influenced Schlager; raspy voice; one of Germany's biggest-selling singles |
+| Die Flippers | *Liebe ist...*, *Träumen mit den Flippers* | 1969-2011 | Keyboard-driven trio; soft romantic Schlager |
+| Nena | *Nena*, *?* (Fragezeichen) | 1983-present | NDW/crossover; "99 Luftballons"; pop-punk energy |
+| Jürgen Drews | *Ein Bett im Kornfeld*, *Wieder alles im Griff* | 1976-present | Party-Schlager pioneer; Mallorca culture icon |
+| Beatrice Egli | *Glücksgefühle*, *Bunt* | 2013-present | Modern pop-Schlager; DSDS winner; youthful energy |
+| Vanessa Mai | *Für Dich*, *Schlager* | 2015-present | EDM-Schlager hybrid; dance-influenced; young demographic |
+
+## Suno Prompt Keywords
+
+```
+schlager, deutscher schlager, german schlager, german pop, europop,
+accordion, keyboard, synthesizer, strings, brass section, orchestral pop,
+polished production, lush arrangement, reverb vocals, radio-friendly,
+upbeat, feel-good, singalong, party music, celebratory, romantic,
+sentimental, nostalgic, heartfelt, bittersweet, emotional ballad,
+clean vocals, powerful vocals, belted chorus, German lyrics, duet,
+danceable, four-on-the-floor, straight beat, waltz,
+volkstümliche musik, alpine, folk-pop, party schlager, discoschlager,
+eurovision, euro pop, schlagerparty, sommerhit,
+80s synth, modern pop production, EDM-influenced, anthemic chorus,
+crowd singalong, key change, dramatic, uplifting
+```
+
+## Reference Tracks
+
+- **Johann Strauss II - "An der schönen blauen Donau" (The Blue Danube)** — The 1867 waltz that gave Schlager its name. A Wiener Fremden-Blatt critic called it a "Schlager" (hit) on opening night. While technically a waltz, it established the concept of the crowd-pleasing, instantly memorable melody that defines the genre to this day.
+
+- **Freddy Quinn - "Die Gitarre und das Meer"** — Post-war Schlager's foundational hit (1959). Quinn's melancholic sailor-wanderer persona over gentle acoustic arrangement defined the genre's emotional template: longing for faraway places, wrapped in a simple, memorable melody. Reached #1 in Germany and stayed there.
+
+- **Udo Jürgens - "Griechischer Wein"** — The 1974 masterwork that elevated Schlager to social commentary. A song about guest workers' homesickness that became a cultural touchstone, reaching #1 in Germany and Switzerland. Jürgens' piano-driven arrangement and earnest delivery proved Schlager could carry weight without losing accessibility.
+
+- **Udo Jürgens - "Merci, Chérie"** — Eurovision 1966 winner for Austria. Piano-led romantic ballad with multilingual charm. Demonstrated Schlager's international potential and established Jürgens as the genre's most respected composer-performer.
+
+- **Nicole - "Ein bisschen Frieden"** — Germany's first Eurovision victory (1982). A gentle peace anthem with acoustic guitar and Nicole's pure vocal delivery. Became a symbol of Cold War-era longing and proved Schlager could carry a political message through simplicity.
+
+- **Matthias Reim - "Verdammt, ich lieb' dich"** — The 1990 mega-hit that sold over 2.5 million copies, one of the best-selling German-language singles ever. Rock guitar meets Schlager chorus; Reim's raspy delivery broke the mold of polished Schlager vocals and brought the genre into the reunification era.
+
+- **Roy Black - "Ganz in Weiß"** — The quintessential 1960s romantic Schlager. Black's warm tenor over lush orchestration singing about a bride in white — pure, unironic sentiment that defined an era. The gold standard for Herzschmerz-Schlager.
+
+- **Andrea Berg - "Du hast mich tausendmal belogen"** — Berg's 2001 breakthrough that revitalized Schlager for a new generation. Driving beat, passionate vocal, and a chorus built for arena singalongs. Proved that emotional Schlager could compete with mainstream pop.
+
+- **Helene Fischer - "Atemlos durch die Nacht"** — The 2013 track that became a national phenomenon. Kristina Bach's lyrics over Jean Frankfurter's EDM-inflected production created the biggest Schlager hit of the 21st century — the fifth most successful song in German chart history. Defined modern pop-Schlager's sound: four-on-the-floor beats, euphoric builds, and a chorus that every German knows.
+
+- **Dschinghis Khan - "Dschinghis Khan"** — The 1979 Eurovision entry that embodied Discoschlager at its most flamboyant. Pounding disco beat, chanting chorus, theatrical performance — camp and irresistible energy that influenced Partyschlager decades later.
+
+- **Nena - "99 Luftballons"** — The 1983 NDW/Schlager crossover that became a worldwide #1. Synth-driven anti-war song with an infectious hook, proving German-language pop could break internationally. Technically Neue Deutsche Welle, but permanently linked to the Schlager ecosystem.
+
+- **Howard Carpendale - "Hello Again"** — The 1984 hit that epitomizes polished 1980s pop-Schlager. Synth pads, clean production, and Carpendale's smooth delivery created a template that dominated German radio through the decade.
+
+- **Roland Kaiser - "Santa Maria"** — The 1980 Latin-flavored Schlager that showcased the genre's ability to absorb international influences. Kaiser's warm baritone over breezy arrangement became one of the most recognized Schlager songs of all time and remains a concert staple.

--- a/skills/genre-creator/SKILL.md
+++ b/skills/genre-creator/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: genre-creator
+description: Create new genre documentation files for the bitwize-music genre library. Use when the user wants to add a genre, says "/genre-creator", "neues Genre erstellen", "Genre hinzufuegen", "add genre", or asks to create genre documentation. Takes a genre name as argument.
+argument-hint: <genre-name e.g. "Math Rock" or "Nu-Metal">
+---
+
+# Genre Creator
+
+Create a new genre README.md for the bitwize-music genre library at `~/.claude/plugins/marketplaces/bitwize-music/genres/`.
+
+**Input**: $ARGUMENTS (genre name, e.g. "Math Rock", "Nu-Metal", "City Pop")
+
+## Workflow
+
+1. **Derive slug**: Lowercase, hyphenated (e.g. "Math Rock" → `math-rock`)
+2. **Check existence**: If `genres/{slug}/README.md` exists → abort, inform user
+3. **Check INDEX.md**: Read `genres/INDEX.md` to confirm genre is not already listed
+4. **Research**: Use WebSearch to verify key facts (origin year, pioneer artists, landmark albums) — do NOT guess dates or album names
+5. **Read 1-2 existing genre files** for structural reference (e.g. `genres/hip-hop/README.md`, `genres/phonk/README.md`)
+6. **Create directory**: `genres/{slug}/`
+7. **Write README.md** following the exact template below
+8. **Update INDEX.md**: Add genre to category table, alphabetical list, and all applicable Quick Reference tables (Tempo, Energy, Instrumentation, Vocals, Mood, Era)
+9. **Do NOT create** an `artists/` subdirectory — those are created separately when artist deep-dives are written
+
+## README.md Template
+
+The file starts directly with `# Genre Name` — no YAML frontmatter.
+
+ALWAYS use this exact section order:
+
+```
+# {Genre Name}
+
+## Genre Overview
+[3 paragraphs — see rules below]
+
+## Characteristics
+[6 bullet fields — see rules below]
+
+## Lyric Conventions
+[6 bullet fields — see rules below]
+
+## Subgenres & Styles
+[Table — see rules below]
+
+## Artists
+[Table — see rules below]
+
+## Suno Prompt Keywords
+[Code block — see rules below]
+
+## Reference Tracks
+[List — see rules below]
+```
+
+### Section Rules
+
+**## Genre Overview** — 3 paragraphs of prose (no bullets):
+- P1: Origin, cultural roots, pioneers with names and years
+- P2: Evolution across decades, key moments, mainstream breakthrough, regional variants
+- P3: Current state, influence on other genres, modern scene
+- Style: Encyclopedic but alive. Concrete names, years, albums. No vague claims.
+
+**## Characteristics** — Bullet list, exactly these 6 fields:
+- **Instrumentation**: Typical instruments, specific models/brands where relevant
+- **Vocals**: Singing style, vocal processing, delivery
+- **Production**: Production techniques, mix aesthetic, sonic character
+- **Energy/Mood**: Mood spectrum, emotional range
+- **Structure**: Song form, typical length, structural quirks
+- **Tempo**: BPM ranges per subgenre, rhythm feel (half-time, swing, straight etc.)
+
+**## Lyric Conventions** — Bullet list, exactly these 6 fields:
+- **Default rhyme scheme**: Typical scheme with shorthand (AABB, ABAB, XAXA etc.)
+- **Rhyme quality**: Expected quality (multisyllabic, slant, internal etc.)
+- **Verse structure**: Line count, bar structure
+- **Key rule**: THE single most important rule for lyrics in this genre
+- **Avoid**: What NOT to do in this genre
+- **Density/pacing (Suno)**: Format: `Default **X lines/verse** at Y BPM. [Context]. Topics: Z/verse.`
+
+**## Subgenres & Styles** — Markdown table:
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+
+- 6-12 subgenres
+- Description: 2-3 sentences with musical specifics, not just adjectives
+- Reference Artists: 3-4 per subgenre
+
+**## Artists** — Markdown table:
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+
+- 10-20 artists, mix of pioneers + peak-era + current acts
+- Albums in italics (*Album Name*)
+- If a deep-dive file exists: append `[Deep Dive](artists/slug.md)` to Style Focus
+
+**## Suno Prompt Keywords** — Fenced code block with comma-separated keywords organized in thematic lines:
+- Genre/subgenre labels
+- Instrument keywords
+- Production keywords
+- Mood/atmosphere keywords
+- Vocal keywords
+- Tempo/rhythm keywords
+- Era/aesthetic keywords
+- All keywords in English. Only use terms Suno actually understands.
+
+**## Reference Tracks** — 10-15 entries:
+- Format: `- **Artist - "Track Title"** — [Description]`
+- Description: 2-3 sentences. Explain WHAT makes this track a genre reference point. Name concrete musical elements. Explain historical/cultural significance.
+- Chronological spread from founding tracks to modern representatives
+
+## Quality Rules
+
+1. **Factual accuracy**: All years, album names, artist names must be correct. Omit rather than guess. Use WebSearch to verify.
+2. **No AI cliches**: Ban these phrases: "tapestry of sound", "sonic landscape", "testament to", "rich tapestry", "sonic journey", "pushing boundaries", "transcends genre". Write direct, concrete prose.
+3. **Suno focus**: Lyric Conventions and Suno Keywords are the most important sections — they directly drive music generation quality.
+4. **Subgenre deduplication**: If a subgenre already has its own genre directory (e.g. Trap exists as standalone genre), reference it instead of duplicating content.
+5. **Language**: English (the entire genre system is in English)
+6. **No empty sections**: Every section must have substantive content. If unsure about a section, research first.


### PR DESCRIPTION
## Summary

- **Schlager genre**: Full documentation (68th genre) covering German-language popular music — from post-war ballads (Freddy Quinn, Peter Alexander) through NDW (Nena, Falco) to modern EDM-infused party Schlager (Helene Fischer, Andreas Gabalier). Includes all 8 standard sections: Overview, Characteristics, Lyric Conventions, Subgenres, Artists, Suno Keywords, and Reference Tracks.
- **INDEX.md update**: New "European Pop" category, Schlager added to alphabetical list and all Quick Reference tables (Tempo, Energy, Instrumentation, Vocals, Mood, Era).
- **genre-creator skill**: New skill (`/bitwize-music:genre-creator <name>`) that standardizes creation of new genre files — enforces consistent section order, fact-checks via WebSearch, and auto-updates INDEX.md.

## Test plan

- [ ] Verify `genres/schlager/README.md` follows the standard 8-section structure
- [ ] Verify INDEX.md genre count updated to 68
- [ ] Verify Schlager appears in all applicable Quick Reference tables
- [ ] Test genre-creator skill with `/bitwize-music:genre-creator <test-genre>`
- [ ] Verify genre-creator aborts if genre already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)