### PR TITLE
chore: add Dependabot for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to automate dependency update PRs
- Covers **pip** (requirements.txt) and **GitHub Actions** version pins
- Weekly schedule, conventional commit prefixes (`chore(deps):`), labeled `dependencies`

## Test plan
- [ ] Verify Dependabot picks up the config after merge to main
- [ ] Confirm PRs use correct commit prefix and labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)