### PR TITLE
fix: classify [End] tags as dedicated section type

### DIFF
--- a/servers/bitwize-music-server/handlers/lyrics_analysis.py
+++ b/servers/bitwize-music-server/handlers/lyrics_analysis.py
@@ -84,6 +84,7 @@ _SECTION_PRIORITY = {
     "outro": 2,
     "verse": 1,
     "intro": 1,
+    "end": 1,
 }
 
 

--- a/tests/unit/state/test_server_lyrics.py
+++ b/tests/unit/state/test_server_lyrics.py
@@ -1085,7 +1085,7 @@ class TestTokenizeLyricsWithSections:
 
     def test_all_section_types_recognized(self):
         """All priority section types should be correctly identified."""
-        for section_type in ["chorus", "hook", "pre-chorus", "bridge", "outro", "verse", "intro"]:
+        for section_type in ["chorus", "hook", "pre-chorus", "bridge", "outro", "verse", "intro", "end"]:
             tag = f"[{section_type.title()}]"
             lyrics = f"{tag}\nTest words here"
             result = _lyrics_analysis_mod._tokenize_lyrics_with_sections(lyrics)


### PR DESCRIPTION
## Summary

- Add `"end"` to `_SECTION_PRIORITY` in `lyrics_analysis.py` so `[End]` tags are recognized as their own section type instead of falling through to `"verse"` default
- Update `test_all_section_types_recognized` to include `"end"`

## Test plan

- [x] All 2,473 tests pass
- [x] `test_all_section_types_recognized` now covers `[End]`

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)