### PR TITLE
feat: add pre-release validation gates

### DIFF
--- a/servers/bitwize-music-server/handlers/gates.py
+++ b/servers/bitwize-music-server/handlers/gates.py
@@ -10,12 +10,14 @@ from typing import Any
 from handlers import _shared
 from handlers import text_analysis as _text_analysis
 from handlers._shared import (
+    TRACK_FINAL,
     _SECTION_TAG_RE,
     _STREAMING_PLACEHOLDER_MARKERS,
     _extract_code_block,
     _extract_markdown_section,
     _find_album_or_error,
     _find_track_or_error,
+    _find_wav_source_dir,
     _safe_json,
 )
 
@@ -551,6 +553,257 @@ async def check_streaming_lyrics(album_slug: str, track_slug: str = "") -> str:
 
 
 # =============================================================================
+# Pre-Release Gates
+# =============================================================================
+
+# Album art file patterns (mirrored from status.py to avoid cross-handler import)
+_ALBUM_ART_PATTERNS = [
+    "album.png", "album.jpg", "album-art.png", "album-art.jpg",
+    "artwork.png", "artwork.jpg", "cover.png", "cover.jpg",
+]
+
+
+def _check_pre_release_gates(
+    album: dict[str, Any],
+    normalized_slug: str,
+    audio_path: Path | None,
+) -> tuple[int, int, list[dict[str, Any]]]:
+    """Run pre-release gates on an album.
+
+    Returns (blocking_count, warning_count, gates_list).
+    """
+    gates: list[dict[str, Any]] = []
+    blocking = 0
+    warnings = 0
+    tracks = album.get("tracks", {})
+
+    # Gate 1: All Tracks Final
+    non_final = [
+        slug for slug, t in tracks.items()
+        if t.get("status") != TRACK_FINAL
+    ]
+    if non_final:
+        gates.append({
+            "gate": "All Tracks Final", "status": "FAIL", "severity": "BLOCKING",
+            "detail": f"{len(non_final)} track(s) not Final: {', '.join(sorted(non_final)[:5])}",
+        })
+        blocking += 1
+    else:
+        gates.append({
+            "gate": "All Tracks Final", "status": "PASS",
+            "detail": f"All {len(tracks)} track(s) are Final",
+        })
+
+    # Gate 2: Audio Files Exist
+    if audio_path is None:
+        gates.append({
+            "gate": "Audio Files Exist", "status": "FAIL", "severity": "BLOCKING",
+            "detail": "Audio directory not found — check config and album genre",
+        })
+        blocking += 1
+    else:
+        wav_dir = _find_wav_source_dir(audio_path)
+        wav_files = list(wav_dir.glob("*.wav"))
+        if not wav_files:
+            gates.append({
+                "gate": "Audio Files Exist", "status": "FAIL", "severity": "BLOCKING",
+                "detail": f"No WAV files in {wav_dir}",
+            })
+            blocking += 1
+        else:
+            gates.append({
+                "gate": "Audio Files Exist", "status": "PASS",
+                "detail": f"{len(wav_files)} WAV file(s) in {wav_dir.name}/",
+            })
+
+    # Gate 3: Mastered Audio Exists
+    if audio_path is None:
+        gates.append({
+            "gate": "Mastered Audio Exists", "status": "FAIL", "severity": "BLOCKING",
+            "detail": "Audio directory not found",
+        })
+        blocking += 1
+    else:
+        mastered_dir = audio_path / "mastered"
+        mastered_files = list(mastered_dir.glob("*.wav")) if mastered_dir.is_dir() else []
+        if not mastered_files:
+            gates.append({
+                "gate": "Mastered Audio Exists", "status": "FAIL", "severity": "BLOCKING",
+                "detail": "No mastered WAV files — run mastering-engineer first",
+            })
+            blocking += 1
+        else:
+            gates.append({
+                "gate": "Mastered Audio Exists", "status": "PASS",
+                "detail": f"{len(mastered_files)} mastered WAV file(s)",
+            })
+
+    # Gate 4: Album Art Exists
+    if audio_path is None:
+        gates.append({
+            "gate": "Album Art Exists", "status": "FAIL", "severity": "BLOCKING",
+            "detail": "Audio directory not found",
+        })
+        blocking += 1
+    else:
+        has_art = any((audio_path / p).exists() for p in _ALBUM_ART_PATTERNS)
+        if not has_art:
+            gates.append({
+                "gate": "Album Art Exists", "status": "FAIL", "severity": "BLOCKING",
+                "detail": f"No album art found in {audio_path} — expected one of: "
+                          + ", ".join(_ALBUM_ART_PATTERNS[:4]),
+            })
+            blocking += 1
+        else:
+            gates.append({
+                "gate": "Album Art Exists", "status": "PASS",
+                "detail": "Album art found",
+            })
+
+    # Gate 5: Streaming Lyrics Ready
+    streaming_issues: list[str] = []
+    for t_slug, t_data in sorted(tracks.items()):
+        track_path_str = t_data.get("path", "")
+        if not track_path_str:
+            streaming_issues.append(f"{t_slug}: no track path")
+            continue
+        try:
+            tfile = Path(track_path_str).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            streaming_issues.append(f"{t_slug}: cannot read track file")
+            continue
+        section = _extract_markdown_section(tfile, "Streaming Lyrics")
+        if not section:
+            streaming_issues.append(f"{t_slug}: missing section")
+            continue
+        block = _extract_code_block(section)
+        if not block or not block.strip():
+            streaming_issues.append(f"{t_slug}: empty")
+            continue
+        if any(m.lower() in block.lower() for m in _STREAMING_PLACEHOLDER_MARKERS):
+            streaming_issues.append(f"{t_slug}: placeholder content")
+
+    if streaming_issues:
+        gates.append({
+            "gate": "Streaming Lyrics Ready", "status": "FAIL", "severity": "BLOCKING",
+            "detail": f"{len(streaming_issues)} track(s) not ready: "
+                      + ", ".join(streaming_issues[:5]),
+        })
+        blocking += 1
+    else:
+        gates.append({
+            "gate": "Streaming Lyrics Ready", "status": "PASS",
+            "detail": f"All {len(tracks)} track(s) have streaming lyrics",
+        })
+
+    # Gate 6: Explicit Flag Consistency
+    album_explicit = album.get("explicit", False)
+    explicit_tracks = [
+        slug for slug, t in tracks.items()
+        if t.get("explicit") is True
+    ]
+    if explicit_tracks and not album_explicit:
+        gates.append({
+            "gate": "Explicit Flag Consistency", "status": "FAIL", "severity": "BLOCKING",
+            "detail": f"Album marked clean but {len(explicit_tracks)} track(s) are explicit: "
+                      + ", ".join(sorted(explicit_tracks)[:5])
+                      + " — set album explicit: true",
+        })
+        blocking += 1
+    elif not explicit_tracks and album_explicit:
+        gates.append({
+            "gate": "Explicit Flag Consistency", "status": "WARN", "severity": "WARNING",
+            "detail": "Album marked explicit but no tracks are flagged explicit — verify this is intentional",
+        })
+        warnings += 1
+    else:
+        label = "explicit" if album_explicit else "clean"
+        gates.append({
+            "gate": "Explicit Flag Consistency", "status": "PASS",
+            "detail": f"Album and tracks consistently {label}",
+        })
+
+    # Gate 7: Streaming URLs Set
+    streaming_urls = album.get("streaming_urls", {})
+    set_urls = {k: v for k, v in streaming_urls.items() if v}
+    if not set_urls:
+        gates.append({
+            "gate": "Streaming URLs Set", "status": "WARN", "severity": "WARNING",
+            "detail": "No streaming URLs set — add after platform uploads with update_streaming_url",
+        })
+        warnings += 1
+    else:
+        gates.append({
+            "gate": "Streaming URLs Set", "status": "PASS",
+            "detail": f"{len(set_urls)} platform(s) set: {', '.join(sorted(set_urls.keys()))}",
+        })
+
+    return blocking, warnings, gates
+
+
+async def run_pre_release_gates(album_slug: str) -> str:
+    """Run all 7 pre-release validation gates on an album.
+
+    Checks that an album is ready for release by verifying audio files,
+    mastering, artwork, streaming lyrics, and metadata consistency.
+
+    Gates:
+        1. All Tracks Final — every track must be at Final status
+        2. Audio Files Exist — WAV files present in audio directory
+        3. Mastered Audio Exists — mastered/ subdirectory has WAV files
+        4. Album Art Exists — album art file in audio directory
+        5. Streaming Lyrics Ready — all tracks have non-placeholder streaming lyrics
+        6. Explicit Flag Consistency — album explicit flag matches track flags
+        7. Streaming URLs Set — at least one streaming URL is populated
+
+    Gates 1-5 are BLOCKING (must pass before release).
+    Gate 6 is BLOCKING if album is clean but tracks are explicit, WARNING if reverse.
+    Gate 7 is WARNING only (URLs are typically added after upload).
+
+    Args:
+        album_slug: Album slug (e.g., "my-album")
+
+    Returns:
+        JSON with gate results and overall verdict
+    """
+    normalized, album, error = _find_album_or_error(album_slug)
+    if error:
+        return error
+    assert album is not None
+
+    # Resolve audio directory
+    state = _shared.cache.get_state()
+    state_config = state.get("config", {})
+    audio_root = state_config.get("audio_root", "")
+    artist_name = state_config.get("artist_name", "")
+    genre = album.get("genre", "")
+
+    audio_path: Path | None = None
+    if audio_root and artist_name and genre:
+        candidate = Path(audio_root) / "artists" / artist_name / "albums" / genre / normalized
+        if candidate.is_dir():
+            audio_path = candidate
+
+    blocking, warnings, gates = _check_pre_release_gates(album, normalized, audio_path)
+
+    if blocking == 0 and warnings == 0:
+        verdict = "READY"
+    elif blocking == 0:
+        verdict = "READY (with warnings)"
+    else:
+        verdict = "NOT READY"
+
+    return _safe_json({
+        "found": True,
+        "album_slug": normalized,
+        "verdict": verdict,
+        "blocking": blocking,
+        "warnings": warnings,
+        "gates": gates,
+    })
+
+
+# =============================================================================
 # Registration
 # =============================================================================
 
