### PR TITLE
fix(promo): use color_hex and glow in line style visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **`line` style ignores `color_hex` and `glow` parameters** — was hardcoded to `colors=white` with no glow support; now uses custom color and glow like all other styles
+
 ## [0.78.1] - 2026-03-24
 
 ### Added

--- a/tools/promotion/generate_promo_video.py
+++ b/tools/promotion/generate_promo_video.py
@@ -272,9 +272,14 @@ def generate_waveform_video(
         viz_filter = f"""[0:a]showfreqs=s={WIDTH}x{viz_height}:mode=line:ascale=sqrt:fscale=log:
              colors=white:win_size=2048:overlap=0.5[wave]"""
     elif style == "line":
-        # Classic waveform - highly reactive, centered
-        viz_filter = f"""[0:a]showwaves=s={WIDTH}x{viz_height}:mode=cline:scale=sqrt:
-             colors=white:rate={FPS}:split_channels=0[wave]"""
+        # Classic waveform - single centered line
+        if glow > 0:
+            viz_filter = f"""[0:a]showwaves=s={WIDTH}x{viz_height}:mode=cline:scale=sqrt:colors={color2}:rate={FPS}:split_channels=0[wave_raw];
+                 [wave_raw]split[w1][w2];
+                 [w2]gblur=sigma={glow_s:.0f}[wave_blur];
+                 [w1][wave_blur]blend=all_mode=screen[wave]"""
+        else:
+            viz_filter = f"""[0:a]showwaves=s={WIDTH}x{viz_height}:mode=cline:scale=sqrt:colors={color2}:rate={FPS}:split_channels=0[wave]"""
     else:  # circular
         # Audio vectorscope - creates wild circular patterns
         viz_filter = f"""[0:a]avectorscope=s=600x600:mode=lissajous_xy:


### PR DESCRIPTION
## Summary
- The `line` visualization style in `generate_promo_videos` had hardcoded `colors=white` and no glow support
- All other styles (mirror, pulse, neon, etc.) correctly use `color_hex` and `glow` parameters
- Now `line` uses the custom color (`color2`) and applies `gblur` + `screen` blend when `glow > 0`

## What changed
- `tools/promotion/generate_promo_video.py`: Added glow branch and replaced `colors=white` with `colors={color2}` for `line` style

## Test plan
- [ ] Generate a promo video with `style=line`, `color_hex=#FFD700`, `glow=0.05` — wave should be gold, not white
- [ ] Generate with `style=line`, `glow=0` — should render without glow artifacts
- [ ] Generate with `style=line`, no `color_hex` — should auto-extract color from artwork
- [ ] Other styles (mirror, pulse, etc.) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)