### PR TITLE
feat(genres): add Schlager, Chanson, and Middle Eastern Pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Schlager genre** — Full genre documentation with subgenres, artists, reference tracks, and Suno prompt keywords
+- **Chanson genre** — French chanson documentation covering réaliste, à texte, rive gauche, musette, nouvelle chanson and more
+- **Middle Eastern Pop genre** — Arabic, Israeli, and North African pop covering raï, Mizrahi, khaleeji, mahraganat, and Arabic-electronic fusion
+- **Mastering presets** — Added Schlager, Chanson, and Middle Eastern Pop (with aliases for arabic-pop, rai, mizrahi, mahraganat) to both `genre-presets.yaml` and `genre-presets.md`
+- **Genre-creator skill update** — Added step 9 to genre-creator workflow: update mastering preset files when creating new genres
+
 ## [0.71.0] - 2026-03-21
 
 ### Added

--- a/genres/INDEX.md
+++ b/genres/INDEX.md
@@ -1,6 +1,6 @@
 # Genre Index
 
-A searchable, categorized guide to all 67 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
+A searchable, categorized guide to all 70 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
 
 ---
 
@@ -17,6 +17,8 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 - [Classical and Opera](#classical-and-opera)
 - [Reggae and Caribbean](#reggae-and-caribbean)
 - [Latin](#latin)
+- [Middle Eastern](#middle-eastern)
+- [European Pop](#european-pop)
 - [Other Genres](#other-genres)
 - [Quick Reference: Find by Characteristic](#quick-reference-find-by-characteristic)
 - [Genre Combinations](#genre-combinations)
@@ -145,6 +147,19 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 |-------|-------------|------|
 | **Latin** | Clave-based rhythms from salsa to reggaeton; pan-American scope | [README](latin/README.md) |
 
+## Middle Eastern
+
+| Genre | Description | Link |
+|-------|-------------|------|
+| **Middle Eastern Pop** | Arabic, Israeli, and North African pop fusing maqam melodies, oud, and darbuka with Western pop, electronic, and dance production | [README](middle-eastern-pop/README.md) |
+
+## European Pop
+
+| Genre | Description | Link |
+|-------|-------------|------|
+| **Chanson** | French-language vocal tradition emphasizing literary lyrics, melodic sophistication, and emotional delivery; from Piaf's cabaret to nouvelle chanson | [README](chanson/README.md) |
+| **Schlager** | German-language popular music with catchy melodies, sentimental lyrics, and singalong choruses; from post-war ballads to EDM-infused party hits | [README](schlager/README.md) |
+
 ---
 
 ## Quick Reference: Find by Characteristic
@@ -153,10 +168,10 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 
 | Speed | Genres |
 |-------|--------|
-| **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads |
-| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time) |
-| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Synthwave](synthwave/README.md) |
-| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md) |
+| **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads, [Chanson](chanson/README.md) (ballads) |
+| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (ballads) |
+| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) |
+| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat) |
 | **Very Fast (140-180+ BPM)** | [Drum and Bass](drum-and-bass/README.md), [Thrash Metal](thrash-metal/README.md), [Hardcore Punk](hardcore-punk/README.md), [Black Metal](black-metal/README.md) |
 
 ### By Energy Level
@@ -164,21 +179,23 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 | Energy | Genres |
 |--------|--------|
 | **Chill/Relaxed** | [Ambient](ambient/README.md), [Lo-Fi](lo-fi/README.md), [Bossa Nova](bossa-nova/README.md), [Chillwave](chillwave/README.md), [Trip-Hop](trip-hop/README.md), [Indie Folk](indie-folk/README.md) |
-| **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md) |
-| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md) |
+| **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md), [Chanson](chanson/README.md) |
+| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat) |
 | **Aggressive** | [Metal](metal/README.md), [Punk](punk/README.md), [Drill](drill/README.md), [Dubstep](dubstep/README.md), [Industrial](industrial/README.md), [Grime](grime/README.md) |
-| **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Disco](disco/README.md) |
+| **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Disco](disco/README.md), [Schlager](schlager/README.md) |
 
 ### By Instrumentation
 
 | Primary Sound | Genres |
 |---------------|--------|
-| **Acoustic Guitar** | [Folk](folk/README.md), [Country](country/README.md), [Americana](americana/README.md), [Indie Folk](indie-folk/README.md), [Blues](blues/README.md) (acoustic), [Singer-Songwriter](singer-songwriter/README.md) |
+| **Acoustic Guitar** | [Folk](folk/README.md), [Country](country/README.md), [Americana](americana/README.md), [Indie Folk](indie-folk/README.md), [Blues](blues/README.md) (acoustic), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md) |
 | **Electric Guitar** | [Rock](rock/README.md), [Metal](metal/README.md), [Blues](blues/README.md), [Punk](punk/README.md), [Grunge](grunge/README.md), [Shoegaze](shoegaze/README.md) |
-| **Synthesizers** | [Electronic](electronic/README.md), [Synthwave](synthwave/README.md), [Trance](trance/README.md), [House](house/README.md), [Ambient](ambient/README.md), [Hyperpop](hyperpop/README.md) |
+| **Synthesizers** | [Electronic](electronic/README.md), [Synthwave](synthwave/README.md), [Trance](trance/README.md), [House](house/README.md), [Ambient](ambient/README.md), [Hyperpop](hyperpop/README.md), [Schlager](schlager/README.md) |
 | **808/Drum Machines** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Phonk](phonk/README.md), [House](house/README.md), [Techno](techno/README.md) |
 | **Orchestra** | [Classical](classical/README.md), [Opera](opera/README.md), [Cinematic](cinematic/README.md), [Disco](disco/README.md) (strings) |
-| **Piano** | [Classical](classical/README.md), [Jazz](jazz/README.md), [Gospel](gospel/README.md), [Blues](blues/README.md), [Pop](pop/README.md) ballads, [Piano Rock](piano-rock/README.md), [Piano Pop](piano-pop/README.md) |
+| **Piano** | [Classical](classical/README.md), [Jazz](jazz/README.md), [Gospel](gospel/README.md), [Blues](blues/README.md), [Pop](pop/README.md) ballads, [Piano Rock](piano-rock/README.md), [Piano Pop](piano-pop/README.md), [Chanson](chanson/README.md) |
+| **Accordion** | [Chanson](chanson/README.md) (musette), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï) |
+| **Oud/Qanun** | [Middle Eastern Pop](middle-eastern-pop/README.md) |
 | **Brass/Horns** | [Jazz](jazz/README.md), [Funk](funk/README.md), [Ska Punk](ska-punk/README.md), [Latin](latin/README.md), [Gospel](gospel/README.md) |
 | **Banjo/Fiddle** | [Bluegrass](bluegrass/README.md), [Folk](folk/README.md), [Country](country/README.md), [Celtic Punk](celtic-punk/README.md) |
 
@@ -186,10 +203,10 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 
 | Vocal Approach | Genres |
 |----------------|--------|
-| **Powerful/Belted** | [Gospel](gospel/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Pop](pop/README.md), [Rock](rock/README.md) |
+| **Powerful/Belted** | [Gospel](gospel/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Pop](pop/README.md), [Rock](rock/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) (réaliste), [Middle Eastern Pop](middle-eastern-pop/README.md) |
 | **Rapped/Spoken** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Grime](grime/README.md), [Nerdcore](nerdcore/README.md) |
 | **Screamed/Harsh** | [Metal](metal/README.md), [Punk](punk/README.md), [Metalcore](metalcore/README.md), [Emo](emo/README.md), [Industrial](industrial/README.md) |
-| **Intimate/Whispered** | [Folk](folk/README.md), [Indie Folk](indie-folk/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Singer-Songwriter](singer-songwriter/README.md) |
+| **Intimate/Whispered** | [Folk](folk/README.md), [Indie Folk](indie-folk/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md) (à texte) |
 | **Processed/Pitch-Shifted** | [Hyperpop](hyperpop/README.md), [Vaporwave](vaporwave/README.md), [Trap](trap/README.md), [Electronic](electronic/README.md) |
 | **Primarily Instrumental** | [Ambient](ambient/README.md), [Post-Rock](post-rock/README.md), [Techno](techno/README.md), [Classical](classical/README.md), [Jazz](jazz/README.md) (much of it) |
 
@@ -198,18 +215,18 @@ A searchable, categorized guide to all 67 genre documentation files in this repo
 | Mood | Genres |
 |------|--------|
 | **Dark/Brooding** | [Black Metal](black-metal/README.md), [Doom Metal](doom-metal/README.md), [Industrial](industrial/README.md), [Drill](drill/README.md), [Grunge](grunge/README.md), [Trip-Hop](trip-hop/README.md) |
-| **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md) |
-| **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md) |
+| **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) |
+| **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) |
 | **Rebellious/Defiant** | [Punk](punk/README.md), [Hip-Hop](hip-hop/README.md), [Metal](metal/README.md), [Grime](grime/README.md) |
 | **Spiritual/Transcendent** | [Gospel](gospel/README.md), [Ambient](ambient/README.md), [Trance](trance/README.md), [Reggae](reggae/README.md), [Classical](classical/README.md) |
-| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md) |
+| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat) |
 
 ### By Era/Aesthetic
 
 | Era | Genres |
 |-----|--------|
-| **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md) |
-| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md) |
+| **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (golden age) |
+| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md) |
 | **1990s** | [Grunge](grunge/README.md), [Hip-Hop](hip-hop/README.md), [Trip-Hop](trip-hop/README.md), [Trance](trance/README.md), [House](house/README.md) |
 | **2000s-2010s** | [EDM](edm/README.md), [Trap](trap/README.md), [Dubstep](dubstep/README.md), [Hyperpop](hyperpop/README.md), [Lo-Fi](lo-fi/README.md) |
 | **Internet/Modern** | [Vaporwave](vaporwave/README.md), [Hyperpop](hyperpop/README.md), [Phonk](phonk/README.md), [Drill](drill/README.md), [Lo-Fi](lo-fi/README.md) |
@@ -256,6 +273,18 @@ These genres commonly blend well together or have natural crossover potential:
 - [Afrobeats](afrobeats/README.md) + [Pop](pop/README.md) = Afropop
 - [Bossa Nova](bossa-nova/README.md) + [Jazz](jazz/README.md) = Brazilian jazz
 
+### Middle Eastern Fusions
+- [Middle Eastern Pop](middle-eastern-pop/README.md) + [Electronic](electronic/README.md) = Arabic-electronic fusion, Acid Arab
+- [Middle Eastern Pop](middle-eastern-pop/README.md) + [Hip-Hop](hip-hop/README.md) = Arabic rap, Mizrahi hip-hop
+- [Middle Eastern Pop](middle-eastern-pop/README.md) + [Rock](rock/README.md) = Arabic rock, raï-rock (Rachid Taha)
+- [Middle Eastern Pop](middle-eastern-pop/README.md) + [Chanson](chanson/README.md) = Mediterranean crossover (Natacha Atlas)
+
+### Chanson Fusions
+- [Chanson](chanson/README.md) + [Jazz](jazz/README.md) = Jazz-chanson, cabaret jazz
+- [Chanson](chanson/README.md) + [Electronic](electronic/README.md) = Electro-chanson (Stromae)
+- [Chanson](chanson/README.md) + [Pop](pop/README.md) = French pop, chanson-pop
+- [Chanson](chanson/README.md) + [Singer-Songwriter](singer-songwriter/README.md) = Chanson à texte, literary songwriting
+
 ### Cinematic Applications
 - [Cinematic](cinematic/README.md) + [Synthwave](synthwave/README.md) = Retro-futurist scores
 - [Ambient](ambient/README.md) + [Classical](classical/README.md) = Neo-classical, film underscore
@@ -277,6 +306,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Blues | Roots | [README](blues/README.md) |
 | Bossa Nova | Jazz/World | [README](bossa-nova/README.md) |
 | Celtic Punk | Rock | [README](celtic-punk/README.md) |
+| Chanson | European Pop | [README](chanson/README.md) |
 | Chillwave | Electronic | [README](chillwave/README.md) |
 | Cinematic | Orchestral | [README](cinematic/README.md) |
 | Classical | Orchestral | [README](classical/README.md) |
@@ -309,6 +339,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Lo-Fi | Electronic | [README](lo-fi/README.md) |
 | Metal | Metal | [README](metal/README.md) |
 | Metalcore | Metal | [README](metalcore/README.md) |
+| Middle Eastern Pop | Middle Eastern | [README](middle-eastern-pop/README.md) |
 | Nerdcore | Hip-Hop | [README](nerdcore/README.md) |
 | New Wave | Rock/Electronic | [README](new-wave/README.md) |
 | Opera | Classical | [README](opera/README.md) |
@@ -323,6 +354,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Reggae | Caribbean | [README](reggae/README.md) |
 | R&B | Soul | [README](rnb/README.md) |
 | Rock | Rock | [README](rock/README.md) |
+| Schlager | European Pop | [README](schlager/README.md) |
 | Shoegaze | Rock | [README](shoegaze/README.md) |
 | Singer-Songwriter | Folk/Pop | [README](singer-songwriter/README.md) |
 | Ska Punk | Rock | [README](ska-punk/README.md) |
@@ -350,4 +382,4 @@ These genres commonly blend well together or have natural crossover potential:
    - Reference artists and albums
    - Suno prompt keywords for AI generation
 
-**Total genres documented: 67**
+**Total genres documented: 70**