@@ -558,3 +811,4 @@ async def check_streaming_lyrics(album_slug: str, track_slug: str = "") -> str:
 def register(mcp: Any) -> None:
     mcp.tool()(run_pre_generation_gates)
     mcp.tool()(check_streaming_lyrics)
+    mcp.tool()(run_pre_release_gates)

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -447,6 +447,7 @@ from handlers.database import (  # noqa: F401
 from handlers.gates import (  # noqa: F401
     check_streaming_lyrics,
     run_pre_generation_gates,
+    run_pre_release_gates,
 )
 
 # Health tools

--- a/skills/release-director/SKILL.md
+++ b/skills/release-director/SKILL.md
@@ -147,18 +147,34 @@ Check for custom release preferences:
 
 ### Step 2: Pre-Release QA
 
-**QA Domains**:
+**First**: Run the automated pre-release gates to catch blocking issues early:
+
+```
+run_pre_release_gates(album_slug)
+```
+
+This validates 7 gates:
+1. **All Tracks Final** — every track at Final status
+2. **Audio Files Exist** — WAV files in audio directory
+3. **Mastered Audio Exists** — mastered/ has WAV files
+4. **Album Art Exists** — art file in audio directory
+5. **Streaming Lyrics Ready** — all tracks have non-placeholder streaming lyrics
+6. **Explicit Flag Consistency** — album explicit flag matches track flags
+7. **Streaming URLs Set** — at least one platform URL populated (warning only)
+
+**If any BLOCKING gate fails**: resolve the issue before continuing. Do NOT proceed past this step with blocking failures.
+
+**Then** run manual QA across these domains:
 1. **Audio Quality** - Files play, no corruption, consistent loudness
 2. **Metadata Completeness** - All album/track info filled
 3. **Source Verification** - If source-based, all verified
 4. **Lyrics Accuracy** - Match source material, pronunciation checked
-5. **Artwork Quality** - Resolution, format, specs met
+5. **Artwork Quality** - Resolution, format, specs met (3000x3000px)
 6. **File Organization** - Correct structure, naming conventions
 7. **Documentation** - README complete, generation logs filled
-8. **Explicit Content** - Flagged correctly
-9. **Promo Copy** (optional) - `promo/` directory has platform copy populated (campaign.md, twitter.md, instagram.md, etc.). Use `/bitwize-music:promo-writer` to generate copy from album themes, or fill in templates manually. Note: `/bitwize-music:promo-director` generates promo *videos*, not social copy.
+8. **Promo Copy** (optional) - `promo/` directory has platform copy populated (campaign.md, twitter.md, instagram.md, etc.). Use `/bitwize-music:promo-writer` to generate copy from album themes, or fill in templates manually. Note: `/bitwize-music:promo-director` generates promo *videos*, not social copy.
 
-**QA Gate**: All checks must pass before proceeding
+**QA Gate**: All automated gates and manual checks must pass before proceeding
 
 ### Step 3: Distribution Prep
 

--- a/tests/unit/state/test_server_pre_release.py
+++ b/tests/unit/state/test_server_pre_release.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""
+Unit tests for run_pre_release_gates MCP tool.
+
+Usage:
+    python -m pytest tests/unit/state/test_server_pre_release.py -v
+"""
+
+import asyncio
+import copy
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Import server module from hyphenated directory via importlib.
+# Same mock setup as test_server.py — the server requires mcp.server.fastmcp
+# which may not be installed in the test environment.
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    """Import the server module from the hyphenated directory."""
+    spec = importlib.util.spec_from_file_location("state_server_pre_release", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod
+from handlers import gates as _gates_mod
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+def _make_sample_state(*, album_status="Complete", track_status="Final",
+                       album_explicit=False, track_explicit=False,
+                       streaming_urls=None):
+    """Build a sample state dict with configurable album/track settings."""
+    return {
+        "version": 2,
+        "config": {
+            "content_root": "/tmp/test-content",
+            "audio_root": "/tmp/test-audio",
+            "documents_root": "/tmp/test-docs",
+            "artist_name": "test-artist",
+            "overrides_path": "/tmp/test-content/overrides",
+            "ideas_file": "/tmp/test-content/IDEAS.md",
+        },
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "status": album_status,
+                "genre": "electronic",
+                "explicit": album_explicit,
+                "path": "/tmp/test-content/artists/test-artist/albums/electronic/test-album",
+                "streaming_urls": streaming_urls or {},
+                "track_count": 2,
+                "tracks": {
+                    "01-first-track": {
+                        "title": "First Track",
+                        "status": track_status,
+                        "explicit": track_explicit,
+                        "has_suno_link": True,
+                        "sources_verified": "N/A",
+                        "path": "",
+                        "mtime": 1234567890.0,
+                    },
+                    "02-second-track": {
+                        "title": "Second Track",
+                        "status": track_status,
+                        "explicit": track_explicit,
+                        "has_suno_link": True,
+                        "sources_verified": "N/A",
+                        "path": "",
+                        "mtime": 1234567891.0,
+                    },
+                },
+                "mtime": 1234567890.0,
+            },
+        },
+        "ideas": {"total": 0, "by_status": {}, "items": []},
+        "session": {
+            "last_album": None, "last_track": None,
+            "last_phase": None, "pending_actions": [],
+            "updated_at": None,
+        },
+        "meta": {"rebuilt_at": "2026-01-01T00:00:00Z", "plugin_version": "0.50.0"},
+    }
+
+
+class MockStateCache:
+    """A mock StateCache that holds state in memory."""
+
+    def __init__(self, state=None):
+        self._state = state if state is not None else _make_sample_state()
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+
+def _make_track_file(content: str = "") -> str:
+    """Build minimal track markdown with streaming lyrics section."""
+    if not content:
+        content = (
+            "---\ntitle: Test\n---\n"
+            "## Streaming Lyrics\n\n"
+            "```\n"
+            "These are real streaming lyrics\n"
+            "With proper capitalization\n"
+            "And enough words to pass validation\n"
+            "```\n"
+        )
+    return content
+
+
+def _setup_audio_dir(tmp_path, *, with_originals=True, with_mastered=True, with_art=True):
+    """Create a realistic audio directory structure.
+
+    Returns the album audio path.
+    """
+    audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    if with_originals:
+        originals = audio_dir / "originals"
+        originals.mkdir(exist_ok=True)
+        (originals / "01-first-track.wav").write_bytes(b"\x00" * 100)
+        (originals / "02-second-track.wav").write_bytes(b"\x00" * 100)
+
+    if with_mastered:
+        mastered = audio_dir / "mastered"
+        mastered.mkdir(exist_ok=True)
+        (mastered / "01-first-track.wav").write_bytes(b"\x00" * 100)
+        (mastered / "02-second-track.wav").write_bytes(b"\x00" * 100)
+
+    if with_art:
+        (audio_dir / "album.png").write_bytes(b"\x89PNG")
+
+    return audio_dir
+
+
+def _setup_track_files(tmp_path, state, *, streaming_lyrics=True, placeholder=False):
+    """Create track markdown files and update state paths.
+
+    Returns the tracks directory.
+    """
+    content_dir = tmp_path / "content" / "artists" / "test-artist" / "albums" / "electronic" / "test-album" / "tracks"
+    content_dir.mkdir(parents=True, exist_ok=True)
+
+    for t_slug in state["albums"]["test-album"]["tracks"]:
+        if streaming_lyrics:
+            if placeholder:
+                lyrics_block = "Plain lyrics here\nCapitalize first letter of each line"
+            else:
+                lyrics_block = (
+                    "These are real streaming lyrics\n"
+                    "With proper capitalization\n"
+                    "And enough words to pass the word count check easily\n"
+                    "Because we need at least twenty words total here now"
+                )
+            content = (
+                f"---\ntitle: {t_slug}\n---\n"
+                f"## Streaming Lyrics\n\n```\n{lyrics_block}\n```\n"
+            )
+        else:
+            content = f"---\ntitle: {t_slug}\n---\n## Notes\n\nNo streaming lyrics yet.\n"
+
+        track_file = content_dir / f"{t_slug}.md"
+        track_file.write_text(content, encoding="utf-8")
+        state["albums"]["test-album"]["tracks"][t_slug]["path"] = str(track_file)
+
+    return content_dir
+
+
+# =============================================================================
+# Tests for run_pre_release_gates
+# =============================================================================
+
+
+class TestPreReleaseGatesAlbumNotFound:
+    """Album lookup failure."""
+
+    def test_unknown_album_returns_error(self):
+        state = _make_sample_state()
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("nonexistent")))
+        assert result["found"] is False
+        assert "not found" in result["error"]
+
+
+class TestPreReleaseGatesAllPass:
+    """All gates pass — album is release-ready."""
+
+    def test_fully_ready_album(self, tmp_path):
+        state = _make_sample_state(
+            track_status="Final",
+            streaming_urls={"soundcloud": "https://soundcloud.com/test"},
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+
+        state["config"]["audio_root"] = str(tmp_path)
+        state["config"]["artist_name"] = "test-artist"
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        assert result["found"] is True
+        assert result["verdict"] == "READY"
+        assert result["blocking"] == 0
+        assert result["warnings"] == 0
+        assert len(result["gates"]) == 7
+
+        gate_names = [g["gate"] for g in result["gates"]]
+        assert "All Tracks Final" in gate_names
+        assert "Audio Files Exist" in gate_names
+        assert "Mastered Audio Exists" in gate_names
+        assert "Album Art Exists" in gate_names
+        assert "Streaming Lyrics Ready" in gate_names
+        assert "Explicit Flag Consistency" in gate_names
+        assert "Streaming URLs Set" in gate_names
+
+        for gate in result["gates"]:
+            assert gate["status"] == "PASS", f"Gate '{gate['gate']}' should PASS but got {gate['status']}"
+
+
+class TestPreReleaseGateTracksNotFinal:
+    """Gate 1: All Tracks Final."""
+
+    def test_non_final_tracks_block(self, tmp_path):
+        state = _make_sample_state(track_status="Generated")
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        assert result["verdict"] == "NOT READY"
+        gate = next(g for g in result["gates"] if g["gate"] == "All Tracks Final")
+        assert gate["status"] == "FAIL"
+        assert gate["severity"] == "BLOCKING"
+
+    def test_mixed_final_and_generated_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        state["albums"]["test-album"]["tracks"]["02-second-track"]["status"] = "Generated"
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "All Tracks Final")
+        assert gate["status"] == "FAIL"
+        assert "1 track(s) not Final" in gate["detail"]
+
+
+class TestPreReleaseGateAudioFiles:
+    """Gate 2: Audio Files Exist."""
+
+    def test_no_audio_dir_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        _setup_track_files(tmp_path, state)
+        state["config"]["audio_root"] = str(tmp_path)
+        # Don't create audio dir
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Audio Files Exist")
+        assert gate["status"] == "FAIL"
+
+    def test_empty_audio_dir_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path, with_originals=False, with_mastered=True, with_art=True)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Audio Files Exist")
+        assert gate["status"] == "FAIL"
+        assert "No WAV" in gate["detail"]
+
+
+class TestPreReleaseGateMasteredAudio:
+    """Gate 3: Mastered Audio Exists."""
+
+    def test_no_mastered_dir_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path, with_mastered=False)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Mastered Audio Exists")
+        assert gate["status"] == "FAIL"
+        assert "mastering-engineer" in gate["detail"]
+
+
+class TestPreReleaseGateAlbumArt:
+    """Gate 4: Album Art Exists."""
+
+    def test_no_art_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path, with_art=False)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Album Art Exists")
+        assert gate["status"] == "FAIL"
+        assert "No album art" in gate["detail"]
+
+    def test_alternative_art_names_pass(self, tmp_path):
+        """Cover various accepted art filenames."""
+        for art_name in ["cover.jpg", "artwork.png", "album-art.jpg"]:
+            state = _make_sample_state(
+                track_status="Final",
+                streaming_urls={"soundcloud": "https://example.com"},
+            )
+            _setup_track_files(tmp_path, state)
+            audio_dir = _setup_audio_dir(tmp_path, with_art=False)
+            (audio_dir / art_name).write_bytes(b"\x89PNG")
+            state["config"]["audio_root"] = str(tmp_path)
+            mock_cache = MockStateCache(state)
+
+            with patch.object(_shared_mod, "cache", mock_cache):
+                result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+            gate = next(g for g in result["gates"] if g["gate"] == "Album Art Exists")
+            assert gate["status"] == "PASS", f"Art file '{art_name}' should be recognized"
+
+
+class TestPreReleaseGateStreamingLyrics:
+    """Gate 5: Streaming Lyrics Ready."""
+
+    def test_missing_streaming_lyrics_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        _setup_track_files(tmp_path, state, streaming_lyrics=False)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Streaming Lyrics Ready")
+        assert gate["status"] == "FAIL"
+        assert "2 track(s) not ready" in gate["detail"]
+
+    def test_placeholder_streaming_lyrics_blocks(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        _setup_track_files(tmp_path, state, streaming_lyrics=True, placeholder=True)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Streaming Lyrics Ready")
+        assert gate["status"] == "FAIL"
+        assert "placeholder" in gate["detail"]
+
+    def test_no_track_path_reported(self, tmp_path):
+        state = _make_sample_state(track_status="Final")
+        # Don't set up track files — paths remain empty
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Streaming Lyrics Ready")
+        assert gate["status"] == "FAIL"
+        assert "no track path" in gate["detail"]
+
+
+class TestPreReleaseGateExplicitConsistency:
+    """Gate 6: Explicit Flag Consistency."""
+
+    def test_album_clean_but_tracks_explicit_blocks(self, tmp_path):
+        state = _make_sample_state(
+            track_status="Final", album_explicit=False, track_explicit=True,
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Explicit Flag Consistency")
+        assert gate["status"] == "FAIL"
+        assert gate["severity"] == "BLOCKING"
+        assert "set album explicit: true" in gate["detail"]
+
+    def test_album_explicit_but_tracks_clean_warns(self, tmp_path):
+        state = _make_sample_state(
+            track_status="Final", album_explicit=True, track_explicit=False,
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Explicit Flag Consistency")
+        assert gate["status"] == "WARN"
+        assert gate["severity"] == "WARNING"
+
+    def test_both_explicit_passes(self, tmp_path):
+        state = _make_sample_state(
+            track_status="Final", album_explicit=True, track_explicit=True,
+            streaming_urls={"soundcloud": "https://example.com"},
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Explicit Flag Consistency")
+        assert gate["status"] == "PASS"
+        assert "explicit" in gate["detail"]
+
+    def test_both_clean_passes(self, tmp_path):
+        state = _make_sample_state(
+            track_status="Final", album_explicit=False, track_explicit=False,
+            streaming_urls={"soundcloud": "https://example.com"},
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Explicit Flag Consistency")
+        assert gate["status"] == "PASS"
+        assert "clean" in gate["detail"]
+
+
+class TestPreReleaseGateStreamingUrls:
+    """Gate 7: Streaming URLs Set."""
+
+    def test_no_urls_warns(self, tmp_path):
+        state = _make_sample_state(track_status="Final", streaming_urls={})
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Streaming URLs Set")
+        assert gate["status"] == "WARN"
+        assert gate["severity"] == "WARNING"
+        # Should not be blocking — URLs are added after upload
+        assert result["blocking"] == 0
+
+    def test_urls_set_passes(self, tmp_path):
+        state = _make_sample_state(
+            track_status="Final",
+            streaming_urls={
+                "soundcloud": "https://soundcloud.com/test/album",
+                "spotify": "https://open.spotify.com/album/123",
+            },
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        gate = next(g for g in result["gates"] if g["gate"] == "Streaming URLs Set")
+        assert gate["status"] == "PASS"
+        assert "2 platform(s)" in gate["detail"]
+
+
+class TestPreReleaseGatesVerdict:
+    """Overall verdict logic."""
+
+    def test_ready_with_warnings(self, tmp_path):
+        """No blocking issues but has warnings → READY (with warnings)."""
+        state = _make_sample_state(
+            track_status="Final", album_explicit=True, track_explicit=False,
+            streaming_urls={},
+        )
+        _setup_track_files(tmp_path, state)
+        _setup_audio_dir(tmp_path)
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        assert result["blocking"] == 0
+        assert result["warnings"] >= 1
+        assert result["verdict"] == "READY (with warnings)"
+
+    def test_not_ready_with_blockers(self, tmp_path):
+        """Blocking issues → NOT READY."""
+        state = _make_sample_state(track_status="In Progress")
+        _setup_track_files(tmp_path, state, streaming_lyrics=False)
+        state["config"]["audio_root"] = str(tmp_path)
+        # No audio dir created
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        assert result["blocking"] > 0
+        assert result["verdict"] == "NOT READY"
+
+    def test_multiple_blocking_gates_counted(self, tmp_path):
+        """Multiple failures are all counted."""
+        state = _make_sample_state(
+            track_status="Generated", album_explicit=False, track_explicit=True,
+        )
+        _setup_track_files(tmp_path, state, streaming_lyrics=False)
+        # No audio dir
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.run_pre_release_gates("test-album")))
+
+        # Should fail: tracks not final, no audio, no mastered, no art,
+        # no streaming lyrics, explicit mismatch
+        assert result["blocking"] >= 5


### PR DESCRIPTION
## Summary

- Adds `run_pre_release_gates` MCP tool with 7 automated gates that validate an album is ready for release
- Integrates the tool into the `release-director` skill as the first step of pre-release QA
- Includes 21 tests covering all gates, verdicts, and edge cases

### Gates

| # | Gate | Severity | What it checks |
|---|------|----------|----------------|
| 1 | All Tracks Final | BLOCKING | Every track at Final status |
| 2 | Audio Files Exist | BLOCKING | WAV files in audio directory |
| 3 | Mastered Audio Exists | BLOCKING | mastered/ subdirectory has WAVs |
| 4 | Album Art Exists | BLOCKING | Art file found (album.png, cover.jpg, etc.) |
| 5 | Streaming Lyrics Ready | BLOCKING | All tracks have non-placeholder streaming lyrics |
| 6 | Explicit Flag Consistency | BLOCKING/WARNING | Album explicit flag matches track flags |
| 7 | Streaming URLs Set | WARNING | At least one platform URL populated |

Closes #117

## Test plan

- [x] 21 new tests in `test_server_pre_release.py` — all passing
- [x] Full test suite (2548 passed, 3 skipped)
- [x] ruff lint clean
- [x] mypy type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)