### PR TITLE
feat: add Ska genre

### DIFF
--- a/genres/INDEX.md
+++ b/genres/INDEX.md
@@ -1,6 +1,6 @@
 # Genre Index
 
-A searchable, categorized guide to all 76 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
+A searchable, categorized guide to all 77 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
 
 ---
 
@@ -143,6 +143,7 @@ A searchable, categorized guide to all 76 genre documentation files in this repo
 | Genre | Description | Link |
 |-------|-------------|------|
 | **Reggae** | Jamaican music with offbeat rhythms, deep bass, and conscious themes | [README](reggae/README.md) |
+| **Ska** | Upbeat Jamaican-born genre with offbeat guitar, walking bass, and prominent horns; three waves from 1960s Kingston to 2 Tone UK to 1990s US | [README](ska/README.md) |
 | **Dancehall** | Digital Jamaican music; party-focused evolution of reggae | [README](dancehall/README.md) |
 | **Afrobeats** | Contemporary West African pop with Afro-Cuban and hip-hop influences | [README](afrobeats/README.md) |
 
@@ -195,7 +196,7 @@ A searchable, categorized guide to all 76 genre documentation files in this repo
 | **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads, [Chanson](chanson/README.md) (ballads), [Children's Music](childrens-music/README.md) (lullabies), [Musicals](musicals/README.md) (ballads), [Soundtrack](soundtrack/README.md) (ballads), [Bollywood](bollywood/README.md) (ghazal/slow ballads) |
 | **Slow (60-90 BPM)** | [Blues](blues/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship ballads), [Worship](worship/README.md) (ballads/intimate), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (ballads), [Bollywood](bollywood/README.md) (romantic ballads) |
 | **Medium (90-120 BPM)** | [Rock](rock/README.md), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Contemporary Christian](contemporary-christian/README.md) (pop/mid-tempo), [Worship](worship/README.md) (anthems), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md), [Children's Music](childrens-music/README.md), [Musicals](musicals/README.md) (dialogue songs), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (mid-tempo/sangeet) |
-| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md), [Contemporary Christian](contemporary-christian/README.md) (rock/anthemic), [Worship](worship/README.md) (uptempo praise), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat), [Musicals](musicals/README.md) (production numbers), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Grime](grime/README.md), [Metal](metal/README.md), [Ska](ska/README.md), [Contemporary Christian](contemporary-christian/README.md) (rock/anthemic), [Worship](worship/README.md) (uptempo praise), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat), [Musicals](musicals/README.md) (production numbers), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
 | **Very Fast (140-180+ BPM)** | [Drum and Bass](drum-and-bass/README.md), [Thrash Metal](thrash-metal/README.md), [Hardcore Punk](hardcore-punk/README.md), [Black Metal](black-metal/README.md) |
 
 ### By Energy Level
@@ -204,7 +205,7 @@ A searchable, categorized guide to all 76 genre documentation files in this repo
 |--------|--------|
 | **Chill/Relaxed** | [Ambient](ambient/README.md), [Lo-Fi](lo-fi/README.md), [Bossa Nova](bossa-nova/README.md), [Chillwave](chillwave/README.md), [Trip-Hop](trip-hop/README.md), [Indie Folk](indie-folk/README.md), [Children's Music](childrens-music/README.md) (lullabies) |
 | **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship/ballad), [Worship](worship/README.md) (intimate/devotional), [Chanson](chanson/README.md), [Children's Music](childrens-music/README.md) (singalong/educational), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (romantic ballads/ghazal) |
-| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **High Energy** | [Rock](rock/README.md), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Ska](ska/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
 | **Aggressive** | [Metal](metal/README.md), [Punk](punk/README.md), [Drill](drill/README.md), [Dubstep](dubstep/README.md), [Industrial](industrial/README.md), [Grime](grime/README.md) |
 | **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (anthemic worship), [Worship](worship/README.md) (anthem/praise), [Disco](disco/README.md), [Schlager](schlager/README.md) |
 
@@ -223,7 +224,7 @@ A searchable, categorized guide to all 76 genre documentation files in this repo
 | **Sitar/Bansuri** | [Bollywood](bollywood/README.md) |
 | **Accordion** | [Chanson](chanson/README.md) (musette), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï) |
 | **Oud/Qanun** | [Middle Eastern Pop](middle-eastern-pop/README.md) |
