### PR TITLE
feat: improve album status management and advancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Album status management improvements** — auto-advancement, batch operations, and documented status flows ([#118](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/118))
+  - CLAUDE.md: documented non-documentary status flow (Concept → In Progress, skipping Research/Sources phases), auto-advancement rules, and batch-approve workflow
+  - Verify-sources: auto-advances album from Research Complete → Sources Verified when all tracks verified, with partial verification progress reports
+  - Resume: phase table covers both documentary and standard album flows, batch-approve path for Generated → Final
+  - Next-step: batch-approve path for all-generated albums
+  - SKILL_INDEX: batch-approve entry in Album Lifecycle table
+
 ## [0.82.0] - 2026-04-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,17 +180,28 @@ Album target duration set during Phase 3 (Sonic Direction). Tracks inherit unles
 - `Generated`: Track generated on Suno, audio exists
 - `Final`: Approved and ready for mastering
 
-**Album statuses** (in order):
+**Album statuses** — two flows depending on album type:
+
+**Documentary/true-story albums** (full flow):
 `Concept` → `Research Complete` → `Sources Verified` → `In Progress` → `Complete` → `Released`
 
+**Standard albums** (non-documentary, skip research statuses):
+`Concept` → `In Progress` → `Complete` → `Released`
+
 - `Concept`: Initial planning, album README created
-- `Research Complete`: All research done, sources gathered (documentary albums)
-- `Sources Verified`: Human verified all track sources
+- `Research Complete`: All research done, sources gathered (documentary albums only)
+- `Sources Verified`: Human verified all track sources (documentary albums only)
 - `In Progress`: Active writing/generation work
 - `Complete`: All tracks Final, ready for mastering/release
 - `Released`: Published to streaming platforms
 
 **Transition rules**: Album status advances when ALL tracks reach the corresponding level. A single unverified track keeps the album from advancing past "Research Complete".
+
+**Auto-advancement**: Skills that complete a phase should advance the album status automatically:
+- `/bitwize-music:verify-sources` → when all tracks verified, advance album to `Sources Verified`
+- When all tracks are `Final` → album advances to `Complete`
+
+**Batch operations**: To mark all Generated tracks as Final after QA, use `update_track_field(album_slug, track_slug, "status", "Final")` for each track via MCP, or ask Claude to batch-approve all tracks when all have ✓ in their Generation Logs.
 
 See `/reference/state-schema.md` for the full state cache schema.
 

--- a/reference/SKILL_INDEX.md
+++ b/reference/SKILL_INDEX.md
@@ -24,6 +24,7 @@ Quick-reference guide for finding the right skill for any task.
 | ...see album progress at a glance | `/album-dashboard <album-name>` |
 | ...know what to do next | `/resume [album-name]` (includes next-step advice) |
 | ...check if album structure is correct | `/validate-album <album-name>` |
+| ...approve all generated tracks at once | Batch-approve via `update_track_field` MCP tool per track |
 | ...release my finished album | `/release-director` |
 
 ### Writing & Quality

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -71,8 +71,14 @@ All tracks have lyrics, none generated
 Some tracks generated, some not
   → "Generate track [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"
 
-All tracks generated
-  → "All tracks generated! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
+All tracks generated, none "Final"
+  → "All tracks generated! Listen to each and approve:
+     Mark keepers with ✓ in Generation Log, then batch-approve:
+     Use update_track_field(album_slug, track_slug, 'status', 'Final') for each.
+     Once all Final, album advances to Complete."
+
+All tracks "Final"
+  → "All tracks approved! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
 
 Album Status = "Complete"
   → "Album is complete! Release with /bitwize-music:release-director"

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -52,12 +52,17 @@ Based on album and track statuses, identify the workflow phase:
 | Album Status | Track Statuses | Current Phase |
 |--------------|----------------|---------------|
 | Concept | Most "Not Started" | Planning - Need to fill in album README and create tracks |
+| Research Complete | Some "Sources Pending" | Verification - Need human verification of sources (documentary albums) |
+| Sources Verified | All sources verified | Ready to Write - Sources cleared, begin lyrics (documentary albums) |
 | In Progress | Mixed, some "Not Started" | Writing - Need to complete lyrics |
 | In Progress | Some "Sources Pending" | Verification - Need human verification of sources |
 | In Progress | All have lyrics | Ready to Generate - Run Ready to Generate checkpoint |
 | In Progress | Some "Generated" | Generating - Continue generating on Suno |
+| In Progress | All "Generated" | Review & Approve - Listen, approve (✓), or regenerate |
 | Complete | All "Final" | Mastering - Ready to master audio |
 | Released | All "Final" | Released - Album is live |
+
+**Note**: Non-documentary albums skip `Research Complete` and `Sources Verified` — they go directly from `Concept` → `In Progress`.
 
 ### Step 5: Report to User
 
@@ -118,8 +123,14 @@ All tracks have lyrics, none generated
 Some tracks generated, some not
   → "Generate [first un-generated track] on Suno. Use /bitwize-music:suno-engineer"
 
-All tracks generated
-  → "All tracks generated! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
+All tracks generated, none "Final"
+  → "All tracks generated! Listen to each and approve:
+     Mark keepers with ✓ in Generation Log, then batch-approve:
+     Use update_track_field(album_slug, track_slug, 'status', 'Final') for each approved track.
+     Once all Final, album advances to Complete automatically."
+
+All tracks "Final"
+  → "All tracks approved! Import audio with /bitwize-music:import-audio, then master with /bitwize-music:mastering-engineer"
 
 Album Status = "Complete"
   → "Album is complete! Release with /bitwize-music:release-director"

--- a/skills/verify-sources/SKILL.md
+++ b/skills/verify-sources/SKILL.md
@@ -98,26 +98,46 @@ When user confirms verification for a track:
 
 3. Move to next pending track
 
-## Step 5: Update Album Status
+## Step 5: Update Album Status (Auto-Advance)
 
-After all tracks are verified:
+After processing all tracks, check if the album status should advance:
 
-1. Check if album status should advance:
-   - If album was `Research Complete` → update to `Sources Verified`
-   - If album was `In Progress` and all tracks now verified → note it
+1. Call `get_album_progress(album_slug)` — check how many tracks are now verified
+2. **If ALL tracks are verified** (no more pending):
+   - Read the album README to check current album status
+   - If album status is `Research Complete`:
+     - Update album README: change `| **Status** | Research Complete |` → `| **Status** | Sources Verified |`
+     - Report: "Album status advanced: Research Complete → Sources Verified"
+   - If album status is `In Progress`:
+     - Report: "All track sources verified. Album status stays In Progress (already past research phase)."
+3. **If some tracks still pending**:
+   - Report how many remain and which ones
+4. **Rebuild state cache**: Call `rebuild_state()` to ensure MCP server has fresh data
 
-2. **Rebuild state cache**: Call `rebuild_state()` to ensure MCP server has fresh data
-
-3. **Summary report**:
+5. **Summary report**:
 ```
 VERIFICATION COMPLETE
 =====================
 Album: [title]
 Tracks verified: X/Y
+Album status: [previous] → [new status]
 Date: YYYY-MM-DD
 
 All sources verified. This album is cleared for lyric writing.
 Next step: /bitwize-music:lyric-writer [track] (write lyrics from verified sources)
+```
+
+**Partial verification report** (if some tracks still pending):
+```
+VERIFICATION PROGRESS
+=====================
+Album: [title]
+Tracks verified this session: X
+Tracks still pending: Y
+  - [track-slug] — [reason if known]
+
+Album status: unchanged ([current])
+Resume verification later with /bitwize-music:verify-sources [album]
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `verify-sources` now auto-advances album status from Research Complete → Sources Verified when all tracks are verified, with partial progress reports for incomplete sessions
- Batch-approve workflow: `resume` and `next-step` guide users through batch-approving Generated → Final via `update_track_field` MCP tool
- Non-documentary status flow documented: standard albums skip Research Complete and Sources Verified phases (Concept → In Progress → Complete → Released)

Closes #118

## Files Changed

| File | Change |
|------|--------|
| `CLAUDE.md` | Two status flows (documentary vs standard), auto-advancement rules, batch-approve workflow |
| `skills/verify-sources/SKILL.md` | Step 5 rewritten: auto-advance album status + partial verification reports |
| `skills/resume/SKILL.md` | Phase table covers both album flows, batch-approve path for all-Generated albums |
| `skills/next-step/SKILL.md` | Batch-approve path for all-Generated albums |
| `reference/SKILL_INDEX.md` | Batch-approve entry in Album Lifecycle table |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] `pytest tests/` — 2530 passed, 0 failed
- [ ] Manual: verify-sources on album with all tracks verified → album status advances
- [ ] Manual: non-documentary album skips Research Complete/Sources Verified in resume output
- [ ] Manual: batch-approve Generated tracks via update_track_field

🤖 Generated with [Claude Code](https://claude.com/claude-code)