### PR TITLE
feat: add Rilo Kiley artist deep-dive to indie-rock references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # User content (private)
-artists/
+/artists/
+!genres/**/artists/
 research/
 IDEAS.md
 

--- a/genres/indie-rock/artists/INDEX.md
+++ b/genres/indie-rock/artists/INDEX.md
@@ -1,0 +1,61 @@
+# Indie Rock — Artist References
+
+Quick-reference Suno keywords extracted from artist deep-dives.
+Read the full deep-dive only when you need detailed history,
+members, discography, or musical analysis.
+
+## Available Deep-Dives
+
+| Artist | Style | Full Reference |
+|--------|-------|----------------|
+| Rilo Kiley | Indie rock/pop evolving from lo-fi folk-pop through Saddle Creek chamber-indie to 70s/80s FM radio pastiche | [Full Deep Dive](rilo-kiley.md) |
+
+## Suno Prompt Keywords
+
+### Rilo Kiley
+```
+indie rock, indie pop, jangly guitars, jangly indie rock,
+picked guitar arpeggios, angular guitar riff, clean guitar tone,
+acoustic guitar, acoustic-driven indie, folk-rock indie,
+pedal steel guitar, alt-country indie, Americana indie rock,
+chamber pop, vibraphone, glockenspiel, bell-like shimmer,
+Wurlitzer electric piano, warm keys, vintage keyboard,
+indie rock ballad, quiet verse loud chorus, dynamic build,
+sparse to full arrangement, intimate to explosive,
+lo-fi indie, DIY indie pop, twee pop, Silver Lake indie,
+Saddle Creek sound, Midwestern indie rock, warm indie production,
+polished indie pop, radio-ready indie, indie pop-rock,
+synth-pop indie, disco-influenced indie, new wave indie rock,
+80s synth pads, shimmering synths, glossy pop-rock,
+driving indie rock, propulsive guitar riff, uptempo indie,
+mid-tempo indie, slow-burn build, extended song form,
+female vocalist, female-fronted indie rock, confessional lyrics,
+narrative songwriting, literary indie rock, storytelling rock,
+vulnerable vocal, intimate vocal delivery, airy vocal,
+sweet melody dark lyrics, ironic juxtaposition,
+emotional indie rock, indie rock anthem, cathartic climax,
+handclaps, tambourine, bouncy rhythm, indie dance,
+girl-group influenced indie, Motown-tinged indie pop,
+Fleetwood Mac-influenced, 70s FM radio, classic rock shimmer,
+glam rock indie, power pop, jangle pop,
+trumpet in indie rock, horn arrangement indie,
+gang vocals, communal chorus, building anthem
+```
+
+## Reference Tracks
+
+### Rilo Kiley
+- "Pictures of Success" (2001) — Extended slow-burn build; spare fingerpicking to full-band catharsis; existential dissatisfaction
+- "Science vs. Romance" (2001) — Angular multi-layered guitars; cerebral vs. emotional tension; extended form
+- "The Execution of All Things" (2002) — Sweet jangly melody over apocalyptic lyrics; Saddle Creek warmth
+- "A Better Son/Daughter" (2002) — Quiet acoustic first half exploding into anthemic rock; definitive indie mental health anthem
+- "With Arms Outstretched" (2002) — Acoustic intimacy building to gang-vocal full-band climax; impermanence and joy
+- "Portions for Foxes" (2004) — Propulsive choppy riff; radio-ready indie rock; toxic relationship anthem; Grey's Anatomy signature
+- "It's a Hit" (2004) — Bright handclap pop disguising sardonic political commentary; album-opening statement
+- "Does He Love You?" (2004) — Slow-burn narrative ballad; sparse to layered; unflinching character study
+- "I Never" (2004) — Country-leaning tenderness; acoustic warmth; genuine romantic vulnerability
+- "Ripchord" (2004) — Stripped acoustic Elliott Smith tribute; devastating brevity at 2:09
+- "Silver Lining" (2007) — Crisp uptempo pop; bright hooks; resilience anthem; polished Elizondo production
+- "The Moneymaker" (2007) — Glam-rock strut under 3 minutes; provocative; bass-heavy; punk economy
+- "Breakin' Up" (2007) — Disco-pop bounce; girl-group/Motown influence; euphoric liberation
+- "Dreamworld" (2007) — Mid-tempo atmosphere; reverb-heavy dreamy guitars; Fleetwood Mac channeling