-| **Brass/Horns** | [Jazz](jazz/README.md), [Funk](funk/README.md), [Ska Punk](ska-punk/README.md), [Latin](latin/README.md), [Gospel](gospel/README.md) |
+| **Brass/Horns** | [Jazz](jazz/README.md), [Funk](funk/README.md), [Ska](ska/README.md), [Ska Punk](ska-punk/README.md), [Latin](latin/README.md), [Gospel](gospel/README.md) |
 | **Banjo/Fiddle** | [Bluegrass](bluegrass/README.md), [Folk](folk/README.md), [Country](country/README.md), [Celtic Punk](celtic-punk/README.md) |
 
 ### By Vocal Style
@@ -235,7 +236,7 @@ A searchable, categorized guide to all 76 genre documentation files in this repo
 | **Screamed/Harsh** | [Metal](metal/README.md), [Punk](punk/README.md), [Metalcore](metalcore/README.md), [Emo](emo/README.md), [Industrial](industrial/README.md) |
 | **Intimate/Whispered** | [Folk](folk/README.md), [Indie Folk](indie-folk/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md) (à texte) |
 | **Processed/Pitch-Shifted** | [Hyperpop](hyperpop/README.md), [Vaporwave](vaporwave/README.md), [Trap](trap/README.md), [Electronic](electronic/README.md) |