--- a/genres/chanson/README.md
+++ b/genres/chanson/README.md
@@ -1,0 +1,93 @@
+# Chanson
+
+## Genre Overview
+
+Chanson — literally "song" in French — refers to a tradition of French-language vocal music that places literary lyrics, melodic sophistication, and emotional delivery at its center. The genre's modern roots trace to the Parisian café-concert and cabaret culture of the late 19th century, where performers like Aristide Bruant brought stories of street life to Montmartre stages in the 1880s and 1890s. Chanson réaliste emerged from this milieu, with female performers like Damia and Fréhel singing raw, unflinching portraits of poverty and heartbreak. The genre transformed in the 1930s when Charles Trenet — "le fou chantant" — introduced jazz-inflected phrasing, personal songwriting, and a lighter, more optimistic tone with songs like "La Mer" (1946). Édith Piaf, whose career began in the mid-1930s, became chanson's most iconic voice, delivering songs like "La Vie en Rose" (1947) and "Non, je ne regrette rien" (1960) with a dramatic intensity that defined the genre for a global audience.
+
+The post-war period from the late 1940s through the 1960s is chanson's golden age. Three towering figures redefined what the genre could be: Jacques Brel, the Belgian whose theatrical intensity and literary ambition produced masterpieces like "Ne me quitte pas" (1959) and "Amsterdam" (1964); Georges Brassens, whose witty, anarchist poetry set to spare guitar accompaniment became a model for the singer-songwriter tradition; and Léo Ferré, who merged chanson with orchestral arrangements and political provocation. This era also saw Boris Vian's satirical "Le Déserteur" (1954), Barbara's confessional piano-driven songs, and Serge Gainsbourg's genre-bending experiments that pushed chanson into rock, reggae, and electronic territory from the 1960s through the 1980s. The rive gauche (Left Bank) scene of Saint-Germain-des-Prés became the genre's intellectual epicenter, where existentialist philosophy met cabaret performance.
+
+Chanson has proven remarkably durable. The nouvelle chanson movement of the late 1990s and 2000s brought a new generation — Benjamin Biolay, Camille, Olivia Ruiz, Keren Ann — who absorbed indie rock, electronic, and world music influences while maintaining the genre's core commitment to French-language lyrical craft. Zaz's debut album (2010) brought jazz-inflected chanson back to mainstream charts. Stromae, though often classified as electro-pop, draws heavily on chanson's tradition of narrative songwriting and social commentary. Clara Luciani, Pomme, and Juliette Armanet continue the tradition into the 2020s, proving that chanson's emphasis on words, melody, and emotional truth remains vital — not as a museum piece, but as a living, evolving practice.
+
+## Characteristics
+
+- **Instrumentation**: Acoustic guitar (nylon-string classical), piano, accordion (particularly in musette-influenced styles), upright bass, orchestral strings and woodwinds. Spare arrangements are traditional — voice plus guitar (Brassens model) or voice plus piano (Barbara model). Orchestral arrangements range from lush (Brel's later work with François Rauber) to intimate chamber settings. Modern chanson incorporates electric guitar, synthesizers, drum machines, and electronic textures while maintaining vocal primacy.
+- **Vocals**: The voice is the absolute center. Delivery ranges from intimate and conversational (Brassens, Gainsbourg) to theatrical and declamatory (Brel, Piaf). Emotional expressiveness is paramount — chanson singers act their songs as much as sing them. Vibrato, dynamic control, and diction are prized. French pronunciation and phrasing give the genre its distinctive musicality. Vocal processing is minimal in traditional chanson; modern artists may use reverb, delay, or light effects.
+- **Production**: Traditional chanson is recorded with transparency — the voice upfront, accompaniment supportive. Studio recordings often aim to capture the feel of a live cabaret performance. Orchestral arrangements, when present, serve the song's dramatic arc. Modern nouvelle chanson production ranges from lo-fi indie aesthetics to polished pop, but the lyric always remains intelligible and central.
+- **Energy/Mood**: Intimate, dramatic, melancholic, wistful, satirical, or joyous — chanson spans the full emotional range but favors depth over surface excitement. The predominant moods are romantic longing, existential reflection, social observation, and bittersweet nostalgia. Even uptempo chanson tends toward sophistication rather than raw energy. Humor — from Brassens's dry wit to Gainsbourg's provocation — is a vital thread.
+- **Structure**: Verse-driven with optional refrains. Many classic chansons are through-composed or use minimal repetition, letting the narrative unfold without rigid pop structure. When a refrain exists, it typically evolves in meaning with each repetition. Typical length is 3-5 minutes, though narrative songs can extend further. Introductions are often atmospheric, setting a scene before the vocal enters.
+- **Tempo**: Generally moderate. Ballads: 50-80 BPM. Mid-tempo: 80-120 BPM. Waltz/musette: 100-140 BPM in 3/4 time. Uptempo swing or java: 120-160 BPM. Chanson favors rhythmic flexibility — rubato, tempo shifts, and dramatic pauses are common expressive tools.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB (couplet) or ABAB — classical French prosody favors clean rhyme. Rimes riches (rich rhymes sharing multiple ending sounds) are valued in the tradition. XAXA also common in more conversational styles.
+- **Rhyme quality**: Clean end rhymes expected in traditional chanson. Rich and sufficient rhymes preferred over approximate rhymes. Internal rhyme and assonance add texture. Modern chanson permits more flexibility, but sloppy rhyming signals lack of craft.
+- **Verse structure**: Typically 4-8 lines per verse, often with a recurring refrain of 2-4 lines. Strophic form (same melody, different lyrics per verse) is the classic model. Bridge sections are less common than in Anglo-American pop — the verse itself carries the narrative weight.
+- **Key rule**: The lyric IS the song. Words must be literary, specific, and emotionally true. Every line should earn its place — chanson does not tolerate filler. Wordplay, double meanings, and poetic imagery are expected. Write as if the lyric must stand alone as a poem.
+- **Avoid**: Generic love clichés without specific imagery. English loanwords (unless used deliberately for effect). Overly simplistic vocabulary — chanson audiences expect linguistic sophistication. Repetitive hooks that substitute for lyrical substance.
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 80-110 BPM. Narrative-driven — each verse advances the story or deepens the emotion. Topics: 1-2/verse (chanson goes deep, not wide). At waltz tempo (3/4), reduce to **4-6 lines/verse**.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Chanson réaliste** | Raw, dramatic songs depicting working-class Parisian life — poverty, prostitution, heartbreak, and street violence. Born in Montmartre cabarets of the 1880s-1930s. Emotionally intense, often tragic, performed primarily by women with powerful voices. | Édith Piaf, Damia, Fréhel, Mistinguett |
+| **Chanson à texte** | Lyric-centered chanson emphasizing poetic quality, intellectual depth, and literary ambition. The words are paramount — accompaniment is deliberately spare to foreground the text. Often politically engaged or philosophically reflective. | Georges Brassens, Léo Ferré, Jacques Brel, Jean Ferrat |
+| **Chanson rive gauche** | Intellectual, Left Bank chanson associated with the existentialist Saint-Germain-des-Prés scene of the 1950s-60s. Characterized by literary wit, sophisticated wordplay, and an intimate cabaret performance style. | Boris Vian, Juliette Gréco, Serge Reggiani, Mouloudji |
+| **Musette / Bal-musette** | Accordion-driven Parisian dance music originating in working-class dance halls. Features waltz (3/4), java, and polka rhythms with nostalgic, sentimental melodies. The accordion's tremolo tuning gives musette its distinctive warm, slightly melancholic timbre. | Yvette Horner, Émile Vacher, Jo Privat, Marcel Azzola |
+| **Yéyé** | 1960s French pop heavily influenced by American and British rock'n'roll and twist. Light, youthful, often with simple lyrics about love and fun. Named after the "yeah yeah" exclamations in English-language pop. More pop than traditional chanson but part of the broader French popular song landscape. | France Gall, Françoise Hardy, Sylvie Vartan, Jacques Dutronc |
+| **Chanson engagée** | Politically committed chanson addressing social injustice, war, colonialism, and class struggle. Direct in its messaging but crafted with poetic skill. Flourished during the Algerian War, May 1968, and periods of social upheaval. | Léo Ferré, Jean Ferrat, Boris Vian, Renaud |
+| **Nouvelle chanson** | Late 1990s/2000s renewal of French chanson adopting contemporary pop, indie, folk, and electronic aesthetics while maintaining the tradition's commitment to French-language lyrical craft. More sonically diverse than its predecessors. | Benjamin Biolay, Camille, Olivia Ruiz, Keren Ann |
+| **Chanson jazz** | Fusion of chanson's lyrical tradition with jazz harmony, swing rhythms, and improvisation. Ranges from cabaret-jazz intimacy to full big-band arrangements. Gainsbourg's early work and modern artists like Zaz draw from this intersection. | Charles Trenet, Serge Gainsbourg (early), Zaz, Madeleine Peyroux |
+| **Chanson rock** | Electric guitar and rock energy merged with chanson's lyrical ambition. Gainsbourg's later work pioneered this fusion; Noir Désir and Téléphone brought rock intensity to French-language songwriting without abandoning narrative depth. | Serge Gainsbourg (late), Noir Désir, Téléphone, Hubert-Félix Thiéfaine |
+
+## Artists
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| Édith Piaf | *La Vie en Rose* (compilations), *Récital 1961* | 1935-1963 | Chanson réaliste; dramatic intensity, powerful vocal delivery |
+| Charles Trenet | *Le Fou chantant*, *La Mer* (compilations) | 1937-1999 | Jazz-inflected chanson; optimistic, inventive phrasing |
+| Jacques Brel | *Olympia 64*, *Ces gens-là*, *J'arrive* | 1953-1977 | Chanson à texte; theatrical, emotionally devastating performances |
+| Georges Brassens | *La Mauvaise Réputation*, *Les Copains d'abord* | 1952-1981 | Chanson à texte; anarchist wit, acoustic guitar, spare arrangements |
+| Léo Ferré | *Avec le temps*, *Amour Anarchie* | 1946-1993 | Chanson engagée; orchestral ambition, political provocation |
+| Serge Gainsbourg | *Confidentiel*, *Histoire de Melody Nelson*, *L'Homme à tête de chou* | 1958-1991 | Genre-bending; jazz, rock, reggae, electronic — always provocative |
+| Barbara | *Ma plus belle histoire d'amour*, *L'Aigle noir* | 1955-1996 | Confessional piano chanson; intimate, emotionally raw |
+| Juliette Gréco | *Jolie Môme*, *Déshabillez-moi* | 1949-2015 | Rive gauche; existentialist cabaret, literary sophistication |
+| Françoise Hardy | *Tous les garçons et les filles*, *La Question* | 1962-2023 | Yéyé to sophisticated chanson; melancholic elegance |
+| Jacques Dutronc | *Et moi, et moi, et moi*, *Guerre et pets* | 1966-present | Ironic, playful chanson-pop; sardonic humor |
+| Renaud | *Mistral gagnant*, *Morgane de toi* | 1975-present | Chanson engagée; working-class narratives, argot, social commentary |
+| Benjamin Biolay | *Rose Kennedy*, *La Superbe*, *Grand Prix* | 2000-present | Nouvelle chanson; cinematic arrangements, Gainsbourg heir |
+| Camille | *Le Fil*, *Music Hole* | 2002-present | Experimental nouvelle chanson; vocal layering, minimalist production |
+| Zaz | *Zaz*, *Recto Verso* | 2010-present | Jazz-chanson; raw energy, street-performance roots |
+| Stromae | *Cheese*, *Racine carrée*, *Multitude* | 2010-present | Electro-chanson; social commentary, hip-hop and electronic fusion |
+| Clara Luciani | *Sainte-Victoire*, *Coeur* | 2018-present | Modern chanson-pop; vintage aesthetics, feminist perspective |
+| Pomme | *Les Failles*, *Consolation* | 2019-present | Indie-folk chanson; intimate, queer perspective, acoustic warmth |
+| Juliette Armanet | *Petite Amie*, *Brûler le feu* | 2017-present | Piano-driven chanson-pop; romantic, disco-influenced |
+
+## Suno Prompt Keywords
+
+```
+chanson, chanson française, French chanson, chanson à texte, nouvelle chanson,
+accordion, musette, nylon guitar, classical guitar, piano, upright bass, orchestral strings, chamber orchestra,
+warm production, intimate recording, cabaret sound, live feel, orchestral arrangement,
+melancholic, romantic, wistful, bittersweet, nostalgic, dramatic, intimate, satirical,
+French vocals, expressive singing, theatrical delivery, conversational vocals, dramatic vibrato,
+waltz, 3/4 time, rubato, swing feel, moderate tempo, ballad,
+Parisian, café, cabaret, rive gauche, retro French, vintage French, 1960s French
+```
+
+## Reference Tracks
+
+- **Édith Piaf - "La Vie en Rose"** — Written in 1945, popularized in 1946. The definitive chanson réaliste performance — Piaf's voice transforms a simple love song into something monumental. The spare orchestral arrangement keeps focus entirely on her vocal delivery. Became France's most internationally recognized song.
+- **Charles Trenet - "La Mer"** — Recorded in 1946. Trenet's jazz-influenced phrasing and buoyant melody created the template for modern chanson's lighter side. The song's flowing structure mirrors its oceanic subject. Later adapted as "Beyond the Sea" by Bobby Darin.
+- **Georges Brassens - "La Mauvaise Réputation"** — Released in 1952. Brassens's debut single established the chanson à texte model: one man, one guitar, and lyrics sharp enough to cut. The anarchist humor and deceptively simple melody set the standard for text-driven chanson.
+- **Boris Vian - "Le Déserteur"** — Written in 1954, first recorded by Mouloudji. An anti-war letter addressed to the French president during the First Indochina War. Banned from French radio, it became chanson engagée's most famous statement — proof that a song could be a political act.
+- **Jacques Brel - "Ne me quitte pas"** — Recorded in 1959. Brel described it not as a love song but as "a hymn to the cowardice of men." The song builds from whispered pleading to theatrical desperation across its verses. The orchestral arrangement by François Rauber is a masterclass in dramatic escalation.
+- **Jacques Brel - "Amsterdam"** — Performed live at the Olympia in 1964. Brel's most physically intense performance — starting with a quiet waltz tempo and building to near-violent catharsis. The song tells a single night among sailors in Amsterdam's port with cinematic specificity.
+- **Serge Gainsbourg - "La Javanaise"** — Released in 1963. Gainsbourg's jazz-chanson period distilled: elegant wordplay, a bossa nova-tinged arrangement, and a melody that makes sophisticated harmony sound effortless. The title is a play on "javanais," a French slang language.
+- **Barbara - "L'Aigle noir"** — Released in 1970. A haunting, piano-driven song built on an insistent arpeggio figure and autobiographical imagery. Barbara's vocal delivery shifts between dreamlike calm and raw emotion. Widely interpreted as addressing childhood trauma.
+- **Serge Gainsbourg - "Bonnie and Clyde"** — Released in 1968 with Brigitte Bardot. Gainsbourg merging chanson storytelling with pop-rock instrumentation and cinematic narrative. The spoken-word passages over driving guitar anticipate chanson's future fusions.
+- **Renaud - "Mistral gagnant"** — Released in 1985. A father's letter to his daughter, recalling childhood candy and fearing the passage of time. Written in Renaud's signature argot-laced French, it is frequently voted France's greatest chanson — proof that the genre remained vital decades after its golden age.
+- **Benjamin Biolay - "La Superbe"** — Title track from his 2009 album. A sprawling, orchestral chanson that earned Biolay the title of Gainsbourg's spiritual successor. Rich string arrangements, literary lyrics, and a cinematic scope that bridges classic and contemporary chanson.
+- **Stromae - "Papaoutai"** — Released in 2013 from *Racine carrée*. Electronic production, hip-hop rhythms, and a chanson's narrative depth — Stromae asking where his absent father is. Demonstrates how chanson's lyrical tradition adapts to 21st-century production without losing emotional weight.
+- **Zaz - "Je veux"** — Released in 2010. A jazz-chanson manifesto rejecting materialism, delivered with street-performer energy over a swinging acoustic arrangement. Brought gypsy-jazz-inflected chanson back to mainstream French charts and international audiences.
+- **Clara Luciani - "La Grenade"** — Released in 2018. Modern chanson-pop with vintage synthesizers and a disco pulse, yet the lyric — a feminist statement of self-worth — carries the weight and specificity of the chanson tradition. Bridges the gap between classic chanson and contemporary pop production.

--- a/genres/middle-eastern-pop/README.md
+++ b/genres/middle-eastern-pop/README.md
@@ -1,0 +1,93 @@
+# Middle Eastern Pop
+
+## Genre Overview
+
+Middle Eastern pop is a broad fusion genre that merges the melodic traditions of the Arab world, North Africa, and the Eastern Mediterranean with Western pop, rock, and electronic production. The genre's roots reach back to the golden age of Arabic music in the mid-20th century, when composers like Mohamed Abdel Wahab introduced Western orchestral instruments into the Egyptian tarab tradition, and Umm Kulthum's legendary performances — including "Enta Omri" (1964), which featured an electric guitar intro over a traditional orchestra — demonstrated that East-West fusion could create something greater than either tradition alone. Abdel Halim Hafez brought romantic Arabic singing to a younger generation, while Fairuz and the Rahbani brothers in Lebanon created a sophisticated fusion of Arabic melody with European orchestral and theatrical forms from the 1950s onward.
+
+The genre exploded internationally in the 1980s and 1990s through several parallel movements. In Algeria, raï music — born in Oran's working-class neighborhoods in the 1920s — was electrified by Khaled, whose "Didi" (1992) became a global hit and whose "Aïcha" (1996) crossed into European mainstream pop. In Israel, Ofra Haza fused Yemenite Jewish folk melodies with synth-pop and dance beats on *Yemenite Songs* (1984) and *Shaday* (1988), becoming one of the first Middle Eastern artists to chart worldwide. In Egypt, Amr Diab's "Nour El Ain" (1996) coined the term "Mediterranean music" for its blend of Arabic vocals with Spanish guitar, French accordion, and electronic beats, selling millions across the region and beyond. Natacha Atlas, working from London with Transglobal Underground, pioneered Arabic-electronic fusion on albums like *Halim* (1997) and *Gedida* (1999), proving that Arabic vocals and maqam melodies could sit naturally over drum'n'bass and trip-hop beats.
+
+The 21st century has seen the genre fragment into vibrant regional scenes. Egyptian mahraganat (electro-shaabi) brought auto-tuned street music to global attention. Mizrahi pop dominates Israeli charts through artists like Eyal Golan, Sarit Hadad, and A-WA, who blend Yemenite folk with electronic and hip-hop production. Khaleeji pop from the Gulf states fuses traditional percussion with slick modern production. Mashrou' Leila brought indie rock sensibilities to Arabic songwriting from Beirut. Artists like Balqees, Elissa, and Nancy Ajram continue the Egyptian-Lebanese pop tradition with increasingly globalized production, while diaspora artists blend Arabic traditions with hip-hop, R&B, and electronic music. The genre's influence extends into Western pop — from Sting's collaboration with Cheb Mami on "Desert Rose" (1999) to the ongoing use of Middle Eastern scales and instruments in contemporary global pop production.
+
+## Characteristics
+
+- **Instrumentation**: Traditional instruments include oud (fretless lute), qanun (plucked zither), ney (end-blown flute), darbuka/tabla (goblet drum), riq (tambourine), kamancheh (spike fiddle), and buzuq (long-necked lute). Modern productions layer these over Western instruments — synthesizers, electric guitars, bass, drum machines, and full orchestral sections. The accordion features prominently in raï. Mizrahi pop favors electronic beats with Middle Eastern percussion. String sections (both Arabic takht ensemble and Western orchestral) are used extensively across all subgenres.
+- **Vocals**: Highly melismatic with ornamental runs (tarab tradition). Maqam-based melodies using quarter tones create intervals absent in Western music. Vocal delivery ranges from the restrained intimacy of Fairuz to the ecstatic power of Umm Kulthum's extended improvisations. Modern pop styles favor cleaner, less ornamented delivery. Raï vocals use a distinctive raw, gritty timbre. Auto-tune is common in mahraganat and modern Gulf pop. Arabic, Hebrew, French, and Amazigh (Berber) are the primary languages.
+- **Production**: Traditional acoustic recordings emphasize the takht (small ensemble) or firqa (large orchestra). Modern production ranges from lush orchestral pop (Amr Diab, Nancy Ajram) to raw electronic street music (mahraganat). Synth-pop and dance production dominate since the late 1980s. Quarter-tone melodies are approximated through pitch bending and microtonal tuning. Reverb is used liberally to create spatial depth. Bass-heavy mixes are standard in contemporary productions.
+- **Energy/Mood**: Spans from contemplative tarab (musical ecstasy through extended listening) to high-energy dance music. Romantic longing is the dominant emotional register in Arabic pop. Raï carries rebellious, street-level energy. Mahraganat is raw party music. Mizrahi pop oscillates between sentimental ballads and euphoric celebration. The concept of tarab — an ecstatic emotional state induced by music — remains central even in modern pop contexts.
+- **Structure**: Traditional Arabic music uses extended, through-composed forms with long instrumental introductions and improvisational sections (taqasim). Modern pop adopts Western verse-chorus structure but often retains longer instrumental intros and melodic interludes. Songs tend to run longer than Western pop — 4-7 minutes is typical. Call-and-response patterns between vocalist and ensemble are common. Key modulations between maqamat (modal scales) create dramatic tension.
+- **Tempo**: Wide range. Ballads: 60-85 BPM. Mid-tempo pop: 90-120 BPM. Dance/raï: 110-140 BPM. Mahraganat: 120-150 BPM. Traditional rhythmic cycles (iqa'at) include maqsum (4/4, the most common), malfuf (fast 2/4), saidi (4/4 with heavy downbeats), and baladi (4/4 earthy feel). Swing and shuffle feels are more common than straight eighth notes.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB (couplet) or AAAA (monorhyme) — Arabic poetry traditions favor extended single-rhyme passages. ABAB also common in modern pop. Classical Arabic poetry forms (qasida, mawwal) influence lyrical structure.
+- **Rhyme quality**: Clean end rhymes are standard. Arabic's rich morphology enables abundant rhyme possibilities through shared verb conjugation patterns and grammatical suffixes. Internal rhyme and assonance add musicality. Wordplay and double meanings (tawriya) are prized in the literary tradition.
+- **Verse structure**: Typically 4-6 lines per verse with a recurring refrain. Traditional forms can be much longer — mawwal (improvised vocal section) precedes the composed song. Modern pop follows Western 4-8 line verse structures. Refrains tend to be shorter and more melodically memorable than verses.
+- **Key rule**: Emotional sincerity above all. Arabic pop lyrics deal overwhelmingly with love — its ecstasy, its agony, the beloved's beauty, separation and longing. Even when simple, the language must feel genuine and heartfelt. Imagery draws from nature (the moon, the sea, the desert, the eyes of the beloved) and should be vivid and specific.
+- **Avoid**: Literal translations from English — Arabic has its own poetic conventions. Overly colloquial language in contexts that demand classical Arabic (fusha) register. Mixing unrelated dialects. Religious references in secular pop contexts unless culturally appropriate.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 90-120 BPM. Melismatic vocal style means fewer words per line than Western pop — give space for ornamental runs. Topics: 1-2/verse. At ballad tempo (60-85 BPM), reduce to **3-4 lines/verse** with extended phrasing.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Arabic Pop (Egyptian)** | Cairo-centered mainstream pop with lush orchestral and electronic production, romantic lyrics, and polished vocals. The commercial heart of the Arabic music industry, blending traditional maqam melodies with Western pop structure and dance beats. | Amr Diab, Nancy Ajram, Tamer Hosny, Sherine |
+| **Arabic Pop (Lebanese)** | Beirut-influenced pop emphasizing vocal elegance, French chanson influences, and sophisticated arrangements. Tends toward a more cosmopolitan, European-influenced sound than Egyptian pop while maintaining Arabic melodic identity. | Fairuz, Elissa, Najwa Karam, Wael Kfoury |
+| **Raï** | Algerian popular music originating in Oran, combining Bedouin folk traditions with Western rock, funk, and electronic production. Raw vocal delivery, accordion, and derbouka percussion define the sound. Socially rebellious lyrics addressing love, alcohol, and social constraints. | Khaled, Cheb Mami, Cheb Hasni, Rachid Taha |
+| **Mizrahi Pop** | Israeli fusion combining Yemenite, Moroccan, Iraqi, and Turkish Jewish musical traditions with Western pop, electronic beats, and Mediterranean influences. Emotionally intense vocals over dance-oriented production with Middle Eastern percussion. | Ofra Haza, Eyal Golan, Sarit Hadad, Zohar Argov |
+| **Khaleeji Pop** | Gulf states pop featuring traditional percussion patterns (khaleeji rhythm), pentatonic melodies, and modern electronic production. Clean, polished vocals with regional dialectal lyrics. Growing global profile through streaming platforms. | Balqees, Hussain Al Jassmi, Rashed Al Majed, Ahlam |
+| **Mahraganat (Electro-Shaabi)** | Egyptian street music born in Cairo's working-class neighborhoods. Heavy electronic synths, auto-tuned vocals, rapid-fire delivery, and raw energy. DIY production aesthetic with maximalist sonic approach. The sound of Egyptian youth culture. | Hassan Shakosh, Wegz, Ahmed Saad, Omar Kamal |
+| **Arabic-Electronic Fusion** | Diaspora-driven blend of Arabic vocals and melodies with Western electronic music — trip-hop, drum'n'bass, house, and ambient. Sophisticated production bridging club culture and Middle Eastern tradition. Often instrumental or featuring vocal samples. | Natacha Atlas, Transglobal Underground, Acid Arab, Deena Abdelwahed |
+| **Yemenite Folk Fusion** | Traditional Yemenite Jewish melodies and rhythms fused with modern production — synth-pop, hip-hop, electronic beats. Distinctive vocal ornamentations and pentatonic scales give a sound distinct from other Middle Eastern fusions. | Ofra Haza, A-WA, Ravid Kahalani (Yemen Blues) |
+| **Arabic Indie / Alternative** | Post-2010 movement of Arabic-language artists drawing from indie rock, post-punk, and electronic music. Socially conscious lyrics, unconventional song structures, and DIY ethos. Centered in Beirut, Cairo, and diaspora communities. | Mashrou' Leila, Cairokee, Tamino, Yasmine Hamdan |
+
+## Artists
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| Umm Kulthum | *Enta Omri*, *Alf Leila Wa Leila* | 1930s-1975 | Golden age tarab; monumental vocal performances, orchestral arrangements |
+| Fairuz | *Bayaa el Khawatem*, *Maarifti Feek* | 1950s-present | Lebanese chanson-classical fusion; elegant vocals, Rahbani compositions |
+| Abdel Halim Hafez | *Ahwak*, *Qari'at al-Fingan* | 1950s-1977 | Romantic Egyptian pop; youthful energy, orchestral sophistication |
+| Ofra Haza | *Yemenite Songs*, *Shaday*, *Kirya* | 1984-2000 | Yemenite-synth-pop fusion; international crossover, dance production |
+| Khaled | *Khaled*, *Sahra*, *C'est la vie* | 1992-present | Raï-pop pioneer; global mainstream crossover, raw charisma |
+| Cheb Mami | *Meli Meli*, *Dellali* | 1986-present | Modern raï; "Prince of Raï," Sting collaboration, vocal virtuosity |
+| Rachid Taha | *Dîwân*, *Tékitoi* | 1981-2018 | Raï-rock-punk fusion; politically charged, genre-bending rebel |
+| Amr Diab | *Nour El Ain*, *Tamally Maak*, *Amarain* | 1983-present | "Father of Mediterranean Music"; Arabic-Western pop fusion, polished production |
+| Natacha Atlas | *Halim*, *Gedida*, *Mounqaliba* | 1995-present | Arabic-electronic fusion; trip-hop meets tarab, cosmopolitan diaspora sound |
+| Nancy Ajram | *Ya Salam*, *Ah W Noss* | 2001-present | Lebanese mainstream pop; dance-oriented, commercial success |
+| Elissa | *Baddi Doub*, *Saharna Ya Leil* | 2000-present | Lebanese pop; romantic ballads, polished vocal delivery |
+| A-WA | *Habib Galbi*, *Bayti Fi Rasi* | 2015-present | Yemenite folk'n'beat; three-part harmonies, electronic-hip-hop fusion |
+| Mashrou' Leila | *Mashrou' Leila*, *Raasuk* | 2009-present | Arabic indie rock; socially progressive, post-punk influences |
+| Cairokee | *Ethbat Makanak*, *Nos Youm* | 2003-present | Egyptian alternative rock; political lyrics, Arabic rock fusion |
+| Eyal Golan | *Derech La'ahava*, *Zokhrim* | 1996-present | Mizrahi pop; emotional intensity, Mediterranean dance production |
+| Balqees | *Majnoun*, *Entaha El Mawdoua* | 2012-present | Khaleeji-Lebanese pop; Gulf-influenced modern production |
+| Stromae | *Racine carrée* | 2013 | Belgian-Rwandan; referenced for Arabic-electronic crossover influence |
+| Tamino | *Amir*, *Sahar* | 2018-present | Arabic-indie fusion; oud meets indie rock, Belgian-Egyptian heritage |
+
+## Suno Prompt Keywords
+
+```
+Middle Eastern pop, Arabic pop, Mizrahi pop, raï, khaleeji,
+oud, qanun, ney flute, darbuka, riq, tabla, buzuq, kamancheh, accordion, orchestral strings,
+maqam, Arabic scale, microtonal, quarter tone, Middle Eastern melody,
+warm production, lush orchestration, electronic beats, synth pop, dance beat,
+romantic, melancholic, passionate, yearning, celebratory, mystical, desert atmosphere,
+Arabic vocals, melismatic singing, ornamental vocals, expressive vibrato, Middle Eastern vocal,
+belly dance rhythm, maqsum, baladi, shuffle feel, swing rhythm,
+Mediterranean, North African, Levantine, Egyptian, Lebanese, Algerian, Oriental
+```
+
+## Reference Tracks
+
+- **Umm Kulthum - "Enta Omri"** — Composed by Mohamed Abdel Wahab in 1964. The electric guitar introduction over a full Arabic orchestra was revolutionary — East meeting West in a single opening phrase. Umm Kulthum's hour-long live performances of this song epitomize tarab, the ecstatic state Arabic music strives to induce. The foundational text of modern Arabic music fusion.
+- **Fairuz - "Nassam Alayna El Hawa"** — A Rahbani brothers composition showcasing Fairuz's crystalline voice over a blend of Arabic melody and European orchestral arrangement. The song's structure bridges Western song form with Arabic modal exploration. Fairuz's influence extends across the entire Arab world, making her Lebanon's most important cultural export.
+- **Ofra Haza - "Im Nin'alu"** — From *Yemenite Songs* (1984), remixed in 1988 into a global club hit. A 17th-century Yemenite Jewish liturgical poem set to synth-pop and dance beats. The track proved that ancient Middle Eastern melodies could work on Western dance floors without losing their identity. Sampled by Eric B. & Rakim and countless others.
+- **Khaled - "Didi"** — Released in 1992, produced by Don Was. The track that brought raï to global mainstream attention. Khaled's raw, passionate vocal delivery over a fusion of traditional Algerian rhythms, rock guitar, and modern production made raï accessible without sanitizing it. Sold millions across Europe, the Middle East, and Asia.
+- **Khaled - "Aïcha"** — Written by Jean-Jacques Goldman in 1996. A raï ballad crossover that reached mainstream charts across Europe. The French-Arabic lyrics and Mediterranean arrangement created a template for North African pop crossover that artists still follow.
+- **Amr Diab - "Nour El Ain"** — Released in 1996. The best-selling album ever by an Arabic artist. Diab fused Arabic vocals with Spanish guitar, French accordion, and electronic dance production, coining the term "Mediterranean music." The song broke Arabic pop out of regional markets and into global consciousness.
+- **Cheb Mami & Sting - "Desert Rose"** — Released in 1999. Mami's raï vocals weaving through Sting's rock-pop arrangement proved that Middle Eastern and Western pop could merge at the highest commercial level. The collaboration introduced raï to audiences who had never heard the genre.
+- **Natacha Atlas - "Mon Amie la Rose"** — From *Gedida* (1999). An Arabic-electronic reimagining of Françoise Hardy's French chanson classic, recorded in both London and Cairo. Atlas layered Arabic ornamentation over trip-hop production, demonstrating that genre boundaries between chanson, Arabic music, and electronic music were artificial.
+- **Rachid Taha - "Rock El Casbah"** — Taha's raï-punk cover of The Clash, recorded for the *1, 2, 3 Soleils* live album (1998) alongside Khaled and Faudel at Paris's Bercy arena. A statement that raï and rock shared the same rebellious DNA. The concert became a landmark moment for North African music in France.
+- **A-WA - "Habib Galbi"** — Released in 2015. Three Yemenite-Israeli sisters singing a traditional Arabic love song over electronic beats and hip-hop production. The track went viral across the Arab world despite — or because of — its Israeli-Yemenite origins. A modern template for how ancient folk traditions can sound completely contemporary.
+- **Mashrou' Leila - "Aoede"** — From *Ibn El Leil* (2015). Arabic indie rock with post-punk guitars and socially charged lyrics. The Beirut band proved that Arabic-language music could occupy the same space as Western indie rock without compromising its cultural identity.
+- **Amr Diab - "Tamally Maak"** — Released in 2000. The follow-up to "Nour El Ain" that cemented Diab's Mediterranean pop formula. Acoustic guitar arpeggios and a lighter electronic touch created the definitive Arabic romantic pop ballad of the 2000s. One of the most-streamed Arabic songs of all time.
+- **Tamino - "Habibi"** — Released in 2018. A Belgian-Egyptian artist playing oud over indie rock arrangements, singing in Arabic and English. The track bridges the gap between traditional Arabic musicianship and Western indie sensibility, representing the sound of diaspora identity in the 21st century.

--- a/genres/schlager/README.md
+++ b/genres/schlager/README.md
@@ -1,0 +1,105 @@
+# Schlager
+
+## Genre Overview
+
+Schlager is a genre of popular music rooted in German-speaking Europe, with origins traceable to Viennese operetta and light entertainment music of the late 19th century. The term itself was first applied to music in an 1867 review of Johann Strauss II's *The Blue Danube* in the Wiener Fremden-Blatt. The genre took its modern form in the 1920s and 1930s through acts like the Comedian Harmonists and Rudi Schuricke, who established the template of catchy melodies with sentimental German-language lyrics. Post-war pioneers including Freddy Quinn, Caterina Valente, and Lale Andersen brought Schlager to mass audiences, with Quinn's "Die Gitarre und das Meer" (1959) becoming one of the first genre-defining chart-toppers.
+
+Schlager reached peak cultural dominance in the 1960s and early 1970s through artists like Peter Alexander, Roy Black, Udo Jürgens, and Heintje. Udo Jürgens elevated the genre with sophisticated compositions and won the Eurovision Song Contest in 1966 with "Merci, Chérie." Nicole repeated this feat in 1982 with "Ein bisschen Frieden," making Germany a Eurovision winner for the first time. Between 1975 and 1981, Schlager absorbed disco influences, blurring boundaries with mainstream dance music. The late 1980s and 1990s saw a split: Volkstümliche Musik catered to older rural audiences, while a revival wave led by Guildo Horn and Dieter Thomas Kuhn reintroduced Schlager to younger listeners with ironic appreciation. Andrea Berg's crossover success from the late 1990s onward attracted a genuinely new, younger fanbase.
+
+The 2010s brought Schlager's biggest commercial peak since the 1970s, driven almost entirely by Helene Fischer, whose 2013 album *Farbenspiel* became the most downloaded album ever by a German artist. Her single "Atemlos durch die Nacht" transcended the genre, becoming the fifth most successful song in German chart history. Today, Schlager remains a dominant force in German-language media with dedicated TV shows (Schlagerboom, Schlagerchampions), festivals (Schlagermove Hamburg), and streaming playlists. Modern acts like Vanessa Mai, Ben Zucker, and Beatrice Egli blend Schlager with EDM, pop, and Latin influences, while Roland Kaiser and Andrea Berg continue to fill arenas. The genre has also influenced Scandinavian schlager (dansband) and the broader Eurovision aesthetic.
+
+## Characteristics
+
+- **Instrumentation**: Keyboards/synthesizers (dominant since the 1980s), acoustic and electric guitar, accordion (especially in Volkstümliche variants), brass sections, string arrangements (often orchestral or sampled), drum machines and programmed beats in modern productions; live bands for arena shows
+- **Vocals**: Clean, powerful, emotionally expressive singing; emphasis on clarity and diction; vibrato common; duets frequent; male and female voices equally represented; German-language lyrics standard with occasional bilingual tracks; belted choruses designed for audience singalong
+- **Production**: Polished and radio-ready; heavy reverb on vocals; lush arrangements with layered synths and strings; modern productions incorporate EDM elements (sidechain compression, build-ups, drops); backing tracks often keyboard-driven; mixing prioritizes vocal intelligibility above all
+- **Energy/Mood**: Predominantly upbeat and feel-good; themes of love, longing, summer, travel, celebration, and nostalgia; emotional range from bittersweet melancholy (Herzschmerz) to euphoric party energy; optimistic tone even in sad songs; escapist and comforting
+- **Structure**: Verse-chorus-verse with prominent, highly singable choruses; bridges common; instrumental breaks often feature accordion or keyboard solos; key changes in final chorus frequent; intros typically 4-8 bars; songs designed for immediate hook recognition
+- **Tempo**: Ballads 60-80 BPM, mid-tempo 90-110 BPM, uptempo/party 120-140 BPM; most hits cluster around 100-130 BPM; straight 4/4 time signature nearly universal; occasional waltz (3/4) in Volkstümliche variants
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB (couplet) dominant, also ABAB and ABCB. Choruses often use AABB for maximum singability.
+- **Rhyme quality**: Clean end rhymes preferred; exact rhymes valued over slant rhymes; occasional internal rhyme but not required; simplicity over cleverness; rhymes should feel natural and effortless, never forced
+- **Verse structure**: 4-8 lines per verse; 4-line choruses most common; pre-chorus (Strophe → Refrain bridge) frequent in modern Schlager; repetition of chorus lyrics expected
+- **Key rule**: The chorus must be instantly memorable and singable by a crowd — if a drunk audience at Schlagermove can't sing along after one listen, the hook fails.
+- **Avoid**: Irony or cynicism (unless deliberately parodic like Guildo Horn); complex metaphors; English lyrics in traditional Schlager (modern hybrid acts excepted); profanity; political content; abstract poetry — Schlager lyrics are direct and emotionally transparent
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 110-120 BPM. At ballad tempo (70-80 BPM): max 4 lines. Chorus: 4 lines, repeated. Topics: 1/verse max — Schlager lyrics are thematically simple and focused.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Traditional Schlager** | Classic post-war style with orchestral arrangements, clean vocals, and sentimental lyrics about love and longing; the foundation of the genre from the 1950s through 1970s | Freddy Quinn, Peter Alexander, Roy Black, Caterina Valente |
+| **Discoschlager** | Late 1970s-early 1980s fusion of Schlager melodies with disco beats, synthesizers, and dance-floor energy; blurred the line between Schlager and mainstream pop | Boney M. (crossover), Dschinghis Khan, Ireen Sheer, Mary Roos |
+| **Volkstümliche Musik** | Rural-oriented variant emphasizing accordion, brass, and Alpine folk elements; slower tempos, traditional dress aesthetics; strong TV presence (Musikantenstadl) | Hansi Hinterseer, Die Kastelruther Spatzen, Stefanie Hertel, Die Amigos |
+| **Partyschlager** | High-energy party variant with EDM influences, crowd-chant choruses, and often comedic or provocative lyrics; Ballermann/Mallorca culture; heavy bass and synth drops | Mickie Krause, Ikke Hüftgold, Lorenz Büffel, Tim Toupet |
+| **Pop-Schlager** | Modern mainstream Schlager blending contemporary pop production (EDM builds, electronic beats) with traditional Schlager vocal delivery and German lyrics; the dominant commercial form since 2010 | Helene Fischer, Vanessa Mai, Beatrice Egli, Ben Zucker |
+| **Herzschmerz-Schlager** | Ballad-heavy emotional Schlager focusing on heartbreak, longing, and romantic pain; lush string arrangements, dramatic vocal delivery, slower tempos | Andrea Berg, Semino Rossi, Claudia Jung, Michelle |
+| **Schlager-Rock** | Guitar-driven Schlager incorporating rock instrumentation and energy while maintaining German-language lyrics and Schlager melodic sensibility | Ben Zucker, Andreas Gabalier (crossover), Matthias Reim |
+| **Euro-Schlager** | Eurovision-adjacent style with multilingual hooks, key changes, and anthemic choruses; polished production designed for international contest appeal | Nicole, Udo Jürgens, Lena (crossover), Wind |
+| **Neue Deutsche Welle** | Early 1980s German-language new wave/synth-pop that briefly overlapped with Schlager; angular synths, ironic lyrics, punk-influenced attitude — technically separate but historically intertwined | Nena, Trio, Falco, Ideal |
+
+## Artists
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| Udo Jürgens | *Merci, Chérie*, *Griechischer Wein*, *Aber bitte mit Sahne* | 1960s-2014 | Sophisticated piano Schlager; Eurovision winner 1966; socially aware lyrics |
+| Helene Fischer | *Farbenspiel*, *Helene Fischer*, *Rausch* | 2006-present | Pop-Schlager queen; EDM-infused productions; arena spectacles |
+| Andrea Berg | *Machtlos*, *Abenteuer*, *Seelenbeben* | 1992-present | Herzschmerz ballads; emotional powerhouse; revitalized genre for younger audience |
+| Roland Kaiser | *Santa Maria*, *Alles oder Dich*, *Perspektiven* | 1980-present | Romantic mid-tempo Schlager; warm baritone; enduring live act |
+| Freddy Quinn | *Freddy*, *Heimweh*, *Die Gitarre und das Meer* | 1956-1990s | Pioneer; sailor/wanderer themes; post-war Schlager foundation |
+| Peter Alexander | *Hier ist ein Mensch*, *Verliebte Musik* | 1950s-1990s | Entertainer; operetta-influenced; comedic and romantic |
+| Nicole | *Ein bißchen Frieden*, *Alles fließt* | 1982-present | Eurovision 1982 winner; peace anthem; gentle delivery |
+| Roy Black | *Ganz in Weiß*, *Frag nur dein Herz* | 1960s-1991 | Classic romantic Schlager; warm tenor; teenage idol |
+| Howard Carpendale | *Hello Again*, *Dann geh doch* | 1970s-present | South African-born German Schlager star; polished pop-Schlager |
+| Matthias Reim | *Verdammt, ich lieb' dich*, *Unendlich* | 1990-present | Rock-influenced Schlager; raspy voice; one of Germany's biggest-selling singles |
+| Die Flippers | *Liebe ist...*, *Träumen mit den Flippers* | 1969-2011 | Keyboard-driven trio; soft romantic Schlager |
+| Nena | *Nena*, *?* (Fragezeichen) | 1983-present | NDW/crossover; "99 Luftballons"; pop-punk energy |
+| Jürgen Drews | *Ein Bett im Kornfeld*, *Wieder alles im Griff* | 1976-present | Party-Schlager pioneer; Mallorca culture icon |
+| Beatrice Egli | *Glücksgefühle*, *Bunt* | 2013-present | Modern pop-Schlager; DSDS winner; youthful energy |
+| Vanessa Mai | *Für Dich*, *Schlager* | 2015-present | EDM-Schlager hybrid; dance-influenced; young demographic |
+
+## Suno Prompt Keywords
+
+```
+schlager, deutscher schlager, german schlager, german pop, europop,
+accordion, keyboard, synthesizer, strings, brass section, orchestral pop,
+polished production, lush arrangement, reverb vocals, radio-friendly,
+upbeat, feel-good, singalong, party music, celebratory, romantic,
+sentimental, nostalgic, heartfelt, bittersweet, emotional ballad,
+clean vocals, powerful vocals, belted chorus, German lyrics, duet,
+danceable, four-on-the-floor, straight beat, waltz,
+volkstümliche musik, alpine, folk-pop, party schlager, discoschlager,
+eurovision, euro pop, schlagerparty, sommerhit,
+80s synth, modern pop production, EDM-influenced, anthemic chorus,
+crowd singalong, key change, dramatic, uplifting
+```
+
+## Reference Tracks
+
+- **Johann Strauss II - "An der schönen blauen Donau" (The Blue Danube)** — The 1867 waltz that gave Schlager its name. A Wiener Fremden-Blatt critic called it a "Schlager" (hit) on opening night. While technically a waltz, it established the concept of the crowd-pleasing, instantly memorable melody that defines the genre to this day.
+
+- **Freddy Quinn - "Die Gitarre und das Meer"** — Post-war Schlager's foundational hit (1959). Quinn's melancholic sailor-wanderer persona over gentle acoustic arrangement defined the genre's emotional template: longing for faraway places, wrapped in a simple, memorable melody. Reached #1 in Germany and stayed there.
+
+- **Udo Jürgens - "Griechischer Wein"** — The 1974 masterwork that elevated Schlager to social commentary. A song about guest workers' homesickness that became a cultural touchstone, reaching #1 in Germany and Switzerland. Jürgens' piano-driven arrangement and earnest delivery proved Schlager could carry weight without losing accessibility.
+
+- **Udo Jürgens - "Merci, Chérie"** — Eurovision 1966 winner for Austria. Piano-led romantic ballad with multilingual charm. Demonstrated Schlager's international potential and established Jürgens as the genre's most respected composer-performer.
+
+- **Nicole - "Ein bisschen Frieden"** — Germany's first Eurovision victory (1982). A gentle peace anthem with acoustic guitar and Nicole's pure vocal delivery. Became a symbol of Cold War-era longing and proved Schlager could carry a political message through simplicity.
+
+- **Matthias Reim - "Verdammt, ich lieb' dich"** — The 1990 mega-hit that sold over 2.5 million copies, one of the best-selling German-language singles ever. Rock guitar meets Schlager chorus; Reim's raspy delivery broke the mold of polished Schlager vocals and brought the genre into the reunification era.
+
+- **Roy Black - "Ganz in Weiß"** — The quintessential 1960s romantic Schlager. Black's warm tenor over lush orchestration singing about a bride in white — pure, unironic sentiment that defined an era. The gold standard for Herzschmerz-Schlager.
+
+- **Andrea Berg - "Du hast mich tausendmal belogen"** — Berg's 2001 breakthrough that revitalized Schlager for a new generation. Driving beat, passionate vocal, and a chorus built for arena singalongs. Proved that emotional Schlager could compete with mainstream pop.
+
+- **Helene Fischer - "Atemlos durch die Nacht"** — The 2013 track that became a national phenomenon. Kristina Bach's lyrics over Jean Frankfurter's EDM-inflected production created the biggest Schlager hit of the 21st century — the fifth most successful song in German chart history. Defined modern pop-Schlager's sound: four-on-the-floor beats, euphoric builds, and a chorus that every German knows.
+
+- **Dschinghis Khan - "Dschinghis Khan"** — The 1979 Eurovision entry that embodied Discoschlager at its most flamboyant. Pounding disco beat, chanting chorus, theatrical performance — camp and irresistible energy that influenced Partyschlager decades later.
+
+- **Nena - "99 Luftballons"** — The 1983 NDW/Schlager crossover that became a worldwide #1. Synth-driven anti-war song with an infectious hook, proving German-language pop could break internationally. Technically Neue Deutsche Welle, but permanently linked to the Schlager ecosystem.
+
+- **Howard Carpendale - "Hello Again"** — The 1984 hit that epitomizes polished 1980s pop-Schlager. Synth pads, clean production, and Carpendale's smooth delivery created a template that dominated German radio through the decade.
+
+- **Roland Kaiser - "Santa Maria"** — The 1980 Latin-flavored Schlager that showcased the genre's ability to absorb international influences. Kaiser's warm baritone over breezy arrangement became one of the most recognized Schlager songs of all time and remains a concert staple.

--- a/skills/genre-creator/SKILL.md
+++ b/skills/genre-creator/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: genre-creator
+description: Create new genre documentation files for the bitwize-music genre library. Use when the user wants to add a genre, says "/genre-creator", "neues Genre erstellen", "Genre hinzufuegen", "add genre", or asks to create genre documentation. Takes a genre name as argument.
+model: claude-sonnet-4-6
+argument-hint: <genre-name e.g. "Math Rock" or "Nu-Metal">
+---
+
+# Genre Creator
+
+## Your Task
+
+Create a new genre README.md for the bitwize-music genre library at `${CLAUDE_PLUGIN_ROOT}/genres/`.
+
+**Input**: $ARGUMENTS (genre name, e.g. "Math Rock", "Nu-Metal", "City Pop")
+
+## Workflow
+
+1. **Derive slug**: Lowercase, hyphenated (e.g. "Math Rock" → `math-rock`)
+2. **Check existence**: If `genres/{slug}/README.md` exists → abort, inform user
+3. **Check INDEX.md**: Read `genres/INDEX.md` to confirm genre is not already listed
+4. **Research**: Use WebSearch to verify key facts (origin year, pioneer artists, landmark albums) — do NOT guess dates or album names
+5. **Read 1-2 existing genre files** for structural reference (e.g. `genres/hip-hop/README.md`, `genres/phonk/README.md`)
+6. **Create directory**: `genres/{slug}/`
+7. **Write README.md** following the exact template below
+8. **Update INDEX.md**: Add genre to category table, alphabetical list, and all applicable Quick Reference tables (Tempo, Energy, Instrumentation, Vocals, Mood, Era)
+9. **Update mastering presets**: Add the new genre to both mastering preset files:
+   - `tools/mastering/genre-presets.yaml` — Add YAML entry with `target_lufs`, `cut_highmid`, `cut_highs` values appropriate for the genre. Place in the correct category section or create a new one.
+   - `skills/mastering-engineer/genre-presets.md` — Add a new `### Genre Name` section under `## Genre Presets` with LUFS target, dynamics, EQ focus, MCP command, and characteristics.
+10. **Do NOT create** an `artists/` subdirectory — those are created separately when artist deep-dives are written
+
+## README.md Template
+
+The file starts directly with `# Genre Name` — no YAML frontmatter.
+
+ALWAYS use this exact section order:
+
+```
+# {Genre Name}
+
+## Genre Overview
+[3 paragraphs — see rules below]
+
+## Characteristics
+[6 bullet fields — see rules below]
+
+## Lyric Conventions
+[6 bullet fields — see rules below]
+
+## Subgenres & Styles
+[Table — see rules below]
+
+## Artists
+[Table — see rules below]
+
+## Suno Prompt Keywords
+[Code block — see rules below]
+
+## Reference Tracks
+[List — see rules below]
+```
+
+### Section Rules
+
+**## Genre Overview** — 3 paragraphs of prose (no bullets):
+- P1: Origin, cultural roots, pioneers with names and years
+- P2: Evolution across decades, key moments, mainstream breakthrough, regional variants
+- P3: Current state, influence on other genres, modern scene
+- Style: Encyclopedic but alive. Concrete names, years, albums. No vague claims.
+
+**## Characteristics** — Bullet list, exactly these 6 fields:
+- **Instrumentation**: Typical instruments, specific models/brands where relevant
+- **Vocals**: Singing style, vocal processing, delivery
+- **Production**: Production techniques, mix aesthetic, sonic character
+- **Energy/Mood**: Mood spectrum, emotional range
+- **Structure**: Song form, typical length, structural quirks
+- **Tempo**: BPM ranges per subgenre, rhythm feel (half-time, swing, straight etc.)
+
+**## Lyric Conventions** — Bullet list, exactly these 6 fields:
+- **Default rhyme scheme**: Typical scheme with shorthand (AABB, ABAB, XAXA etc.)
+- **Rhyme quality**: Expected quality (multisyllabic, slant, internal etc.)
+- **Verse structure**: Line count, bar structure
+- **Key rule**: THE single most important rule for lyrics in this genre
+- **Avoid**: What NOT to do in this genre
+- **Density/pacing (Suno)**: Format: `Default **X lines/verse** at Y BPM. [Context]. Topics: Z/verse.`
+
+**## Subgenres & Styles** — Markdown table:
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+
+- 6-12 subgenres
+- Description: 2-3 sentences with musical specifics, not just adjectives
+- Reference Artists: 3-4 per subgenre
+
+**## Artists** — Markdown table:
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+
+- 10-20 artists, mix of pioneers + peak-era + current acts
+- Albums in italics (*Album Name*)
+- If a deep-dive file exists: append a `Deep Dive` link to the artist file in Style Focus
+
+**## Suno Prompt Keywords** — Fenced code block with comma-separated keywords organized in thematic lines:
+- Genre/subgenre labels
+- Instrument keywords
+- Production keywords
+- Mood/atmosphere keywords
+- Vocal keywords
+- Tempo/rhythm keywords
+- Era/aesthetic keywords
+- All keywords in English. Only use terms Suno actually understands.
+
+**## Reference Tracks** — 10-15 entries:
+- Format: `- **Artist - "Track Title"** — [Description]`
+- Description: 2-3 sentences. Explain WHAT makes this track a genre reference point. Name concrete musical elements. Explain historical/cultural significance.
+- Chronological spread from founding tracks to modern representatives
+
+## Important Notes
+
+1. **Factual accuracy**: All years, album names, artist names must be correct. Omit rather than guess. Use WebSearch to verify.
+2. **No AI cliches**: Ban these phrases: "tapestry of sound", "sonic landscape", "testament to", "rich tapestry", "sonic journey", "pushing boundaries", "transcends genre". Write direct, concrete prose.
+3. **Suno focus**: Lyric Conventions and Suno Keywords are the most important sections — they directly drive music generation quality.
+4. **Subgenre deduplication**: If a subgenre already has its own genre directory (e.g. Trap exists as standalone genre), reference it instead of duplicating content.
+5. **Language**: English (the entire genre system is in English)
+6. **No empty sections**: Every section must have substantive content. If unsure about a section, research first.

--- a/skills/mastering-engineer/genre-presets.md
+++ b/skills/mastering-engineer/genre-presets.md
@@ -102,6 +102,45 @@ Detailed mastering settings by genre.
 - Natural room sound
 - Uncompressed peaks
 
+### Schlager
+**LUFS target**: -12 to -14 LUFS
+**Dynamics**: Moderate-to-heavy compression, radio-ready loudness
+**EQ focus**: Vocal presence (2-5 kHz), bass drum punch (60-100 Hz), bright top end (8-12 kHz for shimmer)
+**MCP command**: `master_audio(album_slug, genre="schlager")`
+
+**Characteristics**:
+- Vocals dominant and upfront
+- Kick drum punchy and defined
+- Bright, polished, singalong-ready
+- Synthesizer and brass clarity
+- Party tracks can push to -11 LUFS
+
+### Middle Eastern Pop
+**LUFS target**: -14 LUFS (mahraganat: -12 LUFS)
+**Dynamics**: Moderate compression, preserve vocal ornamentations and melismatic runs
+**EQ focus**: Vocal presence (1-4 kHz), oud/qanun body (200-600 Hz), darbuka attack (3-5 kHz), gentle high-mid cut to tame synth harshness
+**MCP command**: `master_audio(album_slug, genre="middle-eastern-pop")`
+
+**Characteristics**:
+- Melismatic vocals need headroom — avoid over-compressing ornamental runs
+- Quarter-tone melodies require careful limiting to avoid pitch artifacts
+- Darbuka and riq transients should remain crisp and defined
+- Raï tracks: slightly more aggressive compression, accordion warmth preserved
+- Mahraganat: louder target (-12 LUFS), heavier compression, bass-forward mix
+
+### Chanson
+**LUFS target**: -14 to -16 LUFS
+**Dynamics**: Light compression, preserve natural dynamics and rubato phrasing
+**EQ focus**: Vocal transparency (1-4 kHz), accordion warmth (200-800 Hz), gentle high cut above 12 kHz for vintage warmth
+**MCP command**: `master_audio(album_slug, genre="chanson")`
+
+**Characteristics**:
+- Voice is absolute center — pristine clarity without harshness
+- Accordion/guitar body preserved, not thinned out
+- Room ambience and intimacy maintained
+- Dynamic range wider than pop — quiet passages stay quiet
+- Nouvelle chanson with electronic elements can target -14 LUFS; traditional acoustic chanson sits at -15 to -16
+
 ---
 
 ## Problem-Solving

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -301,6 +301,44 @@ genres:
     cut_highmid: 0
     cut_highs: 0
 
+  # === European Pop ===
+  schlager:
+    target_lufs: -14.0
+    cut_highmid: -1.0
+    cut_highs: 0
+
+  # === Chanson / Cabaret ===
+  chanson:
+    target_lufs: -15.0
+    cut_highmid: -1.5
+    cut_highs: 0
+  cabaret:
+    target_lufs: -15.0
+    cut_highmid: -1.5
+    cut_highs: 0
+
+  # === Middle Eastern ===
+  middle-eastern-pop:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
+  arabic-pop:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
+  rai:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
+  mizrahi:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
+  mahraganat:
+    target_lufs: -12.0
+    cut_highmid: -2.0
+    cut_highs: 0
+
   # === Latin / World ===
   latin:
     target_lufs: -14.0


### PR DESCRIPTION
## Summary

- **3 new genres** with full documentation (README, subgenres, artists, reference tracks, Suno keywords):
  - **Schlager** — German-language pop (party hits to ballads, EDM-infused modern schlager)
  - **Chanson** — French vocal tradition (9 subgenres from réaliste to nouvelle chanson, 18 artists)
  - **Middle Eastern Pop** — Arabic/Israeli/North African fusion (raï, Mizrahi, khaleeji, mahraganat, 18 artists)
- **Mastering presets** for all 3 genres in both `genre-presets.yaml` (with aliases: arabic-pop, rai, mizrahi, mahraganat, cabaret) and `genre-presets.md`
- **Genre-creator skill** updated with new step 9: maintain mastering preset files when creating genres
- **INDEX.md** updated: new Middle Eastern and European Pop category sections, all 6 quick reference tables, genre combinations, alphabetical list (67 → 70 genres)
- **CHANGELOG.md** updated under Unreleased

## Test plan
- [ ] Verify genre READMEs render correctly (section order, tables, code blocks)
- [ ] Verify INDEX.md links resolve to correct genre directories
- [ ] Verify `genre-presets.yaml` parses without errors
- [ ] Verify genre-creator SKILL.md includes mastering preset step
- [ ] Run `/bitwize-music:test all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)