### PR TITLE
feat: add guided regeneration workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Guided regeneration workflow** — structured path for rejecting and regenerating tracks that don't meet quality standards ([#116](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/116))
+  - CLAUDE.md: regeneration workflow documented in Status Tracking section
+  - Resume: detects Generated tracks without approval (✓), offers style/lyrics/retry regeneration paths
+  - Next-step: recommends review and regeneration for unapproved Generated tracks
+  - SKILL_INDEX: new "Track Regeneration" workflow sequence and decision tree entries
+
 ## [0.82.0] - 2026-04-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ Album target duration set during Phase 3 (Sonic Direction). Tracks inherit unles
 - `Sources Pending`: Sources gathered, awaiting human verification
 - `Sources Verified`: Human confirmed all sources via `/bitwize-music:verify-sources`
 - `In Progress`: Lyrics being written or revised
-- `Generated`: Track generated on Suno, audio exists
+- `Generated`: Track generated on Suno, audio exists. User listens and either approves (mark ✓ in Generation Log → advance to `Final`) or rejects (see Regeneration Workflow below)
 - `Final`: Approved and ready for mastering
 
 **Album statuses** (in order):
@@ -191,6 +191,24 @@ Album target duration set during Phase 3 (Sonic Direction). Tracks inherit unles
 - `Released`: Published to streaming platforms
 
 **Transition rules**: Album status advances when ALL tracks reach the corresponding level. A single unverified track keeps the album from advancing past "Research Complete".