-| **Group Singing/Call-and-Response** | [Children's Music](childrens-music/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship), [Worship](worship/README.md) |
+| **Group Singing/Call-and-Response** | [Children's Music](childrens-music/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship), [Worship](worship/README.md), [Ska](ska/README.md) |
 | **Primarily Instrumental** | [Ambient](ambient/README.md), [Post-Rock](post-rock/README.md), [Techno](techno/README.md), [Classical](classical/README.md), [Jazz](jazz/README.md) (much of it) |
 
 ### By Mood/Atmosphere
@@ -245,18 +246,18 @@ A searchable, categorized guide to all 76 genre documentation files in this repo
 | **Dark/Brooding** | [Black Metal](black-metal/README.md), [Doom Metal](doom-metal/README.md), [Industrial](industrial/README.md), [Drill](drill/README.md), [Grunge](grunge/README.md), [Trip-Hop](trip-hop/README.md) |
 | **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) |
 | **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (ballads), [Middle Eastern Pop](middle-eastern-pop/README.md), [Bollywood](bollywood/README.md) |
-| **Rebellious/Defiant** | [Punk](punk/README.md), [Hip-Hop](hip-hop/README.md), [Metal](metal/README.md), [Grime](grime/README.md) |
+| **Rebellious/Defiant** | [Punk](punk/README.md), [Hip-Hop](hip-hop/README.md), [Metal](metal/README.md), [Grime](grime/README.md), [Ska](ska/README.md) (2 Tone) |
 | **Spiritual/Transcendent** | [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md), [Ambient](ambient/README.md), [Trance](trance/README.md), [Reggae](reggae/README.md), [Worship](worship/README.md), [Classical](classical/README.md) |
 | **Playful/Whimsical** | [Children's Music](childrens-music/README.md), [Hyperpop](hyperpop/README.md) |
-| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Ska](ska/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
 | **Spiritual/Devotional** | [Contemporary Christian](contemporary-christian/README.md) (worship), [Worship](worship/README.md), [Bollywood](bollywood/README.md) (qawwali/bhajan) |
 
 ### By Era/Aesthetic
 
 | Era | Genres |
 |-----|--------|
-| **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md), [Musicals](musicals/README.md) (Golden Age), [Soundtrack](soundtrack/README.md) (Hollywood Golden Age, Bond themes), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (golden age), [Children's Music](childrens-music/README.md) (folk era), [Bollywood](bollywood/README.md) (classical filmi golden age) |
-| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Synthwave](synthwave/README.md), [Contemporary Christian](contemporary-christian/README.md) (Jesus Music, early CCM), [Schlager](schlager/README.md), [Soundtrack](soundtrack/README.md) (Saturday Night Fever, Purple Rain), [Bollywood](bollywood/README.md) (disco filmi era) |
+| **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md), [Ska](ska/README.md) (first wave), [Musicals](musicals/README.md) (Golden Age), [Soundtrack](soundtrack/README.md) (Hollywood Golden Age, Bond themes), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (golden age), [Children's Music](childrens-music/README.md) (folk era), [Bollywood](bollywood/README.md) (classical filmi golden age) |
+| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [New Wave](new-wave/README.md), [Ska](ska/README.md) (2 Tone), [Synthwave](synthwave/README.md), [Contemporary Christian](contemporary-christian/README.md) (Jesus Music, early CCM), [Schlager](schlager/README.md), [Soundtrack](soundtrack/README.md) (Saturday Night Fever, Purple Rain), [Bollywood](bollywood/README.md) (disco filmi era) |
 | **1990s** | [Grunge](grunge/README.md), [Hip-Hop](hip-hop/README.md), [Trip-Hop](trip-hop/README.md), [Trance](trance/README.md), [House](house/README.md), [Contemporary Christian](contemporary-christian/README.md) (dc Talk, Amy Grant crossover), [Bollywood](bollywood/README.md) (A.R. Rahman era) |
 | **2000s-2010s** | [Worship](worship/README.md), [EDM](edm/README.md), [Trap](trap/README.md), [Dubstep](dubstep/README.md), [Hyperpop](hyperpop/README.md), [Lo-Fi](lo-fi/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship explosion, CHH), [Musicals](musicals/README.md) (contemporary), [Bollywood](bollywood/README.md) (contemporary pop/bhangra fusion) |
 | **Internet/Modern** | [Vaporwave](vaporwave/README.md), [Hyperpop](hyperpop/README.md), [Phonk](phonk/README.md), [Drill](drill/README.md), [Lo-Fi](lo-fi/README.md), [Contemporary Christian](contemporary-christian/README.md) (TikTok-native CCM), [Children's Music](childrens-music/README.md) (YouTube era) |
@@ -425,6 +426,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Shoegaze | Rock | [README](shoegaze/README.md) |
 | Soundtrack | Classical/Theatrical | [README](soundtrack/README.md) |
 | Singer-Songwriter | Folk/Pop | [README](singer-songwriter/README.md) |
+| Ska | Caribbean | [README](ska/README.md) |
 | Ska Punk | Rock | [README](ska-punk/README.md) |
 | Surf Rock | Rock | [README](surf-rock/README.md) |
 | Swing | Jazz | [README](swing/README.md) |
@@ -451,4 +453,4 @@ These genres commonly blend well together or have natural crossover potential:
    - Reference artists and albums
    - Suno prompt keywords for AI generation
 
-**Total genres documented: 76**
+**Total genres documented: 77**

--- a/genres/ska/README.md
+++ b/genres/ska/README.md
@@ -1,0 +1,141 @@
+# Ska
+
+## Genre Overview
+
+Ska originated in Jamaica in the late 1950s, emerging from Kingston's sound system culture as musicians fused American rhythm and blues, jazz, and the island's indigenous mento folk music into something entirely new. Producers and sound system operators like Clement "Coxsone" Dodd and Duke Reid began recording local artists who emulated the R&B coming from New Orleans radio stations, but the Jamaican interpretation -- with its distinctive emphasis on the offbeat -- quickly developed its own identity. The Skatalites, a group of virtuoso session musicians including trombonist Don Drummond, tenor saxophonist Tommy McCook, and guitarist Ernest Ranglin, became the house band at Dodd's Studio One and laid the instrumental foundation for the genre. Vocalists and bandleaders like Prince Buster, Desmond Dekker, Toots Hibbert and the Maytals, Derrick Morgan, and Jimmy Cliff turned ska into Jamaica's dominant popular music. The genre's rise coincided with Jamaican independence in 1962, and songs like Derrick Morgan's "Forward March" and the Skatalites' "Freedom Sound" became anthems of national pride.
+
+Ska's evolution moved through three distinct waves. The first wave (late 1950s to mid-1960s) was purely Jamaican, driven by sound systems and recording studios in Kingston. As temperatures and tempos slowed, ska gave way to rocksteady around 1966 and then to reggae by 1968. The second wave arrived in late-1970s Britain when the 2 Tone movement, named after Jerry Dammers's Coventry-based label founded in 1979, fused Jamaican ska with punk energy and new wave aesthetics. The Specials, Madness, The Selecter, and The Beat (known as The English Beat in the US) formed multiracial bands that directly confronted Thatcher-era racism and economic decay. The Specials' "Ghost Town" hit number one in the UK in 1981 during actual urban riots, making it one of the most politically charged singles in pop history. The third wave exploded in the United States during the 1990s, rooted in the California and East Coast punk scenes. Operation Ivy's 1989 album *Energy* planted the seeds, and by 1996-1997 bands like the Mighty Mighty Bosstones, Reel Big Fish, Less Than Jake, and Sublime brought ska to MTV and mainstream radio. Labels like Moon Ska Records, Hellcat, and Asian Man built dedicated infrastructure for the scene.
+
+The mainstream bubble burst around 2000, but ska never disappeared. A fourth wave -- sometimes called "New Tone," a term popularized by the New Orleans band Bad Operation and the label Bad Time Records -- emerged in the late 2010s and 2020s, characterized by DIY ethics and internet-driven community building. Artists like Skatune Network, Jeff Rosenstock, and Kill Lincoln have kept the genre visible, while legacy acts continue touring. Ska's influence on other genres has been immense: its offbeat rhythm is the direct ancestor of reggae and dancehall, its brass-and-punk fusion fed into ska-punk (see the dedicated [ska-punk](../ska-punk/README.md) genre entry), and its sound system culture helped birth DJ culture, dub, and by extension hip-hop and electronic music. The 2 Tone movement's visual identity -- black and white checkerboard patterns, rude boy fashion -- remains one of music's most recognizable subcultural aesthetics.
+
+## Characteristics
+
+- **Instrumentation**: Guitar playing staccato offbeat "skank" chords (muted upstrokes on beats 2 and 4); walking melodic bass lines; horn section (trumpet, trombone, alto/tenor saxophone) providing melodic hooks and counterpoint; piano or organ doubling the skank rhythm; drums with emphasis on hi-hat or ride cymbal, snare on 2 and 4, syncopated kick patterns. First wave featured jazz-influenced horn arrangements; 2 Tone added electric keyboards and occasional synthesizers; third wave expanded to include distorted guitars for punk sections.
+- **Vocals**: Ranges from smooth, soulful delivery (first wave) to cool, deadpan singing (2 Tone) to energetic shouting and gang vocals (third wave). Call-and-response patterns are common across all eras. Toasting (rhythmic spoken-word delivery) appears in first wave Jamaican ska and connects directly to the development of dancehall DJing and rap.
+- **Production**: First wave recordings have a raw, live-in-the-studio quality with prominent reverb and echo from Jamaican studios like Studio One and Treasure Isle. 2 Tone productions are cleaner and punchier, influenced by punk and new wave engineering. Third wave varies from polished, radio-ready mixes to raw punk recordings. Horns are typically high in the mix across all eras.
+- **Energy/Mood**: Upbeat, danceable, and kinetic. Even when lyrics address serious social issues (poverty, racism, political oppression), the music maintains a propulsive energy. First wave ska has a celebratory, jazz-inflected swing; 2 Tone carries an urgent, politically charged tension beneath its dance grooves; third wave tends toward party energy with self-aware humor.
+- **Structure**: Verse-chorus form standard. First wave tracks often feature extended instrumental breaks showcasing horn solos. 2 Tone songs tend to be concise (2:30-4:00). Intros frequently establish the skank rhythm before vocals enter. Breakdowns that strip to bass and drums before full-band re-entry are common in later waves.
+- **Tempo**: First wave: 110-140 BPM. 2 Tone: 120-160 BPM. Third wave (non-punk): 130-170 BPM. Ska-punk tempos go higher (see [ska-punk](../ska-punk/README.md)). Traditional ska sits notably faster than the reggae that succeeded it.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB or ABAB -- short, rhythmic, shout-able phrases. First wave favors simpler, more repetitive structures; 2 Tone and third wave allow more complexity.
+- **Rhyme quality**: Near rhymes and half-rhymes acceptable, especially in Jamaican patois-influenced first wave. Precision matters less than groove lock.
+- **Verse structure**: 4-8 lines per verse. Hooks and choruses are designed for crowd participation. Repetition of key phrases is a genre convention, not a weakness.
+- **Key rule**: Lyrics must lock into the offbeat rhythm. The skank pattern creates natural spaces -- words land between the beats, not on them. Social commentary, celebration, and storytelling all work, but the groove comes first.
+- **Avoid**: Fighting the offbeat rhythm. Overly dense or wordy phrasing that crowds the skank. Ignoring the call-and-response tradition. Misusing Jamaican patois without understanding.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 120-140 BPM. Offbeat skank rhythm creates natural spaces between phrases. Horn breaks need room. Topics: 1/verse.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **First Wave / Jamaican Ska** | The original form, born in Kingston's studios in the late 1950s and flourishing through the mid-1960s. Blends American R&B and jazz with Caribbean mento rhythms. Features walking bass, prominent horn sections with jazz-influenced solos, and a celebratory energy tied to Jamaican independence. Production is raw and live-sounding, recorded at studios like Studio One and Treasure Isle. | The Skatalites, Prince Buster, Desmond Dekker, Toots & the Maytals, Derrick Morgan |
+| **2 Tone** | Late-1970s British revival fusing Jamaican ska with punk urgency and new wave aesthetics. Named after Jerry Dammers's label, founded in Coventry in 1979. Explicitly multiracial and political, addressing racism, unemployment, and Thatcher-era social decay. Faster and more angular than first wave, with cleaner production and a distinctive black-and-white visual identity. | The Specials, Madness, The Selecter, The Beat (English Beat), Bad Manners |
+| **Ska-Punk** | High-energy fusion of ska's offbeat rhythms with punk rock speed and aggression. Prominent brass sections, gang vocals, and dynamic shifts between ska grooves and punk explosions. Covered in detail in the dedicated [ska-punk genre entry](../ska-punk/README.md) -- refer there for full subgenre breakdown, artist lists, and prompt keywords. | Operation Ivy, Reel Big Fish, The Mighty Mighty Bosstones, Less Than Jake, Streetlight Manifesto |
+| **Ska-Jazz** | Instrumental-leaning fusion emphasizing jazz improvisation over ska rhythms. Features extended solos, complex horn arrangements, and sophisticated harmony. The term was coined by Fred Reiter of the New York Ska-Jazz Ensemble in 1994. Draws equally from first wave ska's jazz roots and modern jazz vocabulary. | New York Ska-Jazz Ensemble, The Skatalites (later work), Skaos, The Scofflaws |
+| **Traditional Ska Revival** | Modern bands deliberately recreating the first wave Jamaican sound with period-appropriate instrumentation, tempos, and recording aesthetics. Emphasizes authenticity to the 1960s template rather than punk or pop crossover. Often connected to reggae revival scenes. | Hepcat, The Slackers, The Aggrolites, Westbound Train |
+| **Dub-Ska** | Applies dub production techniques (heavy echo, reverb, instrument drop-outs, mixing board as instrument) to ska rhythms. Creates a spacious, hypnotic feel at ska tempos. Bridges the gap between ska and its reggae/dub descendants. Influenced by King Tubby and Lee "Scratch" Perry's studio innovations. | The Slackers, Easy Star All-Stars, Dub Pistols, Mad Professor (ska remixes) |
+| **Ska-Pop** | The most commercially accessible variant, emphasizing melody, hooks, and radio-friendly production over punk aggression or traditional authenticity. Clean vocals, singalong choruses, and polished arrangements. Often features female vocalists. | Save Ferris, No Doubt (early), Aquabats, Buck-O-Nine |
+| **Rocksteady** | The transitional genre between ska and reggae (1966-1968). Slowed ska's tempo, added American soul influences, and introduced the bass-heavy, skanking guitar style that would define reggae. Romantic themes and smooth vocal harmonies. Technically a separate genre but inseparable from ska's lineage. | Alton Ellis, The Paragons, The Heptones, Ken Boothe, Phyllis Dillon |
+
+## Artists
+
+| Artist | Key Albums | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| The Skatalites | *Foundation Ska* (1997 comp.), *Ska Authentic* (1964) | 1964-1965, reunions 1983-present | The definitive first wave ska band. Studio One house band whose instrumental prowess defined the genre. Tommy McCook, Don Drummond, Ernest Ranglin, and other virtuosos created the template for all ska horn sections. |
+| Prince Buster | *I Feel the Spirit* (1963), *Fabulous Greatest Hits* (1968 comp.) | 1960s-2016 | Singer, songwriter, producer, and sound system operator. "Al Capone," "Madness," and "One Step Beyond" directly inspired 2 Tone bands. His Judge Dread character became a ska archetype. |
+| Desmond Dekker | *007 Shanty Town* (1967), *The Israelites* (1968) | 1961-2006 | First Jamaican artist to score a UK number one ("Israelites," 1969) and crack the US top ten. Bridged ska and rocksteady with a knack for melody and socially conscious lyrics about rude boy culture and poverty. |
+| Toots & the Maytals | *Funky Kingston* (1973), *54-46 Was My Number* (1968 single) | 1962-2020 | Toots Hibbert coined the word "reggae" with the 1968 single "Do the Reggay." Raw, soulful vocals drew comparisons to Otis Redding. Spanned ska, rocksteady, and reggae eras with undiminished power. |
+| The Specials | *The Specials* (1979), *More Specials* (1980) | 1977-present | Founded 2 Tone Records and the entire second wave. "Ghost Town," "A Message to You Rudy," and "Gangsters" are genre-defining tracks. Jerry Dammers's songwriting blended political anger with danceable arrangements. |
+| Madness | *One Step Beyond...* (1979), *Absolutely* (1980) | 1976-present | 2 Tone's pop wing. "One Step Beyond" and "Our House" reached global audiences. Suggs and the Nutty Boys brought humor and theatrical energy to ska, making it accessible without diluting its Jamaican roots. |
+| The Selecter | *Too Much Pressure* (1980), *Celebrate the Bullet* (1981) | 1979-present | Pauline Black's powerful vocals fronted one of 2 Tone's most politically engaged bands. *Too Much Pressure* reached number 5 on the UK album chart. Mixed ska, reggae, and punk with lyrical focus on gender and racial politics. |
+| The Beat (English Beat) | *I Just Can't Stop It* (1980), *Wha'ppen?* (1981) | 1978-1983 | Coventry/Birmingham band blending ska, pop, and dub influences. "Mirror in the Bathroom" and "Ranking Full Stop" demonstrated the breadth of 2 Tone's possibilities. Spawned General Public and Fine Young Cannibals after splitting. |
+| Fishbone | *Truth and Soul* (1988), *The Reality of My Surroundings* (1991) | 1979-present | Los Angeles genre-blenders who mixed ska, punk, funk, metal, and soul into a ferocious live act. Angelo Moore's manic energy and the band's multiracial lineup made them forerunners of the third wave and alternative rock broadly. |
+| Bad Manners | *Ska 'n' B* (1980), *Loonee Tunes!* (1980) | 1976-present | Buster Bloodvessel's outsize personality drove 2 Tone's party-ska wing. More comedic and less political than The Specials or Selecter, but their high-energy live shows kept ska visible in the UK throughout the 1980s. |
+| Hepcat | *Out of Nowhere* (1993), *Right On Time* (1998) | 1989-present | Los Angeles traditional ska revivalists who proved first wave authenticity could thrive in the 1990s scene. Smooth vocals, classic horn arrangements, and a dedication to rocksteady and early reggae made them a critic's favorite. |
+| Jimmy Cliff | *The Harder They Come* (1972), *Wonderful World, Beautiful People* (1970) | 1960s-present | Pre-Marley international star who started in ska and evolved with Jamaica's music. Starred in the 1972 film *The Harder They Come*, whose soundtrack introduced Jamaican music to worldwide audiences. Rock and Roll Hall of Fame inductee. |
+| The Slackers | *Better Late Than Never* (1996), *Peculiar* (2006) | 1991-present | New York traditionalists blending ska, rocksteady, soul, and jazz. Among the longest-running American ska bands, known for sophisticated arrangements and a refusal to chase trends. |
+| Derrick Morgan | *Forward March* (1962 single), *Seven Letters* (1969) | 1957-present | One of ska's founding vocalists alongside Prince Buster and Desmond Dekker. "Forward March" became Jamaica's independence anthem in 1962. Prolific recording career spanning ska, rocksteady, and reggae. |
+
+## Suno Prompt Keywords
+
+### Core Ska Terms
+```
+ska, traditional ska, Jamaican ska, classic ska, original ska,
+ska rhythm, offbeat rhythm, upstroke guitar, skank guitar,
+walking bass, walking bassline, ska groove, upbeat ska
+```
+
+### Brass & Horns
+```
+brass section, horns, trumpet, trombone, saxophone, alto sax, tenor sax,
+horn melody, horn hooks, ska brass, punchy horns,
+brass accents, horn section, tight brass arrangement, jazz horns
+```
+
+### Rhythm & Guitar
+```
+offbeat guitar, upstroke guitar, skank guitar, muted strums,
+choppy guitar, ska rhythm, offbeat strumming, guitar chops,
+melodic bass, ska bass, walking bass, organ skank,
+Hammond organ, piano skank, keyboard offbeat
+```
+
+### Vocals
+```
+soulful vocals, smooth vocals, call and response,
+toasting, chanting, group vocals, gang vocals,
+deadpan delivery, cool vocals, crowd singalong
+```
+
+### Energy & Mood
+```
+upbeat, danceable, celebratory, joyful, party,
+energetic, infectious, driving rhythm, kinetic,
+politically charged, defiant, anthemic, rebellious
+```
+
+### Production & Sound
+```
+live band, raw recording, studio one sound, vintage ska,
+horn-forward mix, brass-heavy, warm production,
+2 tone sound, punchy drums, tight arrangement,
+reverb, echo, Jamaican studio sound
+```
+
+### Era & Scene References
+```
+first wave ska, 2 tone, second wave ska, 1960s Jamaica,
+Kingston sound, rude boy, skinhead reggae,
+Coventry ska, British ska, checkered pattern,
+sound system, Studio One, Treasure Isle
+```
+
+## Reference Tracks
+
+- **The Skatalites - "Guns of Navarone" (1965)** -- Instrumental ska at its peak. The walking bass line, punchy horn melody, and jazz-influenced solo breaks demonstrate ska's debt to American big band music filtered through Jamaican rhythmic sensibility. The track moves at a brisk clip with every instrument locked into the groove. Essential for understanding first wave ska's instrumental power.
+
+- **Prince Buster - "Al Capone" (1964)** -- A driving first wave anthem built on a menacing horn riff and Buster's tough-guy vocal persona. The song became a touchstone for 2 Tone bands fifteen years later -- The Specials' "Gangsters" directly interpolates its melody. Demonstrates how first wave ska could be both danceable and dangerous.
+
+- **Desmond Dekker & the Aces - "007 (Shanty Town)" (1967)** -- Rude boy culture distilled into a two-minute single. Dekker's plaintive vocals over a driving ska-to-rocksteady groove captured the reality of Kingston's streets. The horn arrangement is tight and purposeful, the rhythm relentless. A bridge between ska's first wave and rocksteady.
+
+- **Toots & the Maytals - "Pressure Drop" (1969)** -- Toots Hibbert's raw, gospel-inflected vocal over a stripped-back arrangement that sits at the boundary of ska and reggae. The song's simplicity is deceptive; every element serves the groove. Featured in *The Harder They Come* soundtrack and covered by The Clash, connecting first wave Jamaican music to punk.
+
+- **The Specials - "A Message to You Rudy" (1979)** -- The song that connected Jamaican ska to British punk. Rico Rodriguez's trombone solo, Jerry Dammers's organ, and Terry Hall's cool vocal delivery over a classic first wave-style arrangement, performed with 2 Tone urgency. Originally a Dandy Livingstone song from 1967, the cover demonstrates 2 Tone's respect for ska's roots.
+
+- **The Specials - "Ghost Town" (1981)** -- A haunting departure from ska's party mode. Minor-key dub-influenced production, eerie vocal harmonies, and lyrics about urban decay under Thatcher hit number one in the UK during actual riots. Proved ska could be dark, atmospheric, and politically devastating. One of the most important British singles of the 1980s.
+
+- **Madness - "One Step Beyond" (1979)** -- Instrumental energy channeled through Chas Smash's "Hey you, don't watch that, watch this!" introduction and a horn section that refuses to let up. The Nutty Boys at their most kinetic, demonstrating 2 Tone's party potential. Named after a Prince Buster track, closing the loop between first wave and second.
+
+- **The Beat - "Mirror in the Bathroom" (1980)** -- 2 Tone at its most inventive: Dave Wakeling's nervous vocal over a ska-new wave hybrid with dub-influenced echo and a hypnotic bass line from David Steele. Shows how 2 Tone bands pushed ska into unexpected territory without losing the rhythmic foundation.
+
+- **The Selecter - "On My Radio" (1979)** -- Pauline Black's assertive vocals over a punchy ska arrangement with new wave guitar tones. One of 2 Tone's most immediate singles, balancing pop hooks with the movement's characteristic energy. The mixed-gender, multiracial band embodied 2 Tone's integrationist ideals.
+
+- **Fishbone - "Party at Ground Zero" (1985)** -- Los Angeles ska-punk-funk before anyone had a name for it. Angelo Moore's manic vocals, a horn section that stabs rather than sings, and a tempo that threatens to fly apart. Prefigured the third wave's genre-blending approach and proved ska could thrive outside Jamaica and the UK.
+
+- **Hepcat - "No Worries" (1998)** -- Southern California traditional ska revival at its finest. Smooth vocals, classic horn arrangements, and a rocksteady groove that could have come from 1966 Kingston. Demonstrates that first wave authenticity could coexist with the 1990s ska scene without any punk influence at all.
+
+- **The Skatalites - "Freedom Sound" (1964)** -- Tommy McCook's tenor saxophone leads a celebratory instrumental that became associated with Jamaican independence. The interplay between horns, rhythm guitar, and walking bass is a masterclass in first wave ska arrangement. The joy in the performance is audible and infectious.
+
+- **Prince Buster - "Madness" (1963)** -- The track that gave the 2 Tone band their name. A raw, propulsive early ska single with Buster's commanding vocal presence over a driving rhythm section. The influence of American R&B is still audible, but the offbeat emphasis is unmistakably Jamaican.

--- a/skills/mastering-engineer/genre-presets.md
+++ b/skills/mastering-engineer/genre-presets.md
@@ -230,6 +230,21 @@ Detailed mastering settings by genre.
 - Live worship recordings may include audience/congregation — don't over-compress those ambient elements
 - Extended bridges and vamp sections should sustain energy without fatiguing; watch for harsh buildup in layered guitars and keys
 
+### Ska
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate compression; preserve horn transients and the natural punch of the skank guitar; avoid squashing the rhythmic interplay between offbeat guitar and walking bass
+**EQ focus**: Horn clarity (1-4 kHz), bass warmth and definition (80-200 Hz), gentle high-mid cut to tame brass brightness without killing sparkle, skank guitar presence (800 Hz-2 kHz)
+**MCP command**: `master_audio(album_slug, genre="ska")`
+
+**Characteristics**:
+- Horns are the genre's melodic centerpiece -- they must cut through clearly without harshness; watch for Suno-generated brass brightness above 4 kHz
+- Walking bass lines carry melody alongside the vocals; keep bass warm and defined, not boomy
+- Offbeat skank guitar should be crisp and percussive, not muddy; clarity in the 800 Hz-2 kHz range is essential
+- First wave / traditional ska: slightly warmer, more reverb-tolerant, echo effects are authentic to the Studio One sound
+- 2 Tone ska: punchier, drier, more new wave-influenced production; tighter low end
+- For ska-punk mastering, use the ska-punk preset instead (more aggressive high-mid cuts)
+- Drum transients (especially hi-hat and rim clicks) should stay sharp to drive the rhythm
+
 ---
 
 ## Problem-Solving

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -382,6 +382,10 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+  ska:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
 
   # === Christian / Faith ===
   contemporary-christian:


### PR DESCRIPTION
## Summary

- Add **Ska** genre (`genres/ska/`) covering first wave Jamaica, 2 Tone UK, and modern revival
- Update `genres/INDEX.md` with Ska across all category and Quick Reference tables
- Add mastering presets for ska

Closes #150

## Test plan
- [ ] Verify `genres/ska/README.md` follows genre template structure
- [ ] Verify INDEX.md updated correctly
- [ ] Verify mastering presets YAML parses correctly
- [ ] Run `/bitwize-music:test all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)