--- a/genres/indie-rock/artists/rilo-kiley.md
+++ b/genres/indie-rock/artists/rilo-kiley.md
@@ -1,0 +1,494 @@
+# Rilo Kiley — Deep Dive
+
+## Overview
+
+Rilo Kiley was an indie rock band formed in January 1998 in Silver Lake, Los Angeles, California. The band was built around the songwriting partnership of Jenny Lewis (vocals, guitar, keyboards) and Blake Sennett (lead guitar, backing vocals), both former child actors who bonded over music in 1995 — writing two songs the first day they spent together and finishing a dozen by the end of the week. Their first show was at Spaceland in Los Angeles, funded by comedian Dave Foley, who attended the gig.
+
+Over four studio albums (2001-2007), Rilo Kiley traced an arc from lo-fi indie folk-pop through Saddle Creek chamber-indie to polished 70s/80s FM radio pastiche — a sonic evolution that mirrored the tensions that eventually broke them apart. Jenny Lewis emerged as one of indie rock's most formidable songwriters: a narrative storyteller who inhabits morally complex characters without judgment, packages devastating content in pop-friendly structures, and moves fluidly between confessional vulnerability and sardonic wit.
+
+---
+
+## Members
+
+| Member | Role | Years |
+|--------|------|-------|
+| **Jenny Lewis** | Vocals, guitar, keyboards (primary songwriter) | 1998-2011, 2025-present |
+| **Blake Sennett** | Lead guitar, backing vocals | 1998-2011, 2025-present |
+| **Pierre de Reeder** | Bass, backing vocals | 1998-2011, 2025-present |
+| **Jason Boesel** | Drums, percussion, keyboards | 2001-2011, 2025-present |
+| **Dave Rock** | Drums (original) | 1998-2001 |
+
+---
+
+## Timeline
+
+| Year | Event |
+|------|-------|
+| 1998 | Band formed; first show at Spaceland, LA; Sandbox Sessions released |
+| 1999 | Self-titled EP (1st pressing) released independently |
+| 2001 | Dave Rock departs; Jason Boesel joins; Lewis and Sennett end romantic relationship; *Take Offs and Landings* released |
+| 2002 | *The Execution of All Things* released on Saddle Creek |
+| 2004 | *More Adventurous* released via Brute/Beaute (distributed by Warner Bros.) |
+| 2007 | *Under the Blacklight* released on Warner Bros. |
+| 2008 | Final full performance at Greek Theatre, Los Angeles (June 18); Breakin' Up EP released |
+| 2011 | Announced indefinite hiatus; Blake Sennett cited "deception, disloyalty, and greed" |
+| 2013 | *Rkives* compilation released |
+| 2014 | Jenny Lewis confirmed official breakup |
+| 2025 | Reunion announced (February); North American tour "Sometimes When You're On, You're Really F**king On" (May-October); *That's How We Choose to Remember It* greatest hits released (May 9); appeared on Jimmy Kimmel Live performing "Silver Lining" |
+| 2026 | UK dates scheduled (Roundhouse, Shepherd's Bush Empire, London — June) |
+
+---
+
+## Sonic Evolution Summary
+
+| Element | Take Offs (2001) | Execution (2002) | More Adventurous (2004) | Blacklight (2007) |
+|---|---|---|---|---|
+| **Producer** | Self-produced | Mike Mogis | Mogis / Trombino / Tamborello | Lader / Elizondo |
+| **Studio** | Echo Chamber, LA | Presto!, Lincoln NE | Elizondo's studio | Sunset Sound, Hollywood |
+| **Fidelity** | Lo-fi, spare | Warm, richly layered | Polished, expansive | Glossy, radio-ready |
+| **Guitar tone** | Jittery, angular, acoustic | Picked, cascading + pedal steel | Varied (acoustic to aggressive) | Clean, disco-esque, processed |
+| **Keys/Synths** | Light accents | Whirring synths, displaced electronics | Wurlitzer, synth, Memory Man | Dominant 80s synths |
+| **Country elements** | Twangy undertones | Pedal steel, banjo (peak) | Pedal steel, mandolin (present) | Gone entirely |
+| **Lewis vocals** | Restrained, intimate | Exposed, live-wire | Vulnerable, commanding | Airy, polished pop |
+| **Sennett vocals** | Multiple lead tracks | Two lead tracks | Minimal | Nearly absent |
+| **Drums** | Dave Rock, basic indie kit | Boesel, tasteful/restrained | Boesel, dynamic/thunderous | Boesel, disco/electronic feel |
+| **Overall feel** | DIY indie folk-pop | Saddle Creek chamber-indie | Major-label alt-pop peak | 70s/80s FM radio pastiche |
+
+---
+
+## Studio Albums
+
+### Take Offs and Landings (2001)
+
+- **Release date**: July 31, 2001
+- **Label**: Rilo Records (initially), then Barsuk Records
+- **Producer**: Self-produced (Echo Chamber studio, Los Angeles)
+- **Mastering**: Charlie Watts
+- **Track count**: 14 tracks
+- **Chart position**: Did not chart
+
+The debut established the Lewis/Sennett songwriting partnership and the band's early sound: spare, DIY, acoustic-leaning indie pop with emo and twee-pop undertones. This is the most "band as equals" sounding album — Sennett's voice is as prominent as Lewis's, with multiple lead vocal turns.
+
+**Sonic Palette:**
+- Jittery, angular guitar riffs approaching math-rock territory (American Football influence)
+- Clean to lightly overdriven tones; prominent acoustic guitar on ballads
+- Trumpet (Philip Watt) — adds a Neutral Milk Hotel/Belle and Sebastian flavor; unique to this album
+- Synths and keys as textural accents, not lead instruments
+- Light string touches on select arrangements
+- Sparse instrumentation spotlighting the songwriting
+
+**Vocal Style:**
+- **Jenny Lewis**: Direct, personable delivery; more restrained and intimate than later albums. Not yet the confident belter of *More Adventurous*
+- **Blake Sennett**: Sings lead on "August," "Small Figures in a Vast Expanse," "Rest of My Life" — more lead tracks than any subsequent album. His vocals evoke Figure 8-era Elliott Smith: hushed, morose crooning over pseudo-uplifting instrumentals
+- **Harmonies**: Lewis and Sennett duets capture a communal charm — two friends guiding each other through difficulty
+
+**Drum Patterns:**
+- Dave Rock (original drummer) — straightforward indie rock drumming, live kit. Brushes on ballads, standard kit on rockers. Simple patterns serving the songs
+
+**BPM Range**: ~80-140, skewing mid-tempo
+
+**Genre Blend**: Indie pop / twee pop / folk-rock / alt-country touches
+
+**Influences**: Neutral Milk Hotel (horn arrangements, lively instrumentation masking lyrical despair), Belle and Sebastian (twee-pop sensibility, orchestral accents), Elliott Smith (Sennett's vocal tracks), American Football (angular guitar work)
+
+**Key Sonic Signatures:**
+- The trumpet/horn accents (never this prominent again)
+- Most balanced Lewis/Sennett vocal split in the discography
+- Sparse arrangements that let melodies breathe
+- Rougher, more unpolished quality vs. everything that followed
+
+**Key Tracks:**
+
+- **"Pictures of Success"** (~D major, ~100 BPM, 6:51) — Extended slow-burn build. Opens quietly with gentle guitar fingerpicking, gradually layers electric guitars, piano counterpoint, strings. No traditional pop chorus — more of a narrative arc structure. Existential dissatisfaction, the gap between ambition and reality. Early fan favorite that signaled Lewis's potential as a major songwriter.
+- **"Science vs. Romance"** (~C major, ~120 BPM, 5:43) — Multi-layered guitar work, acoustic and electric interweaving. Extended song form with dynamic shifts. The tension between rationality and emotion. The title became something of a thesis statement for Lewis's songwriting — she consistently operates at the intersection of cerebral and emotional.
+- **"Wires and Waves"** — One of the more energetic moments on the album. Driving rhythm section.
+
+**Tracklist:**
+1. Go Ahead
+2. Science vs. Romance
+3. Wires and Waves
+4. Pictures of Success
+5. August
+6. Bulletproof
+7. Plane Crash in C
+8. Variations on a Theme (Science vs. Romance)
+9. Small Figures in a Vast Expanse
+10. Don't Deconstruct
+11. Always
+12. We'll Never Sleep (God Knows We'll Try)
+13. Rest of My Life
+14. Variations on a Theme (Plane Crash in C)
+
+**Critical Reception:**
+- Pitchfork originally gave it 4.0/10, later revised to 8.0/10 ("an undeniable classic")
+- Stereogum praised Lewis and Sennett's "proficiency in indie rock"
+
+---
+
+### The Execution of All Things (2002)
+
+- **Release date**: October 1, 2002
+- **Label**: Saddle Creek Records
+- **Producer**: Mike Mogis (Saddle Creek mainstay, Bright Eyes collaborator)
+- **Recording**: Presto! Studios, Lincoln, Nebraska (March 2002)
+- **Mixing**: Mogis produced/mixed/recorded most tracks; AJ Mogis mixed title track and "Spectacular Views"; Blake Sennett recorded and mixed "With Arms Outstretched"
+- **Mastering**: Charlie Watts
+- **Track count**: 12 tracks
+- **Chart position**: Did not chart on Billboard 200
+
+The album that established Rilo Kiley as critical darlings. Mike Mogis's production brought warmth, richness, and the full Saddle Creek communal musician pool — pedal steel, vibraphone, banjo, and a "wall of friends" ensemble sound. The alt-country/Americana elements peak here and never return this strongly.
+
+**Sonic Palette:**
+- **Pedal steel guitar** (Mike Mogis) on "The Good That Won't Come Out," "Paint's Peeling," "Hail to Whatever You Found in the Sunlight That Surrounds You" — a defining texture
+- **Vibraphone & glockenspiel** (Mogis) — crystalline, bell-like shimmer on multiple tracks
+- **Banjo** (Mogis) on "And That's How I Choose to Remember It"
+- Picked/cascading electric guitars; needling guitar lines; lilting combinations of picked patterns
+- Whirring synthesizers woven in "unusual and displaced-sounding" ways — electronic samplings mixed with organic instruments
+- Strings courtesy of the Saddle Creek communal musician pool
+- Orchestra bells and keyboards rushing in at climactic moments
+
+**Vocal Style:**
+- **Jenny Lewis**: Sings lead on all tracks except two. More exposed and intimate — "live-wire intimacy" on "The Good That Won't Come Out." Growing confidence and emotional directness
+- **Blake Sennett**: Lead vocals on "So Long" and "Three Hopeful Thoughts." Still channeling Elliott Smith's soft crooning
+- **Gang vocals**: "With Arms Outstretched" features Conor Oberst and AJ Mogis alongside band members
+
+**Drum Patterns:**
+- Jason Boesel (joined 2001, replacing Dave Rock) — more nuanced than the debut. Tasteful, restrained playing that supports dynamic builds. Can sit back for quiet passages and push forward at climaxes
+
+**BPM Range**: ~75-135
+
+**Genre Blend**: Indie pop / alt-country / Americana / chamber pop
+
+**Influences**: Bright Eyes / Saddle Creek aesthetic (communal recording, Mogis production), alt-country / Americana (pedal steel, banjo), Elliott Smith, chamber pop (orchestral instrumentation), early indie electronic (displaced sampling)
+
+**Key Sonic Signatures:**
+- Pedal steel guitar as defining textural element
+- The Saddle Creek "wall of friends" ensemble sound
+- Electronic samplings used in displaced, unusual ways
+- Contrast between intimate quietness and full-band swells
+- Vibraphone/glockenspiel shimmer
+
+**Key Tracks:**
+
+- **"The Execution of All Things"** (~G major, ~130 BPM, 4:00) — Sweet melody + apocalyptic lyrics = hallmark Lewis juxtaposition. Political and personal destruction intertwined. Biblical undertones. Acoustic and electric guitars interweave under Mogis's warm Midwestern production. Tambourine and light percussion. The song that gave the album its reputation.
+- **"A Better Son/Daughter"** (E major, 114 BPM, 4:39) — Two distinct halves: a quiet, sparse first section (~2.5 minutes of acoustic guitar/piano and Lewis's voice close and vulnerable) then a dramatic build into an explosive, anthemic second half with driving drums, distorted electric guitars, and urgent declarations of resilience. The dynamic shift mirrors the bipolar experience the lyrics describe. Widely considered Rilo Kiley's masterpiece and one of the definitive indie rock songs about mental health. The quiet/loud structure influenced a generation of indie songwriters.
+- **"With Arms Outstretched"** (~G major, ~135 BPM, 3:43) — Acoustic-driven opening building to full-band indie rock. The dynamic arc mirrors "A Better Son/Daughter" in compressed form. Fleeting joy, impermanence, gratitude. Featured in Season 1 of One Tree Hill (2003). One of the band's most beloved live songs.
+- **"The Good That Won't Come Out"** — Opens with lilting pedal steel and vibraphone. Deeply personal — about secrets, shame, and the parts of ourselves we hide. Confessional, raw.
+
+**Tracklist:**
+1. The Good That Won't Come Out
+2. Paint's Peeling
+3. The Execution of All Things
+4. So Long
+5. Capturing Moods
+6. A Better Son/Daughter
+7. Hail to Whatever You Found in the Sunlight That Surrounds You
+8. My Slumbering Heart
+9. Three Hopeful Thoughts
+10. With Arms Outstretched
+11. Spectacular Views
+12. Outro
+
+**Critical Reception:**
+- Pitchfork: 7.5/10 — "the words here are descriptive and articulate, but gracefully rendered"
+- Metacritic: 80/100
+- The album that established their reputation in the indie rock world
+
+---
+
+### More Adventurous (2004)
+
+- **Release date**: August 17, 2004
+- **Label**: Brute/Beaute Records (band's own imprint), distributed by Warner Bros. Records
+- **Producers**: Mike Mogis, Mark Trombino, Jimmy Tamborello (three producers, remarkably consistent sound)
+- **Studio**: Mike Elizondo's private studio
+- **Recording gear**:
+  - Console: BCM-10 custom racked with 10 Neve 1073 preamps
+  - Other preamps: API 3124, Avalon 2022, SSL AWS900 built-in
+  - Vocal chain: Telefunken 250 mic → Avalon 2022 → Tube Tech CL1B; EQ/Comp on SSL during mix
+  - Guitar signal: 1073 + 2254, TG1, or Distressors depending on desired sound
+  - Bass signal: API + 1176
+- **Track count**: 11 tracks
+- **Chart position**: #161 Billboard 200
+
+The major-label debut and creative peak. More polished and expansive than the first two albums — brighter, more focused, more sophisticated. Each song received its own treatment. Mogis's multi-instrumentalist palette expanded enormously, and Lewis's vocal performance reached its emotional peak.
+
+**Sonic Palette:**
+- **Wurlitzer electric piano** — key warm texture throughout
+- **Mogis multi-instrumental arsenal**: pedal steel, vibraphone, glockenspiel, Memory Man echo pedal, banjo, mandolin, sequencing, Wurlitzer, electric/acoustic guitars, synthesizer
+- Range from sweet acoustic duets ("The Absence of God") to rough, sharp electric guitars ("Love and War (11/11/46)")
+- Jimmy Tamborello (Dntel/Postal Service) co-produces "Accidntel Deth" with more synthetic sound
+- Expanded percussion: timpani, conga, handbell, shaker, metal pipe
+- "No Better Cause" backing vocal group on select tracks
+- String sections on some arrangements
+- Handclaps prominent on "Love and War" and other tracks
+
+**Vocal Style:**
+- **Jenny Lewis**: Peak emotional vulnerability. Recorded her vocal for "I Never" naked in the studio to achieve the intended vulnerable effect. More confident, commanding presence. She owns the album vocally
+- **Blake Sennett**: Reduced vocal presence; Lewis is firmly the star. Sennett focuses more on guitar
+- **Emotional range**: From the ache of "Does He Love You?" to the bitter swagger of "Portions for Foxes"
+- **Backing chorus**: "No Better Cause" adds group vocal support. Less Lewis/Sennett duetting
+
+**Drum Patterns:**
+- Jason Boesel — "alternately understated and thunderous." Attacks his kit with reckless abandon on climactic moments (notably "Portions for Foxes" outro). Plays tambourine, timpani, conga, handbell, shaker, glockenspiel, metal pipe, and percussion far beyond the standard kit. Most dynamic and adventurous drumming in the catalog
+
+**BPM Range**: ~80-150
+
+**Genre Blend**: Indie rock / power pop / alt-country / chamber pop / electronic touches — the most balanced blend of all their albums
+
+**Influences**: Elliott Smith (directly — "Ripchord" and "It Just Is" written in response to his death), power pop / Big Star, Americana / alt-country, The Postal Service (Tamborello collaboration), classic singer-songwriters
+
+**Key Sonic Signatures:**
+- Wurlitzer electric piano warmth throughout
+- Mogis's expanded multi-instrumentalist palette (Memory Man echo pedal as texture)
+- The "big" sound — fuller arrangements, more instruments, more people
+- Guitar tone variety within a single album (acoustic delicacy to aggressive distortion)
+
+**Key Tracks:**
+
+- **"Portions for Foxes"** (~A major, ~140 BPM, ~4:05) — Rilo Kiley's biggest song. 374.9K Last.fm listeners, 2.9M scrobbles. Driven by a propulsive, choppy guitar riff. Tight rhythm section creates urgency. Toxic relationships and sexual compulsion — the narrator knows the relationship is destructive but can't resist. Title references Psalms 63:10 (biblical destruction imagery). Mark Trombino's production is clean and radio-ready. Featured in Grey's Anatomy Season 2 (2005), which massively boosted the band's profile. Released as a single with music video.
+- **"It's a Hit"** (~C major, ~125 BPM, 4:31) — Sardonic political commentary disguised as a pop song. The "hit" is multivalent: a hit song, an attack, a drug. Bright, major-key guitar pop with handclaps, tambourine, horn-like keyboard flourishes. As the album opener, it announces More Adventurous's more polished, commercially aware sound. Political undertones resonated during the Iraq War era.
+- **"Does He Love You?"** (~D minor, ~90 BPM, 5:15) — Slow-building ballad told from "the other woman" perspective. Opens sparse (acoustic guitar and voice), gradually adds layers. Lewis inhabits the character without moralizing. Explicit sexual content grounds it in physical reality. Demonstrates Lewis's most daring narrative songwriting.
+- **"I Never"** (~D major, ~110 BPM, 4:33) — Country-leaning tenderness. Gentle guitar work with pedal steel or slide suggesting Americana. Romantic vulnerability and the terror of genuine intimacy. Each "I never" revelation peels back another layer of emotional armor. One of the warmer, more acoustic tracks on the album.
+- **"Ripchord"** (~C major, ~140 BPM, 2:09) — Elliott Smith tribute. At just over two minutes, it arrives, delivers its emotional payload, and exits before you can fully process it. Stripped-down acoustic arrangement — likely just guitar and voice. The "ripchord" (parachute cord) as metaphor for the life-saving mechanism that wasn't pulled in time. Devastating brevity.
+- **"The Absence of God"** — Gentle acoustic guitar-driven contemplation.
+- **"Accidntel Deth"** — Jimmy Tamborello co-production gives it a more electronic, Postal Service-adjacent feel.
+
+**Tracklist:**
+1. It's a Hit
+2. Does He Love You?
+3. Portions for Foxes
+4. Ripchord
+5. I Never
+6. The Absence of God
+7. Accidntel Deth
+8. More Adventurous
+9. Love and War (11/11/46)
+10. A Man/Me/Then Jim
+11. It Just Is
+
+**Critical Reception:**
+- Pitchfork: 6.7/10 — appreciated Lewis's "pure and versatile" voice
+- AllMusic: 4/5 stars
+- Robert Christgau: #5 best release of 2004; #24 on his list of greatest albums of the 2000s decade
+- #14 on the Pazz & Jop poll for 2004
+- "Portions for Foxes" became the band's most well-known song via Grey's Anatomy
+
+---
+
+### Under the Blacklight (2007)
+
+- **Release date**: August 21, 2007
+- **Label**: Warner Bros. Records
+- **Producers**: Jason Lader (tracks 1-4, 6) and Mike Elizondo (tracks 5, 7-11), co-produced with Rilo Kiley
+- **Studios**: Sunset Sound (Hollywood), Sonora Recorders (Los Feliz), Phantom Studios (Westlake), Mike Elizondo's private studio
+- **Recording gear**: Same high-end chain as *More Adventurous* — Telefunken 250/Avalon 2022/Tube Tech CL1B vocal chain; Neve 1073s; API; SSL AWS900
+- **Track count**: 11 tracks, 38 minutes
+- **Chart position**: #22 Billboard 200 (~27,000 first-week copies); #5 US Top Alternative Albums; #34 UK Albums Chart
+
+The most divisive and commercially successful album. A dramatic departure — Mike Mogis absent for the first time. The band recorded multiple versions of each song in different styles ("this is our Fleetwood Mac version, this is our disco version"). Elizondo was "the first producer they'd worked with who got involved with the arrangements" to make songs tighter. A deliberate move toward mainstream accessibility; a 38-minute love letter to 70s/80s FM radio.
+
+**Sonic Palette:**
+- **Synthesizers dominant** — driving synths, shimmering synths, polished synth pads. Mid-80s Fleetwood Mac-style synths on "Dreamworld"
+- Disco-esque guitar tones on "Breakin' Up"; cleaner, more processed guitar sounds overall
+- Electronic drums/programming on "Give a Little Love" (simple electronic drums and handclaps)
+- Soulful professional backup singers (not band members) on "Breakin' Up" chorus
+- Funk-influenced bass lines on several tracks
+- Horn arrangements on some tracks
+- **No pedal steel, banjo, vibraphone** — the Americana textures are gone entirely
+
+**Vocal Style:**
+- **Jenny Lewis**: Light, airy delivery. Channels The Cardigans' "Lovefool" breeziness. More pop-oriented singing with a Stevie Nicks quality on the Fleetwood Mac-influenced cuts. Less raw vulnerability, more polished confidence
+- **Blake Sennett**: Minimal vocal presence. This is fully Jenny's show
+- **Harmonies**: Professional backup singers rather than band-member harmonies. Soulful, R&B-influenced backing vocals
+- **Processing**: More reverb and polish on vocals than previous records
+
+**Drum Patterns:**
+- Jason Boesel — disco-influenced patterns, electronic feel. Simple electronic drums and handclaps on "Give a Little Love." Steady grooves rather than dynamic indie drumming. Some tracks feel closer to drum machine aesthetics even when live
+
+**BPM Range**: ~100-150, skewing uptempo consistently
+
+**Genre Blend**: Synth-pop / disco / new wave / power pop / glam rock — dramatic departure from alt-country/Americana
+
+**Influences**: Fleetwood Mac (especially Mirage/Tango in the Night era — the dominant influence), Steely Dan (sleek L.A. production), Motown / Stax (soul, R&B pulse), Blondie / new wave, David Bowie (glam rock), The Cardigans (airy pop delivery)
+
+**Key Sonic Signatures:**
+- "Dreamworld" channels Christine McVie so directly "she could probably sue"
+- Disco elements with triumphant soulful choruses
+- The glossy, radio-ready sheen — no rough edges
+- Synthesizers replacing the organic instrumentation of earlier albums
+- Absence of all Americana textures
+
+**Key Tracks:**
+
+- **"Silver Lining"** (~E major, ~145 BPM, 3:36) — Second biggest song (350.1K Last.fm listeners). Tight verse-chorus pop. Bright, immediate, hook-driven. Crisp, radio-ready production by Mike Elizondo. Resilience and optimism tinged with awareness of surrounding darkness. Clean electric guitar tones with subtle distortion. Featured on Grey's Anatomy, Weeds, Chuck. Performed on Jimmy Kimmel Live for 2025 reunion.
+- **"The Moneymaker"** (~Bb major, ~130 BPM, 2:51) — Glam-rock influenced strut. Sex work / commodification of the body as metaphor for the entertainment industry. Under three minutes — punk economy. Bass-heavy mix, 70s rock distorted guitars. Controversial music video featuring adult film performers. The least "indie" sounding song in their catalog.
+- **"Breakin' Up"** (~A major, ~150 BPM, 3:37) — Bouncy disco-pop with 1960s girl-group and Motown influences. Handclaps, driving drums, jangly guitars. The euphoria of ending a relationship — but with an undercurrent of performative happiness (is she truly free or convincing herself?). One of the most purely "fun" songs in their catalog.
+- **"Dreamworld"** (~F major, ~100 BPM, 4:45) — Mid-tempo, atmospheric mood piece. Reverb-heavy guitars create shimmering, dreamlike quality. Synthesizers add ambient washes. Fantasy vs. reality through the lens of Los Angeles culture. The most sonically ambitious track on the album.
+- **"Close Call"** (~A minor, ~135 BPM, 3:20) — Driving guitars with more edge than the poppier tracks. Nervous energy matching lyrics about near-misses. Connects to the rockier work of earlier albums while incorporating the later production polish.
+
+**Tracklist:**
+1. Silver Lining
+2. Close Call
+3. The Moneymaker
+4. Breakin' Up
+5. Under the Blacklight
+6. Dreamworld
+7. Dejalo
+8. 15
+9. Smoke Detector
+10. The Angels Hung Around
+11. Give a Little Love
+
+**Critical Reception:**
+- Metacritic: 71/100 (generally favorable, 32 reviews)
+- Pitchfork: 5.1/10 — praised "pop sheen" but criticized "uneven songwriting and superficial lyrics"
+- Divisive among fans and critics; the pop/R&B/disco shift was polarizing
+- Their highest-charting album commercially by far
+- Reassessed more favorably over time; Consequence of Sound (2025) called it "a misunderstood gem"
+
+---
+
+## EPs
+
+### Sandbox Sessions (1998)
+- Self-released demo recordings. Extremely rare. One of the band's first recordings.
+
+### Rilo Kiley / The Initial Friend EP (1999-2001)
+The debut release went through three pressings with different tracklists:
+- **1st pressing (1999)** — titled *Rilo Kiley*. Included unique track "Steve" and hidden track. Funded by comedian Dave Foley.
+- **2nd pressing (2000)** — titled *Rilo Kiley*. Removed "Steve," added "Always" and "Gravity."
+- **3rd pressing (2001)** — renamed *The Initial Friend EP*. Shuffled tracklist.
+- Core tracks: "Frug," "Troubadours," "Glendora," "Sword," "Papillon"
+- All pressings extremely rare (eBay: $250-400). First officially reissued October 2, 2020, and uploaded to streaming services.
+
+### Live at Fingerprints EP (2004)
+- Recorded live at Fingerprints, Long Beach, CA on August 19, 2004
+- 6 tracks including "More Adventurous," "Ripchord," "The Good That Won't Come Out," "Does He Love You?"
+
+### Breakin' Up EP (2008)
+- Includes Hot Chip Remix (8:00) and The Loving Hand Remix (6:24) of "Breakin' Up," plus "Silver Lining (Recordist Mix)"
+
+---
+
+## Compilations
+
+### Rkives (2013)
+- **Label**: Little Record Company (Pierre de Reeder's label)
+- B-sides, demos, and 9 previously unreleased songs spanning their career
+- 16 tracks including "Let Me Back In," "It'll Get You There," "The Frug"
+- Two hidden tracks: one sung by Lewis (CD), one by Sennett (LP)
+- **Chart**: #18 Heatseekers Albums
+
+### That's How We Choose to Remember It (2025)
+- **Label**: Saddle Creek Records
+- Greatest hits compilation for the reunion
+- Includes "Silver Lining," "Portions for Foxes," "With Arms Outstretched," "A Better Son/Daughter," "The Execution of All Things," "The Moneymaker," "I Never," "Wires and Waves," "The Frug"
+- **Chart**: #79 Billboard 200
+
+---
+
+## Key Tracks — Tempo & Key Reference
+
+| Track | Album | Key | BPM | Duration |
+|-------|-------|-----|-----|----------|
+| Pictures of Success | Take Offs | D | ~100 | 6:51 |
+| Science vs. Romance | Take Offs | C | ~120 | 5:43 |
+| The Execution of All Things | Execution | G | ~130 | 4:00 |
+| A Better Son/Daughter | Execution | E | 114 | 4:39 |
+| With Arms Outstretched | Execution | G | ~135 | 3:43 |
+| Portions for Foxes | More Adv. | A | ~140 | 4:05 |
+| It's a Hit | More Adv. | C | ~125 | 4:31 |
+| Does He Love You? | More Adv. | Dm | ~90 | 5:15 |
+| I Never | More Adv. | D | ~110 | 4:33 |
+| Ripchord | More Adv. | C | ~140 | 2:09 |
+| Silver Lining | Blacklight | E | ~145 | 3:36 |
+| The Moneymaker | Blacklight | Bb | ~130 | 2:51 |
+| Breakin' Up | Blacklight | A | ~150 | 3:37 |
+| Dreamworld | Blacklight | F | ~100 | 4:45 |
+| Close Call | Blacklight | Am | ~135 | 3:20 |
+
+---
+
+## Jenny Lewis Solo Work — Sonic Relationship
+
+### Rabbit Fur Coat (2006) — with The Watson Twins
+
+- **Produced by**: M. Ward and Mike Mogis
+- **Recorded in**: San Fernando Valley, Portland (OR), and Lincoln (NE)
+- **Sound**: Rootsy alt-country/folk/Southern gospel/Americana. Neil Young-influenced production. Acoustic guitars, pedal steel, sparse arrangements
+- **Vocals**: Lewis with Chandra and Leigh Watson's swell harmonies. A "very feminine record" — first album Lewis made without strong male filtering of her songwriting
+- **Key track**: "Run Devil Run" opens with a cappella gospel hymn
+- **Guests**: Ben Gibbard, Conor Oberst, M. Ward on "Handle With Care" (Traveling Wilburys cover)
+- **Relationship to Rilo Kiley**: Represents the alt-country/Americana thread from *Execution of All Things* pulled to its logical extreme. Mogis provides sonic continuity. Where Rilo Kiley traded in "immaculate, gossamer pop songs that leaned emo," Lewis pursued "something altogether more earthy"
+
+### Acid Tongue (2008)
+
+- **Produced by**: Jenny Lewis, Johnathan Rice, Jason Lader, Farmer Dave Scher
+- **Recorded at**: Sound City Studios, Van Nuys, CA — recorded live using analog equipment with minimal overdubs
+- **Sound**: Slide guitar, Hammond B3 organ, funk bass, piano, vibraphone, echo-laden piano, string arrangements, choir backing vocals. Joni Mitchell (*Court and Spark*) meets Rolling Stones (*Sticky Fingers*)
+- **Relationship to Rilo Kiley**: Bridges the gap between *Rabbit Fur Coat*'s rootsy folk and *Under the Blacklight*'s polished pop. Jason Lader co-produced both *Acid Tongue* and *Under the Blacklight*, creating a sonic connection. The analog, live recording approach is the opposite of *Blacklight*'s digital polish — "a balance between the heavily country leanings of *Rabbit Fur Coat* and the schizophrenic funk of *Under the Blacklight*"
+
+---
+
+## Jenny Lewis's Songwriting DNA
+
+### Narrative Style
+Lewis is a storytelling songwriter in the tradition of Joni Mitchell and Loretta Lynn, filtered through indie rock sensibility and California noir. She writes scenes, not just feelings — her songs have settings, characters, and narrative arcs. She grounds abstract emotions in specific, concrete details (a lake, a particular time of day, a physical gesture).
+
+### POV Usage
+Lewis moves fluidly between perspectives:
+- **First-person confessional**: A Better Son/Daughter, I Never
+- **First-person character study/persona**: Does He Love You? (the other woman), The Moneymaker (sex worker/entertainer)
+- **Second-person address**: With Arms Outstretched
+- **Sardonic omniscient narrator**: It's a Hit
+Her willingness to inhabit morally complex characters without judgment is a distinguishing trait.
+
+### Emotional Range
+Extraordinarily wide: from the devastating vulnerability of "A Better Son/Daughter" to the sardonic political wit of "It's a Hit" to the giddy joy of "Breakin' Up" to the unflinching eroticism of "Does He Love You?" Irony and sincerity coexist — she can be simultaneously funny and heartbroken.
+
+### Key Songwriting Techniques
+1. **Ironic juxtaposition** — sweet melodies carrying dark content (The Execution of All Things)
+2. **Dynamic contrast** — quiet/loud structure as emotional device (A Better Son/Daughter)
+3. **Ambiguity** — surface readings and deeper readings coexist (Breakin' Up, Silver Lining)
+4. **Concrete detail** — specific images ground abstract feelings
+5. **Character inhabitation** — perspectives rather than editorializing
+6. **Self-aware narrators** — they see their own flaws clearly but can't always change (Portions for Foxes)
+
+### Literary References
+- Psalms 63:10 in "Portions for Foxes" (portions for foxes = destruction)
+- "The Execution of All Things" — apocalyptic/religious overtones
+- "Ripchord" — parachute cord as metaphor for lifeline
+- Long, literary song titles ("Hail to Whatever You Found in the Sunlight That Surrounds You")
+- California noir and Southern Gothic traditions
+
+### Stated Influences
+- Late 80s/early 90s hip-hop (N.W.A., De La Soul, Beastie Boys — she described herself as "an Easy-E girl")
+- Country, soul, folk (Rabbit Fur Coat described as "a kind of soul record")
+- Joni Mitchell, Loretta Lynn
+
+---
+
+## TV/Film Placements
+
+| Song | Placement | Impact |
+|------|-----------|--------|
+| Portions for Foxes | Grey's Anatomy Season 2 (2005) | Breakthrough moment; massive audience expansion |
+| Silver Lining | Grey's Anatomy, Weeds, Chuck | Second biggest cultural touchpoint |
+| With Arms Outstretched | One Tree Hill Season 1 (2003) | Introduced band to younger audience |
+| Science vs. Romance | Dawson's Creek | Early TV exposure |
+| The Moneymaker | Fox Network promos, Carl's Jr. ad (2009) | Commercial mainstream |
+
+The mid-2000s TV placement era (Grey's Anatomy, The OC, One Tree Hill) was transformative for Rilo Kiley's audience growth, taking them from indie credibility to broader cultural awareness.
+
+---
+
+## 2025 Reunion
+
+- **February 2025**: Reunion announced with all four members (Lewis, Sennett, de Reeder, Boesel)
+- **Tour**: "Sometimes When You're On, You're Really F**king On" — first show May 5, 2025, at Fremont Theater, San Luis Obispo (first performance in 17 years)
+- **Jimmy Kimmel Live**: May 9, 2025, performing "Silver Lining"
+- **Just Like Heaven Festival**: May 10, 2025, Rose Bowl
+- **Greatest hits**: *That's How We Choose to Remember It* (#79 Billboard 200)
+- **UK dates**: Roundhouse and Shepherd's Bush Empire, London (June 2026)
+- No new studio material announced as of latest reports


### PR DESCRIPTION
## Summary

- Add comprehensive Rilo Kiley artist deep-dive to `genres/indie-rock/artists/`
- Add indie-rock genre `INDEX.md` with Suno prompt keywords and reference tracks
- Fix `.gitignore` to stop blocking `genres/**/artists/` directories (the blanket `artists/` rule was meant for user content, not genre references)

## Test plan

- [ ] Verify `.gitignore` fix: `git check-ignore genres/indie-rock/artists/rilo-kiley.md` returns nothing
- [ ] Verify user content still ignored: `git check-ignore artists/` still matches
- [ ] Deep-dive format matches existing references (e.g., `genres/piano-rock/artists/ben-folds-solo.md`)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)