### PR TITLE
fix: update genre index count from 71 to 74

### DIFF
--- a/genres/INDEX.md
+++ b/genres/INDEX.md
@@ -1,6 +1,6 @@
 # Genre Index
 
-A searchable, categorized guide to all 71 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
+A searchable, categorized guide to all 74 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
 
 ---
 


### PR DESCRIPTION
## Summary

- Genre INDEX.md header said "71 genre documentation files" but the actual count is 74 (musicals, soundtrack, and bollywood were added without updating the header)

## Test plan

- [x] `ls -d genres/*/README.md | wc -l` returns 74
- [x] INDEX.md line 3 now reads "74"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)