+
+### Regeneration Workflow
+
+When a user rejects a generated track (doesn't like the result, wrong style, pronunciation issues, etc.):
+
+1. **Log the rejection**: Add a row in the Generation Log with the reason (e.g., "wrong tempo", "vocal too high", "mispronounced name")
+2. **Decide the fix path**:
+   - **Style issue** (wrong genre, tempo, mood) → Revise Style Box via `/bitwize-music:suno-engineer`, then regenerate on Suno
+   - **Lyrics issue** (wrong words, pronunciation) → Fix lyrics via `/bitwize-music:lyric-writer`, re-run `/bitwize-music:pronunciation-specialist`, then regenerate
+   - **Suno interpretation** (right prompt, wrong result) → Regenerate on Suno with same settings (Suno is non-deterministic)
+3. **Regenerate**: Generate again on Suno, log the new attempt
+4. **When satisfied**: Mark the keeper with ✓ in the Generation Log Rating column, then advance Status to `Final`
+
+**Status stays `Generated`** during regeneration — no backward transition needed. The Generation Log tracks all attempts. A track is only `Final` when it has a ✓ in the Rating column.
+
+**Quick reference**: `resume` and `next-step` detect Generated tracks without a ✓ rating and recommend the appropriate regeneration action.
+
+See `/reference/workflows/error-recovery.md` for detailed recovery procedures.
 
 See `/reference/state-schema.md` for the full state cache schema.
 

--- a/reference/SKILL_INDEX.md
+++ b/reference/SKILL_INDEX.md
@@ -37,11 +37,13 @@ Quick-reference guide for finding the right skill for any task.
 | ...check lyrics for plagiarism | `/plagiarism-checker` |
 | ...check lyrics/prose for AI-sounding patterns | `/voice-checker` |
 
-### Suno Generation
+### Suno Generation & Regeneration
 | I need to... | Use this skill |
 |--------------|----------------|
 | ...create Suno prompts and settings | `/suno-engineer` |
 | ...copy lyrics/prompts to clipboard | `/clipboard` |
+| ...regenerate a track I'm not happy with | See Regeneration Workflow below |
+| ...approve a generated track | Mark ✓ in Generation Log, set Status: `Final` |
 
 ### Research (True-Story Albums)
 | I need to... | Use this skill |
@@ -252,6 +254,25 @@ What to have ready before using each skill:
     -> /validate-album <album>
 ```
 
+### Track Regeneration (Rejected Generation)
+```
+[Listen to generated track — not happy?]
+    -> Log rejection reason in Generation Log
+    -> IF style issue:
+        -> /suno-engineer (revise Style Box)
+        -> [Regenerate on Suno]
+    -> IF lyrics issue:
+        -> /lyric-writer (fix lyrics)
+        -> /pronunciation-specialist (re-check)
+        -> [Regenerate on Suno]
+    -> IF bad luck (right prompt, wrong result):
+        -> [Regenerate on Suno with same settings — Suno is non-deterministic]
+    -> Log new attempt in Generation Log
+    -> [Repeat until satisfied]
+    -> Mark ✓ in Generation Log Rating
+    -> Set Status: Final
+```
+
 ### Post-Generation to Release
 ```
 /mix-engineer <album> (optional: polish raw audio)
@@ -369,4 +390,5 @@ Skills are assigned to models based on task complexity. See [model-strategy.md](
 - **Building true-story album?** Always start with `/researcher` before writing
 - **Before Suno?** Run `/lyric-reviewer` to catch issues
 - **Weird pronunciations?** Run `/pronunciation-specialist` on every track
+- **Track sounds wrong?** Log the reason in Generation Log, fix prompt or lyrics, regenerate. See Regeneration Workflow
 - **Not sure what's available?** Run `/help` for categorized skill list

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -69,10 +69,25 @@ All tracks have lyrics, none generated
   → "All lyrics complete! Style prompts should be ready. Run /bitwize-music:pronunciation-specialist to check for pronunciation risks, then /bitwize-music:lyric-reviewer for final QC, then /bitwize-music:pre-generation-check to validate all gates before generating on Suno."
 
 Some tracks generated, some not
-  → "Generate track [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"
+  → Any Generated tracks without ✓ in Generation Log Rating?
+    YES → "Track [name] needs review. Listen and approve (mark ✓ in Generation Log) or regenerate.
+           Style issue → /bitwize-music:suno-engineer to revise Style Box, then regenerate
+           Lyrics issue → /bitwize-music:lyric-writer to fix lyrics, then regenerate
+           Bad luck → Regenerate on Suno (non-deterministic, same settings may give better result)"
+    NO  → "Generate track [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"
 
-All tracks generated
-  → "All tracks generated! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
+All tracks generated, none Final
+  → "All tracks generated! Review each track:
+     Mark keepers with ✓ in Generation Log, regenerate rejected ones.
+     Once all approved, set Status: Final for each."
+
+All tracks generated, some Final
+  → Any Generated (non-Final) without ✓?
+    YES → "Review track [name] — approve (✓) or regenerate"
+    NO  → "All reviewed! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
+
+All tracks Final
+  → "All tracks approved! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
 
 Album Status = "Complete"
   → "Album is complete! Release with /bitwize-music:release-director"

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -55,7 +55,8 @@ Based on album and track statuses, identify the workflow phase:
 | In Progress | Mixed, some "Not Started" | Writing - Need to complete lyrics |
 | In Progress | Some "Sources Pending" | Verification - Need human verification of sources |
 | In Progress | All have lyrics | Ready to Generate - Run Ready to Generate checkpoint |
-| In Progress | Some "Generated" | Generating - Continue generating on Suno |
+| In Progress | Some "Generated" | Generating - Continue generating on Suno. Check Generation Logs for rejected tracks needing regeneration |
+| In Progress | All "Generated", none "Final" | Review & Approve - Listen to generated tracks, mark keepers with ✓, regenerate rejected ones |
 | Complete | All "Final" | Mastering - Ready to master audio |
 | Released | All "Final" | Released - Album is live |
 
@@ -116,10 +117,28 @@ All tracks have lyrics, none generated
   → "All lyrics complete! Style prompts should be ready. Run /bitwize-music:pronunciation-specialist to check for pronunciation risks, then /bitwize-music:lyric-reviewer for final QC, then /bitwize-music:pre-generation-check to validate all gates before generating on Suno."
 
 Some tracks generated, some not
-  → "Generate [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"
+  → Any Generated tracks without ✓ in Generation Log Rating?
+    YES → "Track [name] was generated but not approved. Listen and decide:
+           - Happy? Mark ✓ in Generation Log and set Status: Final
+           - Not happy? Log the reason, then:
+             Style issue → /bitwize-music:suno-engineer to revise Style Box
+             Lyrics issue → /bitwize-music:lyric-writer to fix, then regenerate
+             Bad luck → Regenerate on Suno with same settings (it's non-deterministic)"
+    NO  → "Generate [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"
 
-All tracks generated
-  → "All tracks generated! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
+All tracks generated, none Final
+  → "All tracks generated! Listen to each track and approve:
+     - Mark keepers with ✓ in Generation Log Rating column
+     - Reject and regenerate any that don't meet quality standards
+     - Once all have ✓, advance Status to Final for each"
+
+All tracks generated, some Final
+  → Any Generated (non-Final) tracks without ✓?
+    YES → "Review track [name] — listen and approve (✓) or regenerate"
+    NO  → "All tracks approved! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
+
+All tracks Final
+  → "All tracks approved! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
 
 Album Status = "Complete"
   → "Album is complete! Release with /bitwize-music:release-director"


### PR DESCRIPTION
## Summary

- When a user rejects a generated track, `resume` and `next-step` now detect unapproved tracks (no ✓ in Generation Log Rating) and offer three regeneration paths: style fix, lyrics fix, or simple retry
- Status stays `Generated` during regeneration — no backward transition needed, Generation Log tracks all attempts
- CLAUDE.md documents the complete regeneration workflow in the Status Tracking section

Closes #116

## Files Changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Regeneration workflow in Status Tracking (log → fix path → regen → approve) |
| `skills/resume/SKILL.md` | Detects Generated tracks without ✓, offers regen paths, handles mixed approved/unapproved states |
| `skills/next-step/SKILL.md` | Same detection and routing for unapproved tracks |
| `reference/SKILL_INDEX.md` | New "Track Regeneration" workflow sequence, decision tree entries, quick tip |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] `pytest tests/` — 2530 passed, 0 failed
- [ ] Manual: generate a track, verify `resume` detects it as needing review
- [ ] Manual: approve track with ✓, verify `resume` routes to import/mastering

🤖 Generated with [Claude Code](https://claude.com/claude-code)