### PR TITLE
feat: add Bollywood genre

### DIFF
--- a/genres/INDEX.md
+++ b/genres/INDEX.md
@@ -18,6 +18,7 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 - [Reggae and Caribbean](#reggae-and-caribbean)
 - [Latin](#latin)
 - [Middle Eastern](#middle-eastern)
+- [South Asian](#south-asian)
 - [European Pop](#european-pop)
 - [Children's / Family](#childrens--family)
 - [Other Genres](#other-genres)
@@ -162,6 +163,12 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 |-------|-------------|------|
 | **Children's Music** | Music composed for young audiences; from folk singalongs and lullabies to educational pop and animated YouTube content; includes German Kinderlieder tradition | [README](childrens-music/README.md) |
 
+## South Asian
+
+| Genre | Description | Link |
+|-------|-------------|------|
+| **Bollywood** | Hindi film music (filmi) spanning golden age raga-based orchestral songs to contemporary pop-EDM hybrids; driven by playback singing tradition and cinematic storytelling | [README](bollywood/README.md) |
+
 ## European Pop
 
 | Genre | Description | Link |
@@ -177,10 +184,10 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 
 | Speed | Genres |
 |-------|--------|
-| **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads, [Chanson](chanson/README.md) (ballads), [Children's Music](childrens-music/README.md) (lullabies), [Musicals](musicals/README.md) (ballads), [Soundtrack](soundtrack/README.md) (ballads) |
-| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (ballads) |
-| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md), [Children's Music](childrens-music/README.md), [Musicals](musicals/README.md) (dialogue songs), [Soundtrack](soundtrack/README.md) |
-| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat), [Musicals](musicals/README.md) (production numbers) |
+| **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads, [Chanson](chanson/README.md) (ballads), [Children's Music](childrens-music/README.md) (lullabies), [Musicals](musicals/README.md) (ballads), [Soundtrack](soundtrack/README.md) (ballads), [Bollywood](bollywood/README.md) (ghazal/slow ballads) |
+| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (ballads), [Bollywood](bollywood/README.md) (romantic ballads) |
+| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md), [Children's Music](childrens-music/README.md), [Musicals](musicals/README.md) (dialogue songs), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (mid-tempo/sangeet) |
+| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat), [Musicals](musicals/README.md) (production numbers), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
 | **Very Fast (140-180+ BPM)** | [Drum and Bass](drum-and-bass/README.md), [Thrash Metal](thrash-metal/README.md), [Hardcore Punk](hardcore-punk/README.md), [Black Metal](black-metal/README.md) |
 
 ### By Energy Level
@@ -188,8 +195,8 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 | Energy | Genres |
 |--------|--------|
 | **Chill/Relaxed** | [Ambient](ambient/README.md), [Lo-Fi](lo-fi/README.md), [Bossa Nova](bossa-nova/README.md), [Chillwave](chillwave/README.md), [Trip-Hop](trip-hop/README.md), [Indie Folk](indie-folk/README.md), [Children's Music](childrens-music/README.md) (lullabies) |
-| **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md), [Chanson](chanson/README.md), [Children's Music](childrens-music/README.md) (singalong/educational), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) |
-| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat) |
+| **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md), [Chanson](chanson/README.md), [Children's Music](childrens-music/README.md) (singalong/educational), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (romantic ballads/ghazal) |
+| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
 | **Aggressive** | [Metal](metal/README.md), [Punk](punk/README.md), [Drill](drill/README.md), [Dubstep](dubstep/README.md), [Industrial](industrial/README.md), [Grime](grime/README.md) |
 | **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Disco](disco/README.md), [Schlager](schlager/README.md) |
 
@@ -204,6 +211,8 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 | **808/Drum Machines** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Phonk](phonk/README.md), [House](house/README.md), [Techno](techno/README.md) |
 | **Orchestra** | [Classical](classical/README.md), [Opera](opera/README.md), [Cinematic](cinematic/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (Bond/Golden Age), [Disco](disco/README.md) (strings) |
 | **Piano** | [Classical](classical/README.md), [Jazz](jazz/README.md), [Gospel](gospel/README.md), [Blues](blues/README.md), [Pop](pop/README.md) ballads, [Piano Rock](piano-rock/README.md), [Piano Pop](piano-pop/README.md), [Chanson](chanson/README.md) |
+| **Tabla/Dholak/Harmonium** | [Bollywood](bollywood/README.md) |
+| **Sitar/Bansuri** | [Bollywood](bollywood/README.md) |
 | **Accordion** | [Chanson](chanson/README.md) (musette), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï) |
 | **Oud/Qanun** | [Middle Eastern Pop](middle-eastern-pop/README.md) |
 | **Brass/Horns** | [Jazz](jazz/README.md), [Funk](funk/README.md), [Ska Punk](ska-punk/README.md), [Latin](latin/README.md), [Gospel](gospel/README.md) |
@@ -213,7 +222,7 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 
 | Vocal Approach | Genres |
 |----------------|--------|
-| **Powerful/Belted** | [Gospel](gospel/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (power ballad), [Pop](pop/README.md), [Rock](rock/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) (réaliste), [Middle Eastern Pop](middle-eastern-pop/README.md) |
+| **Powerful/Belted** | [Gospel](gospel/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (power ballad), [Pop](pop/README.md), [Rock](rock/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) (réaliste), [Middle Eastern Pop](middle-eastern-pop/README.md), [Bollywood](bollywood/README.md) |
 | **Rapped/Spoken** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Grime](grime/README.md), [Nerdcore](nerdcore/README.md) |
 | **Screamed/Harsh** | [Metal](metal/README.md), [Punk](punk/README.md), [Metalcore](metalcore/README.md), [Emo](emo/README.md), [Industrial](industrial/README.md) |
 | **Intimate/Whispered** | [Folk](folk/README.md), [Indie Folk](indie-folk/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md) (à texte) |
@@ -227,20 +236,21 @@ A searchable, categorized guide to all 71 genre documentation files in this repo
 |------|--------|
 | **Dark/Brooding** | [Black Metal](black-metal/README.md), [Doom Metal](doom-metal/README.md), [Industrial](industrial/README.md), [Drill](drill/README.md), [Grunge](grunge/README.md), [Trip-Hop](trip-hop/README.md) |
 | **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) |
-| **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (ballads), [Middle Eastern Pop](middle-eastern-pop/README.md) |
+| **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (ballads), [Middle Eastern Pop](middle-eastern-pop/README.md), [Bollywood](bollywood/README.md) |
 | **Rebellious/Defiant** | [Punk](punk/README.md), [Hip-Hop](hip-hop/README.md), [Metal](metal/README.md), [Grime](grime/README.md) |
 | **Spiritual/Transcendent** | [Gospel](gospel/README.md), [Ambient](ambient/README.md), [Trance](trance/README.md), [Reggae](reggae/README.md), [Classical](classical/README.md) |
 | **Playful/Whimsical** | [Children's Music](childrens-music/README.md), [Hyperpop](hyperpop/README.md) |
-| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat) |
+| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **Spiritual/Devotional** | [Bollywood](bollywood/README.md) (qawwali/bhajan) |
 
 ### By Era/Aesthetic
 
 | Era | Genres |
 |-----|--------|
-| **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md), [Musicals](musicals/README.md) (Golden Age), [Soundtrack](soundtrack/README.md) (Hollywood Golden Age, Bond themes), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (golden age), [Children's Music](childrens-music/README.md) (folk era) |
-| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Soundtrack](soundtrack/README.md) (Saturday Night Fever, Purple Rain) |
-| **1990s** | [Grunge](grunge/README.md), [Hip-Hop](hip-hop/README.md), [Trip-Hop](trip-hop/README.md), [Trance](trance/README.md), [House](house/README.md) |
-| **2000s-2010s** | [EDM](edm/README.md), [Trap](trap/README.md), [Dubstep](dubstep/README.md), [Hyperpop](hyperpop/README.md), [Lo-Fi](lo-fi/README.md), [Musicals](musicals/README.md) (contemporary) |
+| **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md), [Musicals](musicals/README.md) (Golden Age), [Soundtrack](soundtrack/README.md) (Hollywood Golden Age, Bond themes), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (golden age), [Children's Music](childrens-music/README.md) (folk era), [Bollywood](bollywood/README.md) (classical filmi golden age) |
+| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Soundtrack](soundtrack/README.md) (Saturday Night Fever, Purple Rain), [Bollywood](bollywood/README.md) (disco filmi era) |
+| **1990s** | [Grunge](grunge/README.md), [Hip-Hop](hip-hop/README.md), [Trip-Hop](trip-hop/README.md), [Trance](trance/README.md), [House](house/README.md), [Bollywood](bollywood/README.md) (A.R. Rahman era) |
+| **2000s-2010s** | [EDM](edm/README.md), [Trap](trap/README.md), [Dubstep](dubstep/README.md), [Hyperpop](hyperpop/README.md), [Lo-Fi](lo-fi/README.md), [Musicals](musicals/README.md) (contemporary), [Bollywood](bollywood/README.md) (contemporary pop/bhangra fusion) |
 | **Internet/Modern** | [Vaporwave](vaporwave/README.md), [Hyperpop](hyperpop/README.md), [Phonk](phonk/README.md), [Drill](drill/README.md), [Lo-Fi](lo-fi/README.md), [Children's Music](childrens-music/README.md) (YouTube era) |
 
 ---

--- a/genres/bollywood/README.md
+++ b/genres/bollywood/README.md
@@ -1,0 +1,111 @@
+# Bollywood
+
+## Genre Overview
+
+Bollywood music — formally known as filmi music — is the song-driven soundtrack tradition of Hindi-language cinema produced in Mumbai (historically Bombay). It began in 1931 with India's first sound film *Alam Ara*, directed by Ardeshir Irani, which featured seven songs sung live on set by actors. The innovation that shaped everything came in 1935, when composer Rai Chand Boral introduced playback singing for the film *Dhoop Chhaon*: pre-recording songs so actors could lip-sync on camera. By the mid-1940s, playback singing was standard practice, separating the roles of actor and singer entirely and creating a parallel industry of professional playback vocalists. Composers like Naushad Ali, S.D. Burman (Sachin Dev Burman), and Shankar-Jaikishan dominated the classical era, blending North Indian raga-based melodies with large Western-style string orchestras and traditional percussion such as tabla and dholak.
+
+The golden age of Bollywood music spans roughly 1950–1975, defined by the voices of Lata Mangeshkar, Mohammed Rafi, Kishore Kumar, Mukesh, and Asha Bhosle. These playback singers became cultural institutions in their own right, each associated with a distinctive emotional register: Rafi with devotion and longing, Kishore Kumar with playful or heartbroken romance, Mangeshkar with crystalline purity and classical precision. The 1970s brought a major stylistic rupture when Bappi Lahiri introduced synthesizer-driven disco rhythms — his work on films like *Disco Dancer* (1982) and *Sharaabi* (1984) defining a brash, Western-influenced sound that drew criticism from classical-era composers including Naushad. The late 1980s saw a period of decline, with formulaic production and recycled melodies. The decisive break came in 1992 when A.R. Rahman composed the soundtrack for the Tamil film *Roja*, directed by Mani Ratnam. The Hindi-dubbed version sold 2.8 million units across India and introduced a new aesthetic: electronic textures, Sufi-influenced vocals, folk elements, and sophisticated orchestration working together. Rahman became the genre's dominant creative force in the 1990s.
+
+Modern Bollywood music, from roughly the 2000s onward, operates as a full-spectrum commercial pop industry. T-Series, the dominant music label, releases hundreds of soundtracks annually. Production incorporates EDM drops, hip-hop beats, trap percussion, and Punjabi bhangra rhythms alongside ghazals and classical raga-based compositions. The item number — a standalone dance track inserted into a film regardless of narrative context — has become a genre staple, prioritizing high BPM and spectacle. Composers like Pritam, Vishal-Shekhar, and Shankar-Ehsaan-Loy have built careers on hybrid sound design that pairs hook-driven pop songwriting with Indian melodic vocabulary. The international reach of Bollywood music expanded dramatically through the Indian diaspora, streaming platforms, and crossover collaborations — Rahman's work on *Slumdog Millionaire* (2008) brought the genre its first mainstream Western recognition with two Academy Awards for Best Original Score and Best Original Song.
+
+## Characteristics
+
+- **Instrumentation**: Tabla (hand drums providing rhythmic foundation), dholak (double-headed barrel drum for energetic dance sequences), harmonium (reed organ central to melodic accompaniment), sitar (plucked string adding classical color), bansuri (bamboo flute), sarangi (bowed fiddle in classical tracks); large Western string orchestras in golden age and orchestral scores; synthesizers and drum machines from the 1980s onward; electronic bass, trap hi-hats, and EDM synths in contemporary productions
+- **Vocals**: Expressive, ornamented singing with strong classical Indian influence; meend (portamento glides between notes), gamak (rapid oscillations), and taan (rapid melodic runs) common in classical-influenced tracks; powerful chest-voice delivery for anthems and dance numbers; light, airy falsetto-adjacent tones in romantic ballads; call-and-response between male and female voices (duet tradition is central); pronounced vibrato in golden age style; pitch-shifted or autotuned vocals in modern dance tracks
+- **Production**: Highly layered and cinematic; golden age recordings use full string sections with live tabla and dholak; 1980s productions mix synthesized bass lines and drum machines with occasional live percussion; contemporary productions integrate Western pop and EDM production (sidechain compression, vocal chops, trap percussion) with Indian melodic writing; mix aesthetic prioritizes vocal clarity and orchestral warmth; recordings often dense with melodic instruments doubling the main vocal line
+- **Energy/Mood**: Extraordinarily wide emotional range by design — Bollywood music must serve narrative, so the same film may require devotional hymns, comedic numbers, grief-laden laments, and high-energy celebration tracks; romantic longing (the most dominant emotional register), patriotic fervor, spiritual ecstasy, comedic buoyancy, and euphoric dance energy all coexist within the genre; modern dance tracks trend toward unambiguous celebratory energy
+- **Structure**: Verse-chorus with a distinctly Indian formal element — the mukhda (refrain/hook, typically 4–8 bars) returns after each antara (verse) rather than building to a single chorus; many compositions include an instrumental interlude or prelude; duets frequently alternate male and female verses before joining in unison on the mukhda; item numbers and dance sequences often feature layered vocal choruses and percussion breaks; most tracks 4–6 minutes for classical-era recordings, 3.5–5 minutes for modern releases
+- **Tempo**: Romantic ballads typically 60–85 BPM (slow tempo crucial for emotional expression and ornamental singing); bhangra-influenced dance tracks 120–145 BPM; item numbers and uptempo dance sequences 115–135 BPM; mid-tempo romantic dance songs (sangeet/wedding repertoire) 95–115 BPM; classical-influenced semi-classical songs can be rubato or follow complex tala cycles not mapped to fixed BPM
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: End rhyme on the mukhda (AABB or ABAB), with the antara verses often using a looser XAXA or XAXB scheme; internal rhyme is valued but secondary to melodic phrase fitting
+- **Rhyme quality**: Urdu-influenced poetic tradition prized for wordplay, double meanings (shayari style), and metaphorical imagery from nature — moon, rain, flowers, rivers; slant and near rhyme accepted; multisyllabic end rhymes common in classic ghazal-influenced tracks; modern item numbers prioritize sonic impact and repetition over poetic depth
+- **Verse structure**: Mukhda (hook) is typically 4 lines, repeated after each verse; antara verses 4–8 lines; full song structure: mukhda → antara 1 → mukhda → antara 2 → mukhda → (optional) antara 3 → mukhda; duet tracks alternate male and female singers per antara
+- **Key rule**: The mukhda is everything — it must be immediately memorable, emotionally complete, and rhythmically satisfying as a standalone phrase; the antatras develop the emotional situation but the mukhda carries the song
+- **Avoid**: Overly dense verse writing that fights the melody's ornamental style; forcing Western pop prosody (stress on beat 1) onto Hindustani melodic phrasing which often lands on beat 2 or 3; clichés around Urdu poetry without understanding the emotional register (using shayari vocabulary out of context sounds hollow); modern dance tracks stuffed with lyrical content when rhythmic chanting is the appropriate mode
+- **Density/pacing (Suno)**: Default **6 lines/verse** at 80–100 BPM for romantic ballads. Dance tracks: **4 lines/verse** at 120–135 BPM with heavy repetition of the mukhda. Item numbers: **4 lines max**, hook repeated 3+ times. Topics: 1 emotional situation per verse, developed through imagery.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Classical Filmi** | Golden age (1950s–1970s) compositions rooted in North Indian classical ragas; songs are built on specific ragas evoking particular moods (Bhairavi for pathos, Bhairav for devotion, Khamaj for romance); large string orchestras, tabla, and live harmonium; melody takes absolute precedence over rhythm | Naushad, S.D. Burman, Shankar-Jaikishan, C. Ramchandra |
+| **Romantic Ballad** | The dominant emotional mode of Bollywood; slow to mid-tempo songs expressing longing, separation, or declarations of love; featuring expressive solo vocals and lush orchestration; from Rafi's era devotional love songs to contemporary guitar-backed pop ballads | Mohammed Rafi, Lata Mangeshkar, Sonu Nigam, Arijit Singh |
+| **Duet** | Male-female vocal interplay central to Hindi film storytelling; verses alternate between singers who represent opposing characters, converging on the mukhda; ranges from playful flirtation to aching longing; requires chemistry between playback voices that often became iconic pairings | Lata Mangeshkar & Mohammed Rafi, Asha Bhosle & Kishore Kumar, Sunidhi Chauhan & Udit Narayan |
+| **Item Number** | High-energy dance track inserted into a film for spectacle, often performed by a guest artist unrelated to the main narrative; typically features female lead vocal, repetitive call-and-response hook, driving percussion, and provocative lyrical imagery; prioritizes danceability and memorable refrain over lyrical depth | Asha Bhosle (1970s–80s), Sunidhi Chauhan, Shreya Ghoshal, Honey Singh (songwriter) |
+| **Bhangra-Influenced** | Punjabi folk music tradition that entered mainstream Bollywood in the 1990s and became dominant in the 2000s; driven by the dhol drum (heavier than dholak), energetic vocal exclamations (hoiye, balle balle), upbeat brass, and fast dance-friendly tempos; celebratory register associated with weddings and parties | Daler Mehndi, Sukhbir, Mika Singh, Honey Singh |
+| **Sufi/Qawwali Fusion** | Devotional music tradition blending Islamic qawwali (repetitive call-and-response vocal praise with harmonium and tabla) with filmi orchestration; can be genuinely devotional or repurposed for romantic expression in films; characterized by building intensity, layered voices, and emotional crescendo | Nusrat Fateh Ali Khan (crossover), A.R. Rahman, Rahat Fateh Ali Khan |
+| **Ghazal-Influenced** | Ghazal is an Urdu poetic form with strict conventions (each couplet self-contained, poet's name in the final couplet); filmi ghazals adapt the form for wider audiences, softening strict rules while preserving the melancholic introspective mood; acoustic instrumentation, rubato phrasing | Jagjit Singh, Pankaj Udhas, Gulzar (lyricist) |
+| **Disco Filmi** | Late 1970s–1980s synthesis of Western disco, funk, and electronic pop with Indian melodic sensibility; synthesizer bass lines, drum machines, electric guitars, and driving four-on-the-floor beats replacing traditional percussion; associated with the action film boom of the 1980s | Bappi Lahiri, Biddu, R.D. Burman (later work) |
+| **Contemporary Bollywood Pop** | Post-2000s mainstream sound blending Western pop production (EDM, hip-hop, trap, R&B) with Indian vocal style and melodic composition; tracks frequently interpolate Western chord progressions while maintaining Hindustani vocal ornamentation; streaming-optimized with front-loaded hooks | Pritam, Vishal-Shekhar, Shankar-Ehsaan-Loy, A.R. Rahman |
+| **Indie/Parallel Cinema Soundtrack** | Music for art house or independent Hindi films (parallel cinema tradition from the 1970s onward); often minimal, folk-influenced, or jazz-tinged; prioritizes atmosphere over commercial hooks; associated with directors like Shyam Benegal, Anurag Kashyap, and Imtiaz Ali | Vanraj Bhatia, Sneha Khanwalkar, A.R. Rahman (Dil Se), Amit Trivedi |
+
+## Artists
+
+| Artist | Key Albums/Films | Era | Style Focus |
+|--------|-----------------|-----|-------------|
+| Naushad Ali | *Mother India* (1957), *Mughal-E-Azam* (1960), *Pakeezah* (1972) | 1940s–1970s | Pioneer of raga-based orchestral film scores; large string arrangements meeting classical North Indian forms |
+| S.D. Burman (Sachin Dev Burman) | *Pyaasa* (1957), *Guide* (1965), *Aradhana* (1969) | 1940s–1970s | Folk and classical synthesis; melodic sophistication; worked closely with lyricist Shailendra |
+| Shankar-Jaikishan | *Awaara* (1951), *Shree 420* (1955), *Sangam* (1964) | 1950s–1970s | Western orchestration married to Indian melody; pioneered use of large string sections; prolific collaborators with Raj Kapoor films |
+| R.D. Burman (Rahul Dev Burman) | *Hare Rama Hare Krishna* (1971), *Sholay* (1975), *Ijaazat* (1987) | 1960s–1980s | Experimental fusion; incorporated rock guitar, Latin percussion, unconventional sounds alongside classical elements; son of S.D. Burman |
+| Lata Mangeshkar | Hundreds of film soundtracks across 70+ years | 1940s–2010s | The defining female playback voice; crystalline clarity, precise classical ornamentation, enormous emotional range |
+| Mohammed Rafi | *Teesri Manzil* (1966), *Jewel Thief* (1967), *Hum Kisi Se Kum Nahin* (1977) | 1940s–1980 | The definitive male romantic and devotional voice; matchless command of both classical expression and modern playfulness |
+| Kishore Kumar | *Aradhana* (1969), *Amar Prem* (1972), *Kati Patang* (1971) | 1960s–1987 | Actor-turned-playback singer; emotional versatility, slight roughness in voice used expressively; dominant voice of 1970s Bollywood |
+| Asha Bhosle | *Teesri Manzil* (1966), *Umrao Jaan* (1981), *Rangeela* (1995) | 1950s–2000s | Versatile sister of Lata Mangeshkar; cabaret, classical, pop, and disco across six decades; signature voice of item numbers and unconventional films |
+| Bappi Lahiri | *Disco Dancer* (1982), *Dance Dance* (1987), *Sharaabi* (1984) | 1970s–2000s | Introduced synthesized disco and electronic music to Bollywood; "Disco King"; controversial among classical purists, enormously popular commercially |
+| A.R. Rahman | *Roja* (1992), *Bombay* (1995), *Dil Se* (1998), *Lagaan* (2001), *Slumdog Millionaire* (2008) | 1992–present | Transformative composer fusing electronic production, Sufi vocals, Tamil and North Indian classical elements; two Academy Awards; redefined modern Bollywood's production standards |
+| Jatin-Lalit | *Dilwale Dulhania Le Jayenge* (1995), *Kuch Kuch Hota Hai* (1998), *Mohabbatein* (2000) | 1990s–2000s | Brothers who defined the melodic 1990s romantic ballad sound; clean orchestration and sing-along hooks for diaspora-targeting films |
+| Pritam | *Barfi!* (2012), *Ae Dil Hai Mushkil* (2016), *Jagga Jasoos* (2017) | 2000s–present | Dominant contemporary composer; adaptable to Western pop and hip-hop production while maintaining Indian melodic sensibility |
+| Shankar-Ehsaan-Loy | *Dil Chahta Hai* (2001), *Kal Ho Na Ho* (2003), *Lakshya* (2004) | 2000s–present | Trio that modernized Bollywood sound in early 2000s; rock, electronic, and orchestral hybrid; worked heavily with Farhan Akhtar and Karan Johar productions |
+| Arijit Singh | *Aashiqui 2* (2013), *Bajrangi Bhaijaan* (2015), *Ae Dil Hai Mushkil* (2016) | 2010s–present | Dominant male playback voice of contemporary Bollywood; emotive delivery bridging classical ornamentation and pop accessibility |
+| Vishal-Shekhar | *Om Shanti Om* (2007), *Band Baaja Baaraat* (2010), *Dilwale* (2015) | 2000s–present | High-energy pop and dance composers; strong item numbers and dance sequences; frequent collaborators with Shah Rukh Khan productions |
+
+## Suno Prompt Keywords
+
+```
+bollywood, filmi music, Hindi film music, Indian cinema soundtrack,
+tabla, dholak, sitar, harmonium, bansuri flute, sarangi, tanpura drone,
+large string orchestra, Indian strings, Hindustani classical, raga-based melody,
+bhangra, dhol drum, Punjabi folk, wedding music, sangeet,
+qawwali, Sufi devotional, call and response vocals,
+playback singing, expressive Indian vocals, meend ornament, vocal glide, taan runs,
+male-female duet, romantic longing, mukhda hook, antara verse,
+item number, dance sequence, Bollywood dance track,
+disco filmi, 80s Bollywood, synthesizer Bollywood,
+contemporary Bollywood pop, modern filmi, EDM Bollywood, trap filmi,
+romantic ballad, tearjerker, emotional Hindi song,
+patriotic anthem, devotional song, bhajan,
+Bollywood wedding, celebratory, festive Indian music,
+lush orchestration, cinematic, melodramatic
+```
+
+## Reference Tracks
+
+- **K.L. Saigal - "Do Naina Matware" from *Devdas* (1935)** — One of the earliest playback-era recordings, establishing the standard of melodic vocal expressiveness that would define the genre; Saigal's trembling tenor and intimate delivery set the emotional template for Hindi film song
+
+- **Mohammed Rafi - "Teri Galiyon Mein Na Rakhenge Qadam" from *Sharafat* (1970)** — Rafi at the peak of his powers: an aching breakup lyric over S.D. Burman's orchestration; demonstrates the male romantic ballad's capacity for pure vocal storytelling without instrumental distraction
+
+- **Lata Mangeshkar - "Lag Ja Gale" from *Woh Kaun Thi?* (1964), music by Madan Mohan** — Perhaps the most covered song in Hindi film history; spare string arrangement, Urdu poetry by Raja Mehdi Ali Khan, and Mangeshkar's restraint make it a master class in intimate longing
+
+- **Shankar-Jaikishan - "Awara Hoon" from *Awaara* (1951)** — A vagabond anthem that became globally recognized, reportedly popular in the Soviet Union and across Asia; illustrates the universal melodic simplicity at the heart of golden age filmi
+
+- **R.D. Burman - "Dum Maro Dum" from *Hare Rama Hare Krishna* (1971), sung by Asha Bhosle** — Western pop and Indian film music fusion at its first modern peak; bluesy organ, electric guitar, Bhosle's seductive delivery; signaled the genre's willingness to absorb rock and counterculture aesthetics
+
+- **Bappi Lahiri - "I Am A Disco Dancer" from *Disco Dancer* (1982)** — The defining track of Bollywood's disco era; synthesized bass, drum machine, electric guitars, Hindi lyrics — the unapologetic embrace of Western pop idioms that scandalized classical purists and sold millions
+
+- **A.R. Rahman - "Dil Se Re" from *Dil Se* (1998)** — Rahman integrating electronic production, Sufi vocal layers, and Hindustani ornamentation into a single coherent track; the rhythmic complexity and timbral richness demonstrated what post-Rahman Bollywood could accomplish
+
+- **A.R. Rahman - "Jai Ho" from *Slumdog Millionaire* (2008)** — The track that crossed Bollywood into international mainstream awareness; bhangra percussion, choral voices, electronic underpinning, and an irresistible hook; won the Academy Award for Best Original Song
+
+- **Jatin-Lalit - "Tujhe Dekha To" from *Dilwale Dulhania Le Jayenge* (1995), sung by Lata Mangeshkar & Udit Narayan** — Quintessential 1990s romantic ballad; acoustic guitar, strings, and two vocalists in a duet that captures the diaspora-targeted romantic formula perfectly; soundtrack voted best Hindi album of all time in a 2005 BBC Asian Network poll
+
+- **Shankar-Ehsaan-Loy - "Rock On" from *Rock On!!* (2008)** — Bollywood embracing rock idioms without apology; electric guitars, stadium energy, Hindi lyrics — proved the genre could absorb Western rock vocabulary while remaining distinctly filmi
+
+- **Nusrat Fateh Ali Khan & A.R. Rahman - "Akhiyan Udeek Diyan"** — Qawwali tradition meeting modern filmi production; Nusrat's devotional power channeled into romantic longing; demonstrates Bollywood's deep relationship with Sufi musical vocabulary
+
+- **Pritam - "Galliyan" from *Ek Villain* (2014), sung by Ankit Tiwari** — Contemporary Bollywood ballad with acoustic guitar and restrained production; emotional delivery, urban melancholy, and streaming-optimized length; shows how the romantic ballad tradition continued evolving
+
+- **Honey Singh - "Lungi Dance" from *Chennai Express* (2013)** — Item number at peak commercial power: Punjabi hip-hop production, bhangra percussion, repetitive hook, and deliberate absurdism; illustrates the 2010s merger of filmi spectacle with rap and EDM aesthetics
+
+- **Arijit Singh - "Tum Hi Ho" from *Aashiqui 2* (2013)** — The track that established Singh as Bollywood's dominant contemporary voice; piano ballad, restrained orchestration, emotionally raw delivery; became one of the most-streamed Hindi songs of its era

--- a/skills/mastering-engineer/genre-presets.md
+++ b/skills/mastering-engineer/genre-presets.md
@@ -183,6 +183,21 @@ Detailed mastering settings by genre.
 - Low dynamic range preferred — avoid sudden volume jumps (safety for children's playback)
 - Ukulele and xylophone brightness tamed without losing sparkle
 
+### Bollywood
+**LUFS target**: -14 LUFS (classical filmi/ghazal: -15 LUFS; bhangra/item numbers: -13 LUFS)
+**Dynamics**: Moderate compression; preserve vocal ornamentation (meend glides and taan runs need headroom); allow natural dynamic arc from intimate verse to full-orchestra chorus
+**EQ focus**: Vocal clarity (2-5 kHz), tabla and dholak attack (3-5 kHz), string warmth (200-600 Hz), gentle high-mid cut to tame Suno-generated brightness in orchestral layers
+**MCP command**: `master_audio(album_slug, genre="bollywood")`
+
+**Characteristics**:
+- Playback vocal is always the center — strings, tabla, and harmonium exist to support it, never overwhelm
+- Ornamental vocal runs (meend, taan) require headroom — over-compression smears them into muddy sustain
+- Tabla transients should remain crisp and defined; dholak body (150-250 Hz) needs warmth without muddiness
+- Classical filmi tracks (-15 LUFS): preserve the wide dynamic range between intimate vocal passages and full orchestral moments
+- Bhangra and item numbers (-13 LUFS): more compression acceptable, dhol punch at 60-100 Hz, bright top end for dancefloor energy
+- Sitar and bansuri harmonics sit in 1.5-4 kHz range — avoid over-cutting here or they disappear in the mix
+- Contemporary Bollywood pop with electronic production: treat sub-bass and EDM elements like mainstream pop; maintain vocal warmth on top
+
 ---
 
 ## Problem-Solving

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -363,6 +363,12 @@ genres:
     cut_highmid: -2.0
     cut_highs: 0
 
+  # === South Asian ===
+  bollywood:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
+
   # === Latin / World ===
   latin:
     target_lufs: -14.0


### PR DESCRIPTION
## Summary

Cherry-pick of #141 by @markus-michalski, rebased onto current `develop` to satisfy branch protection.

- New genre `genres/bollywood/README.md` — 3 paragraphs of history, 10 subgenres, 15 artists, 14 reference tracks, Suno keywords, mukhda/antara lyric conventions
- `genres/INDEX.md` — new "South Asian" section + all Quick Reference tables updated
- `tools/mastering/genre-presets.yaml` — Bollywood preset (-14 LUFS)
- `skills/mastering-engineer/genre-presets.md` — Bollywood mastering section with variant LUFS targets

Closes #141

## Test plan

- [x] README follows 7-section genre template (no YAML frontmatter)
- [x] INDEX.md Quick Reference tables include Bollywood
- [x] Mastering YAML syntax valid, LUFS consistent with prose
- [x] No AI clichés

🤖 Generated with [Claude Code](https://claude.ai/claude-code)