### PR TITLE
feat: add instrumental track support across workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Instrumental track support** — tracks can be marked `instrumental: true` in frontmatter to skip the lyrics workflow entirely ([#115](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/115))
+  - Track template: new `instrumental` field in frontmatter and Track Details table
+  - Pre-generation-check: Gates 2 (Lyrics), 3 (Pronunciation), 4 (Explicit) auto-skip for instrumental tracks
+  - Lyric-writer, lyric-reviewer, pronunciation-specialist: instrumental guard stops execution with clear routing to suno-engineer
+  - Resume & next-step: decision trees route instrumental tracks directly to `/suno-engineer`
+  - Suno-engineer: expanded instrumental guidance (Style Box without vocals, section tags only, Instrumental: On)
+  - Album-conceptualizer: Phase 4 asks vocal/instrumental split per track
+  - SKILL_INDEX: explicit instrumental workflow path and mixed album (vocal + instrumental) sequence
+  - New-album: tip about instrumental track support for OST/soundtrack albums
+
 ## [0.82.0] - 2026-04-03
 
 ### Added

--- a/reference/SKILL_INDEX.md
+++ b/reference/SKILL_INDEX.md
@@ -41,6 +41,7 @@ Quick-reference guide for finding the right skill for any task.
 | I need to... | Use this skill |
 |--------------|----------------|
 | ...create Suno prompts and settings | `/suno-engineer` |
+| ...create a Style Box for an instrumental track | `/suno-engineer` (entry point for instrumental tracks — skips lyric-writer) |
 | ...copy lyrics/prompts to clipboard | `/clipboard` |
 
 ### Research (True-Story Albums)
@@ -169,8 +170,8 @@ What to have ready before using each skill:
 | `/pronunciation-specialist` | Lyrics written |
 | `/lyric-reviewer` | Lyrics complete, pronunciation checked |
 | `/voice-checker` | Lyrics written, lyric-reviewer passed |
-| `/pre-generation-check` | Lyrics written, pronunciation resolved, style prompt created |
-| `/suno-engineer` | Lyrics written (auto-invoked by lyric-writer) |
+| `/pre-generation-check` | Lyrics written, pronunciation resolved, style prompt created (instrumental: only Style Box needed) |
+| `/suno-engineer` | Lyrics written (auto-invoked by lyric-writer). For instrumental tracks: invoked directly as entry point |
 | `/mix-engineer` | WAV files (stems preferred) imported from Suno |
 | `/mastering-engineer` | WAV files downloaded from Suno (or polished output) |
 | `/promo-director` | Mastered audio + album artwork |
@@ -219,22 +220,30 @@ What to have ready before using each skill:
     -> [Generate in Suno] -> /mix-engineer (optional) -> /mastering-engineer -> /release-director
 ```
 
-### OST Album
+### OST / Mixed Album (Vocal + Instrumental)
 ```
 /new-album <name> <genre>
-    -> /album-conceptualizer (plan world, leitmotifs, scene mapping)
-    -> /lyric-writer (for vocal tracks — auto-invokes /suno-engineer)
-    -> [For instrumental tracks: /suno-engineer directly with Instrumental: On]
-    -> /pronunciation-specialist (for vocal tracks)
-    -> /lyric-reviewer (for vocal tracks)
-    -> /pre-generation-check (validate all gates)
-    -> [Generate in Suno — use Instrumental: On for instrumental tracks]
+    -> /album-conceptualizer (plan world, leitmotifs, scene mapping, mark tracks as vocal/instrumental)
+    -> For each track:
+        VOCAL TRACK:
+            -> /lyric-writer (auto-invokes /suno-engineer)
+            -> /pronunciation-specialist
+            -> /lyric-reviewer
+        INSTRUMENTAL TRACK (instrumental: true in frontmatter):
+            -> /suno-engineer directly (Style Box + section tags only, no lyrics)
+    -> /pre-generation-check (validates all gates — auto-skips lyrics gates for instrumental tracks)
+    -> [Generate in Suno — instrumental tracks use Instrumental: On]
     -> /mix-engineer (optional: polish raw audio)
     -> /mastering-engineer (master audio)
     -> /album-art-director (world-themed artwork)
     -> /promo-director (optional: promo videos)
     -> /release-director (release to platforms)
 ```
+
+**Note**: Any album type can have instrumental tracks — OST is just the most common case.
+Mark a track as instrumental by setting `instrumental: true` in track frontmatter.
+Instrumental tracks skip: lyric-writer, pronunciation-specialist, lyric-reviewer.
+Pre-generation-check auto-skips Gates 2 (Lyrics), 3 (Pronunciation), 4 (Explicit) for instrumentals.
 
 ### Resume Existing Work
 ```
@@ -369,4 +378,5 @@ Skills are assigned to models based on task complexity. See [model-strategy.md](
 - **Building true-story album?** Always start with `/researcher` before writing
 - **Before Suno?** Run `/lyric-reviewer` to catch issues
 - **Weird pronunciations?** Run `/pronunciation-specialist` on every track
+- **Instrumental track?** Set `instrumental: true` in frontmatter, then use `/suno-engineer` directly (skips lyrics workflow)
 - **Not sure what's available?** Run `/help` for categorized skill list

--- a/skills/album-conceptualizer/SKILL.md
+++ b/skills/album-conceptualizer/SKILL.md
@@ -241,6 +241,7 @@ See also: `${CLAUDE_PLUGIN_ROOT}/reference/workflows/album-planning-phases.md`
 - How many tracks can tell this concept?
 - What does each track cover?
 - Working titles, core focus, connection to whole
+- **Vocal or Instrumental?** — For each track, decide if it has vocals or is purely instrumental. Mark instrumental tracks with `instrumental: true` in frontmatter. Mixed albums (especially OST/soundtrack) commonly have both — e.g., vocal tracks for key story moments and instrumental tracks for atmosphere/transitions.
 
 **Sequencing**:
 1. Lay out all tracks in rough order
@@ -329,6 +330,9 @@ Once concept is solid, create:
 2. **RESEARCH.md** (if source-based) - Consolidated research
 3. **SOURCES.md** (if source-based) - Bibliography
 4. `tracks/XX-track-name.md` - Individual track files
+   - For instrumental tracks: set `instrumental: true` in frontmatter and `**Instrumental** | Yes` in Track Details
+   - Instrumental tracks skip lyrics-related workflow sections (Streaming Lyrics, Pronunciation Notes, Phonetic Review Checklist)
+   - Workflow routing: instrumental tracks go directly to `/bitwize-music:suno-engineer` (no lyric-writer/reviewer/pronunciation)
 
 ---
 

--- a/skills/lyric-reviewer/SKILL.md
+++ b/skills/lyric-reviewer/SKILL.md
@@ -18,6 +18,14 @@ allowed-tools:
 
 **Input**: $ARGUMENTS
 
+### Instrumental Guard
+
+When reviewing a track, **first check** the track's frontmatter for `instrumental: true` or the Track Details table for `**Instrumental** | Yes`. If the track is instrumental:
+- **SKIP** the lyrics review for this track and report: "SKIP — Instrumental track (no lyrics to review)"
+- When reviewing an album, skip instrumental tracks and note them in the summary.
+
+### Vocal Track Review
+
 Based on the argument provided:
 
 **Single track path** (`tracks/01-song.md`):
@@ -27,7 +35,7 @@ Based on the argument provided:
 
 **Album path** (`artists/[artist]/albums/[genre]/album-name/`):
 - Glob all track files in `tracks/`
-- Run 14-point checklist on each
+- Run 14-point checklist on each (skip instrumental tracks)
 - Generate consolidated album report
 
 **Default behavior**:

--- a/skills/lyric-writer/SKILL.md
+++ b/skills/lyric-writer/SKILL.md
@@ -16,6 +16,14 @@ allowed-tools:
 
 **Input**: $ARGUMENTS
 
+### Instrumental Guard
+
+When invoked with a track file path, **first check** the track's frontmatter for `instrumental: true` or the Track Details table for `**Instrumental** | Yes`. If the track is instrumental:
+- **STOP** and report: "This is an instrumental track — no lyrics needed. Use `/bitwize-music:suno-engineer` to create the Style Box directly."
+- Do NOT write lyrics for instrumental tracks.
+
+### Vocal Track Workflow
+
 When invoked with a track file path:
 1. Read the track file
 2. Scan existing lyrics for issues (rhyme, prosody, POV, pronunciation)

--- a/skills/new-album/SKILL.md
+++ b/skills/new-album/SKILL.md
@@ -106,6 +106,12 @@ Next steps:
   Option 2 - Manual:
     1. Edit README.md with your album concept
     2. Create tracks with /import-track or manually in tracks/
+
+Tip: For OST/soundtrack albums with a mix of vocal and instrumental
+tracks, the album-conceptualizer will ask about the vocal/instrumental
+split per track. Set `instrumental: true` in track frontmatter for
+instrumental tracks — they skip the lyrics workflow and go directly
+to /bitwize-music:suno-engineer.
 ```
 
 ## Error Handling

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -45,7 +45,9 @@ You analyze the current state of albums and tracks and recommend the optimal nex
 
 ## Decision Tree
 
-Analyze album and track statuses to determine the optimal next action:
+Analyze album and track statuses to determine the optimal next action.
+
+**Instrumental detection**: Check each track's frontmatter for `instrumental: true` or Track Details table for `**Instrumental** | Yes`. Instrumental tracks bypass the lyrics workflow (lyric-writer, pronunciation-specialist, lyric-reviewer) and go directly to `/bitwize-music:suno-engineer` for Style Box creation.
 
 ```
 Album Status = "Concept"
@@ -54,10 +56,14 @@ Album Status = "Concept"
 Album Status = "Research Complete"
   → Any tracks Sources Pending?
     YES → "Sources need verification. Review SOURCES.md and verify each source."
-    NO  → "Ready to write! Pick a track and use /bitwize-music:lyric-writer"
+    NO  → First "Not Started" track instrumental?
+      YES → "Create Style Box for instrumental track [name]. Use /bitwize-music:suno-engineer"
+      NO  → "Ready to write! Pick a track and use /bitwize-music:lyric-writer"
 
 Album has tracks with status "Not Started"
-  → "Write lyrics for track [first not-started track]. Use /bitwize-music:lyric-writer"
+  → First not-started track instrumental?
+    YES → "Create Style Box for instrumental track [name]. Use /bitwize-music:suno-engineer directly"
+    NO  → "Write lyrics for track [first not-started track]. Use /bitwize-music:lyric-writer"
 
 Album has tracks with status "In Progress" (lyrics partially written)
   → "Finish lyrics for track [first in-progress track]. Use /bitwize-music:lyric-writer"
@@ -65,8 +71,10 @@ Album has tracks with status "In Progress" (lyrics partially written)
 Album has tracks with status "Sources Pending"
   → "Verify sources for track [name]. Check SOURCES.md, then update sources_verified field."
 
-All tracks have lyrics, none generated
-  → "All lyrics complete! Style prompts should be ready. Run /bitwize-music:pronunciation-specialist to check for pronunciation risks, then /bitwize-music:lyric-reviewer for final QC, then /bitwize-music:pre-generation-check to validate all gates before generating on Suno."
+All tracks have lyrics (or Style Box for instrumentals), none generated
+  → Has vocal tracks?
+    YES → "Run /bitwize-music:pronunciation-specialist on vocal tracks, then /bitwize-music:lyric-reviewer for final QC, then /bitwize-music:pre-generation-check to validate all gates (instrumental tracks auto-skip lyrics gates)."
+    NO (all instrumental) → "All Style Boxes ready! Run /bitwize-music:pre-generation-check to validate gates before generating on Suno."
 
 Some tracks generated, some not
   → "Generate track [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"

--- a/skills/pre-generation-check/SKILL.md
+++ b/skills/pre-generation-check/SKILL.md
@@ -36,6 +36,16 @@ lyric-writer (+ suno-engineer) → pronunciation-specialist → lyric-reviewer �
 
 ---
 
+## Instrumental Track Detection
+
+**Before running gates**, check the track's frontmatter for `instrumental: true` or the Track Details table for `**Instrumental** | Yes`.
+
+**If instrumental**: Skip Gates 2 (Lyrics Reviewed), 3 (Pronunciation Resolved), and 4 (Explicit Flag). Mark them as `SKIP — Instrumental track`. Only run Gates 1, 5, and 6.
+
+**Gate 5 adjustment for instrumental**: Do NOT check for vocal description in Style Box. Instead verify the Style Box has genre/instrumentation/mood. Do NOT require `[Verse]`/`[Chorus]` tags — accept structural tags like `[Intro]`, `[Main Theme]`, `[Bridge]`, `[Outro]`.
+
+---
+
 ## The 6 Gates
 
 ### Gate 1: Sources Verified
@@ -158,5 +168,6 @@ lyric-writer (+ suno-engineer) → pronunciation-specialist → lyric-reviewer �
 3. **Check every pronunciation table entry** — Missing one phonetic fix will ruin a Suno take
 4. **Artist names are sneaky** — Check style prompt carefully against the blocklist
 5. **Be specific** — "Gate failed" is useless. "live in V2:L3 unresolved" is actionable
+6. **Instrumental tracks skip lyrics gates** — Gates 2, 3, 4 are N/A for instrumental tracks
 
 **Your deliverable**: Pass/fail report with album-level verdict.

--- a/skills/pronunciation-specialist/SKILL.md
+++ b/skills/pronunciation-specialist/SKILL.md
@@ -18,6 +18,14 @@ allowed-tools:
 
 **Input**: $ARGUMENTS
 
+### Instrumental Guard
+
+When invoked with a track file path, **first check** the track's frontmatter for `instrumental: true` or the Track Details table for `**Instrumental** | Yes`. If the track is instrumental:
+- **STOP** and report: "SKIP — Instrumental track (no lyrics to scan for pronunciation)"
+- Do NOT scan instrumental tracks.
+
+### Vocal Track Workflow
+
 Based on the argument provided:
 - **If given a track file path**: Read it, scan lyrics for pronunciation risks, report issues with fixes
 - **If given lyrics directly**: Scan and flag risky words

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -52,7 +52,7 @@ Based on album and track statuses, identify the workflow phase:
 | Album Status | Track Statuses | Current Phase |
 |--------------|----------------|---------------|
 | Concept | Most "Not Started" | Planning - Need to fill in album README and create tracks |
-| In Progress | Mixed, some "Not Started" | Writing - Need to complete lyrics |
+| In Progress | Mixed, some "Not Started" | Writing - Need to complete lyrics (or route instrumental tracks to suno-engineer) |
 | In Progress | Some "Sources Pending" | Verification - Need human verification of sources |
 | In Progress | All have lyrics | Ready to Generate - Run Ready to Generate checkpoint |
 | In Progress | Some "Generated" | Generating - Continue generating on Suno |
@@ -69,7 +69,7 @@ Present a clear status report:
    Status: [Album Status]
 
 📊 Progress:
-   - Tracks: [X completed / Y total]
+   - Tracks: [X completed / Y total] ([N vocal, M instrumental])
    - Not Started: X
    - In Progress: Y
    - Generated: Z
@@ -94,6 +94,8 @@ Pick ONE clear recommendation from the decision tree below. Don't list 5 options
 
 **Decision Tree** (evaluate top-to-bottom, first match wins):
 
+**Instrumental detection**: Check each track's frontmatter for `instrumental: true` or Track Details table for `**Instrumental** | Yes`. Instrumental tracks skip the lyrics workflow entirely and go straight to `/bitwize-music:suno-engineer`.
+
 ```
 Album Status = "Concept"
   → "Define the album concept. Run /bitwize-music:album-conceptualizer"
@@ -101,10 +103,14 @@ Album Status = "Concept"
 Album Status = "Research Complete"
   → Any tracks Sources Pending?
     YES → "Sources need verification. Run /bitwize-music:verify-sources [album]"
-    NO  → "Ready to write! Pick a track and use /bitwize-music:lyric-writer"
+    NO  → Any "Not Started" tracks instrumental?
+      YES → "Create Style Box for instrumental track [name]. Use /bitwize-music:suno-engineer"
+      NO  → "Ready to write! Pick a track and use /bitwize-music:lyric-writer"
 
 Album has tracks with "Not Started"
-  → "Write lyrics for [first not-started track]. Use /bitwize-music:lyric-writer"
+  → Is the first not-started track instrumental?
+    YES → "Create Style Box for [track]. Use /bitwize-music:suno-engineer directly (instrumental track)"
+    NO  → "Write lyrics for [first not-started track]. Use /bitwize-music:lyric-writer"
 
 Album has tracks with "In Progress" (lyrics partially written)
   → "Finish lyrics for [first in-progress track]. Use /bitwize-music:lyric-writer"
@@ -112,8 +118,10 @@ Album has tracks with "In Progress" (lyrics partially written)
 Album has tracks with "Sources Pending"
   → "Verify sources for [track]. Run /bitwize-music:verify-sources [album]"
 
-All tracks have lyrics, none generated
-  → "All lyrics complete! Style prompts should be ready. Run /bitwize-music:pronunciation-specialist to check for pronunciation risks, then /bitwize-music:lyric-reviewer for final QC, then /bitwize-music:pre-generation-check to validate all gates before generating on Suno."
+All tracks have lyrics (or Style Box for instrumentals), none generated
+  → Mixed album (vocal + instrumental)?
+    YES → "All tracks ready! Run /bitwize-music:pronunciation-specialist on vocal tracks, then /bitwize-music:lyric-reviewer, then /bitwize-music:pre-generation-check to validate all gates (instrumental tracks auto-skip lyrics gates)."
+    NO  → "All lyrics complete! Style prompts should be ready. Run /bitwize-music:pronunciation-specialist to check for pronunciation risks, then /bitwize-music:lyric-reviewer for final QC, then /bitwize-music:pre-generation-check to validate all gates before generating on Suno."
 
 Some tracks generated, some not
   → "Generate [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -21,9 +21,17 @@ allowed-tools:
 
 When invoked with a track file:
 1. Read the track file
-2. Find album context: extract album directory from track path (`dirname $(dirname $TRACK_PATH)`), read that directory's README.md for album-level genre/theme/style. If README missing, use only track-level context.
-3. Construct optimal Suno V5 style prompt and settings
-4. Update the track file's Suno Inputs section
+2. **Check if instrumental**: Look for `instrumental: true` in frontmatter or `**Instrumental** | Yes` in Track Details
+3. Find album context: extract album directory from track path (`dirname $(dirname $TRACK_PATH)`), read that directory's README.md for album-level genre/theme/style. If README missing, use only track-level context.
+4. Construct optimal Suno V5 style prompt and settings
+5. Update the track file's Suno Inputs section
+
+**For instrumental tracks** (no lyric-writer prerequisite):
+- Set `Instrumental: On` in Suno settings
+- Style Box: Focus on genre, instrumentation, mood, tempo — no vocal description needed
+- Lyrics Box: Use structural section tags only (`[Intro]`, `[Main Theme]`, `[Bridge]`, `[Outro]`, `[End]`) — no sung lyrics
+- Skip Streaming Lyrics, Pronunciation Notes, and Phonetic Review sections
+- This skill is the **entry point** for instrumental tracks (they skip lyric-writer entirely)
 
 When invoked with a concept:
 1. Design complete Suno prompting strategy

--- a/templates/track.md
+++ b/templates/track.md
@@ -1,6 +1,7 @@
 ---
 title: "[Track Title]"
 track_number: 0
+instrumental: false
 explicit: false
 suno_url: ""
 sheet_music:
@@ -21,6 +22,7 @@ sheet_music:
 | **Status** | Not Started |
 | **Suno Link** | — |
 | **Stems** | No |
+| **Instrumental** | No |
 | **Explicit** | Yes / No |
 | **POV** | [Character/Perspective] |
 | **Role** | [Track's role in the album narrative] |
@@ -161,7 +163,11 @@ Space is not a constraint. Thoroughness is the priority.]
 ### Lyrics Box
 *Copy this into Suno's "Lyrics" field:*
 
-<!-- WARNING: Suno sings EVERYTHING literally including parenthetical directions.
+<!-- INSTRUMENTAL TRACKS: If instrumental: true, use only section tags (no sung lyrics).
+     Example: [Intro]\n\n[Main Theme]\n\n[Bridge]\n\n[Outro]\n\n[End]
+     Set "Instrumental: On" in Suno. -->
+
+<!-- VOCAL TRACKS: WARNING: Suno sings EVERYTHING literally including parenthetical directions.
      NEVER use (whispered), (softly), (screaming), (spoken), (laughing), etc.
      Use metatags like [Whispered] or put delivery notes in the Style Box instead. -->
 
@@ -183,6 +189,8 @@ Space is not a constraint. Thoroughness is the priority.]
 ```
 <!-- /SERVICE: suno -->
 
+<!-- VOCAL TRACKS ONLY: Remove this section for instrumental tracks -->
+
 ## Streaming Lyrics
 
 *For distributor submission (Spotify, Apple Music, etc.). No section tags, repeats written out, plain text.*
@@ -195,6 +203,8 @@ Write out all repeats fully
 Blank lines between sections only]
 ```
 
+<!-- END VOCAL ONLY -->
+
 ## Production Notes
 
 - [Technical considerations]
@@ -203,6 +213,8 @@ Blank lines between sections only]
 <!-- SERVICE: suno -->
 - [V5 optimization tips if applicable]
 <!-- /SERVICE: suno -->
+
+<!-- VOCAL TRACKS ONLY: Remove these sections for instrumental tracks -->
 
 ## Pronunciation Notes
 
@@ -229,6 +241,8 @@ Blank lines between sections only]
 |------|---------|----------|--------|
 | — | — | — | — |
 <!-- /SERVICE: suno -->
+
+<!-- END VOCAL ONLY -->
 
 ## Generation Log
 


### PR DESCRIPTION
## Summary

- Adds `instrumental: true` frontmatter field to track template for marking tracks as purely instrumental
- Instrumental tracks skip the entire lyrics workflow (lyric-writer, pronunciation-specialist, lyric-reviewer) and route directly to suno-engineer
- Pre-generation-check auto-skips Gates 2 (Lyrics), 3 (Pronunciation), 4 (Explicit) for instrumental tracks
- Resume and next-step decision trees support per-track routing in mixed vocal/instrumental albums (common for OST/soundtracks)
- 12 files changed across skills, templates, and reference docs

Closes #115

## Files Changed

| File | Change |
|------|--------|
| `templates/track.md` | New `instrumental` field in frontmatter + Track Details table |
| `skills/pre-generation-check/SKILL.md` | Instrumental detection + gate skip logic |
| `skills/lyric-writer/SKILL.md` | Instrumental guard |
| `skills/lyric-reviewer/SKILL.md` | Instrumental guard |
| `skills/pronunciation-specialist/SKILL.md` | Instrumental guard |
| `skills/resume/SKILL.md` | Per-track instrumental routing in decision tree |
| `skills/next-step/SKILL.md` | Per-track instrumental routing in decision tree |
| `skills/suno-engineer/SKILL.md` | Instrumental entry point with specific guidance |
| `skills/album-conceptualizer/SKILL.md` | Phase 4: vocal/instrumental split per track |
| `skills/new-album/SKILL.md` | Tip about instrumental support for OST albums |
| `reference/SKILL_INDEX.md` | Explicit instrumental workflow path + mixed album sequence |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] `pytest tests/` — 2530 passed, 0 failed
- [x] `pytest tests/plugin/` — 223 passed, 0 failed
- [ ] Manual: create album with mixed vocal/instrumental tracks, verify routing
- [ ] Manual: run pre-generation-check on instrumental track, verify gates 2/3/4 skip
- [ ] Manual: invoke lyric-writer on instrumental track, verify guard message

🤖 Generated with [Claude Code](https://claude.com/claude-code)