### PR TITLE
docs: add German pronunciation section to Suno guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **German pronunciation section in Suno pronunciation guide** — documents vowel length fixes (single → double vowel for long sounds, e.g. `juchhe` → `juchee`), umlaut handling, and German interjection pronunciation table
+
 ## [0.77.1] - 2026-03-23
 
 ### Fixed

--- a/reference/suno/pronunciation-guide.md
+++ b/reference/suno/pronunciation-guide.md
@@ -328,6 +328,47 @@ Style prompt: Include both language indicators: "bilingual, Spanish verse, Engli
 
 ---
 
+## German Pronunciation
+
+Suno interprets German vowels using English phonetic rules, which causes specific mispronunciations. These fixes apply to **all German-language lyrics**, regardless of genre.
+
+### Short vs Long Vowels
+
+Suno treats single German vowels as short English vowels. To force the correct long German pronunciation, **double the vowel**.
+
+| German Word | Suno Reads As | Fix | Why |
+|-------------|---------------|-----|-----|
+| juchhe | "juch-heh" (short e) | **juchee** | Double-e forces long "ee" sound |
+| Schnee | "schneh" (short e) | **Schnee** (usually OK) | Double-e already present |
+| See | "seh" (short e) | **See** (usually OK) | Double-e already present |
+
+**Rule of thumb**: If a German word ends in a single vowel that should be long, double it for Suno. Test by generating — if the vowel sounds clipped, double it.
+
+### German Umlauts
+
+Suno handles umlauts inconsistently. Test first, fix if needed.
+
+| Character | Suno Behavior | Fix If Wrong |
+|-----------|--------------|--------------|
+| ä | Sometimes reads as "a" | Use "ae" |
+| ö | Sometimes reads as "o" | Use "oe" |
+| ü | Sometimes reads as "u" | Use "ue" |
+| ß | Usually reads as "ss" | Usually OK |
+
+### German Interjections
+
+Common German exclamations that Suno may mispronounce:
+
+| Word | Expected | Suno Risk | Fix |
+|------|----------|-----------|-----|
+| juchhe | "juch-HEE" | Short clipped "heh" | **juchee** |
+| juhu | "yoo-HOO" | May stress wrong syllable | Usually OK |
+| hurra | "hoo-RAH" | Usually OK | — |
+| ach | "ahh" (guttural) | May say "atch" | Usually OK |
+| oho | "oh-HOH" | Usually OK | — |
+
+---
+
 ## Quick Reference Card
 
 ```


### PR DESCRIPTION
## Summary
- Adds new **German Pronunciation** section to `reference/suno/pronunciation-guide.md`
- Documents vowel length fixes: Suno treats single German vowels as short English vowels — doubling forces correct long pronunciation (e.g. `juchhe` → `juchee`)
- Adds umlaut handling table (ä→ae, ö→oe, ü→ue fallbacks)
- Adds German interjections pronunciation table (juchhe, juhu, hurra, ach, oho)

## Context
Discovered during German Kinderlied production: Suno clipped the final vowel in "juchhe" to a short "heh" instead of long "hee". Replacing with "juchee" fixed it. This pattern applies to all German lyrics.

## Test plan
- [ ] Verify pronunciation guide renders correctly
- [ ] Verify CHANGELOG.md entry under Unreleased
- [ ] No existing sections modified — addition only

🤖 Generated with [Claude Code](https://claude.com/claude-code)