### PR TITLE
fix: automate version badge, dev bump, and Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    groups:
+      pip-all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,3 +23,7 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -99,3 +99,28 @@ jobs:
           echo "2. Add new [Unreleased] section above it"
           echo "3. Commit and push to main"
         fi
+
+    - name: Bump develop to next dev version
+      if: steps.check_tag.outputs.exists == 'false'
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        # Calculate next dev version (bump minor, reset patch, add -dev)
+        IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+        NEXT_MINOR=$((MINOR + 1))
+        DEV_VERSION="${MAJOR}.${NEXT_MINOR}.0-dev"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git fetch origin develop
+        git checkout develop
+
+        # Update version files
+        jq ".version = \"$DEV_VERSION\"" .claude-plugin/plugin.json > /tmp/plugin.json && mv /tmp/plugin.json .claude-plugin/plugin.json
+        jq ".plugins[0].version = \"$DEV_VERSION\"" .claude-plugin/marketplace.json > /tmp/marketplace.json && mv /tmp/marketplace.json .claude-plugin/marketplace.json
+
+        git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+        git commit -m "chore: bump develop to $DEV_VERSION"
+        git push origin develop
+        echo "Bumped develop to $DEV_VERSION"

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - '.claude-plugin/plugin.json'
       - '.claude-plugin/marketplace.json'
-      - 'README.md'
       - 'skills/*/SKILL.md'
       - 'tests/**'
 
@@ -43,23 +42,3 @@ jobs:
         echo ""
         echo "[OK] Version files are in sync: $PLUGIN_VERSION"
 
-    - name: Verify README badges match
-      run: |
-        PLUGIN_VERSION=$(jq -r '.version' .claude-plugin/plugin.json)
-        ERRORS=0
-
-        # Check version badge (skip on -dev versions — badge shows last release)
-        if echo "$PLUGIN_VERSION" | grep -q '\-dev'; then
-          echo "[SKIP] Dev version ($PLUGIN_VERSION) — badge check skipped"
-        elif grep -qF "badge/version-${PLUGIN_VERSION}-blue" README.md; then
-          echo "[OK] Version badge matches: $PLUGIN_VERSION"
-        else
-          README_BADGE=$(grep -oP 'badge/version-\K[^-]+' README.md || echo "not found")
-          echo "[FAIL] Version badge ($README_BADGE) does not match plugin.json ($PLUGIN_VERSION)"
-          echo "  Update README.md: badge/version-${PLUGIN_VERSION}-blue"
-          ERRORS=$((ERRORS + 1))
-        fi
-
-        if [ "$ERRORS" -gt 0 ]; then
-          exit 1
-        fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ I love music but never learned an instrument. AI became the creative outlet that
 
 What it actually does: a Claude Code plugin that turns a conversation into a full album production pipeline. You describe what you want to make, and it handles concept development, lyrics, [Suno](https://suno.com) prompts (an AI music generation platform), audio mastering, and release prep — with quality gates and source verification at every stage.
 
-![Version](https://img.shields.io/badge/version-0.79.3-blue)
+![Version](https://img.shields.io/github/v/release/bitwize-music-studio/claude-ai-music-skills?label=version&color=blue)
 
 > [!NOTE]
 > Active development happens on the `develop` branch — `main` only receives tested, stable releases. If you run into issues, [open an issue](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues) or submit a PR.

--- a/hooks/check_version_sync.py
+++ b/hooks/check_version_sync.py
@@ -5,6 +5,7 @@ Only activates when editing plugin.json or marketplace.json.
 """
 import json
 import os
+import subprocess
 import sys
 
 
@@ -44,6 +45,21 @@ def check_sync(data: dict) -> list[str]:
         marketplace_version = plugins[0].get("version", "")
 
     if plugin_version and marketplace_version and plugin_version != marketplace_version:
+        # If the other file is also modified in the working tree, this is
+        # a mid-edit pair (user updating both files sequentially). Skip.
+        try:
+            result = subprocess.run(
+                ["git", "diff", "--name-only"],
+                capture_output=True, text=True, timeout=5,
+                cwd=plugin_dir,
+            )
+            modified = set(result.stdout.strip().splitlines())
+            other_file = "marketplace.json" if file_path.endswith("plugin.json") else "plugin.json"
+            if other_file in modified or os.path.join(".claude-plugin", other_file) in modified:
+                return []
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
         return [
             f"Version mismatch: plugin.json has '{plugin_version}' "
             f"but marketplace.json has '{marketplace_version}'. "


### PR DESCRIPTION
## Summary
Three automation improvements that eliminate manual steps from every release:

- **Dynamic version badge** — README badge now reads from GitHub releases via shields.io. Never needs manual updating.
- **Automated dev bump** — auto-release workflow pushes `X.Y+1.0-dev` to develop after creating a release. No more manual post-release commit.
- **Version sync hook fix** — hook now checks `git diff` to detect when both version files are being edited sequentially. Skips the false positive instead of erroring.
- **Dependabot grouping** — all pip updates batched into one PR, all Actions updates batched into one PR. No more 13 individual PRs.
- **Removed version badge CI check** — no longer needed with dynamic badge.

## What this eliminates from the release process
| Before | After |
|--------|-------|
| Manually update README version badge | Automatic |
| Manually bump develop to -dev | Automatic |
| False positive hook errors during version edits | Suppressed |
| 10+ individual Dependabot PRs | 1 pip PR + 1 Actions PR |

## Test plan
- [ ] CI passes
- [ ] Verify dynamic badge renders on GitHub (after merge to main)
- [ ] Next release: confirm auto-release bumps develop
- [ ] Next Dependabot cycle: confirm grouped PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)