### PR TITLE
fix: auto-release dev bump handles patch releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -116,11 +116,19 @@ jobs:
         git fetch origin develop
         git checkout develop
 
+        # Check if develop already has this or a higher dev version
+        CURRENT_DEV=$(jq -r '.version' .claude-plugin/plugin.json)
+        if [ "$CURRENT_DEV" = "$DEV_VERSION" ]; then
+          echo "develop is already at $DEV_VERSION, skipping bump"
+          exit 0
+        fi
+
         # Update version files
         jq ".version = \"$DEV_VERSION\"" .claude-plugin/plugin.json > /tmp/plugin.json && mv /tmp/plugin.json .claude-plugin/plugin.json
         jq ".plugins[0].version = \"$DEV_VERSION\"" .claude-plugin/marketplace.json > /tmp/marketplace.json && mv /tmp/marketplace.json .claude-plugin/marketplace.json
 
         git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+        git diff --cached --quiet && { echo "No version change needed, skipping"; exit 0; }
         git commit -m "chore: bump develop to $DEV_VERSION"
         git push origin develop
         echo "Bumped develop to $DEV_VERSION"


### PR DESCRIPTION
## Summary

- Auto-release workflow failed on 0.84.1 because the dev bump step tried to set develop to `0.85.0-dev`, but it was already at `0.85.0-dev` from the 0.84.0 release
- Added early-exit checks: skip if develop already has the target version, and bail if `git diff` shows no changes

## Test plan

- [ ] CI passes
- [ ] Next patch release doesn't fail the auto-release workflow

🤖 Generated with [Claude Code](https://claude.ai/claude-code)