### PR TITLE
feat: add 9 genres (Death Metal, Jungle, UK Garage, Cumbia, Samba, Highlife, J-Pop, City Pop, Dub)

### DIFF
--- a/genres/INDEX.md
+++ b/genres/INDEX.md
@@ -1,6 +1,6 @@
 # Genre Index
 
-A searchable, categorized guide to all 82 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
+A searchable, categorized guide to all 91 genre documentation files in this repository. Use this index to find the right genre for your album or discover genres you might want to explore.
 
 ---
 
@@ -16,6 +16,7 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 - [Jazz](#jazz)
 - [Classical and Opera](#classical-and-opera)
 - [Reggae and Caribbean](#reggae-and-caribbean)
+- [African](#african)
 - [Latin](#latin)
 - [Middle Eastern](#middle-eastern)
 - [South Asian](#south-asian)
@@ -61,6 +62,7 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 | **Metal** | Heavy, distorted guitar-driven music spanning traditional to extreme styles | [README](metal/README.md) |
 | **Black Metal** | Extreme metal with tremolo picking, blast beats, and atmospheric darkness | [README](black-metal/README.md) |
 | **Doom Metal** | Slow, crushing riffs with melancholic or occult atmospheres | [README](doom-metal/README.md) |
+| **Death Metal** | Extreme metal with growled vocals, blast beats, and technical riffing | [README](death-metal/README.md) |
 | **Thrash Metal** | Fast, aggressive metal with technical riffing and hardcore punk influence | [README](thrash-metal/README.md) |
 | **Metalcore** | Metal meets hardcore: breakdowns, screamed vocals, melodic passages | [README](metalcore/README.md) |
 | **Nu-Metal** | 1990s metal-hip-hop-funk fusion; downtuned grooves, rapped vocals, DJ scratching | [README](nu-metal/README.md) |
@@ -77,6 +79,8 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 | **Trance** | Euphoric, melodic electronic with dramatic builds and breakdowns | [README](trance/README.md) |
 | **Dubstep** | Heavy bass, wobble synths, and half-time rhythms; UK garage origins | [README](dubstep/README.md) |
 | **Drum and Bass** | Fast breakbeats (160-180 BPM) with heavy bass; jungle origins | [README](drum-and-bass/README.md) |
+| **Jungle** | UK breakbeat electronic with chopped Amen breaks, sub-bass, and ragga vocals; 160-170 BPM | [README](jungle/README.md) |
+| **UK Garage** | Syncopated 2-step dance music from late 1990s UK; shuffled beats, R&B vocals, garage house roots | [README](uk-garage/README.md) |
 | **Synthwave** | 1980s-inspired synth music; neon nostalgia and retro-futurism | [README](synthwave/README.md) |
 | **Ambient** | Atmospheric, textural soundscapes; meditative and immersive | [README](ambient/README.md) |
 | **Chillwave** | Hazy, nostalgic synth-pop with lo-fi production and dreamy vocals | [README](chillwave/README.md) |
@@ -103,6 +107,8 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 |-------|-------------|------|
 | **Pop** | Catchy, accessible music prioritizing hooks and broad appeal | [README](pop/README.md) |
 | **K-Pop** | Korean pop with synchronized choreography and high production values | [README](k-pop/README.md) |
+| **J-Pop** | Japanese pop spanning idol pop, visual kei, Vocaloid, and anime music | [README](j-pop/README.md) |
+| **City Pop** | Japanese 1980s funk/boogie/AOR; urban sophistication, internet revival | [README](city-pop/README.md) |
 | **Piano Pop** | Piano-driven pop prioritizing melody, warmth, and emotional accessibility | [README](piano-pop/README.md) |
 
 ## R&B, Soul, and Funk
@@ -150,13 +156,22 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 | **Reggae** | Jamaican music with offbeat rhythms, deep bass, and conscious themes | [README](reggae/README.md) |
 | **Ska** | Upbeat Jamaican-born genre with offbeat guitar, walking bass, and prominent horns; three waves from 1960s Kingston to 2 Tone UK to 1990s US | [README](ska/README.md) |
 | **Dancehall** | Digital Jamaican music; party-focused evolution of reggae | [README](dancehall/README.md) |
+| **Dub** | Jamaican remix/production genre; bass, echo, and subtraction as composition (King Tubby, Lee Perry) | [README](dub/README.md) |
+
+## African
+
+| Genre | Description | Link |
+|-------|-------------|------|
 | **Afrobeats** | Contemporary West African pop with Afro-Cuban and hip-hop influences | [README](afrobeats/README.md) |
+| **Highlife** | West African guitar music from Ghana; soukous/Congolese rumba connection | [README](highlife/README.md) |
 
 ## Latin
 
 | Genre | Description | Link |
 |-------|-------------|------|
 | **Latin** | Clave-based rhythms from salsa to reggaeton; pan-American scope | [README](latin/README.md) |
+| **Cumbia** | Colombian-origin dance music with shuffling rhythm, accordion/gaita melodies; spread across Latin America | [README](cumbia/README.md) |
+| **Samba** | Afro-Brazilian rhythmic music from Rio; surdo/tamborim/cavaquinho; Carnival tradition | [README](samba/README.md) |
 
 ## Middle Eastern
 
@@ -199,19 +214,21 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 | Speed | Genres |
 |-------|--------|
 | **Very Slow (40-80 BPM)** | [Doom Metal](doom-metal/README.md), [Stoner Rock](stoner-rock/README.md) (stoner doom), [Ambient](ambient/README.md), [Classical](classical/README.md) ballads, [Chanson](chanson/README.md) (ballads), [Children's Music](childrens-music/README.md) (lullabies), [Musicals](musicals/README.md) (ballads), [Soundtrack](soundtrack/README.md) (ballads), [Bollywood](bollywood/README.md) (ghazal/slow ballads) |
-| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Stoner Rock](stoner-rock/README.md) (stoner metal/doom), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship ballads), [Worship](worship/README.md) (ballads/intimate), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (ballads), [Bollywood](bollywood/README.md) (romantic ballads) |
-| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Stoner Rock](stoner-rock/README.md) (desert rock/fuzz rock), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Nu-Metal](nu-metal/README.md), [Math Rock](math-rock/README.md), [Post-Punk](post-punk/README.md), [Contemporary Christian](contemporary-christian/README.md) (pop/mid-tempo), [Worship](worship/README.md) (anthems), [Synthwave](synthwave/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md), [Children's Music](childrens-music/README.md), [Musicals](musicals/README.md) (dialogue songs), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (mid-tempo/sangeet) |
-| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Post-Punk](post-punk/README.md) (dance-punk), [Math Rock](math-rock/README.md) (fast strains), [Grime](grime/README.md), [Metal](metal/README.md), [Ska](ska/README.md), [Contemporary Christian](contemporary-christian/README.md) (rock/anthemic), [Worship](worship/README.md) (uptempo praise), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat), [Musicals](musicals/README.md) (production numbers), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
-| **Very Fast (140-180+ BPM)** | [Drum and Bass](drum-and-bass/README.md), [Thrash Metal](thrash-metal/README.md), [Hardcore Punk](hardcore-punk/README.md), [Black Metal](black-metal/README.md), [Noise Rock](noise-rock/README.md) (fast strains) |
+| **Slow (60-90 BPM)** | [Blues](blues/README.md), [Stoner Rock](stoner-rock/README.md) (stoner metal/doom), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship ballads), [Worship](worship/README.md) (ballads/intimate), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Reggae](reggae/README.md), [Dub](dub/README.md), [Trap](trap/README.md) (half-time), [Schlager](schlager/README.md) (ballads), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (ballads), [Bollywood](bollywood/README.md) (romantic ballads) |
+| **Medium (90-120 BPM)** | [Rock](rock/README.md), [Stoner Rock](stoner-rock/README.md) (desert rock/fuzz rock), [Country](country/README.md), [Folk](folk/README.md), [R&B](rnb/README.md), [Hip-Hop](hip-hop/README.md), [Pop](pop/README.md), [Nu-Metal](nu-metal/README.md), [Math Rock](math-rock/README.md), [Post-Punk](post-punk/README.md), [Contemporary Christian](contemporary-christian/README.md) (pop/mid-tempo), [Worship](worship/README.md) (anthems), [Synthwave](synthwave/README.md), [Cumbia](cumbia/README.md), [Highlife](highlife/README.md), [City Pop](city-pop/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md), [Children's Music](childrens-music/README.md), [Musicals](musicals/README.md) (dialogue songs), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (mid-tempo/sangeet) |
+| **Medium-Fast (110-140 BPM)** | [Samba](samba/README.md), [J-Pop](j-pop/README.md), [UK Garage](uk-garage/README.md) |
+| **Fast (120-140 BPM)** | [House](house/README.md), [Disco](disco/README.md), [Trance](trance/README.md), [Punk](punk/README.md), [Post-Punk](post-punk/README.md) (dance-punk), [Math Rock](math-rock/README.md) (fast strains), [Grime](grime/README.md), [Metal](metal/README.md), [Ska](ska/README.md), [UK Garage](uk-garage/README.md), [Contemporary Christian](contemporary-christian/README.md) (rock/anthemic), [Worship](worship/README.md) (uptempo praise), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï/mahraganat), [Musicals](musicals/README.md) (production numbers), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **Very Fast (140-180+ BPM)** | [Drum and Bass](drum-and-bass/README.md), [Jungle](jungle/README.md), [Thrash Metal](thrash-metal/README.md), [Death Metal](death-metal/README.md), [Hardcore Punk](hardcore-punk/README.md), [Black Metal](black-metal/README.md), [Noise Rock](noise-rock/README.md) (fast strains) |
 
 ### By Energy Level
 
 | Energy | Genres |
 |--------|--------|
-| **Chill/Relaxed** | [Ambient](ambient/README.md), [Lo-Fi](lo-fi/README.md), [Bossa Nova](bossa-nova/README.md), [Chillwave](chillwave/README.md), [Trip-Hop](trip-hop/README.md), [Indie Folk](indie-folk/README.md), [Children's Music](childrens-music/README.md) (lullabies) |
-| **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md), [Post-Punk](post-punk/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship/ballad), [Worship](worship/README.md) (intimate/devotional), [Chanson](chanson/README.md), [Children's Music](childrens-music/README.md) (singalong/educational), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (romantic ballads/ghazal) |
-| **High Energy** | [Rock](rock/README.md), [Stoner Rock](stoner-rock/README.md) (desert rock/fuzz rock), [House](house/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Math Rock](math-rock/README.md), [Ska](ska/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
-| **Aggressive** | [Metal](metal/README.md), [Nu-Metal](nu-metal/README.md), [Punk](punk/README.md), [Noise Rock](noise-rock/README.md), [Drill](drill/README.md), [Dubstep](dubstep/README.md), [Industrial](industrial/README.md), [Grime](grime/README.md) |
+| **Chill/Relaxed** | [Ambient](ambient/README.md), [Lo-Fi](lo-fi/README.md), [Bossa Nova](bossa-nova/README.md), [Chillwave](chillwave/README.md), [Trip-Hop](trip-hop/README.md), [Dub](dub/README.md), [Indie Folk](indie-folk/README.md), [Children's Music](childrens-music/README.md) (lullabies) |
+| **Moderate** | [Folk](folk/README.md), [Country](country/README.md), [R&B](rnb/README.md), [Jazz](jazz/README.md), [Blues](blues/README.md), [Synthwave](synthwave/README.md), [City Pop](city-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Piano Pop](piano-pop/README.md), [Post-Punk](post-punk/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship/ballad), [Worship](worship/README.md) (intimate/devotional), [Chanson](chanson/README.md), [Children's Music](childrens-music/README.md) (singalong/educational), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md), [Bollywood](bollywood/README.md) (romantic ballads/ghazal) |
+| **Moderate-High** | [Highlife](highlife/README.md), [J-Pop](j-pop/README.md) (varies) |
+| **High Energy** | [Rock](rock/README.md), [Stoner Rock](stoner-rock/README.md) (desert rock/fuzz rock), [House](house/README.md), [Jungle](jungle/README.md), [UK Garage](uk-garage/README.md), [Funk](funk/README.md), [Disco](disco/README.md), [Pop](pop/README.md), [Hip-Hop](hip-hop/README.md), [Math Rock](math-rock/README.md), [Ska](ska/README.md), [Cumbia](cumbia/README.md), [Samba](samba/README.md), [Piano Rock](piano-rock/README.md), [Schlager](schlager/README.md) (party), [Middle Eastern Pop](middle-eastern-pop/README.md) (dance/mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **Aggressive** | [Metal](metal/README.md), [Death Metal](death-metal/README.md), [Nu-Metal](nu-metal/README.md), [Punk](punk/README.md), [Noise Rock](noise-rock/README.md), [Drill](drill/README.md), [Dubstep](dubstep/README.md), [Industrial](industrial/README.md), [Grime](grime/README.md) |
 | **Euphoric** | [Trance](trance/README.md), [EDM](edm/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (anthemic worship), [Worship](worship/README.md) (anthem/praise), [Disco](disco/README.md), [Schlager](schlager/README.md) |
 
 ### By Instrumentation
@@ -220,16 +237,17 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 |---------------|--------|
 | **Acoustic Guitar** | [Worship](worship/README.md) (acoustic/unplugged), [Folk](folk/README.md), [Country](country/README.md), [Americana](americana/README.md), [Indie Folk](indie-folk/README.md), [Blues](blues/README.md) (acoustic), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md), [Children's Music](childrens-music/README.md) |
 | **Ukulele/Xylophone** | [Children's Music](childrens-music/README.md) |
-| **Electric Guitar** | [Rock](rock/README.md), [Metal](metal/README.md), [Nu-Metal](nu-metal/README.md), [Stoner Rock](stoner-rock/README.md), [Blues](blues/README.md), [Punk](punk/README.md), [Post-Punk](post-punk/README.md), [Math Rock](math-rock/README.md), [Noise Rock](noise-rock/README.md), [Grunge](grunge/README.md), [Shoegaze](shoegaze/README.md) |
-| **Synthesizers** | [Electronic](electronic/README.md), [Synthwave](synthwave/README.md), [Trance](trance/README.md), [House](house/README.md), [Ambient](ambient/README.md), [Hyperpop](hyperpop/README.md), [Schlager](schlager/README.md) |
-| **808/Drum Machines** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Phonk](phonk/README.md), [House](house/README.md), [Techno](techno/README.md) |
+| **Electric Guitar** | [Rock](rock/README.md), [Metal](metal/README.md), [Death Metal](death-metal/README.md), [Nu-Metal](nu-metal/README.md), [Stoner Rock](stoner-rock/README.md), [Blues](blues/README.md), [Punk](punk/README.md), [Post-Punk](post-punk/README.md), [Math Rock](math-rock/README.md), [Noise Rock](noise-rock/README.md), [Grunge](grunge/README.md), [Shoegaze](shoegaze/README.md), [Highlife](highlife/README.md), [City Pop](city-pop/README.md) |
+| **Synthesizers** | [Electronic](electronic/README.md), [Synthwave](synthwave/README.md), [Trance](trance/README.md), [House](house/README.md), [Ambient](ambient/README.md), [Hyperpop](hyperpop/README.md), [UK Garage](uk-garage/README.md), [City Pop](city-pop/README.md), [J-Pop](j-pop/README.md), [Schlager](schlager/README.md) |
+| **808/Drum Machines** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Phonk](phonk/README.md), [House](house/README.md), [Techno](techno/README.md), [Jungle](jungle/README.md), [UK Garage](uk-garage/README.md) |
 | **Orchestra** | [Classical](classical/README.md), [Opera](opera/README.md), [Cinematic](cinematic/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (Bond/Golden Age), [Disco](disco/README.md) (strings) |
 | **Piano** | [Classical](classical/README.md), [Jazz](jazz/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (ballads/worship), [Worship](worship/README.md), [Blues](blues/README.md), [Pop](pop/README.md) ballads, [Piano Rock](piano-rock/README.md), [Piano Pop](piano-pop/README.md), [Chanson](chanson/README.md) |
 | **Tabla/Dholak/Harmonium** | [Bollywood](bollywood/README.md) |
 | **Sitar/Bansuri** | [Bollywood](bollywood/README.md) |
-| **Accordion** | [Chanson](chanson/README.md) (musette), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï) |
+| **Accordion** | [Chanson](chanson/README.md) (musette), [Middle Eastern Pop](middle-eastern-pop/README.md) (raï), [Cumbia](cumbia/README.md) |
+| **Surdo/Tamborim/Cavaquinho** | [Samba](samba/README.md) |
 | **Oud/Qanun** | [Middle Eastern Pop](middle-eastern-pop/README.md) |
-| **Brass/Horns** | [Jazz](jazz/README.md), [Funk](funk/README.md), [Ska](ska/README.md), [Ska Punk](ska-punk/README.md), [Latin](latin/README.md), [Gospel](gospel/README.md) |
+| **Brass/Horns** | [Jazz](jazz/README.md), [Funk](funk/README.md), [Ska](ska/README.md), [Ska Punk](ska-punk/README.md), [Latin](latin/README.md), [Highlife](highlife/README.md), [Gospel](gospel/README.md) |
 | **Banjo/Fiddle** | [Bluegrass](bluegrass/README.md), [Folk](folk/README.md), [Country](country/README.md), [Celtic Punk](celtic-punk/README.md) |
 
 ### By Vocal Style
@@ -238,23 +256,23 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 |----------------|--------|
 | **Powerful/Belted** | [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md), [R&B](rnb/README.md), [Opera](opera/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (power ballad), [Pop](pop/README.md), [Rock](rock/README.md), [Stoner Rock](stoner-rock/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md) (réaliste), [Middle Eastern Pop](middle-eastern-pop/README.md), [Bollywood](bollywood/README.md) |
 | **Rapped/Spoken** | [Hip-Hop](hip-hop/README.md), [Trap](trap/README.md), [Drill](drill/README.md), [Grime](grime/README.md), [Nerdcore](nerdcore/README.md), [Nu-Metal](nu-metal/README.md) |
-| **Screamed/Harsh** | [Metal](metal/README.md), [Nu-Metal](nu-metal/README.md), [Punk](punk/README.md), [Noise Rock](noise-rock/README.md), [Metalcore](metalcore/README.md), [Emo](emo/README.md), [Industrial](industrial/README.md) |
+| **Screamed/Harsh** | [Metal](metal/README.md), [Death Metal](death-metal/README.md), [Nu-Metal](nu-metal/README.md), [Punk](punk/README.md), [Noise Rock](noise-rock/README.md), [Metalcore](metalcore/README.md), [Emo](emo/README.md), [Industrial](industrial/README.md) |
 | **Intimate/Whispered** | [Folk](folk/README.md), [Indie Folk](indie-folk/README.md), [Lo-Fi](lo-fi/README.md), [Trip-Hop](trip-hop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Post-Punk](post-punk/README.md) (deadpan/spoken), [Chanson](chanson/README.md) (à texte) |
-| **Processed/Pitch-Shifted** | [Hyperpop](hyperpop/README.md), [Vaporwave](vaporwave/README.md), [Trap](trap/README.md), [Electronic](electronic/README.md) |
+| **Processed/Pitch-Shifted** | [Hyperpop](hyperpop/README.md), [Vaporwave](vaporwave/README.md), [Trap](trap/README.md), [Electronic](electronic/README.md), [UK Garage](uk-garage/README.md) |
 | **Group Singing/Call-and-Response** | [Children's Music](childrens-music/README.md), [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship), [Worship](worship/README.md), [Ska](ska/README.md) |
-| **Primarily Instrumental** | [Ambient](ambient/README.md), [Math Rock](math-rock/README.md), [Post-Rock](post-rock/README.md), [Techno](techno/README.md), [Classical](classical/README.md), [Jazz](jazz/README.md) (much of it) |
+| **Primarily Instrumental** | [Ambient](ambient/README.md), [Dub](dub/README.md), [Math Rock](math-rock/README.md), [Post-Rock](post-rock/README.md), [Techno](techno/README.md), [Classical](classical/README.md), [Jazz](jazz/README.md) (much of it) |
 
 ### By Mood/Atmosphere
 
 | Mood | Genres |
 |------|--------|
-| **Dark/Brooding** | [Black Metal](black-metal/README.md), [Doom Metal](doom-metal/README.md), [Nu-Metal](nu-metal/README.md), [Stoner Rock](stoner-rock/README.md) (stoner doom/stoner metal), [Industrial](industrial/README.md), [Noise Rock](noise-rock/README.md), [Post-Punk](post-punk/README.md), [Drill](drill/README.md), [Grunge](grunge/README.md), [Trip-Hop](trip-hop/README.md) |
-| **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [Lo-Fi](lo-fi/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Math Rock](math-rock/README.md) (midwest emo wing) |
+| **Dark/Brooding** | [Black Metal](black-metal/README.md), [Death Metal](death-metal/README.md), [Doom Metal](doom-metal/README.md), [Nu-Metal](nu-metal/README.md), [Stoner Rock](stoner-rock/README.md) (stoner doom/stoner metal), [Industrial](industrial/README.md), [Noise Rock](noise-rock/README.md), [Post-Punk](post-punk/README.md), [Drill](drill/README.md), [Grunge](grunge/README.md), [Trip-Hop](trip-hop/README.md), [Dub](dub/README.md) (roots dub) |
+| **Nostalgic** | [Synthwave](synthwave/README.md), [Vaporwave](vaporwave/README.md), [Chillwave](chillwave/README.md), [City Pop](city-pop/README.md), [Lo-Fi](lo-fi/README.md), [Schlager](schlager/README.md), [Chanson](chanson/README.md), [Math Rock](math-rock/README.md) (midwest emo wing) |
 | **Romantic/Emotional** | [R&B](rnb/README.md), [Jazz](jazz/README.md) ballads, [Bossa Nova](bossa-nova/README.md), [Pop](pop/README.md) ballads, [Country](country/README.md), [Piano Pop](piano-pop/README.md), [Singer-Songwriter](singer-songwriter/README.md), [Chanson](chanson/README.md), [Musicals](musicals/README.md), [Soundtrack](soundtrack/README.md) (ballads), [Middle Eastern Pop](middle-eastern-pop/README.md), [Bollywood](bollywood/README.md) |
 | **Rebellious/Defiant** | [Punk](punk/README.md), [Nu-Metal](nu-metal/README.md), [Noise Rock](noise-rock/README.md), [Post-Punk](post-punk/README.md), [Hip-Hop](hip-hop/README.md), [Metal](metal/README.md), [Grime](grime/README.md), [Ska](ska/README.md) (2 Tone) |
 | **Spiritual/Transcendent** | [Gospel](gospel/README.md), [Contemporary Christian](contemporary-christian/README.md), [Ambient](ambient/README.md), [Trance](trance/README.md), [Reggae](reggae/README.md), [Worship](worship/README.md), [Classical](classical/README.md) |
 | **Playful/Whimsical** | [Children's Music](childrens-music/README.md), [Hyperpop](hyperpop/README.md) |
-| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Dancehall](dancehall/README.md), [Ska](ska/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
+| **Party/Celebratory** | [Disco](disco/README.md), [Funk](funk/README.md), [EDM](edm/README.md), [Jungle](jungle/README.md), [UK Garage](uk-garage/README.md), [Dancehall](dancehall/README.md), [Ska](ska/README.md), [Cumbia](cumbia/README.md), [Samba](samba/README.md), [Latin](latin/README.md), [K-Pop](k-pop/README.md), [J-Pop](j-pop/README.md), [Schlager](schlager/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (mahraganat), [Bollywood](bollywood/README.md) (bhangra/item numbers) |
 | **Spiritual/Devotional** | [Contemporary Christian](contemporary-christian/README.md) (worship), [Worship](worship/README.md), [Bollywood](bollywood/README.md) (qawwali/bhajan) |
 
 ### By Era/Aesthetic
@@ -262,10 +280,10 @@ A searchable, categorized guide to all 82 genre documentation files in this repo
 | Era | Genres |
 |-----|--------|
 | **Vintage (Pre-1970s)** | [Blues](blues/README.md), [Jazz](jazz/README.md), [Classical](classical/README.md), [Gospel](gospel/README.md), [Opera](opera/README.md), [Ska](ska/README.md) (first wave), [Musicals](musicals/README.md) (Golden Age), [Soundtrack](soundtrack/README.md) (Hollywood Golden Age, Bond themes), [Chanson](chanson/README.md), [Middle Eastern Pop](middle-eastern-pop/README.md) (golden age), [Children's Music](childrens-music/README.md) (folk era), [Bollywood](bollywood/README.md) (classical filmi golden age) |
-| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [Post-Punk](post-punk/README.md), [Noise Rock](noise-rock/README.md), [New Wave](new-wave/README.md), [Ska](ska/README.md) (2 Tone), [Synthwave](synthwave/README.md), [Contemporary Christian](contemporary-christian/README.md) (Jesus Music, early CCM), [Schlager](schlager/README.md), [Soundtrack](soundtrack/README.md) (Saturday Night Fever, Purple Rain), [Bollywood](bollywood/README.md) (disco filmi era) |
-| **1990s** | [Grunge](grunge/README.md), [Nu-Metal](nu-metal/README.md), [Stoner Rock](stoner-rock/README.md), [Hip-Hop](hip-hop/README.md), [Math Rock](math-rock/README.md), [Trip-Hop](trip-hop/README.md), [Trance](trance/README.md), [House](house/README.md), [Contemporary Christian](contemporary-christian/README.md) (dc Talk, Amy Grant crossover), [Bollywood](bollywood/README.md) (A.R. Rahman era) |
+| **1970s-80s** | [Disco](disco/README.md), [Funk](funk/README.md), [Punk](punk/README.md), [Post-Punk](post-punk/README.md), [Noise Rock](noise-rock/README.md), [New Wave](new-wave/README.md), [Dub](dub/README.md), [Ska](ska/README.md) (2 Tone), [City Pop](city-pop/README.md), [Synthwave](synthwave/README.md), [Contemporary Christian](contemporary-christian/README.md) (Jesus Music, early CCM), [Schlager](schlager/README.md), [Soundtrack](soundtrack/README.md) (Saturday Night Fever, Purple Rain), [Bollywood](bollywood/README.md) (disco filmi era) |
+| **1990s** | [Grunge](grunge/README.md), [Nu-Metal](nu-metal/README.md), [Death Metal](death-metal/README.md), [Stoner Rock](stoner-rock/README.md), [Hip-Hop](hip-hop/README.md), [Math Rock](math-rock/README.md), [Trip-Hop](trip-hop/README.md), [Jungle](jungle/README.md), [UK Garage](uk-garage/README.md), [Trance](trance/README.md), [House](house/README.md), [J-Pop](j-pop/README.md), [Contemporary Christian](contemporary-christian/README.md) (dc Talk, Amy Grant crossover), [Bollywood](bollywood/README.md) (A.R. Rahman era) |
 | **2000s-2010s** | [Worship](worship/README.md), [EDM](edm/README.md), [Trap](trap/README.md), [Dubstep](dubstep/README.md), [Hyperpop](hyperpop/README.md), [Lo-Fi](lo-fi/README.md), [Contemporary Christian](contemporary-christian/README.md) (worship explosion, CHH), [Musicals](musicals/README.md) (contemporary), [Bollywood](bollywood/README.md) (contemporary pop/bhangra fusion) |
-| **Internet/Modern** | [Vaporwave](vaporwave/README.md), [Hyperpop](hyperpop/README.md), [Phonk](phonk/README.md), [Drill](drill/README.md), [Lo-Fi](lo-fi/README.md), [Contemporary Christian](contemporary-christian/README.md) (TikTok-native CCM), [Children's Music](childrens-music/README.md) (YouTube era) |
+| **Internet/Modern** | [Vaporwave](vaporwave/README.md), [Hyperpop](hyperpop/README.md), [Phonk](phonk/README.md), [Drill](drill/README.md), [Lo-Fi](lo-fi/README.md), [City Pop](city-pop/README.md) (internet revival), [Contemporary Christian](contemporary-christian/README.md) (TikTok-native CCM), [Children's Music](childrens-music/README.md) (YouTube era) |
 
 ---
 
@@ -297,6 +315,10 @@ These genres commonly blend well together or have natural crossover potential:
 - [Trance](trance/README.md) + [Progressive Rock](progressive-rock/README.md) = Progressive trance
 - [Dubstep](dubstep/README.md) + [Trap](trap/README.md) = Hybrid trap
 - [Disco](disco/README.md) + [House](house/README.md) = Nu-disco, French touch
+- [Jungle](jungle/README.md) + [Drum and Bass](drum-and-bass/README.md) = Liquid jungle, neurofunk origins
+- [UK Garage](uk-garage/README.md) + [Dubstep](dubstep/README.md) = Post-dubstep, future garage
+- [UK Garage](uk-garage/README.md) + [Jungle](jungle/README.md) = Speed garage, breakstep
+- [Dub](dub/README.md) + [Electronic](electronic/README.md) = Digital dub, dub techno
 
 ### Christian / Worship Fusions
 - [Worship](worship/README.md) + [Gospel](gospel/README.md) = Gospel worship (Maverick City Music)
@@ -325,8 +347,22 @@ These genres commonly blend well together or have natural crossover potential:
 ### World/Regional Fusions
 - [Latin](latin/README.md) + [Hip-Hop](hip-hop/README.md) = Latin trap, reggaeton
 - [Reggae](reggae/README.md) + [Electronic](electronic/README.md) = Dub, dubstep (origins)
+- [Dub](dub/README.md) + [Reggae](reggae/README.md) = Roots dub, dub poetry
 - [Afrobeats](afrobeats/README.md) + [Pop](pop/README.md) = Afropop
+- [Highlife](highlife/README.md) + [Afrobeats](afrobeats/README.md) = Contemporary Ghanaian pop
+- [Highlife](highlife/README.md) + [Funk](funk/README.md) = Afrofunk, Fela Kuti-influenced Afrobeat
+- [Cumbia](cumbia/README.md) + [Electronic](electronic/README.md) = Digital cumbia, cumbia villera
+- [Cumbia](cumbia/README.md) + [Psychedelic Rock](psychedelic-rock/README.md) = Chicha, Peruvian cumbia
+- [Samba](samba/README.md) + [Jazz](jazz/README.md) = Samba-jazz, MPB
+- [Samba](samba/README.md) + [Rock](rock/README.md) = Samba-rock, Tropicalia
 - [Bossa Nova](bossa-nova/README.md) + [Jazz](jazz/README.md) = Brazilian jazz
+
+### J-Pop / City Pop Fusions
+- [J-Pop](j-pop/README.md) + [Electronic](electronic/README.md) = Vocaloid, denpa
+- [J-Pop](j-pop/README.md) + [Metal](metal/README.md) = Visual kei, kawaii metal (BABYMETAL)
+- [J-Pop](j-pop/README.md) + [Hip-Hop](hip-hop/README.md) = Japanese hip-hop
+- [City Pop](city-pop/README.md) + [Funk](funk/README.md) = Japanese boogie, AOR
+- [City Pop](city-pop/README.md) + [Bossa Nova](bossa-nova/README.md) = Japanese soft jazz-pop
 
 ### Middle Eastern Fusions
 - [Middle Eastern Pop](middle-eastern-pop/README.md) + [Electronic](electronic/README.md) = Arabic-electronic fusion, Acid Arab
@@ -387,20 +423,25 @@ These genres commonly blend well together or have natural crossover potential:
 | Black Metal | Metal | [README](black-metal/README.md) |
 | Bluegrass | Folk/Country | [README](bluegrass/README.md) |
 | Blues | Roots | [README](blues/README.md) |
+| Bollywood | South Asian | [README](bollywood/README.md) |
 | Bossa Nova | Jazz/World | [README](bossa-nova/README.md) |
 | Celtic Punk | Rock | [README](celtic-punk/README.md) |
 | Chanson | European Pop | [README](chanson/README.md) |
 | Children's Music | Children's/Family | [README](childrens-music/README.md) |
 | Chillwave | Electronic | [README](chillwave/README.md) |
 | Cinematic | Orchestral | [README](cinematic/README.md) |
+| City Pop | Pop/Japanese | [README](city-pop/README.md) |
 | Classical | Orchestral | [README](classical/README.md) |
 | Contemporary Christian | Christian/Faith | [README](contemporary-christian/README.md) |
 | Country | Folk/Country | [README](country/README.md) |
+| Cumbia | Latin | [README](cumbia/README.md) |
 | Dancehall | Caribbean | [README](dancehall/README.md) |
+| Death Metal | Metal | [README](death-metal/README.md) |
 | Disco | Dance | [README](disco/README.md) |
 | Doom Metal | Metal | [README](doom-metal/README.md) |
 | Drill | Hip-Hop | [README](drill/README.md) |
 | Drum and Bass | Electronic | [README](drum-and-bass/README.md) |
+| Dub | Caribbean | [README](dub/README.md) |
 | Dubstep | Electronic | [README](dubstep/README.md) |
 | EDM | Electronic | [README](edm/README.md) |
 | Electronic | Electronic | [README](electronic/README.md) |
@@ -412,6 +453,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Grime | Hip-Hop/Electronic | [README](grime/README.md) |
 | Grunge | Rock | [README](grunge/README.md) |
 | Hardcore Punk | Rock | [README](hardcore-punk/README.md) |
+| Highlife | African | [README](highlife/README.md) |
 | Hip-Hop | Hip-Hop | [README](hip-hop/README.md) |
 | House | Electronic | [README](house/README.md) |
 | Hyperpop | Electronic/Pop | [README](hyperpop/README.md) |
@@ -419,6 +461,8 @@ These genres commonly blend well together or have natural crossover potential:
 | Indie Rock | Rock | [README](indie-rock/README.md) |
 | Industrial | Electronic/Metal | [README](industrial/README.md) |
 | Jazz | Jazz | [README](jazz/README.md) |
+| J-Pop | Pop/Japanese | [README](j-pop/README.md) |
+| Jungle | Electronic | [README](jungle/README.md) |
 | K-Pop | Pop | [README](k-pop/README.md) |
 | Latin | World | [README](latin/README.md) |
 | Lo-Fi | Electronic | [README](lo-fi/README.md) |
@@ -444,6 +488,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Reggae | Caribbean | [README](reggae/README.md) |
 | R&B | Soul | [README](rnb/README.md) |
 | Rock | Rock | [README](rock/README.md) |
+| Samba | Latin | [README](samba/README.md) |
 | Schlager | European Pop | [README](schlager/README.md) |
 | Shoegaze | Rock | [README](shoegaze/README.md) |
 | Soundtrack | Classical/Theatrical | [README](soundtrack/README.md) |
@@ -458,6 +503,7 @@ These genres commonly blend well together or have natural crossover potential:
 | Thrash Metal | Metal | [README](thrash-metal/README.md) |
 | Trance | Electronic | [README](trance/README.md) |
 | Trap | Hip-Hop | [README](trap/README.md) |
+| UK Garage | Electronic | [README](uk-garage/README.md) |
 | Trip-Hop | Electronic | [README](trip-hop/README.md) |
 | Vaporwave | Electronic | [README](vaporwave/README.md) |
 | Worship | Christian/Faith | [README](worship/README.md) |
@@ -476,4 +522,4 @@ These genres commonly blend well together or have natural crossover potential:
    - Reference artists and albums
    - Suno prompt keywords for AI generation
 
-**Total genres documented: 82**
+**Total genres documented: 91**

--- a/genres/city-pop/README.md
+++ b/genres/city-pop/README.md
@@ -1,0 +1,111 @@
+# City Pop
+
+## Genre Overview
+
+City pop emerged in the late 1970s as Japan's economy accelerated into its postwar boom. The genre crystallized when Japanese musicians, steeped in American AOR, funk, disco, and jazz fusion, began filtering those Western influences through a distinctly Japanese sensibility tied to new urban affluence. Early touchstones like Sugar Babe's *Songs* (1975) and Haruomi Hosono's tropical-tinged arrangements with Tin Pan Alley laid the groundwork, but the sound came into focus as consumer technologies -- the Walkman, car-mounted cassette decks, FM stereo -- created demand for polished, sophisticated pop that matched the aspirational lifestyles of young professionals in Tokyo, Osaka, and Yokohama. Record labels and music magazine editors adopted the term "city pop" to market this music with an urban, cosmopolitan atmosphere.
+
+The golden era arrived in the early-to-mid 1980s, coinciding with Japan's bubble economy and its attendant mood of limitless possibility. Tatsuro Yamashita's *Ride on Time* (1980) and *For You* (1982) defined the template: meticulous studio production, session musicians drawn from jazz fusion circles, Yamaha DX7 FM synthesis layered over live rhythm sections, and vocals that balanced Western soul phrasing with Japanese lyrical sensibility. Mariya Takeuchi, Toshiki Kadomatsu, Anri, Taeko Onuki, and Miki Matsubara each carved distinct spaces within the genre's broad tent, which stretched from slick boogie-funk to contemplative ballads to tropical exotica. Japanese studios and engineers -- many trained under American and British producers -- achieved recording fidelity that rivaled or exceeded their Western counterparts, giving city pop its trademark pristine sheen. The genre's commercial peak lasted roughly from 1980 to 1988, after which the bubble's collapse and shifting musical tastes pushed it from the mainstream.
+
+City pop's second life began in the early 2010s, driven by internet culture rather than industry machinery. Vaporwave producers sampled city pop records for their ironic commentary on consumer capitalism, introducing the sound to online communities worldwide. The decisive moment came when an upload of Mariya Takeuchi's "Plastic Love" (originally released in 1984) was picked up by YouTube's recommendation algorithm around 2017, eventually accumulating tens of millions of views and becoming a gateway track for an entire generation of international listeners. Future funk artists built dance tracks from city pop samples, TikTok spread snippets of Miki Matsubara's "Stay With Me" to millions more, and reissue labels like Light in the Attic curated compilations such as *Pacific Breeze* that gave the genre critical legitimacy outside Japan. What had been a niche domestic format became a global phenomenon, its glossy production and wistful nostalgia resonating with audiences who had no firsthand memory of the era it soundtracked.
+
+## Characteristics
+
+- **Instrumentation**: Live rhythm sections (bass, drums, rhythm guitar) augmented by synthesizers (Yamaha DX7, Roland Juno-60, Prophet-5), electric piano (Fender Rhodes, Yamaha CP), alto and tenor saxophone, brass sections, and acoustic piano. Session musicians from jazz fusion backgrounds were standard, lending harmonic sophistication uncommon in pop music.
+- **Harmony**: Jazz-influenced chord progressions using extended voicings -- major 7ths, 9ths, 11ths, 13ths, diminished passing chords, and chromatic substitutions. Key changes within songs are frequent. The harmonic language sits between Steely Dan-style AOR complexity and Quincy Jones-era R&B smoothness.
+- **Production**: High-fidelity, polished mixes with generous plate and hall reverb, chorus effects on electric piano and guitar, tight compression on vocals, and clean separation between instruments. FM synthesis patches (electric piano, bells, pads) became signature textures after 1983. Japanese studios in the 1980s operated at a technical standard that gave city pop its distinctive clarity.
+- **Vocals**: Smooth, controlled delivery influenced by American soul and AOR singing. Japanese lyrics sung with attention to melodic phrasing over natural speech rhythm. Vocal harmonies and layered backing vocals are common. Male vocalists tend toward a warm tenor; female vocalists range from breathy intimacy to powerful belt.
+- **Rhythm**: Syncopated grooves drawn from funk, disco, and boogie, typically in 4/4 time. Drum patterns often feature tight hi-hat work, ghost notes on snare, and punchy kick patterns. Bass lines are melodically active, frequently employing slap technique or octave runs. Tempos generally range from 95-130 BPM for uptempo tracks, 70-95 BPM for mid-tempo and ballads.
+- **Mood**: Aspirational, breezy, and nostalgic -- evoking summer drives along coastal highways, neon-lit nightlife, and the confident optimism of economic prosperity. Ballads carry a sophisticated melancholy, wistful rather than heavy. The overall feel is urbane, warm, and meticulously crafted.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Flexible -- Japanese lyric conventions differ from English. Rhyme is less structurally rigid than in Western pop; assonance, syllable-count balance, and melodic fit take priority over end rhyme. When writing in English for Suno, use ABAB or XAXA loosely.
+- **Rhyme quality**: Melodic flow matters more than strict rhyme. Smooth syllable placement that fits the groove is paramount. Near rhymes and vowel matching are acceptable and idiomatic.
+- **Verse structure**: Verse-chorus with optional pre-chorus (common in Japanese pop structure). Verses typically 4-8 lines, choruses 4-6 lines. Bridge sections are frequent and often harmonically adventurous.
+- **Key rule**: Lyrics evoke urban life, romance, summer, nightlife, driving, and cosmopolitan aspiration. Imagery is sensory and specific -- neon reflections, ocean breezes, city lights at dusk, the hum of a car stereo. Emotional tone is wistful or celebratory, never crude.
+- **Avoid**: Heavy-handed metaphors, aggressive or dark themes, slang-heavy language, anything that breaks the genre's polished, sophisticated atmosphere. Explicit content is foreign to the style. Overly literal or prosaic language that lacks the genre's romantic sheen.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 100-125 BPM. Clean, smooth vocal delivery over polished instrumentation. Lyrics should breathe -- leave space for instrumental interplay. Topics: 1-2/verse. Suno handles the breezy, mid-tempo pocket well.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists | Era |
+|-------|-------------|-------------------|-----|
+| **AOR City Pop** | The genre's most polished wing, drawing directly from American album-oriented rock and Steely Dan-influenced sophistication. Emphasis on meticulous studio craft, jazz harmony, and pristine vocal production. | Tatsuro Yamashita, Toshiki Kadomatsu, Kazumasa Oda | 1979-1988 |
+| **Boogie/Funk City Pop** | Groove-forward tracks built on syncopated bass lines, slap bass, tight drum programming, and funk guitar scratching filtered through Japanese pop sensibility. Dancefloor-oriented. | Toshiki Kadomatsu, Junko Ohashi, Yasuko Agawa | 1980-1986 |
+| **New Music** | The broader Japanese pop movement from which city pop branched. Singer-songwriter-focused, more introspective and less groove-driven, blending folk, soft rock, and jazz elements. City pop's contemplative sibling. | Taeko Onuki, Yumi Matsutoya, Eiichi Ohtaki | 1974-1985 |
+| **Tropical/Resort Pop** | Beach-and-summer-themed city pop emphasizing breezy arrangements, steel drums, Latin percussion, and exotica influences. Marketed alongside travel and resort culture during the bubble era. | Anri, Haruomi Hosono, Tatsuro Yamashita (select works) | 1978-1987 |
+| **Fusion City Pop** | Instrumental-leaning work by jazz fusion guitarists and keyboardists who operated within city pop's commercial framework. Technically demanding, with extended solos and complex arrangements. | Masayoshi Takanaka, Casiopea, T-Square | 1977-1988 |
+| **Idol City Pop** | Major-label productions that applied city pop's sonic palette to idol singers, pairing glossy arrangements with more accessible vocal performances and straightforward pop structures. | Meiko Nakahara, Seiko Matsuda, Momoko Kikuchi | 1981-1986 |
+| **Electro City Pop** | Later-period city pop that leaned heavily into synthesizers and drum machines, reflecting the global shift toward electronic production in the mid-to-late 1980s. | Toshiki Kadomatsu (later work), Omega Tribe, Tomoko Aran | 1984-1988 |
+| **City Pop Ballad** | Slow-tempo, harmony-rich ballads showcasing vocal and arranging craft. Often featuring string sections, piano, and restrained rhythm accompaniment. The genre's emotional core. | Mariya Takeuchi, Taeko Onuki, Anri | 1978-1988 |
+| **Shibuya-kei (Adjacent)** | 1990s Tokyo movement that drew on city pop's sophistication and record-collector ethos, filtering it through French pop, bossa nova, and indie sensibility. Not city pop itself, but a direct descendant. | Pizzicato Five, Flipper's Guitar, Kahimi Karie | 1990-1998 |
+| **Future Funk** | 2010s electronic microgenre built on chopped and looped city pop samples, adding four-on-the-floor beats and heavy sidechain compression. The genre that reintroduced city pop to global audiences through internet culture. | Macross 82-99, Saint Pepsi/Skylar Spence, Night Tempo | 2012-present |
+| **Neo City Pop** | Contemporary Japanese artists reviving or reinterpreting city pop sounds with modern production tools. Ranges from faithful recreation to genre-blending experimentation. | Tofubeats, Suchmos, Friday Night Plans | 2015-present |
+
+## Artists
+
+| Artist | Notable Works | Style Focus | Era | Notes |
+|--------|---------------|-------------|-----|-------|
+| **Tatsuro Yamashita** | *Ride on Time* (1980), *For You* (1982), *Melodies* (1983) | AOR City Pop | 1976-present | Often called the "king of city pop." Former Sugar Babe member whose solo career defined the genre's golden-era sound. Most commercially successful Japanese male solo artist on the album chart. |
+| **Mariya Takeuchi** | *Variety* (1984), *Request* (1987), "Plastic Love" (1984) | AOR City Pop, Ballad | 1978-present | Her song "Plastic Love" became the genre's global calling card after going viral on YouTube in the late 2010s. Married to Tatsuro Yamashita. Career spans four decades. |
+| **Toshiki Kadomatsu** | *Sea Breeze* (1981), *After 5 Clash* (1984), *Gold Digger* (1985) | Boogie/Funk, AOR | 1981-present | Singer-songwriter, guitarist, and producer whose funk-inflected arrangements pushed city pop toward the dancefloor. Prolific producer for other artists throughout the 1980s. |
+| **Taeko Onuki** | *Sunshower* (1977), *Romantique* (1980), *Aventure* (1981) | New Music, AOR | 1973-present | Sugar Babe co-founder whose solo work bridged new music and city pop. *Sunshower* is a foundational city pop album blending pop melody with jazz texture. |
+| **Anri** | *Timely!!* (1983), *Coool* (1984), *Bi・Ki・Ni* (1983) | Tropical/Resort, Boogie | 1978-present | Her bright, summer-tinged sound became synonymous with resort city pop. "Remember Summer Days" and "I Can't Stop the Loneliness" are genre staples. |
+| **Miki Matsubara** | *Pocket Park* (1980), "Stay With Me" (1979) | Boogie/Funk | 1979-1989 | Singer-songwriter whose "Mayonaka no Door / Stay With Me" became one of the genre's most globally recognized tracks via TikTok and streaming. Passed away in 2004. |
+| **Haruomi Hosono** | *Paraiso* (1978), *Philharmony* (1982), *Pacific* (1978, with Suzuki and Yamashita) | Tropical, Experimental | 1969-present | Foundational figure whose work with Tin Pan Alley and Happy End predated city pop. Co-founded Yellow Magic Orchestra. Hosono's tropical exotica and electronic experiments shaped the genre's boundaries. |
+| **Junko Ohashi** | *Magical* (1984), *Full House* (1979) | Boogie/Funk, Soul | 1978-1990s | Powerful vocalist whose soul-influenced delivery and funk-driven arrangements distinguished her within city pop. Known for energetic, dance-oriented tracks. |
+| **Masayoshi Takanaka** | *An Insatiable High* (1977), *Rainbow Goblins* (1981), *Traumatic* (1985) | Fusion, Guitar-driven | 1976-present | Jazz fusion guitarist whose prolific catalog of guitar-centered albums operated at the intersection of city pop and instrumental fusion. Known for virtuosic technique and tropical themes. |
+| **Meiko Nakahara** | *Mint* (1982), *Lotos* (1984), "Fantasy" (1982) | Idol City Pop, Electro | 1982-1990s | Idol-era singer whose recordings received unusually sophisticated city pop production. "Fantasy" remains a fan favorite. |
+| **Yumi Matsutoya** | *Surf & Snow* (1980), *Pearl Pierce* (1982), *Voyager* (1983) | New Music, Ballad | 1972-present | Known earlier as Yumi Arai, her work as a songwriter and artist predated and paralleled city pop. One of the best-selling solo artists in Japanese history. |
+| **Omega Tribe** (1986 Omega Tribe / S. Kiyotaka & Omega Tribe) | *Aqua City* (1983), *River's Island* (1984), *Navigator* (1986) | AOR, Electro | 1983-1988 | Studio project masterminded by producer Tetsuji Hayashi. Both iterations of the group delivered polished, hook-driven city pop with strong AOR leanings. |
+| **Tomoko Aran** | *Fuyu Kukan* (1983), "I'm in Love" (1983), "Midnight Pretenders" (1983) | Electro City Pop | 1983-1987 | Brief but impactful career producing synth-heavy city pop. "Midnight Pretenders" has become a cult favorite in the genre's online revival. |
+| **Yasuko Agawa** | *L.A. Night* (1977), *Skyscrapers* (1979) | Boogie/Funk, Soul | 1976-1990s | Vocalist who brought a jazz and soul edge to city pop, with arrangements leaning toward American R&B sophistication. |
+| **Tatsuhiko Yamamoto** | *Lollipop Sonic* (1984), "Runway" (1980) | AOR, Boogie | 1978-1990s | Singer and songwriter whose smooth vocal style and polished arrangements fit squarely within city pop's AOR wing. |
+
+## Suno Prompt Keywords
+
+```
+city pop, japanese city pop, 80s japanese pop, J-pop,
+AOR, album-oriented rock, japanese AOR, soft rock,
+funk, boogie, disco, jazz fusion, fusion pop,
+FM synthesis, DX7, Fender Rhodes, electric piano, synth pads,
+smooth, polished, glossy production, lush reverb, chorus effect,
+saxophone, alto sax, brass section, live drums, slap bass,
+extended chords, jazz chords, major 7th, 9th chords,
+breezy, summer, tropical, coastal, resort pop,
+neon, nightlife, urban, cosmopolitan, sophisticated,
+driving groove, syncopated bass, tight rhythm section,
+warm vocals, smooth vocals, layered harmonies, backing vocals,
+nostalgic, wistful, romantic, aspirational, upbeat,
+mid-tempo groove, uptempo funk, slow ballad,
+80s production, analog warmth, digital clarity,
+Japanese pop, Tokyo nightlife, bubble era
+```
+
+## Reference Tracks
+
+- **Tatsuro Yamashita - "Sparkle" (1982)** -- From *For You*, this track is city pop's production ideal: a locked-in funk groove with slap bass, crisp rhythm guitar, DX7 electric piano, punchy brass stabs, and Yamashita's warm tenor riding the beat. The arrangement is dense but never cluttered -- every element occupies its own frequency space with studio precision that still sounds contemporary decades later.
+
+- **Mariya Takeuchi - "Plastic Love" (1984)** -- The song that reignited global interest in city pop. A mid-tempo disco-funk groove with one of the genre's most recognizable bass lines, shimmering synth pads, and Takeuchi's controlled vocal delivery carrying lyrics about romantic disillusionment. Produced by Tatsuro Yamashita, it balances dancefloor momentum with emotional complexity.
+
+- **Miki Matsubara - "Mayonaka no Door / Stay With Me" (1979)** -- A driving boogie-funk track with propulsive bass, tight rhythm guitar, and Matsubara's assured vocal performance. The song's global resurgence on TikTok and Spotify in the 2020s introduced millions to city pop. Its verse-chorus structure and infectious hook demonstrate how the genre made sophisticated arrangements feel immediate and accessible.
+
+- **Tatsuro Yamashita - "Ride on Time" (1980)** -- The title track from the album often cited as the first true city pop record. A breezy, mid-tempo groove with layered synthesizers, smooth vocal harmonies, and a production clarity that set the standard for the genre's golden era. The song captures the optimism and forward momentum of Japan's economic ascent.
+
+- **Anri - "Remember Summer Days" (1983)** -- From *Timely!!*, a sun-drenched pop track with bright brass, rhythmic guitar scratching, and Anri's warm vocal tone. The arrangement references American boogie and AOR while maintaining a distinctly Japanese lightness. Exemplifies the resort-pop wing of city pop tied to leisure culture and summer nostalgia.
+
+- **Toshiki Kadomatsu - "If You Wanna Dance Tonight" (1984)** -- Funk-driven city pop with aggressive slap bass, tight drum programming, and Kadomatsu's guitar work anchoring the groove. Demonstrates the boogie end of the city pop spectrum where the primary purpose is making people move. The production is immaculate, with every rhythmic element locked into the pocket.
+
+- **Taeko Onuki - "4:00 A.M." (1977)** -- From *Sunshower*, a foundational city pop track that bridges the new music singer-songwriter tradition with the genre's emerging sophistication. Jazz-informed chord changes, restrained arrangement, and Onuki's intimate vocal delivery create a late-night atmosphere. The song demonstrates city pop's contemplative, introspective side.
+
+- **Junko Ohashi - "Telephone Number" (1984)** -- An uptempo funk-pop track with a relentless groove, punchy horn stabs, and Ohashi's powerhouse vocal delivery. The bass line alone justifies the track's reputation. Shows the soul and energy that distinguished Ohashi within a genre that sometimes leaned toward smoothness over intensity.
+
+- **Omega Tribe - "Aqua City" (1983)** -- Produced by Tetsuji Hayashi, this track showcases the polished, hook-driven AOR side of city pop. Clean guitar arpeggios, synth pads, and a mid-tempo groove create an atmosphere of nighttime urban sophistication. Represents the studio-project approach where producers shaped the genre as much as the vocalists.
+
+- **Meiko Nakahara - "Fantasy" (1982)** -- A synth-forward track that bridges idol pop and city pop production values. Pulsing electronic bass, layered synths, and Nakahara's pop vocal style over a driving beat demonstrate how the genre's sonic palette elevated commercial pop into something more musically ambitious.
+
+- **Haruomi Hosono, Shigeru Suzuki, Tatsuro Yamashita - "Coral Reef" (1978)** -- From the collaborative album *Pacific*, a tropical-tinged instrumental that helped establish the exotica wing of city pop. Steel drums, gentle percussion, and ambient textures evoke island leisure -- the soundtrack to Japan's growing fascination with resort culture and Pacific travel.
+
+- **Tomoko Aran - "Midnight Pretenders" (1983)** -- Synth-heavy city pop with a driving electronic groove, layered keyboards, and Aran's cool vocal delivery. A cult favorite in the genre's internet revival, the track represents the electro-leaning later period of city pop where synthesizers and drum machines began displacing live rhythm sections.
+
+- **Masayoshi Takanaka - "Blue Lagoon" (1980)** -- A jazz fusion instrumental built on Takanaka's fluid guitar work over a tight funk rhythm section. Demonstrates the instrumental, fusion-oriented side of city pop where virtuosic musicianship took center stage. The tropical theme and polished production place it firmly within the genre's aesthetic world.

--- a/genres/cumbia/README.md
+++ b/genres/cumbia/README.md
@@ -1,0 +1,148 @@
+# Cumbia
+
+## Genre Overview
+
+Cumbia originated on Colombia's Caribbean coast, in the Momposina region along the Magdalena River delta between Barranquilla and Cartagena, as a courtship dance among Afro-Colombian and Indigenous communities during the colonial era. The music fused three distinct cultural streams: West African percussion traditions (tambora, llamador, maracas), Indigenous wind instruments (gaita flutes, guacharaca scraper), and European melodic and lyrical structures that later introduced the accordion. In the 1940s, bandleader and clarinetist Lucho Bermudez adapted cumbia's rhythmic core into a big band format, bringing the music from regional folk tradition to national prominence across Colombia and opening the door to its spread throughout Latin America.
+
+From the 1950s onward, cumbia migrated and mutated as it crossed borders. Andres Landero adapted the gaita melodies to accordion and popularized a new cumbia style that traveled deep into Mexico. In Peru, cumbia absorbed Andean folk melodies and psychedelic rock guitar to become chicha. In Argentina, it evolved into cumbia santafesina (guitar-and-accordion-driven romantic cumbia from Santa Fe Province) and later cumbia villera, a raw, punk-influenced variant born in Buenos Aires shantytowns during the late-1990s economic crisis. Mexico developed its own branches: cumbia sonidera emerged from Mexico City's sonidero sound system culture, while artists like Celso Pina in Monterrey fused cumbia with norteno accordion traditions. Each country reshaped the rhythm to reflect local realities while preserving cumbia's fundamental pulse.
+
+The 21st century brought digital cumbia and electronic reinterpretations that connected the genre to global club culture. Argentine producer Chancha Via Circuito and Buenos Aires label ZZK Records pioneered a sound that layered cumbia rhythms over electronic production, attracting audiences far beyond Latin America. Bomba Estereo from Colombia blended cumbia with electro-pop and punk energy, earning Grammy nominations and festival headlining slots worldwide. Los Angeles Azules, a Mexican cumbia institution since the late 1970s, found a second life through collaborations with pop and rock artists. Cumbia's adaptability has made it one of Latin America's most durable and democratic musical forms -- a rhythm that belongs to street parties and experimental studios alike.
+
+## Characteristics
+
+- **Rhythmic foundation**: Cumbia's groove is built on a steady, swaying 2/4 or 4/4 pattern with a characteristic shuffle feel. The tambora (double-headed drum) provides the rhythmic anchor, the llamador keeps a steady pulse on beats, and the alegre (or repicador) adds syncopated accents and improvisations on top. The guacharaca scraper drives the shuffle with a continuous rasping pattern that gives cumbia its forward motion.
+- **Melodic instruments**: Traditional cumbia centers on gaita flutes (long wooden flutes played with circular breathing) or accordion, which carry the main melodies. As the genre modernized, electric guitar, clarinet, keyboards, and brass sections took on melodic roles depending on regional style. The melody tends toward pentatonic and diatonic scales with repetitive, singable phrases.
+- **Bass and harmonic simplicity**: Cumbia typically uses simple two- or three-chord progressions (I-IV, I-V, I-IV-V) that support dancing rather than harmonic complexity. The bass -- whether tuba, electric bass, or synthesized -- locks into the rhythmic pattern with a bouncing, repetitive figure that reinforces the groove's circular feel.
+- **Call-and-response vocals**: Inherited from African and Indigenous traditions, cumbia vocals frequently alternate between a lead singer and a responding chorus. Lyrics are delivered with rhythmic clarity and festive energy, prioritizing danceability and communal participation over vocal virtuosity.
+- **Tempo and feel**: Cumbia sits in a moderate tempo range (typically 80-110 BPM), slower than salsa but with a persistent, infectious shuffle that makes it accessible to dancers of all levels. The rhythm has a rolling, hypnotic quality that builds energy through repetition rather than acceleration.
+- **Regional instrumentation shifts**: Colombian cumbia uses gaitas, tambora, llamador, alegre, and maracas. Mexican cumbia adds brass sections and keyboards. Argentine cumbia foregrounds electric guitar and synthesizers. Peruvian chicha features fuzz-drenched electric guitars and Farfisa organs. Digital cumbia replaces acoustic percussion with programmed beats and layered electronic textures. The core rhythm persists across all variants.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB or ABAB -- straightforward end rhymes that support sing-along participation. Cumbia lyrics favor clarity and repetition over intricate rhyme structures.
+- **Rhyme quality**: Spanish-language rhyming conventions. Consonant rhyme (rima consonante) is common, but assonance (rima asonante, matching only vowel sounds) is equally accepted and natural in the style.
+- **Verse structure**: Short verses (4-6 lines) with a prominent, repeating chorus. Many cumbias use a verse-chorus-verse pattern with instrumental breaks (often accordion or guitar solos) between sections. Repetition of the chorus multiple times at the end is standard.
+- **Key rule**: Lyrics serve the dance. Phrasing must lock into the shuffle rhythm without fighting it. Themes center on love, heartbreak, celebration, daily life, and community. Regional variants may address social themes (cumbia villera addresses poverty and marginalization; chicha reflects Andean migrant experience).
+- **Avoid**: Overly complex vocabulary or dense imagery that breaks the communal, participatory feel. Cumbia lyrics should feel like something a crowd can shout back. Stiff phrasing that ignores the natural syncopation of the rhythm.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 80-110 BPM. Shuffle rhythm creates natural breathing room between phrases. Leave space for instrumental hooks and call-and-response. Topics: 1 per verse, with the chorus providing the emotional anchor.
+
+## Subgenres & Styles
+
+| Style | Description | BPM Range | Reference Artists |
+|-------|-------------|-----------|-------------------|
+| **Cumbia Colombiana** | The original form, rooted in Colombia's Caribbean coast. Traditional instrumentation features gaita flutes, tambora, llamador, alegre drums, and guacharaca. Modernized in the 1940s-50s with big band arrangements and later accordion adaptations. The template from which all other cumbias descend. | 80-100 | Lucho Bermudez, Andres Landero, Totó la Momposina, Los Gaiteros de San Jacinto |
+| **Cumbia Sonidera** | Born in Mexico City's Tepito and Penon de los Banos neighborhoods in the 1960s-90s, tied to the sonidero sound system culture. Sonideros play cumbia records at street dances while shouting dedications (saludos) over the music. The sound features echo effects, reverb-drenched vocals, and modified playback speeds layered over Colombian and Mexican cumbia recordings. | 85-105 | Sonido La Changa, Grupo Cañaveral, Super Grupo Colombia, Sonido Condor |
+| **Cumbia Villera** | Argentine subgenre from Buenos Aires shantytowns (villas miseria), born in the late 1990s during Argentina's economic collapse. Raw, confrontational lyrics address poverty, drugs, crime, and class resentment over stripped-down electronic cumbia beats. Influenced by Argentine punk rock and ska. Pablo Lescano of Damas Gratis is considered the genre's creator. | 90-110 | Damas Gratis, Pibes Chorros, Yerba Brava, Mala Fama |
+| **Chicha (Cumbia Amazonica)** | Peruvian psychedelic cumbia blending Colombian cumbia rhythms with Andean folk melodies, surf rock, and 1960s psychedelia. Defined by fuzz-drenched electric guitars, wah-wah pedals, and Farfisa organs. Amazonian bands added the carimbo drum and Indigenous musical elements. Experienced international revival through the 2007 compilation *The Roots of Chicha*. | 85-110 | Los Mirlos, Los Destellos, Juaneco y Su Combo, Los Shapis |
+| **Cumbia Nortena** | Fusion of Colombian cumbia with northern Mexican norteno traditions, centered in Monterrey. The accordion is the lead instrument, played with the aggressive attack of norteno music but over cumbia's shuffle rhythm. Celso Pina pioneered this crossover, incorporating reggae and ska influences alongside traditional cumbia and Colombian vallenato. | 90-115 | Celso Pina y Su Ronda Bogota, Fito Olivares, Control Machete (cumbia-influenced) |
+| **Cumbia Texana / Tejana** | Tex-Mex adaptation of cumbia incorporating polka rhythms, synthesizers, and bilingual sensibilities from the Texas-Mexico border. Emerged from the broader Tejano music scene. Selena brought Tejano cumbia to massive crossover audiences in the early 1990s. Features keyboards, accordion, and a polished pop production approach. | 85-105 | Selena, Fito Olivares, La Mafia, Grupo Mazz |
+| **Cumbia Santafesina** | Argentine romantic cumbia from Santa Fe Province, developed from the mid-1960s with Italian and Polish immigrant influences shaping its melodic character. Guitar and accordion are the primary instruments, with smoother production and romantic lyrical themes compared to cumbia villera's rawness. Los Palmeras are the genre's most enduring ambassadors. | 85-100 | Los Palmeras, Leo Mattioli, Grupo Santa Cecilia, Dalila |
+| **Digital Cumbia** | 21st-century electronic reinterpretation that layers cumbia rhythms over synthesizers, drum machines, and laptop production. Emerged from Buenos Aires clubs and the ZZK Records label around 2008-2010. Bridges Latin American folk rhythms with global bass music, dubstep, and IDM. Aimed at both dancefloors and headphone listening. | 80-120 | Chancha Via Circuito, El Remolón, Frikstailers, Tremor |
+| **Cumbia Electronica / Electrotropical** | Colombian electronic cumbia blending traditional Caribbean rhythms with synth-pop, electro, and indie rock production. More song-oriented than digital cumbia's club focus. Bomba Estereo and Systema Solar brought this sound to international festival circuits and mainstream Latin pop audiences. | 90-130 | Bomba Estereo, Systema Solar, Meridian Brothers, Ondatropica |
+| **Mexican Cumbia (Tropical)** | Broad category covering Mexico's mainstream cumbia tradition since the 1960s, featuring brass sections, keyboards, and a polished tropical sound. Groups like La Sonora Dinamita (originally Colombian but hugely popular in Mexico) and Los Angeles Azules defined the sound of Mexican parties and quinceañeras for decades. | 85-110 | Los Angeles Azules, La Sonora Dinamita, Grupo Cañaveral, La Sonora Santanera |
+
+## Artists
+
+| Artist | Key Works | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| **Lucho Bermudez** | *Lucho Bermudez y Su Orquesta* (Discos Fuentes, 1961), "Gaita de Las Flores," "Carmen de Bolivar" | 1930s-1994 | Father of modern cumbia; Colombian clarinetist and bandleader who adapted Caribbean folk cumbia into big band format, making it Colombia's national popular music |
+| **Andres Landero** | *El Rey de la Cumbia* compilation (Vampi Soul, 2016), "La Pava Congona" | 1950s-2000 | "The King of Cumbia"; self-taught accordionist who translated gaita melodies to accordion, creating a cumbia style that spread across the Americas and deeply influenced Mexican cumbia |
+| **La Sonora Dinamita** | *Escandalo* (1985), "Mi Cucu," "Se Me Perdio La Cadenita," "Que Nadie Sepa Mi Sufrir" | 1960-present | Colombian group formed in Cartagena, reformed in 1975 under Fruko's direction at Discos Fuentes; one of the first cumbia acts to achieve pan-Latin American success, defining the sound of tropical cumbia |
+| **Totó la Momposina** | *La Candela Viva* (1993, Real World), *Pacanto* (2000) | 1960s-present | Colombian folk artist preserving and performing traditional Caribbean cumbia, bullerengue, and other Afro-Colombian styles; brought Colombian roots music to world music audiences via Peter Gabriel's label |
+| **Los Mirlos** | *El Sonido Selvático de los Mirlos* (1973), "La Danza de los Mirlos" | 1973-present | Peruvian chicha pioneers from the Amazon region; psychedelic guitar over cumbia rhythms with a tropical, surf-influenced tone that defined the Amazonian cumbia sound |
+| **Los Destellos** | *Los Destellos* (1968), "Ontem, Hoje e Amanhã" | 1966-present | Peruvian chicha founders led by guitarist Enrique Delgado; fused cumbia with psychedelic rock guitar, earning Delgado the title "father of chicha" |
+| **Celso Pina** | *Barrio Bravo* (2001), "Cumbia Sobre el Rio" | 1980s-2019 | "El Rebelde del Acordeon"; Monterrey-based accordionist who fused Colombian cumbia with norteno, reggae, and ska; his 2001 hit "Cumbia Sobre el Rio" was a massive crossover |
+| **Los Angeles Azules** | *Como Te Voy a Olvidar* (1996), *Como Te Voy a Olvidar: Edicion De Super Lujo!* (2015), "El Liston de Tu Pelo" | 1976-present | Iztapalapa, Mexico City sibling ensemble; defined Mexican cumbia with brass-and-keyboard sound; found second life through pop/rock collaborations with Natalia Lafourcade, Saul Hernandez, and others |
+| **Selena** | *Amor Prohibido* (1994), *Dreaming of You* (1995), "Como la Flor," "Bidi Bidi Bom Bom" | 1980s-1995 | Queen of Tejano; brought cumbia to mainstream American audiences through Tex-Mex adaptations with pop polish; cultural icon whose influence transcends genre |
+| **La Sonora Santanera** | *La Sonora Santanera* (1960s, various on CBS Columbia), "El Ladrón" | 1955-present | Long-running Mexican tropical ensemble known for polished brass-driven cumbia and bolero; staple of Mexican celebrations for over six decades |
+| **Damas Gratis** | *100% Villero* (various), "Se Te Ve la Tanga," "Me Vas a Extrañar" | 1999-present | Argentine cumbia villera flagship led by Pablo Lescano, the genre's creator; raw, confrontational lyrics over stripped-down electronic cumbia beats reflecting shantytown life in Buenos Aires |
+| **Los Palmeras** | *Cumbia Caliente* (1980s), *30 Años* (2002) | 1972-present | Argentine cumbia santafesina institution from Santa Fe Province; romantic, guitar-and-accordion-driven sound with decades of hits across Latin America |
+| **Bomba Estereo** | *Elegancia Tropical* (2012), *Amanecer* (2015), "Fuego," "To My Love" | 2005-present | Colombian electrotropical group led by Simon Mejia and vocalist Li Saumet; blends cumbia with synth-pop, punk, and electronic production; Grammy-nominated, international festival headliners |
+| **Chancha Via Circuito** | *Rio Arriba* (2010), *Amansara* (2014) | 2007-present | Argentine electronic producer Pedro Canale; central figure in digital cumbia and the ZZK Records scene; layers cumbia rhythms over ambient textures and bass music production |
+| **Juaneco y Su Combo** | *Mas Exitos* (1970s), "Ya Se Ha Muerto Mi Abuelo" | 1966-present | Peruvian chicha group from Pucallpa in the Amazon; pioneered the "Amazonian wave" (ola Amazonica) by adding Indigenous instrumentation and costumes to psychedelic cumbia |
+| **Los Gaiteros de San Jacinto** | *Un Fuego de Sangre Pura* (2006, Smithsonian Folkways) | 1940s-present | Traditional Colombian gaita ensemble from San Jacinto, Bolivar; Grammy-winning guardians of cumbia's oldest acoustic form; gaita flutes and hand drums without modern instrumentation |
+
+## Suno Prompt Keywords
+
+### Core Cumbia Terms
+```
+cumbia, colombian cumbia, traditional cumbia, tropical cumbia,
+cumbia rhythm, cumbia shuffle, cumbia beat, latin cumbia,
+danceable, festive, party, celebratory, street party,
+shuffle rhythm, syncopated, swaying groove
+```
+
+### Instrumentation
+```
+accordion, cumbia accordion, gaita flute, guacharaca, tambora,
+llamador drum, alegre drum, maracas, hand percussion,
+brass section, trumpet, trombone, clarinet,
+electric guitar, bass guitar, keyboards, organ,
+synthesizer, electronic beats, drum machine
+```
+
+### Subgenre Specifiers
+```
+cumbia colombiana, cumbia sonidera, cumbia villera,
+chicha, peruvian cumbia, psychedelic cumbia, amazonian cumbia,
+cumbia norteña, tejano cumbia, tex-mex cumbia,
+cumbia santafesina, argentine cumbia,
+digital cumbia, electronic cumbia, electrotropical,
+mexican cumbia, tropical cumbia
+```
+
+### Production and Sound
+```
+reverb-drenched, echo effects, lo-fi cumbia, analog warmth,
+fuzz guitar, wah-wah pedal, psychedelic guitar, surf guitar,
+brass-heavy, keyboard-driven, accordion-led,
+electronic production, programmed beats, bass music,
+stripped-down, raw, polished tropical, big band arrangement
+```
+
+### Vocal Styles
+```
+call and response, group vocals, chorus vocals,
+festive vocals, rhythmic singing, melodic vocals,
+raw vocals, street vocals, romantic vocals, crooning,
+shout-along, sing-along, communal vocals,
+male vocals, female vocals, bilingual
+```
+
+### Mood and Energy
+```
+festive, celebratory, joyful, uplifting, party energy,
+romantic, nostalgic, melancholic, bittersweet,
+hypnotic, rolling, infectious, driving,
+raw, confrontational, street-level, working-class,
+psychedelic, trippy, dreamy, tropical heat,
+laid-back, swaying, danceable, communal
+```
+
+## Reference Tracks
+
+1. **Lucho Bermudez - "Carmen de Bolivar"** - The template for modern Colombian cumbia. Bermudez's clarinet leads a big band arrangement that swings over the traditional cumbia rhythm, demonstrating how he elevated folk cumbia to a polished, nationally popular form in the 1940s-50s. The interplay between brass, clarinet, and percussion preserves the Afro-Colombian rhythmic DNA while adding orchestral sophistication.
+
+2. **Andres Landero - "La Pava Congona"** - Accordion-driven cumbia at its most joyful and direct. Landero's playing translates the gaita flute's melodic tradition to the accordion with effortless fluency, backed by tambora and guacharaca. The song's simplicity is its power -- a handful of chords, a repeating melody, and a rhythm that locks dancers into the shuffle.
+
+3. **La Sonora Dinamita - "Mi Cucu"** - The song that made cumbia a pan-Latin American phenomenon. An infectious accordion melody, playful vocals, and the unstoppable cumbia groove turned this track into a staple from Cartagena to Mexico City to Chicago. Demonstrates cumbia's power to cross borders through sheer rhythmic irresistibility.
+
+4. **Los Mirlos - "La Danza de los Mirlos"** - Peruvian chicha at its psychedelic peak. A reverb-soaked electric guitar carries the melody over a cumbia rhythm stripped to its essentials, creating a sound that belongs equally to the Amazon and the surf rock coast. The track captures chicha's unique alchemy of Colombian rhythm, Andean soul, and 1960s guitar distortion.
+
+5. **Los Destellos - "Ontem, Hoje e Amanha"** - Enrique Delgado's fuzz-toned guitar over a hypnotic cumbia groove demonstrates why he earned the title "father of chicha." The interplay between electric guitar and organ creates a psychedelic atmosphere while the rhythm section holds a steady, danceable pulse. A foundational track for understanding Peruvian cumbia's experimental spirit.
+
+6. **Celso Pina - "Cumbia Sobre el Rio"** - Cumbia nortena's breakthrough moment. Pina's accordion attacks the cumbia rhythm with the aggressive energy of northern Mexican music, while the arrangement incorporates ska and reggae influences. The 2001 hit proved that cumbia could fuse with virtually any genre and come out stronger, and it made Pina's Ronda Bogota a crossover force from Monterrey to Chicago.
+
+7. **Los Angeles Azules - "Como Te Voy a Olvidar"** - The definitive Mexican cumbia anthem. Brass, keyboards, and a locked-in rhythm section carry a heartbreak lyric that every Spanish-speaking person in the Americas seems to know. The 1996 hit encapsulates Mexican cumbia's ability to make sadness danceable, and its 2015 remake with Natalia Lafourcade showed the song's timelessness.
+
+8. **Selena - "Como la Flor"** - Tejano cumbia that crosses the border in both directions. Selena's voice carries all the heartbreak while the cumbia rhythm stays understated and elegant beneath her. The song demonstrates how cumbia adapted to Tex-Mex sensibilities -- keyboards replace accordion, pop structure frames the groove -- without losing the rhythm's essential warmth.
+
+9. **Bomba Estereo - "Fuego"** - Electronic cumbia that hits like a club track. Li Saumet's vocals ride over a production that layers synthesizers, programmed percussion, and distorted bass over a cumbia foundation. The track shows how far cumbia can stretch from its acoustic origins while retaining its rhythmic identity and dancefloor purpose.
+
+10. **Chancha Via Circuito - "Cumbion de las Aves"** - Digital cumbia as ambient art. Pedro Canale strips the rhythm to its skeletal pulse and surrounds it with synthesizer textures, sampled voices, and sub-bass. The track demonstrates ZZK Records' approach to cumbia: respectful of the rhythm's ancestry but aimed at headphones and festival sound systems rather than street dances.
+
+11. **Damas Gratis - "Se Te Ve la Tanga"** - Cumbia villera at its most unapologetic. Pablo Lescano's raw vocals and provocative lyrics ride a stripped-down electronic cumbia beat that reflects the sound of Buenos Aires villas. The track captures the genre's punk-like refusal to polish away the roughness of its origins, using cumbia as a vehicle for class anger and dark humor.
+
+12. **Los Gaiteros de San Jacinto - "Candelaria"** - Traditional cumbia in its oldest surviving acoustic form. Gaita flutes weave over tambora, llamador, and maracas without any modern instrumentation. The Grammy-winning ensemble preserves the sound of cumbia before Bermudez's big band era, connecting listeners directly to the music's Afro-Indigenous roots on Colombia's Caribbean coast.
+
+13. **Juaneco y Su Combo - "Ya Se Ha Muerto Mi Abuelo"** - Amazonian chicha that sounds like nothing else. The band's feathered costumes matched their music's wildness -- carimbo drums, surf-influenced guitar, and a cumbia groove filtered through Indigenous Amazonian aesthetics. The track captures the ola Amazonica that made Pucallpa an unlikely center of psychedelic cumbia innovation in the 1970s.

--- a/genres/death-metal/README.md
+++ b/genres/death-metal/README.md
@@ -1,0 +1,142 @@
+# Death Metal
+
+## Genre Overview
+
+Death metal coalesced in the mid-1980s from the most extreme fringes of thrash metal, driven by bands that wanted to push speed, heaviness, and aggression beyond what thrash had established. Possessed's *Seven Churches* (1985), recorded by Bay Area teenagers during their Easter break, is widely considered the first death metal album, and its track "Death Metal" gave the genre its name. But it was Chuck Schuldiner's band Death, operating out of the Tampa Bay area, that became the genre's defining act. Alongside Death, the Florida scene produced Morbid Angel (formed 1983), Obituary (formed 1984), and Deicide (formed 1987), all recording at Morrisound Studios with producer Scott Burns, whose dry, punchy production style became the genre's sonic blueprint. Simultaneously, a New York scene built around Suffocation, Immolation, and Incantation developed a denser, more dissonant strain, while Bolt Thrower in England and Entombed in Sweden proved death metal was not exclusively an American phenomenon.
+
+Through the 1990s, death metal fractured into increasingly specialized subgenres. Suffocation's *Effigy of the Forgotten* (1991) laid groundwork for brutal death metal with its breakdowns and guttural vocals. At the Gates and In Flames spearheaded the Gothenburg melodic death metal movement, fusing Iron Maiden-style harmonies with death metal's intensity. Opeth merged death metal with progressive rock across marathon compositions. Cryptopsy and later Necrophagist pushed technical complexity to extremes. Death-doom slowed things down through bands like Paradise Lost, My Dying Bride, and Autopsy. Each branch expanded the genre's vocabulary while maintaining the core identity: growled vocals, down-tuned guitars, blast beats, and subject matter that confronted mortality head-on.
+
+Today, death metal remains one of extreme music's most active and diverse genres. Old-school death metal revival bands like Blood Incantation, Tomb Mold, and Undeath have brought renewed attention to the classic sound. Technical death metal continues to evolve through acts like Archspire and Rivers of Nihil. The genre's influence extends well beyond its own borders, shaping deathcore, blackened death metal, and progressive metal. Festivals like Maryland Deathfest and established labels like Relapse, Earache, and Metal Blade continue to support a global underground that shows no signs of slowing down, more than four decades after Possessed first crossed the line from thrash into something heavier.
+
+## Characteristics
+
+- **Instrumentation**: Down-tuned guitars (drop D through drop A and lower), heavy palm-muting and tremolo picking, bass guitar often mirroring rhythm guitar or providing its own low-end counterpoint, double bass drumming and blast beats as rhythmic foundation. Lead guitar ranges from chaotic atonal soloing (Slayer-influenced) to technically precise shred (Schuldiner, Muhammed Suicmez). Keyboards rare outside progressive and symphonic crossovers.
+- **Vocals**: Deep guttural growls are the genre standard, ranging from low gutturals (Chris Barnes, Frank Mullen) to mid-range roars (Chuck Schuldiner, John Tardy) to high-pitched shrieks used for contrast. Vocal intelligibility varies widely by subgenre. Lyrics are typically delivered in rhythmic patterns that lock with the riff rather than following melodic contour.
+- **Production**: Ranges from the tight, dry Morrisound template (clear separation, punchy drums, scooped guitar tone) to the buzzsaw Swedish tone (Boss HM-2 pedal through a cranked amp, as heard on Entombed and Dismember records) to raw, cavernous lo-fi recordings in underground scenes. Modern productions tend toward high clarity with triggered or sample-replaced drums and precise editing.
+- **Energy/Mood**: Relentless intensity and physicality. The mood ranges from violent aggression (brutal death metal) to morbid dread (old school) to cerebral complexity (technical) to crushing despair (death-doom). Sustained tension rather than dynamic builds distinguishes death metal from thrash.
+- **Structure**: Riff-driven compositions with frequent tempo and time signature changes. Traditional verse-chorus structures exist but are often obscured by riff transitions, breakdowns, and extended instrumental passages. Songs average 3-5 minutes in standard death metal, extending to 8-15+ minutes in progressive variants. Intros, bridges, and solos serve structural variety rather than pop convention.
+- **Tempo**: 120-260+ BPM. Old school death metal typically sits at 140-180 BPM with tempo shifts. Brutal and technical variants push 200-260 BPM during blast sections. Death-doom drops to 60-100 BPM. Most death metal songs contain multiple tempo zones within a single track.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Optional but common. ABAB and AABB patterns appear frequently, though many bands prioritize rhythmic fit over strict rhyme.
+- **Rhyme quality**: Near rhymes, slant rhymes, and consonance are standard. Perfect rhymes work but are not expected. Forced rhyme stands out more than absent rhyme.
+- **Verse structure**: 4-8 lines per verse at moderate death metal tempos. Dense phrasing matches riff patterns. Verse-chorus form exists but choruses are often short, brutal refrains rather than melodic hooks.
+- **Key rule**: Subject matter confronts extremes: mortality, violence, disease, war, existential horror, anti-religion, philosophical darkness. Language is visceral and direct. Technical/progressive subgenres allow more abstract or intellectual themes (Schuldiner's later work, Gorguts, Atheist).
+- **Avoid**: Sentimentality, vagueness, filler words. Lyrics that feel detached from the music's physicality. Cliched gore without purpose (unless writing intentional brutal/slam death metal, where graphic content is a genre convention).
+- **Density/pacing (Suno)**: Default **6-8 lines/verse** at 140-200 BPM. Growled delivery obscures syllables, so strong consonant sounds and rhythmic phrasing matter more than nuance. Keep vocabulary blunt and impactful. Topics: 1-2 per verse.
+
+## Subgenres & Styles
+
+| Style | Description | Characteristics | Reference Artists |
+|-------|-------------|-----------------|-------------------|
+| **Old School Death Metal (OSDM)** | The original death metal sound from the late 1980s and early 1990s. Raw, riff-driven, with a focus on groove and morbid atmosphere over technical showmanship. Experiencing a major revival since the 2010s. | 140-180 BPM, mid-paced grooves with blast sections, analog production, morbid themes | Death (early), Obituary, Autopsy, Bolt Thrower, Asphyx |
+| **Florida Death Metal** | The Tampa Bay scene that defined the genre's classic sound. Tight, dry production (Morrisound Studios), precise drumming, and technically proficient but riff-focused songwriting. | 150-200 BPM, punchy production, palm-muted riffs, double bass, anti-religious themes | Death, Morbid Angel, Deicide, Obituary, Cannibal Corpse |
+| **Swedish Death Metal** | The Stockholm and Gothenburg scenes that developed a distinct guitar tone and approach. The "buzzsaw" HM-2 tone and d-beat influenced drumming set it apart from the American sound. | 140-200 BPM, buzzsaw guitar tone, d-beat sections, raw energy, punk influence | Entombed, Dismember, Grave, Unleashed, Carnage |
+| **Brutal Death Metal** | Extreme speed, guttural vocals pushed to inhuman lows, and relentless blast beats. Prioritizes heaviness and intensity above all else. New York scene (Suffocation) was foundational. | 180-260 BPM, ultra-low vocals, constant blast beats, breakdowns, graphic themes | Suffocation, Cryptopsy, Dying Fetus, Devourment, Defeated Sanity |
+| **Technical Death Metal** | Virtuosic musicianship, complex time signatures, jazz and classical influences, and intricate arrangements. Precision and compositional ambition define the style. | 160-240 BPM, odd meters, sweep picking, fretless bass, progressive structures | Necrophagist, Obscura, Spawn of Possession, Archspire, Beyond Creation |
+| **Melodic Death Metal** | Fusion of death metal aggression with Iron Maiden-style harmonized guitar melodies. Originated in Gothenburg, Sweden in the early 1990s. More accessible than other death metal styles while retaining harsh vocals and intensity. | 140-200 BPM, twin guitar harmonies, melodic leads, occasional clean vocals | At the Gates, In Flames, Dark Tranquillity, Carcass (later), Amon Amarth |
+| **Death-Doom** | Death metal's heaviness merged with doom metal's crushing slow tempos and despairing atmosphere. Among the earliest extreme metal fusions, predating most death metal subgenres. | 60-120 BPM, slow crushing riffs, deep growls, melancholic atmosphere, long compositions | Paradise Lost (early), My Dying Bride, Autopsy, Asphyx, Hooded Menace |
+| **Slam Death Metal** | Evolved from brutal death metal's breakdown sections, emphasizing mid-tempo "slam" riffs and guttural vocals over speed or technicality. Influenced by hardcore punk breakdowns and hip-hop rhythms. | 80-180 BPM, slam riffs, breakdowns, inhale vocals, simple structures | Devourment, Cephalotripsy, Abominable Putridity, Kraanium |
+| **Progressive Death Metal** | Extended compositions incorporating progressive rock dynamics, clean passages, acoustic sections, and genre-defying experimentation while maintaining death metal foundations. | Variable BPM, long-form structures, clean/harsh dynamics, genre fusion | Opeth, Cynic, Atheist, Edge of Sanity, Rivers of Nihil |
+| **Blackened Death Metal** | Fusion of death metal's heaviness and technicality with black metal's tremolo picking, blast beats, and dark atmosphere. Often features themes of occultism and anti-religion. | 160-240 BPM, tremolo picking, blast beats, both growls and shrieks, occult themes | Behemoth, Belphegor, Angelcorpse, Akercocke, Order of Orias |
+
+## Artists
+
+| Artist | Era | Country | Key Albums | Style Focus |
+|--------|-----|---------|------------|-------------|
+| Death | 1984-2001 | USA (Florida) | *Scream Bloody Gore* (1987), *Leprosy* (1988), *Human* (1991), *Symbolic* (1995), *The Sound of Perseverance* (1998) | Chuck Schuldiner's band traced the entire arc of death metal in seven albums, from the raw brutality of *Scream Bloody Gore* to the progressive complexity of *The Sound of Perseverance*. Schuldiner is widely regarded as the "father of death metal." His death from brain cancer in 2001 at age 34 ended one of extreme metal's most important careers. |
+| Morbid Angel | 1983-present | USA (Florida) | *Altars of Madness* (1989), *Blessed Are the Sick* (1991), *Covenant* (1993) | Trey Azagthoth's otherworldly guitar work and the band's occult intensity made their first three albums cornerstones of the genre. *Altars of Madness* set a new standard for speed and precision in death metal. David Vincent's vocals and lyrics brought a Satanic gravitas that influenced countless bands. |
+| Cannibal Corpse | 1988-present | USA (New York, relocated to Florida) | *Tomb of the Mutilated* (1992), *The Bleeding* (1994), *Kill* (2006) | The best-selling death metal band of all time. Graphic lyrical content and album art made them a lightning rod for censorship battles in the 1990s. George "Corpsegrinder" Fisher replaced Chris Barnes in 1995 and brought a more powerful vocal approach. Consistent output across three decades. |
+| Obituary | 1984-present | USA (Florida) | *Slowly We Rot* (1989), *Cause of Death* (1990), *World Demise* (1994) | John Tardy's unique, anguished vocal style and the Tardy brothers' groove-oriented approach gave Obituary a sound distinct from their Tampa peers. *Cause of Death* featured James Murphy's memorable lead guitar work and remains a genre benchmark. |
+| Suffocation | 1989-present | USA (New York) | *Effigy of the Forgotten* (1991), *Pierced from Within* (1995), *Pinnacle of Bedlam* (2013) | Frank Mullen's guttural vocals and Mike Smith's drumming established the blueprint for brutal death metal. Suffocation's use of breakdowns, palm-muted slams, and complex rhythmic shifts influenced brutal death metal, slam, and deathcore alike. |
+| At the Gates | 1990-present | Sweden | *The Red in the Sky Is Ours* (1992), *Slaughter of the Soul* (1995), *To Drink from the Night Itself* (2018) | *Slaughter of the Soul* is the single most influential melodic death metal album, its razor-sharp riffs and concise song structures becoming the template for an entire subgenre. Tomas Lindberg's raspy vocals and the Bjorler twins' guitar work defined the Gothenburg sound. |
+| Opeth | 1990-present | Sweden | *Blackwater Park* (2001), *Still Life* (1999), *Ghost Reveries* (2005) | Mikael Akerfeldt built Opeth into progressive death metal's most acclaimed act through long-form compositions that seamlessly blended brutal death metal with acoustic passages, clean vocals, and 1970s progressive rock. Later albums abandoned harsh vocals entirely, but the death metal-era records remain genre-defining. |
+| Nile | 1993-present | USA (South Carolina) | *Amongst the Catacombs of Nephren-Ka* (1998), *Black Seeds of Vengeance* (2000), *Annihilation of the Wicked* (2005) | Karl Sanders fused technical death metal with Ancient Egyptian themes, scales, and instrumentation. The combination of Middle Eastern melodic elements with crushing brutality gave Nile a unique identity. *Annihilation of the Wicked* is widely considered their masterpiece. |
+| Bolt Thrower | 1986-2015 | England | *Realm of Chaos* (1989), *...For Victory* (1994), *Those Once Loyal* (2005) | War-themed death metal with a tank-like mid-tempo approach. Bolt Thrower never chased trends, delivering the same crushing, groove-heavy sound across their career. *Those Once Loyal* capped their discography as a late-career high point before drummer Martin Kearns' death in 2015 ended the band. |
+| Entombed | 1987-present | Sweden | *Left Hand Path* (1990), *Clandestine* (1991), *Wolverine Blues* (1993) | Pioneers of the Swedish death metal sound, defined by Nihilist guitarist Nicke Andersson and the Boss HM-2 "buzzsaw" guitar tone. *Left Hand Path* is a foundational Swedish death metal record. Later pivoted toward death 'n' roll with *Wolverine Blues*, influencing bands in both directions. |
+| Deicide | 1987-present | USA (Florida) | *Deicide* (1990), *Legion* (1992), *Once Upon the Cross* (1995) | Glen Benton's inverted-cross brand and anti-Christian fury made Deicide death metal's most overtly blasphemous band. *Legion* featured some of the fastest, most chaotic drumming (Steve Asheim) in early death metal. The first three albums are considered essential. |
+| Cryptopsy | 1988-present | Canada | *None So Vile* (1996), *Blasphemy Made Flesh* (1994), *And Then You'll Beg* (2000) | Lord Worm's inhuman vocal performance and Flo Mounier's drumming on *None So Vile* produced one of brutal/technical death metal's most celebrated albums. Canadian death metal's flagship band, combining relentless speed with jazz-influenced complexity. |
+| Immolation | 1986-present | USA (New York) | *Dawn of Possession* (1991), *Close to a World Below* (2000), *Acts of God* (2022) | Robert Vigna's dissonant, atonal guitar style and Ross Dolan's cavernous vocals created a dark, suffocating atmosphere unique among death metal bands. Consistent quality across three decades without ever compromising their approach. A cornerstone of the New York death metal scene. |
+| Dying Fetus | 1991-present | USA (Maryland) | *Destroy the Opposition* (2000), *War of Attrition* (2007), *Reign Supreme* (2012) | Merged brutal death metal with hardcore breakdowns and politically charged lyrics. John Gallagher's dual vocal approach (growls and shrieks) and the band's groove-heavy slam sections made them a bridge between death metal and hardcore/deathcore audiences. |
+| Autopsy | 1987-present | USA (California) | *Severed Survival* (1989), *Mental Funeral* (1991), *Macabre Eternal* (2011) | Chris Reifert (Death's original drummer) formed Autopsy and pioneered death-doom by slowing death metal to crawling tempos while maintaining its filth. *Mental Funeral* is a landmark in both death metal and doom, its lurching, sludgy riffs influencing generations of extreme bands. |
+| Possessed | 1983-present | USA (California) | *Seven Churches* (1985), *Beyond the Gates* (1986), *Revelations of Oblivion* (2019) | Released what is widely considered the first death metal album while still in high school. *Seven Churches* was faster and more extreme than anything in 1985, and its title track gave the genre its name. Jeff Becerra's vocals bridged the gap between thrash shouting and death metal growling. |
+
+## Suno Prompt Keywords
+
+### Core Death Metal Terms
+```
+death metal, extreme metal, growled vocals, guttural vocals, blast beats,
+double bass drums, down-tuned guitars, heavy distortion, palm-muted riffs,
+tremolo picking, brutal, aggressive, intense, crushing, relentless
+```
+
+### Subgenre-Specific
+```
+old school death metal, OSDM, Florida death metal, Swedish death metal,
+brutal death metal, technical death metal, melodic death metal,
+death-doom, slam death metal, progressive death metal, blackened death metal,
+Gothenburg melodic death, buzzsaw guitar tone, HM-2 tone
+```
+
+### Production & Tone
+```
+heavy production, punchy drums, scooped mids, thick distortion,
+down-tuned heavy, cavernous sound, raw death metal, dry mix,
+buzzsaw guitar, Swedish tone, triggered drums, tight production,
+murky atmosphere, lo-fi death metal, analog warmth, massive low end
+```
+
+### Vocal Styles
+```
+guttural growls, deep growls, death growls, low vocals, brutal vocals,
+guttural death metal vocals, mid-range roar, harsh vocals, inhuman vocals,
+dual vocals, high screams, death metal shrieks, cavernous vocals
+```
+
+### Drum Patterns
+```
+blast beats, double bass drumming, gravity blasts, relentless drumming,
+d-beat, grindcore blasts, mid-tempo groove, half-time slam,
+precise drumming, triggered kicks, thunderous drums, pounding rhythm
+```
+
+### Thematic Keywords
+```
+death, mortality, violence, gore, war, horror, anti-religion,
+darkness, decay, suffering, annihilation, existential dread,
+occult, morbid, macabre, apocalyptic, ancient, brutal
+```
+
+### Structural Elements
+```
+riff-driven, tempo changes, breakdown, slam riff, tremolo section,
+guitar solo, technical passage, groove section, blast to groove transition,
+complex arrangement, dynamic shifts, extended instrumental, mid-tempo crush
+```
+
+## Reference Tracks
+
+### Foundational Classics
+- **Possessed - "Death Metal" (1985)**: The song that named the genre. Jeff Becerra's vocals on *Seven Churches* crossed the line from thrash into something new, faster and more extreme than anything else in 1985. The raw aggression and proto-growl vocal style laid the groundwork for everything that followed.
+- **Death - "Pull the Plug" (1988)**: Chuck Schuldiner at his early best. *Leprosy* refined the raw chaos of *Scream Bloody Gore* into focused, riff-driven death metal with memorable hooks. The main riff is one of death metal's most recognizable, and the song structure demonstrated that brutality and songcraft could coexist.
+- **Morbid Angel - "Maze of Torment" (1989)**: Trey Azagthoth's frenetic soloing and the band's relentless speed on *Altars of Madness* set the bar for technical precision in death metal. This track captures the controlled chaos that made the album a genre landmark.
+- **Obituary - "Chopped in Half" (1990)**: John Tardy's tortured vocals over grinding, groove-heavy riffs on *Cause of Death*. The mid-tempo stomp proved death metal did not need constant blast beats to be devastating. James Murphy's guest lead guitar work adds melodic depth.
+
+### Brutal & Technical
+- **Suffocation - "Liege of Inveracity" (1991)**: The blueprint for brutal death metal. Frank Mullen's guttural delivery, Mike Smith's blast beats, and the band's pioneering use of breakdowns on *Effigy of the Forgotten* influenced brutal death metal, slam, and deathcore for decades.
+- **Cryptopsy - "Slit Your Guts" (1996)**: *None So Vile* in concentrated form. Flo Mounier's drumming operates at superhuman speed and precision while Lord Worm's vocals defy human physiology. Technical brutality taken to its logical extreme.
+- **Nile - "Lashed to the Slave Stick" (2005)**: Karl Sanders' Egyptian-themed technical death metal at its peak. *Annihilation of the Wicked* combined Middle Eastern scales and ancient themes with modern brutal death metal production and musicianship.
+
+### Swedish & Melodic
+- **Entombed - "Left Hand Path" (1990)**: The title track that defined the Swedish death metal guitar tone. The Boss HM-2 buzzsaw distortion became Stockholm's signature, and the song's combination of punk energy with death metal heaviness spawned an entire regional sound.
+- **At the Gates - "Blinded by Fear" (1995)**: The opening track of *Slaughter of the Soul*, the album that launched a thousand melodic death metal bands. Compact, precise, and ferocious, with harmonized guitar leads that proved melody and death metal were not mutually exclusive.
+- **In Flames - "Jotun" (1996)**: *The Jester Race* crystallized the Gothenburg sound alongside At the Gates. Acoustic intros giving way to twin harmonized leads over blast beats became the melodic death metal formula, and this track captures it at its freshest.
+
+### Progressive & Experimental
+- **Death - "Crystal Mountain" (1995)**: Chuck Schuldiner's evolution from genre founder to progressive visionary. *Symbolic* retained death metal's intensity while incorporating sophisticated harmony, clean passages, and introspective lyrics that expanded the genre's intellectual scope.
+- **Opeth - "Blackwater Park" (2001)**: Mikael Akerfeldt's masterwork. Twelve minutes of seamless transitions between acoustic beauty and crushing death metal, produced by Steven Wilson. The title track demonstrated that death metal could sustain long-form progressive compositions without losing its weight.
+
+### War & Doom
+- **Bolt Thrower - "...For Victory" (1994)**: Mid-tempo death metal as heavy artillery. Karl Willetts' commanding growl over tank-treading riffs embodied the band's war-metal approach. No frills, no pretension, just crushing forward momentum.
+- **Autopsy - "Twisted Mass of Burnt Decay" (1991)**: Death-doom's filthiest moment. *Mental Funeral* alternated between grinding blasts and lurching, doom-paced sections that sounded like music decomposing in real time. Chris Reifert proved that slowing down could be heavier than speeding up.

--- a/genres/dub/README.md
+++ b/genres/dub/README.md
@@ -1,0 +1,120 @@
+# Dub
+
+## Genre Overview
+
+Dub is a production-driven genre that originated in Kingston, Jamaica during the late 1960s and early 1970s, born from the practice of creating instrumental "versions" of reggae tracks for sound system DJs and toasters. What began as simply stripping vocals from existing recordings became a radical new art form when engineers like King Tubby and producers like Lee "Scratch" Perry began treating the mixing console as an instrument in its own right. Tubby, working from his modest home studio in the Waterhouse district of Kingston, purchased a secondhand MCI mixing desk from Dynamic Sounds in 1972 and used it to deconstruct reggae tracks — dropping instruments in and out of the mix, drenching signals in spring reverb and tape delay, and foregrounding bass and drums to create music that was as much about absence and space as it was about sound. Perry, working from his Black Ark studio built behind his home in Washington Gardens, pushed the approach further into psychedelic territory, layering found sounds, phase effects, and unpredictable textures over roots reggae rhythms. Together, they invented the concept of the remix and established the producer-as-artist model that would reshape popular music.
+
+Dub's influence on electronic music and global production culture is difficult to overstate. The genre's core techniques — studio manipulation, effects processing, emphasis on bass frequency, and the remix as a creative act rather than a reproduction — became foundational to post-punk, hip-hop, house, techno, ambient, drum and bass, and trip-hop. Post-punk artists like Public Image Ltd and The Clash drew directly from dub's sonic vocabulary. Hip-hop's use of breakdowns and echo effects traces back to sound system culture. In the early 1990s, Berlin producers Moritz von Oswald and Mark Ernestus (Basic Channel) fused dub's spatial production with Detroit techno minimalism to create dub techno, an entire subgenre built on dub's delay-and-reverb DNA. Bristol's trip-hop scene — Massive Attack, Tricky — absorbed dub's bass weight and atmospheric depth. Every time a producer uses a send effect, automates a filter sweep, or treats silence as a compositional element, they are working in a tradition that King Tubby and Lee Perry established.
+
+The modern dub scene spans continents and generations. In the UK, the tradition runs unbroken from Jah Shaka's sound system dances through Adrian Sherwood's On-U Sound label and Mad Professor's Ariwa studio into contemporary producers working with digital tools. European producers in Germany, France, and Austria have built thriving dub communities, often crossing over with electronic music scenes. In Jamaica, the original roots dub tradition persists alongside digital production. Artists like Ott, Gaudi, and the Easy Star All-Stars have carried dub into the 21st century, while the genre's production philosophy continues to permeate mainstream music through its influence on mixing and remixing practices worldwide. Dub remains less a fixed style than a production approach — a way of thinking about sound, space, and the relationship between what is present and what is removed.
+
+## Characteristics
+
+- **Bass and drums as foundation**: The kick and bass guitar dominate the mix, often mixed louder and lower than in any other genre. Bass lines are melodic and prominent, meant to be felt physically through large speaker stacks. The drums — typically one drop or steppers patterns inherited from reggae — provide the skeletal framework that everything else hangs on.
+- **Effects as instruments**: Spring reverb, tape delay, phaser, and flanger are not decorative — they are structural. Delay throws are timed to the rhythm, creating ghost notes and rhythmic echoes. Reverb tails fill the spaces left by dropped instruments. The mixing board is played in real time, with faders, sends, and effects returns treated as performance tools.
+- **Subtraction and space**: Where most genres build by adding, dub builds by removing. Instruments drop out without warning, leaving only bass and drums, or only reverb tails, or silence. These dropouts create tension and release that functions like a melodic hook. The space between sounds carries as much weight as the sounds themselves.
+- **Tempo and rhythm**: Typically 65-85 BPM, inheriting reggae's relaxed pace. The one drop pattern (kick on beat 3 only) and the steppers pattern (four-on-the-floor kick) are the two primary rhythmic foundations. Hi-hats provide steady eighth or sixteenth notes, and rim clicks accent the backbeat.
+- **Melodic fragments**: Melodica, organ stabs, guitar skank, and horn phrases appear as brief, reverb-soaked fragments rather than sustained melodies. Augustus Pablo's use of the melodica as a lead instrument defined the "Far East" sound of dub — mournful, minor-key phrases floating over heavy rhythm sections.
+- **Analog warmth and saturation**: Classic dub production favors the coloration of tube electronics, tape compression, and transformer saturation. Even modern digital dub productions often aim to replicate the warmth and unpredictability of analog signal chains, where overdriven preamps and worn tape stock contributed to the genre's thick, textured sound.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Minimal or absent — dub is primarily instrumental. When vocals appear, they are fragments: a phrase, a chant, a single line repeated and drenched in delay. Rhyme serves rhythm more than narrative.
+- **Rhyme quality**: Not a primary concern. Vocal fragments prioritize sonic texture and rhythmic fit over poetic structure. Patois phrasing and Rastafarian invocations follow their own internal logic.
+- **Verse structure**: No conventional verse-chorus form. Vocal lines appear and disappear like any other instrument — faded in for a bar or two, then swallowed by echo. When longer vocal passages occur (as in dub poetry), they follow a spoken-word cadence over the rhythm, typically 4-8 lines.
+- **Key rule**: Less is more. A single repeated phrase ("jah," "dub it," "version") can anchor an entire track. Vocals serve the groove, not the other way around. When writing for dub, think of lyrics as one element the engineer can drop in and out — never the center of the arrangement.
+- **Avoid**: Dense lyrical content that demands attention. Conventional pop hooks or chorus structures. Anything that fights the bass-and-space aesthetic. Lyrics that would suffer from being fragmented, echoed, or partially obscured.
+- **Density/pacing (Suno)**: Default **2-4 lines per section** at 65-85 BPM. Heavy use of instrumental breaks and echo. Vocal fragments rather than full verses. Repetition over development. Topics: 1 per track at most.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Roots Dub** | The original Jamaican form: stripped-down reggae instrumentals with heavy echo, reverb, and mixing board manipulation. Bass and drums forward, everything else treated as material to be deconstructed. The foundation all other dub subgenres build from. | King Tubby, Lee "Scratch" Perry, Augustus Pablo |
+| **Digital Dub** | Emerged in the 1980s as synthesizers and drum machines replaced live instrumentation in Jamaican music. Applies dub's spatial production techniques to electronic sound sources. Mad Professor's Dub Me Crazy series helped bridge the analog-to-digital transition. | Mad Professor, Scientist, Prince Jammy |
+| **UK Dub** | The British dub tradition, running from the late 1970s through the present. Informed by the Caribbean diaspora experience in London and other cities, often incorporating post-punk, industrial, and electronic influences alongside traditional dub techniques. | Adrian Sherwood, Jah Shaka, Dennis Bovell, The Disciples |
+| **Dub Poetry** | Spoken-word performance over dub rhythms, emerging simultaneously in Kingston and London in the late 1970s. Politically charged, rooted in oral traditions, and distinct from toasting in its literary ambition. Oku Onuora is credited with popularizing the term. | Linton Kwesi Johnson, Mutabaruka, Jean "Binta" Breeze, Mikey Smith |
+| **Dub Techno** | Fusion of dub's delay-and-reverb production with Detroit techno's minimalism, pioneered by Basic Channel in early 1990s Berlin. Characterized by deep atmospheric soundscapes, sparse percussion, and slowly evolving textures. Typically 110-125 BPM. | Basic Channel, Rhythm & Sound, Pole, Monolake |
+| **Steppers** | A dub style built on the four-on-the-floor kick drum pattern rather than the one drop. More driving and hypnotic than standard dub, often used in sound system culture for extended, trance-inducing sets. The relentless pulse creates a marching, meditative quality. | Alpha & Omega, Jah Shaka, Aba Shanti-I |
+| **Dubtronica** | Contemporary electronic music that applies dub production principles — heavy bass, spatial effects, echo manipulation — to broader electronic frameworks. Sits at the intersection of dub, ambient, and IDM. | Ott, Bluetech, Gaudi |
+| **Psydub** | Psychedelic dub blending dub's bass weight and effects processing with psychedelic trance textures, ambient soundscapes, and world music elements. Often associated with festival culture. | Ott, Kalya Scintilla, Desert Dwellers |
+| **Reggae** | Dub's parent genre. Every dub track originates from a reggae rhythm, and the two genres remain deeply intertwined. Reggae provides the rhythmic and harmonic raw material that dub producers deconstruct. See **genres/reggae/** for full coverage. | Bob Marley, Peter Tosh, Burning Spear |
+| **Dubstep** | Originally emerged in early 2000s South London, drawing from dub's bass emphasis and spatial production alongside UK garage and grime. The name directly references its dub lineage, though the genre evolved far from traditional dub aesthetics. See **genres/dubstep/** if available. | Burial, Digital Mystikz, Mala |
+
+## Artists
+
+| Artist | Era | Style Focus | Key Albums | Influence/Legacy |
+|--------|-----|-------------|------------|------------------|
+| **King Tubby** | 1960s-1989 | Roots Dub | *Dub from the Roots* (1974), *The Roots of Dub* (1975) | Born Osbourne Ruddock. Invented dub by treating the mixing desk as an instrument. Created the concept of the remix. Trained Scientist and Prince Jammy. Murdered in 1989 outside his Kingston home. |
+| **Lee "Scratch" Perry** | 1960s-2021 | Roots Dub, Psychedelic Dub | *Blackboard Jungle Dub* (1973), *Super Ape* (1976), *Return of the Super Ape* (1978) | Built the Black Ark studio in his backyard (1973). Produced Bob Marley, Junior Murvin, The Congos, Max Romeo. Pushed dub into psychedelic territory. Allegedly burned the Black Ark down in 1979. |
+| **Augustus Pablo** | 1971-1999 | Far East Dub, Roots Dub | *King Tubbys Meets Rockers Uptown* (1976), *East of the River Nile* (1977) | Pioneered the melodica as a lead dub instrument. Created the "Far East" sound — mournful, minor-key melodies over heavy dub rhythms. His collaboration with King Tubby produced some of the genre's most celebrated recordings. |
+| **Scientist** | 1979-present | Roots Dub, Digital Dub | *Scientist Rids the World of the Evil Curse of the Vampires* (1981), *Heavyweight Dub Champion* (1980) | Born Hopeton Brown. Apprenticed under King Tubby at age 18. Extended Tubby's techniques into the dancehall era. Known for his series of themed dub albums with pulp-horror artwork. |
+| **Mad Professor** | 1980s-present | Digital Dub, UK Dub | *Dub Me Crazy* series (1982-1993), *No Protection* (1995, with Massive Attack) | Born Neil Fraser in Guyana. Runs Ariwa studio and label in South London. Bridged analog and digital dub eras. His remix of Massive Attack's *Protection* brought dub techniques to a mainstream audience. |
+| **Adrian Sherwood** | 1980s-present | UK Dub, Industrial Dub | *Never Trust a Hippy* (2003), On-U Sound catalog | Founded On-U Sound Records in 1981. Fused dub with post-punk, industrial, and hip-hop. Produced African Head Charge, Tackhead, New Age Steppers, Dub Syndicate. Key figure connecting dub to the UK underground. |
+| **Prince Jammy** | 1970s-present | Roots Dub, Digital | *Kamikaze Dub* (1979), *Sleng Teng* riddim (1985) | Born Lloyd James. Trained under King Tubby. Later became King Jammy. His "Sleng Teng" riddim (1985), built on a Casio keyboard preset, launched the digital dancehall revolution. |
+| **Dennis Bovell** | 1970s-present | UK Dub, Lovers Rock | *Brain Damage* (1981), *Audio Active* (1986) | Pioneered UK dub and lovers rock production. Produced Linton Kwesi Johnson's albums. Mixed for The Slits, The Pop Group, and Fela Kuti. One of the first to bring Jamaican dub techniques to British recording studios. |
+| **Jah Shaka** | 1970s-2023 | Sound System Dub, Steppers | *Commandments of Dub* series (1980s-1990s) | Legendary UK sound system operator. Known for marathon dub sessions emphasizing spiritual experience through bass weight. His sound system dances were communal, almost ceremonial events. |
+| **Linton Kwesi Johnson** | 1978-present | Dub Poetry | *Dread Beat an' Blood* (1978), *Bass Culture* (1980), *Making History* (1984) | Jamaica-born, London-based. First dub poet published in the Penguin Modern Classics series. Fused politically charged spoken word with Dennis Bovell's dub production. Addressed racism, police brutality, and Black British experience. |
+| **The Congos** | 1977-present | Roots Dub, Vocal Dub | *Heart of the Congos* (1977) | Cedric Myton and Roydel Johnson. Their sole Black Ark album, produced by Lee Perry, is regarded as one of the greatest reggae/dub recordings. Ethereal falsetto harmonies over heavy dub production. |
+| **Alpha & Omega** | 1988-present | UK Dub, Steppers | *Daniel in the Lions Den* (1990), *King & Queen* (1994) | Christine Woodbridge and John Sprosen. UK dub duo combining roots dub with sound system culture. Prolific output on their own A&O label. Key figures in the UK steppers scene. |
+| **Basic Channel** | 1993-1995 | Dub Techno | *BCD* (1995), *Quadrant Dub* (1994) | Moritz von Oswald and Mark Ernestus. Berlin duo who fused dub's spatial production with Detroit techno minimalism. Defined dub techno as a subgenre. Later continued as Rhythm & Sound, applying dub techno to Jamaican vocal styles. |
+| **Ott** | 2002-present | Dubtronica, Psydub | *Blumenkraft* (2003), *Skylon* (2008) | British producer who worked as an engineer at Twisted Records. Blends dub bass and delay techniques with psychedelic textures and world music samples. Key figure in the modern festival dub scene. |
+
+## Suno Prompt Keywords
+
+```
+dub, roots dub, heavy dub, dub reggae, classic dub,
+deep bass, sub bass, dub bass, bass heavy, bass weight,
+echo, heavy echo, tape delay, spring reverb, dub delay,
+reverb drenched, cavernous reverb, spacious, vast,
+mixing board, studio dub, analog dub, warm analog,
+one drop, steppers rhythm, four on the floor kick,
+melodica, organ stabs, guitar skank, rim click,
+instrument dropout, stripped down, deconstructed,
+Kingston, Jamaica, sound system, dub plate,
+hypnotic, meditative, trance-inducing, deep,
+dark, nocturnal, cavernous, subterranean,
+dub techno, minimal dub, digital dub, modern dub,
+psychedelic dub, dubbed out, version, dub mix
+```
+
+## Reference Tracks
+
+1. **King Tubby - "Dub from the Roots" (1974)**
+   The template for all dub music. Tubby takes a Bunny Lee production and strips it to its bones, dropping instruments in and out while drenching the remaining signals in reverb and delay. The bass line holds the center while everything else orbits around it, appearing and disappearing. Demonstrates how the mixing board became an instrument and how subtraction became a creative act.
+
+2. **Lee "Scratch" Perry - "Blackboard Jungle Dub" (1973)**
+   Perry's Black Ark studio at its most unhinged. Where Tubby was a precision engineer, Perry was an alchemist — layering found sounds, distortion, and unpredictable effects over roots rhythms to create something that sounded like it was transmitting from another dimension. This record influenced punk and post-punk as much as it influenced electronic music.
+
+3. **Augustus Pablo - "King Tubbys Meets Rockers Uptown" (1976)**
+   Pablo's mournful melodica floating over Tubby's mixing board manipulation. The "Far East" sound — minor-key melodies suggesting Middle Eastern and Asian scales — combined with heavy dub production. The track feels like it exists outside of time, which is why it remains a touchstone for ambient, electronic, and dub producers decades later.
+
+4. **Scientist - "Your Teeth in My Neck" from *Scientist Rids the World of the Evil Curse of the Vampires* (1981)**
+   Scientist extending King Tubby's techniques into the early dancehall era. The Roots Radics provide the rhythm foundation while Scientist applies dramatic echo throws and instrument dropouts with a precision that borders on theatrical. The entire album's horror-movie theming reflects dub's playful relationship with its own intensity.
+
+5. **Mad Professor - "Dub Me Crazy Part One" (1982)**
+   The opening salvo of Mad Professor's 12-volume Dub Me Crazy series, recorded at his Ariwa studio in South London. Bridges the analog and digital eras of dub, applying classic techniques to newer electronic sound sources. Demonstrates how dub traveled from Kingston to London and adapted without losing its essence.
+
+6. **The Congos - "Fisherman" from *Heart of the Congos* (1977)**
+   Lee Perry's Black Ark production at its most sublime. Cedric Myton's unearthly falsetto harmonies over a roots rhythm that Perry dubs into something approaching gospel from another planet. The reverb on the vocals turns human voices into instruments. One of the most celebrated recordings in reggae and dub history.
+
+7. **Linton Kwesi Johnson - "Inglan Is a Bitch" (1980)**
+   Dub poetry at its most politically direct. Johnson's spoken-word delivery in Jamaican Patois rides Dennis Bovell's sparse dub production, addressing the reality of Black immigrant life in Britain. The rhythm section provides the foundation while Johnson's words hit with the weight of lived experience. Proof that dub can carry narrative and political force.
+
+8. **Adrian Sherwood - "Never Trust a Hippy" (2003)**
+   Sherwood's On-U Sound aesthetic: dub filtered through post-punk, industrial, and hip-hop sensibilities. Heavier and more aggressive than Jamaican dub, with distorted bass, clattering percussion, and a sense of urban menace. Represents the UK's distinct contribution to the dub tradition.
+
+9. **Basic Channel - "Quadrant Dub I" (1994)**
+   The sound of dub meeting Berlin techno. Von Oswald and Ernestus reduce both genres to their essentials — deep bass, hissing delay, sparse percussion — and let the resulting texture slowly evolve over seven minutes. No drops, no builds, just a sustained, immersive field of sound. The blueprint for dub techno as a genre.
+
+10. **Jah Shaka - "Commandments of Dub, Chapter 1" (1980s)**
+    Sound system dub designed for physical impact. Jah Shaka's productions emphasize sub-bass frequencies and steppers rhythms that are meant to be experienced through massive speaker stacks at high volume. Minimal arrangement, maximum weight. The spiritual dimension of dub as communal experience.
+
+11. **Prince Jammy - "Kamikaze Dub" (1979)**
+    Tubby's apprentice establishing his own voice. Prince Jammy (later King Jammy) applies his mentor's techniques with a slightly cleaner, more precise touch. The track demonstrates the continuity of the Kingston dub lineage from Tubby through his students, each generation refining and extending the approach.
+
+12. **Alpha & Omega - "King & Queen" (1994)**
+    UK steppers dub with a heavy four-on-the-floor kick and hypnotic bass line. Christine Woodbridge and John Sprosen represent the British dub tradition at its most focused — roots-oriented production without nostalgia, functional music for sound system dances that also works as deep listening.
+
+13. **Ott - "The Queen of All Everything" from *Blumenkraft* (2003)**
+    Modern dubtronica that expands dub's palette with psychedelic textures, world music samples, and meticulous digital production while retaining the genre's commitment to bass weight and spatial effects. Demonstrates how dub's production philosophy translates into 21st-century electronic music without losing its identity.

--- a/genres/highlife/README.md
+++ b/genres/highlife/README.md
@@ -1,0 +1,162 @@
+# Highlife
+
+## Genre Overview
+
+Highlife is the foundational popular music genre of West Africa, originating in coastal Ghana (then the Gold Coast) in the late 19th and early 20th centuries. The genre emerged from a collision of local Akan musical traditions -- particularly Fante osibisaba rhythms and Ashanti percussion -- with the brass band music of colonial military ensembles, European ballroom dance styles like the foxtrot and waltz, and the portable guitars brought by sailors and traders along the West African coast. By the 1920s, the term "highlife" was in use, originally a reference to the exclusive social clubs in Accra, Cape Coast, and Sekondi where orchestras like the Jazz Kings and the Cape Coast Sugar Babies performed these new hybridized dance songs for the urban elite. The genre democratized rapidly through guitar bands and palm wine gatherings, spreading from Ghana into Sierra Leone, Liberia, and Nigeria, where it put down deep roots among Yoruba and Igbo communities. E.T. Mensah and the Tempos crystallized the postwar sound in the late 1940s and 1950s, blending jazz-influenced horns with African rhythmic foundations and earning Mensah the title "King of Highlife."
+
+Highlife's influence radiated across the African continent, and its encounter with Cuban son and rumba proved especially consequential. Cuban records arrived in West and Central Africa via sailors and radio broadcasts in the 1930s and 1940s, and African musicians recognized familiar rhythmic structures -- patterns that had traveled to Cuba centuries earlier through the slave trade and were now returning home transformed. In the Belgian Congo, this cross-pollination produced Congolese rumba in the late 1940s and 1950s, pioneered by bands like African Jazz (led by Grand Kalle) and OK Jazz (led by Franco Luambo). By the early 1960s, younger Congolese musicians accelerated the tempo and intensified the guitar work, giving rise to soukous -- a term derived from the French "secouer" (to shake). Soukous emphasized virtuosic, interlocking electric guitar lines and the extended sebene instrumental section that drove dancers into sustained motion. Through artists like Franco, Tabu Ley Rochereau, and Dr. Nico Kasanda, Congolese rumba and soukous became the dominant popular music across much of sub-Saharan Africa from the 1960s through the 1980s, influencing everything from Senegalese mbalax to Kenyan benga to Zimbabwean chimurenga.
+
+Today, highlife and its related traditions are experiencing renewed vitality. In Ghana, veteran artists like Pat Thomas and Gyedu-Blay Ambolley continue performing alongside younger acts who fold highlife sensibilities into contemporary production. In Nigeria, The Cavemen have spearheaded a highlife revival with their live instrumentation and fusion approach, while Flavour N'abania has modernized Igbo highlife for the Afrobeats era. Hiplife -- coined by Reggie Rockstone in the mid-1990s -- fused highlife rhythms with hip-hop lyricism in Ghanaian languages, producing a genre that dominated Ghanaian popular music for two decades. Afrobeats itself owes a substantial debt to highlife, inheriting its melodic guitar patterns, horn arrangements, and celebration-oriented energy. Meanwhile, reissue labels and crate-diggers have brought 1970s recordings by Ebo Taylor, C.K. Mann, and others to global audiences who hear in vintage highlife a sophistication and groove that remains fresh.
+
+## Characteristics
+
+- **Guitar-centered melodic architecture.** Interlocking guitar lines are the genre's signature -- typically a lead guitar playing melodic phrases over a rhythm guitar providing chordal comping or arpeggiated patterns. In guitar band highlife, acoustic and semi-acoustic guitars dominate; in dance band highlife, electric guitars share space with horn sections. Soukous pushes guitar virtuosity further, with rapid-fire sebene patterns played at high fret positions.
+
+- **Horn-driven harmonic richness.** Trumpets, trombones, and saxophones play arranged melodic lines, call-and-response figures with vocals, and rhythmic punctuation. Dance band highlife borrowed this directly from colonial brass bands and swing-era jazz, while Congolese rumba used horns more sparingly, favoring guitar and vocal interplay.
+
+- **Polyrhythmic percussion with a steady pulse.** Highlife grooves layer multiple rhythmic patterns -- typically a bell timeline (often based on a 12/8 or 6/8 pattern), congas or bongos, shakers, and a trap kit playing a steady, danceable pulse. The rhythmic feel is buoyant and circular rather than linear, inviting continuous movement on the dance floor.
+
+- **BPM range of 100-130.** Classic highlife sits around 100-115 BPM; guitar band highlife tends toward the lower end with a relaxed swing, while soukous pushes higher (115-130+ BPM) especially during sebene sections. Palm wine guitar is the slowest variant, often below 100 BPM.
+
+- **Vocal warmth and storytelling.** Singing is melodic, warm, and often delivered in local languages -- Twi, Fante, Ga, Yoruba, Igbo, Lingala, or Pidgin English. Lyrics typically carry social commentary, moral instruction, praise, celebration, or philosophical reflection. Call-and-response between lead vocalist and chorus is fundamental. Congolese rumba and soukous feature the practice of "animation" -- vocalists shouting encouragement, names, and dance instructions over instrumental sections.
+
+- **Analog and live-band production values.** Classic highlife recordings emphasize the warmth of live instrumentation -- real horns, acoustic percussion, tube amplifiers, tape saturation. Even modern productions that use digital tools tend to preserve the organic feel, with horn arrangements, live drums, and guitar work played by musicians rather than programmed. The bass guitar is melodically active, often playing countermelodies rather than sitting on root notes.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Flexible and rhythm-driven. End rhyme is common but not mandatory; the melodic contour of the vocal line and its fit with the guitar groove take priority over strict rhyme patterns.
+- **Rhyme quality**: Near rhymes and tonal rhymes are natural, especially in tonal languages like Twi, Yoruba, and Igbo where vowel quality and pitch matter more than consonant matching. Repetition of key phrases serves the same structural role as rhyme in English-language music.
+- **Verse structure**: Call-and-response between lead and chorus is the organizing principle. Verses are typically 4-8 lines, often with a repeated refrain or choral response after every 1-2 lead lines. Extended songs may cycle through multiple verse-refrain pairs without a fixed bridge or middle eight.
+- **Key rule**: Lyrics serve dual purposes -- they entertain dancers and deliver a message. Proverbs, moral instruction, social commentary, and praise of individuals or communities are all standard. In Congolese styles, the lyrical content may thin out during sebene sections, replaced by shout-outs (mabanga), dance calls, and vocal animation.
+- **Avoid**: Forcing Western pop verse-chorus-bridge structures onto highlife phrasing. Ignoring the tonal qualities of African languages when writing lyrics. Overloading verses with dense text -- highlife vocals breathe with the groove.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 100-120 BPM. Relaxed, melodic phrasing with space for instrumental responses. Call-and-response hooks. Topics: 1-2 per verse. Allow room for guitar and horn interludes.
+
+## Subgenres & Styles
+
+| Style | Description | BPM Range | Reference Artists |
+|-------|-------------|-----------|-------------------|
+| **Palm Wine Guitar** | Acoustic guitar-based style originating among Kru sailors and coastal communities in Sierra Leone, Liberia, and Ghana. Named after gatherings where palm wine was served and guitarists played. Intimate, finger-picked melodies with sparse percussion. The earliest ancestor of highlife guitar traditions. | 80-105 | S.E. Rogie, Koo Nimo, Ebenezer Obey (early work) |
+| **Dance Band Highlife** | Orchestral style featuring horn sections, keyboards, and full rhythm sections modeled on swing-era big bands. Dominated Ghana's urban nightclub scene from the 1940s through the 1960s. Polished arrangements, sophisticated harmonies, and a cosmopolitan feel. | 100-120 | E.T. Mensah & The Tempos, King Bruce & The Black Beats, Broadway Dance Band |
+| **Guitar Band Highlife** | Stripped-down, guitar-driven variant that emerged in rural and semi-urban Ghana. Features interlocking acoustic or semi-electric guitars, percussion, and vocals sung in local languages. More rawer and rootsy than dance band highlife, with stronger ties to traditional Akan music. | 95-115 | E.K. Nyame, C.K. Mann, Alex Konadu, Dr. K. Gyasi |
+| **Congolese Rumba** | Kinshasa-born fusion of Cuban son/rumba with Central African vocal and rhythmic traditions. Characterized by elegant guitar work, vocal harmonies in Lingala, and the interplay between rhythm and lead guitars. Dominated Central and East African popular music from the 1950s onward. | 95-115 | Franco & TPOK Jazz, Grand Kalle & African Jazz, Tabu Ley Rochereau |
+| **Soukous** | High-energy evolution of Congolese rumba, emphasizing speed, virtuosic guitar sebene sections, and dance-floor intensity. The sebene -- an extended instrumental passage with rapid, interlocking guitar lines -- became the genre's defining feature. Spread across Africa and into Parisian diaspora communities. | 115-140 | Kanda Bongo Man, Pepe Kalle, Diblo Dibala, Papa Wemba |
+| **Igbo Highlife** | Nigerian variant rooted in Igbo musical traditions, featuring melodic guitar lines, Igbo-language lyrics rich in proverbs and philosophy, and a distinctive rhythmic feel drawn from traditional Igbo percussion. Thrived particularly in eastern Nigeria from the 1960s through the 1980s. | 100-120 | Chief Stephen Osita Osadebe, Oliver de Coque, Celestine Ukwu, Oriental Brothers |
+| **Juju** | Yoruba-language Nigerian genre that shares highlife's guitar-centered approach but incorporates talking drums (dundun), call-and-response praise singing, and polyrhythmic layering derived from Yoruba traditional music. Often features extended playing for social events. See also: [afrobeats](../afrobeats/README.md) for the modern evolution. | 100-120 | King Sunny Ade, Ebenezer Obey, I.K. Dairo, Shina Peters |
+| **Afro-Funk Highlife** | 1970s fusion blending highlife's melodic sensibility with funk, soul, and psychedelic rock influences. Ghanaian and Nigerian bands adopted wah-wah guitars, clavinet, extended jams, and heavier grooves while retaining highlife's horn arrangements and rhythmic foundations. | 105-125 | Ebo Taylor, C.K. Mann (Funky Highlife era), Pat Thomas, Gyedu-Blay Ambolley |
+| **Burger Highlife** | Synthesizer-driven modernization developed by Ghanaian musicians in the diaspora (particularly Hamburg, Germany -- "Burger" from "Hamburg") during the 1980s. Replaced live horns and guitars with keyboards and drum machines while retaining highlife song structures and vocal styles. | 100-120 | George Darko, Charles Amoah, Lee Dodou, Daddy Lumba |
+| **Hiplife** | Ghanaian hip-hop/highlife fusion coined by Reggie Rockstone in the mid-1990s. Rap-style lyrics delivered in Twi, Ga, and other Ghanaian languages over highlife-influenced beats. Dominated Ghanaian pop from the late 1990s through the 2010s. | 95-120 | Reggie Rockstone, Obrafour, Sarkodie (early work), VIP/VVIP |
+| **Modern Highlife Revival** | Contemporary artists reviving highlife instrumentation and compositional approaches, often blending them with Afrobeats production, jazz, and soul. Emphasizes live performance and organic sound as a counterpoint to heavily programmed Afrobeats production. | 95-120 | The Cavemen, Flavour N'abania, Adekunle Gold, Kuami Eugene |
+
+## Artists
+
+| Artist | Era | Style Focus | Key Albums | Notes |
+|--------|-----|-------------|------------|-------|
+| **E.T. Mensah** | 1940s-1990s | Dance band highlife | *Day by Day* (1956), *All for You* (1959) | "King of Highlife"; led The Tempos; played with Louis Armstrong in Accra (1956); defined the postwar Ghanaian sound |
+| **E.K. Nyame** | 1950s-1970s | Guitar band highlife | Singles and 78rpm releases through the 1950s-60s | Pioneered Akan-language guitar band highlife; actor and bandleader; brought highlife to rural audiences via concert parties |
+| **Franco Luambo** | 1956-1989 | Congolese rumba, soukous | *Francophonic Vol. 1 & 2* (compilations), *Mario* (1985) | Led TPOK Jazz for over 30 years; pioneered the odemba guitar style; one of the most prolific and influential African musicians of the 20th century |
+| **Tabu Ley Rochereau** | 1959-2013 | Congolese rumba, soukous | *Babeti Soukous* (1989), *Muzina* (1996) | Composed over 3,000 songs; co-founded African Fiesta with Dr. Nico; formed Orchestre Afrisa International; rival and peer of Franco |
+| **King Sunny Ade** | 1967-present | Juju | *Juju Music* (1982), *Synchro System* (1983) | Introduced pedal steel guitar and synthesizers to juju; first Nigerian Grammy nominee; international breakthrough on Island Records |
+| **Chief Stephen Osita Osadebe** | 1960s-2007 | Igbo highlife | *Osondi Owendi* (1984), *Kedu America* (1996) | "Doctor of Hypertension"; four-decade career; master of proverb-laden Igbo lyrics; soothing vocal delivery became his trademark |
+| **Oliver de Coque** | 1970s-2008 | Igbo highlife, soukous-influenced | *People's Club of Nigeria* (1981), *Ogene Sound Super of Africa* (1984) | "Highlife King of Africa"; fused Igbo highlife with Congolese guitar techniques; prolific recording output |
+| **S.E. Rogie** | 1940s-1994 | Palm wine guitar | *Palm Wine Guitar Music* (1960s recordings), *Dead Men Don't Smoke Marijuana* (1994) | Sierra Leonean palm wine master; sang in English, Krio, Mende, and Temne; late-career international revival |
+| **Ebo Taylor** | 1956-2024 | Afro-funk highlife | *Twer Nyame* (1978), *Life Stories* (2011) | Ghanaian guitarist, composer, arranger; collaborated with Fela Kuti in London; fused highlife with funk and jazz; rediscovered by international audiences in the 2000s |
+| **C.K. Mann** | 1960s-2000s | Guitar band highlife, funk | *Funky Highlife* (1970s recordings) | Led His Carousel 7; "Asafo Beesuon" sampled by hip-hop producers; fused Fante highlife with funk and soul |
+| **Osibisa** | 1969-present | Afro-rock, highlife fusion | *Osibisa* (1971), *Woyaya* (1971) | Ghanaian-Caribbean band formed in London; name derives from "osibisaba" (Fante word for highlife); introduced African music to Western rock audiences; credited with establishing Afro-rock as a genre |
+| **Pat Thomas** | 1970s-present | Highlife, Afro-funk | *Pat Thomas Introduces Kwashibu Area Band* (2015) | Veteran Ghanaian vocalist; plaintive, expressive delivery; international comeback via Strut Records |
+| **Gyedu-Blay Ambolley** | 1970s-present | Highlife, simigwa | *Simigwa* (1975), *Wake Up Afrika* (2018) | Created "simigwa" style fusing highlife with rap and funk; first Ghanaian musician to incorporate rap into highlife |
+| **Orchestra Baobab** | 1970-present | Afro-Cuban, highlife, mbalax | *Pirate's Choice* (1982), *Specialist in All Styles* (2002) | Senegalese band blending Cuban son, highlife, and Wolof griot traditions; influential reunion album in 2002 |
+| **Kanda Bongo Man** | 1980s-present | Soukous | *Kwassa Kwassa* (1989), *Soukous in Central Park* (1993) | Congolese soukous star; popularized the kwassa kwassa dance; took Kinshasa dance music to world festival stages |
+| **Flavour N'abania** | 2005-present | Modern Igbo highlife | *Uplifted* (2010), *Blessed* (2012) | Modernized Osadebe-era guitar riffs for the digital age; bridges highlife tradition and Afrobeats audience |
+| **The Cavemen** | 2018-present | Modern highlife fusion | *Roots* (2020), *Love and Highlife* (2021) | Lagos-based sibling duo (Kingsley and Benjamin Okorie); live instrumentation; featured on Davido's Grammy-nominated *Timeless*; leading the Nigerian highlife revival |
+
+## Suno Prompt Keywords
+
+### Core Highlife Terms
+```
+highlife, west african highlife, ghanaian highlife, nigerian highlife,
+african guitar music, palm wine guitar, guitar highlife,
+dance band highlife, highlife orchestra,
+african dance music, west african groove
+```
+
+### Congolese Rumba & Soukous Terms
+```
+congolese rumba, soukous, african rumba,
+sebene, congolese guitar, lingala music,
+kinshasa sound, afro-cuban guitar
+```
+
+### Instrumentation
+```
+interlocking guitars, african guitar, melodic guitar lines,
+clean electric guitar, fingerpicked guitar, rhythm guitar,
+horn section, trumpet, saxophone, trombone,
+brass arrangement, horn melody, brass stabs,
+congas, bongos, shakers, bell pattern, african percussion,
+melodic bass, walking bass, bass guitar,
+Hammond organ, keyboards, clavinet
+```
+
+### Rhythmic & Production
+```
+polyrhythmic, syncopated, danceable groove,
+12/8 feel, african rhythm, circular rhythm,
+live band, organic production, analog warmth,
+vintage african recording, warm production,
+call and response, african vocal harmony
+```
+
+### Mood & Energy
+```
+celebratory, joyful, danceable, uplifting,
+palm wine, laid-back, breezy, tropical,
+energetic, driving, dance-floor,
+reflective, philosophical, storytelling
+```
+
+### Subgenre Specific
+```
+palm wine, acoustic highlife, unplugged african guitar,
+afro-funk, funky highlife, psychedelic african,
+juju music, yoruba percussion, talking drums,
+igbo highlife, eastern nigerian,
+burger highlife, synth highlife, 80s african pop,
+hiplife, ghanaian hip-hop, twi rap
+```
+
+### Tempo & Feel
+```
+105 bpm, 110 bpm, 115 bpm, 120 bpm,
+mid-tempo groove, swinging feel, buoyant rhythm,
+uptempo dance, relaxed groove, palm wine tempo
+```
+
+## Reference Tracks
+
+- **E.T. Mensah & The Tempos - "All for You"** -- The sound of highlife at its midcentury peak. Mensah's horn-driven arrangements marry swing-era sophistication with West African rhythmic vitality. Clean trumpet lines, a walking bass, and a buoyant groove demonstrate why the Tempos defined an era and why Mensah earned the "King of Highlife" title.
+
+- **Franco & TPOK Jazz - "Mario"** -- A sprawling masterwork of Congolese rumba at full maturity. Franco's guitar tone -- warm, slightly distorted, rhythmically conversational -- leads the listener through extended passages that build from gentle rumba into driving sebene. Shows how a single song could fill an entire LP side and hold a dance floor for thirty minutes.
+
+- **King Sunny Ade - "Ja Funmi" (from Juju Music)** -- The track that introduced juju to the world. Layers of interlocking guitars, talking drums, and pedal steel create a shimmering, hypnotic groove. Ade's vocal is relaxed and melodic, floating above the polyrhythmic web. Demonstrates juju's relationship to highlife and its distinct Yoruba identity.
+
+- **S.E. Rogie - "My Lovely Elizabeth"** -- Palm wine guitar at its most beguiling. Rogie's finger-picked acoustic guitar carries the melody, harmony, and rhythm simultaneously, with a gentle swing that captures the intimate, communal spirit of palm wine gatherings. The simplicity is deceptive -- the guitar technique is deeply accomplished.
+
+- **Osibisa - "Woyaya"** -- Afro-rock highlife fusion that brought Ghanaian musical DNA to Western rock audiences. Horns, electric guitars, and African percussion merge into a message of optimism ("We are going, heaven knows where we are going"). The song demonstrates highlife's adaptability and its power as a vehicle for uplifting themes.
+
+- **Chief Stephen Osita Osadebe - "Osondi Owendi"** -- Igbo highlife philosophy distilled into a single phrase: "one man's joy is another man's sorrow." Osadebe's unhurried vocal delivery over gentle guitar and percussion exemplifies the reflective, proverb-centered approach of eastern Nigerian highlife. The melodic bass line carries as much weight as the vocal.
+
+- **Ebo Taylor - "Love and Death"** -- Afro-funk highlife at its most potent. Taylor's guitar work fuses highlife melodicism with funk's rhythmic urgency, layered over horn arrangements that owe debts to both Accra dance bands and James Brown. Rediscovered decades later, the recording sounds as vital as anything being made today.
+
+- **Tabu Ley Rochereau - "Sorozo"** -- Congolese rumba elegance in its purest form. Rochereau's silky tenor floats over intricate guitar interplay and understated percussion. The song builds slowly, each section adding a new melodic or rhythmic layer, showcasing the sophistication that made Afrisa International one of Africa's greatest bands.
+
+- **C.K. Mann & His Carousel 7 - "Asafo Beesuon"** -- Thirteen minutes of funky Fante highlife that refuses to let up. The interlocking guitars lock into a groove that layers funk wah-wah over traditional highlife patterns, while the rhythm section drives relentlessly. Later sampled by hip-hop producers, proving the groove's cross-cultural staying power.
+
+- **Orchestra Baobab - "Utrus Horas"** -- Senegalese Afro-Cuban highlife at its most seductive. Baobab's signature blend of Cuban son guitar, Wolof vocals, and West African percussion creates something that belongs to no single tradition yet feels deeply rooted in all of them. From the landmark album *Pirate's Choice* (1982).
+
+- **Oliver de Coque - "People's Club of Nigeria"** -- Igbo highlife meets Congolese guitar technique. De Coque's fleet-fingered guitar work reveals soukous influence while remaining grounded in Igbo melodic and lyrical traditions. The extended instrumental passages show how highlife guitar music rewards patience and repetition.
+
+- **The Cavemen - "Anita"** -- Modern highlife revival done right. Live bass, drums, and guitar create an organic warmth that deliberately contrasts with Afrobeats' programmed production. The Okorie brothers draw a direct line from Osadebe and Oliver de Coque to the present without resorting to nostalgia.
+
+- **Kanda Bongo Man - "Monie"** -- Soukous stripped to its dance-floor essentials. The sebene guitar lines are rapid, precise, and interlocking; the rhythm section is relentless; and the vocal animation propels dancers forward. Demonstrates soukous at its most kinetic and joyful, the sound that conquered African dance floors in the 1980s.
+
+- **Flavour N'abania - "Nwa Baby (Ashawo Remix)"** -- Contemporary Igbo highlife meeting modern production. Flavour's melodic vocal delivery and guitar-centered arrangement connect directly to the Osadebe tradition, while the production carries enough Afrobeats-era polish to reach a younger audience. Shows highlife's continued capacity for reinvention.

--- a/genres/j-pop/README.md
+++ b/genres/j-pop/README.md
@@ -1,0 +1,147 @@
+# J-Pop
+
+## Genre Overview
+
+J-Pop (Japanese Pop) traces its lineage to kayokyoku, the broad category of Japanese popular music that dominated from the 1920s through the 1980s. Kayokyoku drew on Western jazz, blues, and chanson traditions, filtered through Japanese melodic sensibilities and enka vocal techniques. The shift toward what became known as J-Pop began in the late 1960s and 1970s when bands like Happy End fused Beatles-influenced rock with Japanese lyrics, and city pop artists like Tatsuro Yamashita and Mariya Takeuchi blended funk, boogie, and AOR with sophisticated Japanese songwriting. The term "J-Pop" itself was coined by the radio station J-WAVE in the late 1980s to distinguish a new wave of Japanese pop from the older kayokyoku tradition, marking a conscious break toward more Westernized vocal delivery, production techniques, and song structures.
+
+The 1990s represented J-Pop's golden era and commercial peak. Japan claimed the second-largest music industry in the world, and domestic artists routinely sold millions of physical units. The early 1990s were shaped by Being Inc. artists like B'z, Zard, and T-Bolan, while the mid-to-late decade saw the emergence of solo powerhouses: Namie Amuro brought Eurobeat-influenced dance-pop; Utada Hikaru's debut album *First Love* (1999) became the best-selling album in Japanese history; Ayumi Hamasaki dominated with emotionally confessional pop-rock across 13 consecutive years of number-one albums. Bands like Mr. Children and Southern All Stars achieved massive sales with melodic rock. The decade also birthed subcultures that redefined the genre's boundaries: visual kei bands like X Japan and L'Arc-en-Ciel merged theatrical aesthetics with hard rock, while Shibuya-kei artists like Pizzicato Five and Cornelius built a lounge-pop movement steeped in French ye-ye, bossa nova, and crate-digging eclecticism.
+
+The 2000s and 2010s saw J-Pop fragment and globalize in unexpected ways. Idol culture exploded with AKB48's "handshake economy" and Johnny's groups like Arashi dominating television and concert halls. Vocaloid technology, particularly the 2007 release of Hatsune Miku, created an entirely new creator ecosystem on Nico Nico Douga, where amateur producers built careers writing for synthetic voices. That Vocaloid pipeline directly fed the current era: YOASOBI's ikura began as a Vocaloid-adjacent vocalist, and Kenshi Yonezu started as the Vocaloid producer "Hachi" before becoming one of Japan's biggest solo artists. The streaming age has propelled J-Pop to global audiences through anime tie-ins -- YOASOBI's "Idol" (2023) became the nineteenth best-selling song worldwide per the IFPI -- and through artists like Fujii Kaze, Ado, and Creepy Nuts who blend J-Pop traditions with R&B, rock, and hip-hop for international consumption.
+
+## Characteristics
+
+- **Melodic construction**: Strong emphasis on memorable, singable melodies often built on pentatonic scales layered over Western diatonic harmony, producing a distinctly Japanese melodic character; frequent use of minor keys and bittersweet chord progressions; key changes and modulatory bridges are standard, with half-step modulations at the final chorus being a common structural device
+- **Production approach**: Blends electronic and organic elements -- synthesizers, programmed drums, and samples alongside live guitar, bass, piano, and strings; production tends toward clarity and brightness rather than lo-fi grit; heavy use of reverb on vocals and instruments creates a spacious, polished sound; modern productions use DAWs extensively with precise pitch correction and vocal stacking
+- **Vocal style**: Clean, forward vocals with a more Westernized delivery than traditional kayokyoku; high-pitched singing is common across genders, not reserved for climactic moments as in Western pop; harmonized backing vocals, call-and-response patterns, and layered vocal arrangements add depth; idol music frequently features alternating solo lines between group members (utawari structure)
+- **Song structure**: Chorus-centric with extended arrangements -- songs commonly run 4:00-5:30, longer than Western pop; typical structure includes A-melody (verse), B-melody (pre-chorus), and sabi (chorus), often with a C-melody bridge and instrumental break; post-chorus hooks and extended outros are common; anime tie-in tracks tend toward more compressed, hook-forward structures
+- **Rhythmic character**: Tempo range from ballads (65-80 BPM) through mid-tempo (100-120 BPM) to uptempo dance tracks (125-150 BPM); dance-pop tracks favor four-on-the-floor kicks; rock-influenced tracks use driving eighth-note patterns; syncopation is less aggressive than in Western R&B, favoring straight rhythmic feels that support melodic clarity
+- **Genre fluidity**: J-Pop absorbs rock, electronic, R&B, funk, hip-hop, classical, and traditional Japanese elements freely within single tracks; genre boundaries are treated as a palette rather than a constraint; a single artist's discography may span multiple Western genre categories without this being considered unusual
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Japanese lyrics rely less on end-rhyme than Western pop due to the language's phonetic structure (most words end in vowels); instead, emphasis falls on rhythm, syllable count, and emotional resonance; when rhyme is used, vowel-matching (in-in) and internal assonance are preferred over hard end-rhyme
+- **Language mixing**: Japanese lyrics with scattered English words and phrases are standard; English appears in hooks, titles, and refrains for rhythmic punch and international appeal; full English choruses are less common than in K-Pop but occur in internationally-targeted releases; romanized Japanese or phonetically adapted English is sometimes used to smooth vocal delivery
+- **Verse structure**: Verses typically 4-8 lines; pre-choruses (B-melody) serve as emotional ramps; choruses (sabi) are the structural and emotional centerpiece, often longer and more melodically complex than Western pop choruses; bridge sections (C-melody) are standard and frequently introduce new melodic material
+- **Thematic range**: Love and heartbreak dominate, but J-Pop also frequently addresses loneliness, nostalgia, seasonal imagery (cherry blossoms in spring, fireworks in summer), personal growth, and existential themes; anime tie-in tracks reflect their source material's narrative themes; Vocaloid-influenced tracks often explore darker or more abstract subject matter
+- **Key rule**: Emotional sincerity is paramount -- lyrics that feel performative or artificially clever lose credibility with Japanese audiences; natural phrasing that mirrors spoken Japanese cadence is valued over technical lyrical craft; seasonal and nature imagery carries deep cultural weight and should be used with awareness of its associations
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 110-130 BPM. At 90-110 BPM (ballads): up to 6 lines. Japanese syllable density is higher than English for equivalent line counts due to syllabic writing -- account for this when estimating vocal density. Topics: 1/verse. Sabi (chorus) lines should be the most melodically memorable.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Idol Pop** | Manufactured group pop built around youth, personality, and fan engagement; features alternating solo vocal lines (utawari), choreographed performances, and aggressive marketing systems including handshake events and voting singles; sound ranges from bubblegum to EDM-influenced dance-pop | AKB48, Morning Musume, Arashi, Nogizaka46 |
+| **J-Rock** | Guitar-driven pop-rock and rock that forms a major pillar of the J-Pop ecosystem; ranges from melodic pop-rock to harder alternative; many of Japan's best-selling artists are rock bands operating within mainstream pop contexts | Mr. Children, B'z, BUMP OF CHICKEN, Asian Kung-Fu Generation, RADWIMPS |
+| **Visual Kei** | Theatrical rock movement defined by elaborate costumes, makeup, and androgynous aesthetics rather than a single sound; musically spans glam rock, metal, gothic rock, and symphonic elements; pioneered in the 1980s and peaked commercially in the mid-1990s | X Japan, L'Arc-en-Ciel, Dir En Grey, Buck-Tick, Malice Mizer |
+| **Shibuya-kei** | 1990s microgenre blending 1960s French ye-ye, bossa nova, lounge, baroque pop, and jazz with sampling and electronic production; named after Tokyo's Shibuya district record shops; emphasized musical eclecticism and retro sophistication | Pizzicato Five, Cornelius, Flipper's Guitar, Kahimi Karie |
+| **City Pop** | Late 1970s-1980s fusion of funk, boogie, AOR, and jazz-fusion with Japanese pop songwriting; experienced massive international revival in the 2010s-2020s through YouTube and sampling culture; warm analog production with lush arrangements | Tatsuro Yamashita, Mariya Takeuchi, Toshiki Kadomatsu, Taeko Ohnuki |
+| **Anime/Game Music** | Theme songs and soundtracks for anime, video games, and related media; often the primary pathway for international J-Pop discovery; ranges from orchestral to rock to electronic; anime tie-ins are a major commercial driver for mainstream artists | YOASOBI, LiSA, Kenshi Yonezu, Aimer, Linked Horizon |
+| **Vocaloid/Net Music** | Music created using vocal synthesis software (Hatsune Miku, etc.) and shared on platforms like Nico Nico Douga and YouTube; spawned a generation of producers who later transitioned to mainstream success; characterized by complex arrangements, fast tempos, and experimental structures | ryo (supercell), wowaka, DECO*27, Kenshi Yonezu (as Hachi) |
+| **Electropop/Technopop** | Synthesizer-forward pop emphasizing digital production, robotic vocal processing, and futuristic aesthetics; influenced by Kraftwerk and Yellow Magic Orchestra; ranges from accessible dance-pop to experimental electronic art | Perfume, Kyary Pamyu Pamyu, Capsule, Yellow Magic Orchestra |
+| **J-R&B/Neo Soul** | R&B and soul-influenced Japanese pop with smooth vocals, jazzy chord progressions, and contemporary production; growing presence in the streaming era as artists blend Western R&B traditions with Japanese sensibilities | Fujii Kaze, Hikaru Utada (later work), SIRUP, Iri |
+| **Kayokyoku Revival** | Modern artists drawing on pre-J-Pop kayokyoku and enka traditions -- orchestral arrangements, dramatic vocal delivery, and nostalgic melodic patterns recontextualized with contemporary production | Ado (selective tracks), various indie artists |
+
+## Artists
+
+| Artist | Key Works | Era | Style Focus |
+|--------|-----------|-----|-------------|
+| Utada Hikaru | *First Love* (1999), *Deep River* (2002), *Fantome* (2016), *BADモード* (2022) | 1998-present | Best-selling album in Japanese history with *First Love* (7.65M+ copies); R&B-influenced pop with introspective songwriting; bilingual career (English albums as "Utada"); *Kingdom Hearts* theme songs bridged J-Pop and gaming worldwide |
+| B'z | *LOOSE* (1995), *The Best "Pleasure"* (1998), *Brotherhood* (1999) | 1988-present | Best-selling artist in Japanese music history (86M+ records via Oricon); hard rock duo combining Tak Matsumoto's blues-rock guitar with Koshi Inaba's powerful vocals; 50 consecutive number-one singles |
+| Ayumi Hamasaki | *LOVEppears* (1999), *Duty* (2000), *A BEST* (2001) | 1998-present | "Empress of Pop"; emotionally confessional lyrics with pop-rock and electronic production; 13 consecutive years of number-one albums on Oricon; defined late-1990s/2000s J-Pop aesthetics and fashion |
+| Mr. Children | *Atomic Heart* (1994), *Shinkai* (1996), *Bolero* (1997) | 1989-present | Over 75 million records sold; melodic rock with introspective, literary lyrics; Kazutoshi Sakurai's songwriting bridges accessible pop hooks with emotional complexity; soundtrack work for films and dramas |
+| YOASOBI | *THE BOOK* (2021), *THE BOOK 2* (2022), *THE BOOK 3* (2023) | 2019-present | Duo adapting novels and short stories into songs; "Idol" (2023) broke Billboard Japan Hot 100 records with 22 weeks at number one and became the 19th best-selling song worldwide; Vocaloid-adjacent production style with ikura's expressive vocals |
+| Kenshi Yonezu | *BOOTLEG* (2017), *STRAY SHEEP* (2020), *LOST CORNER* (2024) | 2012-present | Former Vocaloid producer "Hachi" turned solo artist; "Lemon" (2018) became one of Japan's most-streamed songs with 850M+ YouTube views; genre-fluid songwriting spanning pop, rock, electronic, and folk; prolific anime tie-in creator |
+| Namie Amuro | *Sweet 19 Blues* (1996), *181920* (1998), *Past < Future* (2009) | 1992-2018 | Pioneered Eurobeat-influenced dance-pop in the "Amura" era; fashion trendsetter who defined 1990s youth culture; transitioned through multiple eras from teen idol to mature R&B-pop; retired at career peak in 2018 |
+| Southern All Stars | *Kamakura* (1985), *Young Love* (1996), *Kiseki no Hoshi* (2022) | 1978-present | Led by Keisuke Kuwata; blended rock, pop, and humor across five decades; "TSUNAMI" (2000) is one of the best-selling singles in Japanese history; defined the "summer rock" sound |
+| X Japan | *Blue Blood* (1989), *Jealousy* (1991), *Dahlia* (1996) | 1982-1997, 2007-present | Pioneers of visual kei; Yoshiki's compositions fused speed metal with orchestral balladry; *Art of Life* (1993) is a single 29-minute symphonic metal track; massive influence on Japanese rock and visual culture |
+| Fujii Kaze | *Help Ever Hurt Never* (2020), *Love All Serve All* (2022) | 2019-present | Soul, jazz, and R&B-influenced singer-songwriter from Okayama; "Shinunoga E-Wa" went viral internationally; piano-centered compositions with warm, organic production; 17 nominations at the 2025 Music Awards Japan |
+| Ado | *Kyogen* (2023), *Zanmu* (2024) | 2020-present | Debuted at 17 with the viral hit "Usseewa"; powerhouse vocals blending rock, Vocaloid, and theatrical delivery; "New Genesis" from *One Piece Film: Red* brought global attention; faceless artist identity (performs without showing her face) |
+| Perfume | *GAME* (2008), *Triangle* (2009), *LEVEL3* (2013) | 2000-present | Electropop trio produced by Yasutaka Nakata (Capsule); synchronized choreography with robotic precision; vocoder-processed vocals over technopop production; performed at Coachella 2019; pioneered projection-mapping live shows |
+| AKB48 | *Koisuru Fortune Cookie* (2013), various singles | 2005-present | "Idols you can meet"; 48-member group with theater-based model, handshake events, and general election voting system; redefined idol economics; spawned sister groups across Asia (SKE48, NMB48, JKT48, BNK48) |
+| L'Arc-en-Ciel | *True* (1996), *HEART* (1998), *KISS* (2001) | 1991-present | Arena rock with visual kei origins; first Japanese rock band to play Madison Square Garden; hyde's versatile vocals spanning tender ballads to aggressive rock; genre range from pop-rock to electronic to new wave |
+| LiSA | *LEO-NiNE* (2020), *LANDER* (2022) | 2010-present | "Rock heroine" of anime music; "Gurenge" (2019, *Demon Slayer* theme) and "Homura" (2020) became massive crossover hits; energetic rock vocals with emotional range; bridged anime fandom and mainstream pop |
+
+## Suno Prompt Keywords
+
+### Core J-Pop Terms
+```
+j-pop, japanese pop, jpop, japanese music,
+catchy melody, bright pop, polished production,
+japanese vocals, melodic hook, sabi, emotional pop
+```
+
+### Vocal & Delivery
+```
+japanese female vocals, japanese male vocals,
+high-pitched vocals, clean vocals, expressive singing,
+harmonized vocals, layered vocals, breathy vocals,
+vocal stacking, call and response, alternating vocals
+```
+
+### Production Style
+```
+j-pop production, bright synths, warm reverb,
+electronic pop, synth layers, clean guitar,
+piano-driven, string arrangement, orchestral pop,
+polished mix, crisp drums, programmed beats,
+analog warmth, digital production, lush arrangement
+```
+
+### Subgenre Specific
+```
+j-rock, japanese rock, pop-rock, guitar-driven,
+visual kei, theatrical rock, symphonic,
+city pop, funk bass, boogie, retro japanese,
+shibuya-kei, lounge pop, bossa nova influence,
+idol pop, group vocals, dance-pop, upbeat,
+anime opening, anime theme, dramatic intro,
+vocaloid-style, fast tempo, complex melody,
+technopop, electropop, vocoder, futuristic pop
+```
+
+### Energy & Mood
+```
+energetic, upbeat, anthemic, triumphant,
+melancholic, bittersweet, nostalgic, wistful,
+dreamy, atmospheric, ethereal, gentle,
+dramatic, intense, passionate, soaring,
+playful, youthful, bright, warm
+```
+
+### Thematic & Structural
+```
+cherry blossom, seasonal, coming of age,
+key change, modulation, extended chorus,
+pre-chorus build, instrumental break, bridge section,
+anime tie-in, emotional climax, sweeping finale
+```
+
+## Reference Tracks
+
+- **Utada Hikaru - "First Love"** (1999) -- The song that defined a generation of J-Pop: gentle acoustic guitar and piano underpin Utada's breathy, intimate vocals in a ballad about lost love. The track's restraint and emotional directness made it ubiquitous in Japan. From the best-selling album in Japanese history. Template for the modern J-Pop ballad.
+
+- **B'z - "ultra soul"** (2001) -- Hard rock energy channeled into an arena-ready pop hook: Tak Matsumoto's distorted guitar riff drives a song that became a cultural fixture (adopted as an unofficial swimming competition anthem in Japan). Demonstrates how J-Pop's best-selling act blends Western hard rock with Japanese pop melodicism.
+
+- **YOASOBI - "Idol"** (2023) -- Genre-shifting structure that mirrors its source material's themes of idol duality: opens with a capella chanting, cycles through dance-pop, rock, and rapid-fire sections, all held together by ikura's precise vocal delivery. Spent 22 weeks at number one on Billboard Japan Hot 100. Represents the novel-to-song concept and anime tie-in pipeline driving modern J-Pop globally.
+
+- **Kenshi Yonezu - "Lemon"** (2018) -- Haunting pop with a restrained arrangement built on acoustic guitar and programmed beats; Yonezu's distinctive mid-range delivery carries lyrics about grief with understated emotional weight. Over 850 million YouTube views. Exemplifies the Vocaloid-to-mainstream pipeline and J-Pop's capacity for introspective, non-formulaic songwriting.
+
+- **Namie Amuro - "CAN YOU CELEBRATE?"** (1997) -- Wedding ballad that became one of the best-selling singles in Japanese history: orchestral arrangement building to a soaring chorus, with Amuro's controlled vocal delivery anchoring a track designed for maximum emotional impact. Defined the late-1990s J-Pop ballad template.
+
+- **X Japan - "Endless Rain"** (1989) -- Power ballad from visual kei's founding band: Yoshiki's piano introduction gives way to full orchestral and rock instrumentation, with Toshi's operatic vocals building through a five-minute arc from intimate to monumental. Blueprint for the visual kei ballad tradition.
+
+- **Mr. Children - "Innocent World"** (1994) -- Melodic rock anthem with Kazutoshi Sakurai's earnest vocals over jangly guitars and driving rhythm; won the Japan Record Award and sold 1.93 million copies. Represents the golden-era sound of Japanese pop-rock that dominated mid-1990s charts.
+
+- **Pizzicato Five - "Twiggy Twiggy"** (1991) -- Shibuya-kei distilled: Maki Nomiya's cool, detached vocals float over a collage of lounge samples, 1960s pop references, and breezy production by Yasuharu Konishi. Demonstrates the movement's signature blend of retro sophistication and postmodern playfulness.
+
+- **Perfume - "Polyrhythm"** (2007) -- Yasutaka Nakata's technopop production at its most inventive: vocoder-processed vocals over shifting polyrhythmic electronic beats that justify the title. The song's inclusion in a Japanese recycling campaign made it a mainstream breakthrough, proving that experimental electronic pop could reach mass audiences.
+
+- **Ado - "Usseewa"** (2020) -- Raw, aggressive rock-pop debut from a then-17-year-old anonymous singer: distorted guitars, dramatic dynamic shifts, and Ado's commanding vocal performance expressing generational frustration. Went viral on YouTube and signaled a new wave of Vocaloid-influenced artists breaking into the mainstream.
+
+- **Fujii Kaze - "Shinunoga E-Wa"** (2020) -- Soul-influenced pop built on warm piano chords and Fujii's rich vocal tone; bilingual delivery (Japanese/English) with a deceptively simple arrangement that highlights melodic craft. Went viral internationally on TikTok years after release, demonstrating J-Pop's growing global reach through streaming platforms.
+
+- **Mariya Takeuchi - "Plastic Love"** (1984) -- City pop's most famous track, rediscovered through a 2017 YouTube algorithm recommendation that sparked global interest in the genre: funk bass, disco groove, and Takeuchi's smooth vocals create an irresistibly polished sound. The definitive reference point for the city pop revival.
+
+- **LiSA - "Gurenge"** (2019) -- *Demon Slayer* opening theme that broke anime music into Japan's mainstream consciousness: driving rock production with LiSA's powerful, emotionally charged vocals; dramatic dynamics matching the anime's intensity. Became the first song to top the Oricon chart in over a year of streaming-era dominance.
+
+- **Yoko Takahashi - "A Cruel Angel's Thesis"** (1995) -- *Neon Genesis Evangelion* opening theme and Japan's eternal karaoke champion: brass-heavy arrangement with an instantly recognizable melody line; Takahashi's authoritative vocal delivery over a track that transcended its anime origins to become one of the most-performed songs in Japanese culture.

--- a/genres/jungle/README.md
+++ b/genres/jungle/README.md
@@ -1,0 +1,89 @@
+# Jungle
+
+## Genre Overview
+
+Jungle is a genre of electronic music that emerged from the UK rave scene in the early 1990s, born out of the breakbeat hardcore movement that dominated illegal warehouse parties, pirate radio stations, and sound system dances across London, Bristol, and the Midlands. The genre fused accelerated breakbeats -- particularly the iconic "Amen break" from The Winstons' 1969 track "Amen, Brother" -- with deep sub-bass frequencies rooted in Jamaican dub and reggae. London's multicultural inner-city communities, shaped by the Windrush generation's musical legacy, provided the cultural crucible where sound system culture collided with rave energy. By 1992-1993, the breakbeat hardcore scene was fragmenting, and jungle crystallized as a distinct style: faster, darker, and more rhythmically complex than its predecessor, with reggae and dancehall vocal samples layered over frenetic, chopped-up breaks.
+
+The genre's golden era ran from roughly 1993 to 1997, a period that saw jungle move from underground pirate radio to the UK charts. Ragga jungle dominated 1994-1995, with tracks like Shy FX and UK Apache's "Original Nuttah" and M-Beat featuring General Levy's "Incredible" crossing over to mainstream audiences. Simultaneously, the darker end of the spectrum produced darkcore and hardstep, while LTJ Bukem's Good Looking Records championed the atmospheric, jazz-inflected sound that became known as intelligent jungle. Goldie's landmark 1995 album Timeless -- a 21-minute title track fusing orchestral textures with jungle breakbeats -- proved the genre could sustain long-form artistic ambition. The post-Thatcher economic landscape of early 1990s Britain gave jungle an edge of urgency and defiance that separated it from the euphoric optimism of earlier rave music.
+
+By the mid-to-late 1990s, jungle's evolution led to what became classified as drum and bass -- a broader umbrella term reflecting the genre's increasing sophistication and stylistic diversification. The distinction between jungle and drum and bass remains debated, but the shift generally marks a move toward more refined production techniques, less reliance on reggae/dancehall samples, and wider sonic experimentation. Roni Size & Reprazent's Mercury Prize-winning New Forms (1997) exemplified this transition. Jungle's influence never disappeared, however. The sound has experienced periodic revivals, and its DNA runs through virtually all subsequent UK bass music. The chopped Amen break, the rolling sub-bass, the MC culture -- these elements remain foundational to electronic music worldwide. See also: [Drum and Bass](../drum-and-bass/README.md) for the genre that grew directly from jungle's roots.
+
+## Characteristics
+
+- **Tempo and rhythm**: 155-170 BPM with heavily syncopated, chopped breakbeats as the rhythmic foundation. The Amen break is the most iconic source, but producers also drew from funk and soul breaks (Think break, Apache break, Funky Drummer). Breaks are time-stretched, pitch-shifted, and re-sequenced into complex, rolling patterns that distinguish jungle from the straighter kick-snare patterns of other electronic genres.
+- **Bass**: Deep sub-bass lines inherited from Jamaican dub and reggae sound system culture, typically sine-wave or Reese bass (detuned sawtooth waves) occupying the 30-80 Hz range. Bass patterns often follow half-time or reggae-influenced rhythms beneath the rapid breakbeats, creating a tension between the speed of the drums and the weight of the low end.
+- **Sampling and vocals**: Heavily sample-based production drawing from reggae, dancehall, soul, funk, hip-hop, and film dialogue. Ragga jungle featured prominent dancehall MC vocal samples or live toasting. Darkcore drew from horror films and darker sources. The genre's sample-driven approach gives it a collage-like, layered texture distinct from purely synthesized electronic music.
+- **Production**: Raw, sample-heavy production compared to later drum and bass. Tracks were built primarily on hardware samplers (Akai S-series, E-mu SP-1200) and early Atari ST sequencers. The characteristic "chopped Amen" sound -- slicing breakbeats into individual hits and reassembling them -- became a defining production technique. Dub-influenced effects (echo, reverb, filtering) added depth and space.
+- **Structure**: Tracks often open with atmospheric intros or vocal samples before the break drops. Builds use filtered breaks and rising tension. Drops hit with full breakbeat intensity and sub-bass weight. Reggae-style breakdowns strip back to bass and vocals. Typical length 4-7 minutes, reflecting the genre's roots in DJ culture and extended mixing.
+- **Energy and mood**: Ranges from euphoric and celebratory (ragga jungle) to dark and menacing (darkcore) to ethereal and meditative (intelligent jungle). The constant across all styles is kinetic energy -- the rapid breaks create a restless, forward-driving momentum. The genre carries a distinctly urban, multicultural British identity shaped by sound system culture and inner-city experience.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Minimal -- MC toasting, ragga vocal samples, and short hooks over fast breakbeats. No traditional verse-chorus structure.
+- **Rhyme quality**: When present (ragga style), dancehall-influenced patois delivery with internal rhyme and rapid-fire phrasing. Near rhymes and rhythmic flow take priority over strict rhyme schemes.
+- **Verse structure**: Short vocal bursts, sampled dancehall phrases, MC chat, and one-line hooks. Ragga jungle features longer toasted sections but still built around repetition and call-and-response patterns rather than narrative verses.
+- **Key rule**: Vocals must ride the breakbeats, not fight them. Delivery is rhythmic and percussive, treating the voice as another layer of the drum pattern. Patois and dancehall phrasing are authentic to the genre -- do not sanitize or standardize dialect.
+- **Avoid**: Long narrative passages, slow melodic singing over fast breaks, lyrics that ignore the genre's roots in sound system and MC culture. Dense multi-syllable wordplay that clashes with the tempo.
+- **Density/pacing (Suno)**: Default **2-4 lines/verse** at 160+ BPM. MC-style toasting can be denser in short bursts. Sampled vocal hooks work best as 1-2 line phrases repeated over the break. Topics: 1/verse maximum.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| Ragga Jungle | Dancehall and reggae-heavy jungle with prominent ragga MC vocals, sound clash culture, and Jamaican musical influences; dominated 1994-1995 | Shy FX, General Levy, Congo Natty, UK Apache, Top Cat |
+| Darkcore | Dark, menacing jungle with horror-film samples, industrial stabs, and eerie atmospheres; emerged from late 1992 as the genre's first darker offshoot | 2 Bad Mice, DJ Crystl, Remarc, Doc Scott |
+| Intelligent Jungle | Atmospheric, melodic jungle emphasizing jazz-influenced textures, ambient pads, and soulful samples over complex but restrained breakbeats; also called ambient jungle | LTJ Bukem, Omni Trio, Peshay, Wax Doctor, Blu Mar Ten |
+| Hardstep | Aggressive, stripped-back jungle with heavy emphasis on punchy breaks and driving basslines; precursor to jump-up drum and bass | DJ Hype, Pascal, DJ Zinc, Dillinja |
+| Jump-Up Jungle | High-energy jungle built for dancefloor reaction, with prominent bass drops and groove-oriented patterns; the audience "jumped up" in anticipation of the drop. Evolved into [Jump-Up DnB](../drum-and-bass/README.md) | DJ Zinc, DJ Hype, Aphrodite, Mickey Finn |
+| Junglist | Broad term for the classic 1993-1995 jungle sound before subgenre fragmentation; rolling Amen breaks, dub bass, and sample collage production | Goldie (as Rufige Kru), 4hero, A Guy Called Gerald, Remarc |
+| Ambient Jungle | Downtempo-influenced jungle with spacious arrangements, reverb-drenched breaks, and meditative atmospheres; overlaps significantly with intelligent jungle | LTJ Bukem, Tayla, Aquarius, Deep Blue |
+| Drum and Bass | The broader genre that evolved directly from jungle in the mid-to-late 1990s, incorporating wider sonic experimentation and refined production. See [Drum and Bass](../drum-and-bass/README.md) for full coverage | Goldie, Roni Size, LTJ Bukem, Dillinja |
+
+## Artists
+
+| Artist | Era | Key Releases | Region | Style Focus |
+|--------|-----|--------------|--------|-------------|
+| Goldie | 1990s-present | Timeless (1995), Saturnz Return (1998) | UK (Birmingham/London) | Founded Metalheadz in 1994 with Kemistry & Storm; Timeless entered UK Albums Chart at number 7 and became jungle's first platinum album; orchestral jungle and soul-influenced production |
+| LTJ Bukem | 1990s-present | Journey Inwards (2000), Logical Progression compilations | UK (London) | Pioneer of intelligent/ambient jungle; founded Good Looking Records; jazz-influenced atmospheric breakbeats that laid the groundwork for liquid drum and bass |
+| Shy FX | 1990s-present | "Original Nuttah" (1994), Raggamuffin Soundtape (2019) | UK (London) | Co-created one of jungle's most enduring tracks with UK Apache; ragga jungle pioneer who evolved into broader bass music production |
+| Roni Size | 1990s-present | New Forms (1997), In the Mode (2000) | UK (Bristol) | Won 1997 Mercury Prize with Reprazent, beating Radiohead and The Prodigy; fused live double bass and drums with jungle breakbeats; Bristol sound system culture |
+| A Guy Called Gerald | 1990s-present | Black Secret Technology (1995), Essence (2000) | UK (Manchester) | Black Secret Technology widely regarded as one of the greatest jungle albums ever made; psychedelic, textural production that pushed the genre's boundaries |
+| Congo Natty | 1990s-present | Jungle Revolution (2013), Rebel MC catalogue | UK (London) | Formerly known as Rebel MC; brought sound system vibes into hardcore as early as 1990; Rastafarian themes and deep cultural roots in reggae-jungle fusion |
+| General Levy | 1990s-present | "Incredible" with M-Beat (1994) | UK (London) | Energetic dancehall vocalist whose "Incredible" became a crossover jungle hit; ragga jungle's most recognizable voice |
+| 4hero | 1990s-present | Parallel Universe (1995), Two Pages (1998) | UK (London) | Pioneers from breakbeat hardcore through jungle to broken beat; Parallel Universe voted NME dance album of the year 1995; Reinforced Records founders |
+| Dillinja | 1990s-present | Cybotron (2001) | UK (London) | Known for intricate drum programming and heavy bass; key figure in jungle's darker, more aggressive side; Valve Recordings founder |
+| DJ Hype | 1990s-present | Ganja Records catalogue | UK (London) | Foundational jungle DJ and producer; established Ganja Records; bridged jungle into hardstep and jump-up |
+| Remarc | 1990s | Sound Murderer (compilations, 1993-1997 material) | UK (London) | Master of the Amen break chop; raw, frenetic breakbeat manipulation that defined jungle's rhythmic intensity; Suburban Base releases |
+| Omni Trio | 1990s-2000s | The Deepest Cut series, Vol. 1 (1995) | UK | Rob Haigh's melodic, atmospheric jungle; key figure in the intelligent jungle movement alongside LTJ Bukem |
+| DJ Zinc | 1990s-present | "Super Sharp Shooter" (1995) | UK (London) | Created one of jungle's most anthemic tracks; hip-hop sampling pioneer in the genre; bridged jungle and jump-up |
+| Alex Reece | 1990s | So Far (1996) | UK (London) | "Pulp Fiction" (1995) became one of jungle's biggest crossover singles; signed to Island Records subsidiary; smooth, accessible jungle production |
+| Top Cat | 1990s-present | "Original Ses" and ragga jungle singles | UK (London) | Dancehall MC who became a cornerstone of ragga jungle; authentic Jamaican vocal style over rolling breaks |
+
+## Suno Prompt Keywords
+
+```
+chopped amen break, fast breakbeats, 160 BPM, rolling breaks, sub-bass, dub bass, reggae influence,
+dancehall samples, ragga vocals, MC toasting, sound system culture, jungle breakbeat, syncopated drums,
+time-stretched breaks, pitched breakbeats, reese bass, deep sub-bass, dub echo, reverb dub,
+dark atmosphere, rave energy, pirate radio, raw production, sample-heavy, funk breaks, soul samples,
+chopped drums, rolling bassline, jungle rollers, atmospheric pads, dark jungle, ragga jungle,
+intelligent jungle, ambient breakbeats, jazz-influenced, soulful jungle, heavy breaks, percussive energy,
+UK rave, urban jungle, breakbeat manipulation, frenetic rhythm, dubbed-out bass, half-time bass,
+sound clash, junglist, old school jungle, 90s rave, hardcore jungle
+```
+
+## Reference Tracks
+
+- Shy FX & UK Apache - "Original Nuttah" (1994) - [Ragga Jungle] Defining ragga jungle anthem with UK Apache's dancehall toasting over relentless Amen breaks; one of the genre's most enduring and recognizable tracks, still a guaranteed crowd reaction decades later
+- M-Beat feat. General Levy - "Incredible" (1994) - [Ragga Jungle] Massive crossover hit that brought jungle to mainstream UK audiences; General Levy's high-energy dancehall vocal over rolling breaks became the genre's most commercially successful moment
+- Goldie - "Inner City Life" (1995) - [Intelligent Jungle] Diane Charlemagne's haunting vocals over cascading breaks and jazz chords; the opening track from Timeless that proved jungle could be emotionally complex and artistically ambitious
+- Goldie (as Rufige Kru) - "Terminator" (1993) - [Darkcore] Early Goldie production under his Rufige Kru alias; dark, time-stretched breakbeats and menacing atmosphere that helped define the darkcore sound
+- A Guy Called Gerald - "Finley's Rainbow" (1995) - [Intelligent Jungle] From the landmark Black Secret Technology album; psychedelic, liquid textures over intricate break programming that redefined what jungle production could achieve
+- LTJ Bukem - "Horizons" (1995) - [Ambient Jungle] Dreamy, jazz-inflected soundscape that established the blueprint for atmospheric jungle and later liquid drum and bass; Good Looking Records at its finest
+- Roni Size/Reprazent - "Brown Paper Bag" (1997) - [Jungle/DnB] Mercury Prize-winning Bristol sound; live bass, organic breaks, and hip-hop sensibility bridging jungle's raw energy with the sophistication of emerging drum and bass
+- DJ Zinc - "Super Sharp Shooter" (1995) - [Jump-Up Jungle] Hip-hop-sampling jungle anthem built around a sampled vocal hook and driving breaks; became a dancefloor staple and helped define the jump-up sound
+- Remarc - "Sound Murderer" (1994) - [Darkcore/Junglist] Ferocious Amen break chopping with sound clash vocals and dub effects; Remarc's breakbeat manipulation technique remains unmatched in its raw intensity
+- Alex Reece - "Pulp Fiction" (1995) - [Intelligent Jungle] Smooth, accessible jungle that crossed over to mainstream audiences; rolling two-step break with deep bass and understated elegance
+- 4hero - "Mr Kirk's Nightmare" (1990) - [Proto-Jungle/Hardcore] Early Reinforced Records release that helped bridge breakbeat hardcore into what would become jungle; dark vocal sample over accelerating breaks
+- Omni Trio - "Renegade Snares" (1993) - [Intelligent Jungle] Rob Haigh's melodic breakbeat classic; atmospheric strings and pads over intricate break programming that defined the thoughtful end of early jungle
+- Congo Natty - "Junglist" (1994) - [Ragga Jungle] Rebel MC's declaration of junglist identity; Rastafarian themes and deep reggae roots fused with raw breakbeats and sound system weight

--- a/genres/samba/README.md
+++ b/genres/samba/README.md
@@ -1,0 +1,94 @@
+# Samba
+
+## Genre Overview
+
+Samba emerged in the early twentieth century from the Afro-Brazilian communities of Rio de Janeiro, forged by formerly enslaved Bahians who settled in the port-area neighborhoods known as "Little Africa" after abolition in 1888. These communities fused West African drumming traditions, Portuguese melodic structures, and the circular Bahian samba de roda into a new urban sound. The genre's early years were marked by persecution -- police regularly shut down gatherings, arrested musicians, and destroyed instruments -- forcing samba underground into private homes and terreiros. Donga's 1916 recording of "Pelo Telefone" is widely cited as the first commercially recorded samba, though the communal origins of the music meant authorship was always contested. By the late 1920s, the first escolas de samba (samba schools) had formed as neighborhood organizations devoted to music, dance, and community identity, with Mangueira (co-founded by Cartola in 1928) and Portela among the earliest.
+
+Samba became the heartbeat of Rio's Carnival in the 1930s, when large batucadas and marching groups began leading parade processions through the streets. The escolas de samba grew into massive organizations with hundreds of percussionists (the bateria), dancers, float designers, and choreographers, all preparing year-round for the annual desfile. The 1984 inauguration of the Sambadrome Marques de Sapucai, designed by Oscar Niemeyer, gave Carnival a permanent stage and formalized the spectacle. The samba-enredo -- a narrative song composed specifically for each school's parade theme -- became the genre's most public-facing form, with thousands of voices singing in unison as the escola processes down the runway. Carnival transformed samba from neighborhood music into a national symbol, though the genre's deepest roots remained in the intimate roda de samba, where musicians gather in a circle to play, improvise, and pass songs around.
+
+The 1970s brought a samba revival led by artists like Beth Carvalho, Martinho da Vila, and Clara Nunes, who brought samba back to radio after years of bossa nova and Tropicalia dominance. The 1980s saw the rise of pagode, a more informal, acoustic offshoot pioneered by Fundo de Quintal that introduced new instruments like the tantan and repique de mao and made samba accessible to a younger generation. Samba-reggae emerged from Salvador da Bahia through blocos afro like Olodum and Ile Aiye, blending samba percussion with reggae grooves. Jorge Ben Jor fused samba with funk and rock to create samba-rock. Today samba remains a living tradition -- from the velha guarda (old guard) keepers of tradition to contemporary artists who blend samba with hip-hop, electronic music, and pop production -- while the roda de samba continues as the genre's spiritual home.
+
+## Characteristics
+
+- **Rhythm and meter**: 2/4 time signature with heavy syncopation and a characteristic Brazilian swing called "suingue" -- a micro-timing push that accelerates into each beat and relaxes before the next. The surdo bass drums establish the pulse while tamborims, agogo bells, and cuicas layer interlocking patterns on top. Polyrhythm is fundamental; no single instrument carries the full rhythm.
+- **Instrumentation**: The bateria (percussion ensemble) forms the foundation: surdo (bass drums in three sizes -- primeira, segunda, terceira), pandeiro (tunable frame drum with metal jingles), tamborim (small hand drum played with a flexible beater), cuica (friction drum producing its signature vocal-like cry), agogo (double bell), reco-reco (scraper), chocalho (shaker), and caixa (snare). Melodic/harmonic instruments include cavaquinho (small four-string instrument providing rhythmic-harmonic drive), acoustic guitar (violao), and sometimes brass or keyboards in larger arrangements.
+- **Vocals**: Powerful, rhythmically grounded singing that prioritizes groove and phrasing over technical display. Call-and-response between soloist and coro (chorus) is central, especially in partido alto and samba-enredo. Vocal improvisation (partido alto soloing) and storytelling are valued. Delivery ranges from the raw, earthy tone of roots samba to the polished warmth of pagode crooners.
+- **Song structure**: Typically verse-refrain with a strong, repeatable chorus designed for group singing. Partido alto features an alternating structure of fixed refrains and improvised solo verses. Samba-enredo follows a longer narrative arc tied to the school's parade theme. Many sambas use a two-part form (primeira and segunda) with distinct melodic sections.
+- **Energy and mood**: Ranges from the thunderous, communal energy of Carnival batucadas to the intimate warmth of a backyard roda de samba. Common emotional threads include saudade (bittersweet longing), celebration of everyday life, romantic devotion, social commentary, and pride in community and Afro-Brazilian identity. The groove is physically compelling -- samba is fundamentally dance music.
+- **Production (recorded)**: Traditional recordings emphasize live percussion, acoustic instruments, and natural room sound. Pagode recordings favor a warm, close-miked acoustic feel. Modern samba productions may incorporate electronic elements, but the rhythmic foundation of interlocking percussion remains non-negotiable. The surdo pulse and tamborim patterns should be felt even in stripped-down arrangements.
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: AABB or ABAB with natural, speech-like phrasing. Rhymes should feel conversational, not forced. Refrains are designed for crowd singalong -- simple, memorable, rhythmically strong.
+- **Rhyme quality**: Portuguese-language rhyming conventions favor vowel-rich end rhymes and assonance. In English-language samba writing, prioritize rhythmic fit over perfect rhyme. Near rhymes and slant rhymes work well when they serve the groove.
+- **Verse structure**: Short, punchy verses with a strong refrain. Partido alto uses a fixed chorus alternating with solo verses (often improvised). Keep sections tight -- the rhythm carries the song, not lyric density.
+- **Key rule**: Lyrics must lock to the samba groove. Syllables fall on syncopated beats; phrasing follows the percussion, not the other way around. The best samba lyrics feel like natural speech rhythmically aligned to the batucada. Themes of daily life, neighborhood pride, love, saudade, and social observation are the genre's bread and butter.
+- **Avoid**: Overloading verses with syllables that fight the rhythm. Abstract philosophizing disconnected from lived experience. Losing the conversational directness that defines samba lyricism. Ignoring the call-and-response dynamic -- the coro needs something singable.
+- **Density/pacing (Suno)**: Default **4-6 lines/verse** at 90-130 BPM. Percussion-driven -- leave rhythmic space for the batucada to breathe. Refrains should be short and highly repeatable. Topics: 1/verse, grounded in concrete imagery.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **Samba de roda** | The oldest form, originating in the Reconcavo Baiano region of Bahia. Performers sing and play in a circle while dancers take turns in the center. Recognized by UNESCO as Intangible Cultural Heritage in 2005. Foundation of all subsequent samba styles. | Riachao, Dona Edith do Prato, traditional Bahian communities |
+| **Samba-enredo** | Composed specifically for Carnival parade by a samba school, narrating the escola's chosen theme for that year. Performed by a lead singer (puxador) with a massive chorus and full bateria. Structured as a long, narrative song meant to sustain energy across the parade route. | Mangueira, Portela, Salgueiro, Beija-Flor (samba school composers) |
+| **Partido alto** | The most improvisational samba form. Built on a fixed refrain (refrains sung by the group) alternating with solo verses invented on the spot. Considered the purest test of a sambista's skill. Thrives in the roda de samba setting. | Zeca Pagodinho, Martinho da Vila, Bezerra da Silva, Jovelina Perola Negra |
+| **Pagode** | Acoustic, informal samba style that emerged in early 1980s Rio, pioneered by Fundo de Quintal. Introduced new instruments (tantan, repique de mao, four-string banjo) and a more intimate, backyard-party feel. Became commercially dominant in the 1990s. | Fundo de Quintal, Zeca Pagodinho, Jorge Aragao, Beth Carvalho |
+| **Samba-cancao** | A slower, more romantic samba form that emerged in the 1930s-40s, emphasizing melody and emotional lyrics over rhythmic drive. Bridge between traditional samba and bossa nova. Sometimes called "samba de meio de ano" (mid-year samba) for its distance from Carnival energy. | Cartola, Nelson Cavaquinho, Lupicinio Rodrigues, Dolores Duran |
+| **Samba-rock (samba-funk)** | Fusion of samba rhythm with rock, funk, and soul elements. Emerged in the 1960s-70s Sao Paulo dance scene. Characterized by electric guitars, bass-heavy grooves, and a looser rhythmic feel that invites partner dancing. | Jorge Ben Jor, Trio Mocoto, Ed Motta |
+| **Samba-reggae** | Born in Salvador da Bahia in the 1980s through blocos afro (Afro-Brazilian Carnival groups). Merges samba percussion patterns with reggae's offbeat emphasis and slower tempo. Closely tied to Black consciousness movements in Bahia. | Olodum, Ile Aiye, Timbalada, Daniela Mercury |
+| **Samba de terreiro** | The internal samba of the samba school community, played in the escola's quadra (rehearsal court) year-round rather than for Carnival competition. More relaxed and communal than samba-enredo, focused on celebrating the school's identity and history. | Velha Guarda da Portela, Velha Guarda da Mangueira |
+| **Bossa nova** | Emerged in late 1950s Rio as a fusion of samba rhythm with jazz harmonics and intimate vocal delivery. Revolutionized Brazilian and global popular music. Has its own genre entry -- see [bossa-nova](../bossa-nova/README.md) for full coverage. | Joao Gilberto, Tom Jobim, Vinicius de Moraes |
+| **Samba de breque** | "Break samba" featuring sudden rhythmic stops where the singer inserts spoken-word passages, jokes, or dramatic narration before the groove resumes. Comic timing and theatrical delivery are essential. | Moreira da Silva, Germano Mathias |
+
+## Artists
+
+| Artist | Primary Era | Notable Work | Contribution |
+|--------|------------|--------------|--------------|
+| Cartola | 1930s-1980 | *Cartola* (1974), *Cartola II* (1976), "As Rosas Nao Falam" | Co-founder of Mangueira samba school (1928); composed over 500 songs; poetic lyrics elevated samba songwriting; recorded solo albums only in his final years |
+| Noel Rosa | 1929-1937 | "Com Que Roupa?", "Conversa de Botequim", "Feitio de Oracao" | Brought witty, urbane social commentary to samba; composed over 250 songs before dying of tuberculosis at 26; pivotal figure in legitimizing samba as art |
+| Clara Nunes | 1960s-1983 | *Brasil Mestico*, *Guerreira*, "O Mar Serenou" | First female samba artist to sell over 100,000 copies; fused samba with Afro-Brazilian religious and folk traditions; powerful stage presence |
+| Beth Carvalho | 1960s-2019 | *De Pe no Chao* (1978), *Andanca* (1969), "Vou Festejar" | "Madrinha do Samba" (Godmother of Samba); championed overlooked composers like Cartola and Nelson Cavaquinho; discovered Zeca Pagodinho |
+| Zeca Pagodinho | 1980s-present | *Zeca Pagodinho* (1986), *Agua da Minha Sede*, "Deixa a Vida Me Levar" | Master of partido alto improvisation; brought pagode to mainstream audiences; embodies the informal, joyful spirit of the roda de samba |
+| Martinho da Vila | 1960s-present | *Martinho da Vila* (1969), "Casa de Bamba", "Canta Canta, Minha Gente" | Pioneered a lighter, melodic samba style; prolific composer; connected samba to broader MPB audiences; cultural ambassador |
+| Jorge Ben Jor | 1960s-present | *Samba Esquema Novo* (1963), *A Tabua de Esmeralda* (1974), "Mas Que Nada" | Father of samba-rock; fused samba with funk, soul, and rock; "Mas Que Nada" became one of the most internationally recognized Brazilian songs |
+| Dona Ivone Lara | 1960s-2018 | "Sonho Meu", "Alguem Me Avisou", *Sorriso de Crianca* | First woman admitted to the composers' wing of a samba school (Imperio Serrano, 1965); elegant melodic craft; known as the First Lady of Samba |
+| Paulinho da Viola | 1960s-present | *Paulinho da Viola* (1968), "Foi um Rio que Passou em Minha Vida", *Bebadachama* | Refined, poetic approach to samba composition; connected to Portela samba school; bridges tradition and modernity with understated sophistication |
+| Alcione | 1970s-present | *A Voz do Samba* (1975), "Nao Deixe o Samba Morrer", *Eterna Alegria* | Known as "A Marrom"; powerful voice from Maranhao; over 40 albums spanning samba, MPB, and bolero; kept samba visible through changing musical fashions |
+| Bezerra da Silva | 1970s-2005 | *Presidente Capo*, "Malandragem Da Pra Viver" | Voice of the Rio favelas; partido alto specialist whose lyrics chronicled life in marginalized communities with humor and unflinching honesty |
+| Nelson Cavaquinho | 1930s-1986 | "A Flor e o Espinho", "Quando Eu Me Chamar Saudade" | Dark, melancholic samba songwriting; sparse guitar style; composed some of samba's most emotionally devastating songs |
+| Adoniran Barbosa | 1930s-1982 | "Trem das Onze", "Saudosa Maloca", "Iracema" | Samba paulista (Sao Paulo samba); working-class storytelling in colloquial language; humor mixed with social awareness; distinct from Rio tradition |
+| Fundo de Quintal | 1977-present | *Samba e No Fundo de Quintal* (1980), "A Batucada dos Nossos Tantans" | Pioneered pagode movement; invented the tantan drum; introduced four-string banjo and repique de mao to samba instrumentation |
+| Jovelina Perola Negra | 1980s-1998 | *Perola Negra* (1986), "Bagaco da Laranja" | Powerful partido alto vocalist; one of pagode's defining voices; raw, percussive singing style |
+
+## Suno Prompt Keywords
+
+```
+samba, brazilian samba, samba rhythm, batucada, pagode, partido alto,
+cavaquinho, pandeiro, surdo, tamborim, cuica, agogo, reco-reco,
+acoustic guitar, percussion ensemble, call-and-response,
+syncopated, polyrhythmic, danceable, festive, celebratory,
+Rio de Janeiro, Carnival, roda de samba, afro-brazilian,
+warm vocals, group chorus, rhythmic singing, samba groove,
+samba-rock, samba funk, samba soul, brazilian funk,
+acoustic samba, backyard samba, intimate percussion,
+saudade, romantic samba, samba cancao, melodic samba,
+upbeat, joyful, communal, street party, neighborhood pride
+```
+
+## Reference Tracks
+
+- Donga - "Pelo Telefone" (1916; widely cited as the first recorded samba; captures the genre's transition from oral tradition to commercial recording)
+- Noel Rosa - "Com Que Roupa?" (1930; breakthrough hit that brought urbane wit and social commentary to samba; defined the genre's lyrical ambitions)
+- Cartola - "As Rosas Nao Falam" (poetic samba-cancao from one of the genre's greatest composers; understated melody, devastating emotional depth)
+- Adoniran Barbosa - "Trem das Onze" (Sao Paulo samba classic; working-class storytelling in colloquial language over a buoyant groove)
+- Paulinho da Viola - "Foi um Rio que Passou em Minha Vida" (declaration of love for Portela samba school; elegant melody, refined composition)
+- Clara Nunes - "O Mar Serenou" (Afro-Brazilian samba fusing percussion-heavy rhythm with spiritual and folk traditions; commanding vocal performance)
+- Jorge Ben Jor - "Mas Que Nada" (1963; samba-rock landmark that became one of Brazil's most internationally recognized songs; infectious groove bridging samba and soul)
+- Beth Carvalho - "Vou Festejar" (pagode-era anthem that brought samba back to mainstream radio; joyful, communal energy)
+- Fundo de Quintal - "A Batucada dos Nossos Tantans" (pagode at its source; the tantan and repique de mao in their natural habitat; intimate backyard groove)
+- Zeca Pagodinho - "Deixa a Vida Me Levar" (modern partido alto; easygoing philosophy over a classic samba groove; became an unofficial Brazilian anthem)
+- Martinho da Vila - "Casa de Bamba" (1969; light, melodic samba that helped revive the genre in the 1970s; natural, conversational delivery)
+- Alcione - "Nao Deixe o Samba Morrer" (powerful vocal performance that became a plea for the genre's survival; emotionally direct and deeply felt)
+- Dona Ivone Lara - "Sonho Meu" (composed by one of samba's greatest female songwriters; popularized by Maria Bethania and Gal Costa; graceful melodic craft)
+- Olodum - "Faraoh, Divindade do Egito" (samba-reggae from Salvador da Bahia; massive percussion arrangement blending samba and reggae rhythms; tied to Afro-Brazilian identity)

--- a/genres/uk-garage/README.md
+++ b/genres/uk-garage/README.md
@@ -1,0 +1,103 @@
+# UK Garage
+
+## Genre Overview
+
+UK garage (UKG) is a genre of electronic dance music that originated in England in the early to mid-1990s, rooted in the soulful house sound of New York's Paradise Garage nightclub where Larry Levan held residency from 1977 to 1987. British DJs importing US garage house records began pitching them up from around 120 BPM to the high 120s and low 130s, adding tighter percussion and heavier basslines suited to the energy of London's club scene. The resulting sound drew from jungle's breakbeat complexity, R&B vocal stylings, and the rhythmic push of dancehall, producing something distinctly British that owed a clear debt to its American ancestors. By the mid-1990s, producers like Tuff Jam, Todd Edwards, and Grant Nelson were shaping a UK-specific garage identity, released on white labels and championed by pirate radio stations including Rinse FM, Deja Vu FM, and Flex FM.
+
+The genre split into two dominant branches by the late 1990s. Speed garage, driven by rolling snares, pitched-up vocals, and warped sub-bass, brought an aggressive, rave-influenced energy that crossed over into mainstream clubs. The 2-step variant stripped out the predictable four-on-the-floor kick pattern, removing the second and fourth kick from each bar to create a syncopated, shuffling rhythm that felt lighter and more sophisticated. This 2-step sound propelled UKG into the UK charts: Shanks & Bigfoot's "Sweet Like Chocolate" hit number one in May 1999, Artful Dodger featuring Craig David reached number two with "Re-Rewind" that November, and Craig David's solo debut "Fill Me In" entered at number one in April 2000. MJ Cole, Wookie, DJ Luck & MC Neat, and Sweet Female Attitude all scored top-ten hits during the same period, making 1999-2001 the commercial peak of UK garage.
+
+The genre's mainstream window closed by 2002-2003, but its influence fractured into some of the most significant UK electronic movements of the 21st century. The darker, more minimal productions of El-B, Zed Bias, and Horsepower Productions laid direct groundwork for dubstep (see `genres/dubstep/`). Meanwhile, the MC-led, aggressive end of the garage spectrum -- pirate radio MCs rapping over stripped-back instrumentals at 140 BPM -- evolved into grime (see `genres/grime/`). Bassline house emerged from Sheffield's Niche nightclub in the mid-2000s, carrying forward garage's rhythmic DNA with heavier low-end. UKG itself has experienced repeated revivals, with Disclosure bringing garage-influenced production to global pop audiences via "Settle" (2013), and a new generation including Conducta, Interplanetary Criminal, and PinkPantheress keeping the sound alive and evolving into the present day.
+
+## Characteristics
+
+- **Instrumentation**: Syncopated drum programming (shuffled hi-hats, skip-kick patterns), deep sub-bass and reese basslines, chopped and pitched vocal samples, warm chord stabs (organ, Rhodes, string pads), garage-style snare rolls, percussive shakers and rim shots, occasional brass or woodwind samples
+- **Vocals**: Soulful R&B-influenced singing (often female), chopped and time-stretched vocal samples, MC toasting and rapid-fire chat over instrumentals (derived from jungle and dancehall MC traditions), pitched-up or pitched-down vocal processing, call-and-response between singer and MC
+- **Production**: 2-step or 4x4 kick patterns at 130-140 BPM, distinctive swing and shuffle on hi-hats (typically 55-60% swing), heavy use of sidechain compression, basslines that roll and bounce rather than sustain, layered percussion with syncopation across every element, time-stretching and pitch-shifting as creative tools rather than corrections
+- **Energy/Mood**: Sophisticated and soulful but physically demanding on the dance floor; ranges from euphoric vocal tracks to dark, minimal bass workouts; late-night energy that balances warmth with tension; equally suited to intimate club sets and large-scale raves
+- **Structure**: Intro-verse-chorus structures more common than in house, but still built for DJ mixing with extended intros and outros (16-32 bars); breakdowns strip to vocals or percussion before bass drops return; tracks typically 4-6 minutes; instrumental dub versions standard for DJ use
+- **Rhythm**: The defining feature -- syncopated kick drum patterns that break from house music's rigid four-on-the-floor grid; the "2-step" feel comes from removing or displacing kicks on beats 2 and 4, creating a shuffling, swinging groove that forces the body to move differently than standard house or techno
+
+## Lyric Conventions
+
+- **Default rhyme scheme**: Verse-chorus with R&B influence. Sung hooks carry the track; MC bars ride between vocal sections. Rhyme serves melody, not the other way around.
+- **Rhyme quality**: Smooth and melodic for sung parts; tight internal rhyme and percussive wordplay for MC sections. Words should sit in the swing, not fight it.
+- **Verse structure**: Sung verses of 4-8 lines with strong melodic hooks; MC verses in 8-16 bar blocks. Contrast between the two styles creates dynamic range within a track.
+- **Key rule**: Vocals must lock to the syncopated rhythm -- syllables land between kicks and snares, not on them. The voice is a percussive instrument in UKG. Bright vowel sounds cut through dense mixes.
+- **Avoid**: Overcrowding the track with lyrics. Dense rap verses that ignore the swing. American idioms where British slang fits naturally. Lyrics that compete with the bassline rather than riding above it.
+- **Density/pacing (Suno)**: Default **4 lines/verse** at 130-140 BPM. Sung sections should breathe -- leave space for the production. MC sections can be denser (6-8 lines) but must respect the shuffle. Topics: 1-2/verse max. Love, nightlife, and dance floor themes dominate.
+
+## Subgenres & Styles
+
+| Style | Description | Reference Artists |
+|-------|-------------|-------------------|
+| **2-Step Garage** | The signature UKG sound: syncopated kick patterns with the 2nd and 4th kicks removed or displaced, shuffled hi-hats, soulful vocals, and sophisticated R&B-influenced production | MJ Cole, Artful Dodger, Craig David, DJ Luck & MC Neat |
+| **Speed Garage** | Faster, harder variant with rolling snares, warped sub-bass (often from pitching up jungle basslines), pitched-up vocal samples, and rave-influenced energy; emerged mid-1990s | Armand Van Helden, DJ Timo, Shanks & Bigfoot, 187 Lockdown |
+| **4x4 Garage** | Retains the standard four-on-the-floor kick pattern from house but adds UKG's shuffled percussion, vocal chops, and bassline style; higher energy, more straightforward for DJ mixing | Tuff Jam, Sunship, Grant Nelson |
+| **Bassline** | Mid-2000s evolution from Sheffield's Niche nightclub; heavy wobbling basslines, rapid-fire vocals, 4x4 kicks at 138-142 BPM; carries UKG's rhythmic DNA with maximal low-end | DJ Q, T2, Jamie Duggan, Pleasurehead |
+| **Dark Garage** | Stripped-back, minimal, and bass-heavy variant that emerged in the late 1990s; removed the soulful vocals in favor of dub plates and sub-bass pressure; direct ancestor of dubstep (see `genres/dubstep/`) | El-B, Zed Bias, Horsepower Productions, Ghost |
+| **Vocal Garage** | Pop-oriented UKG built around strong R&B vocal performances and polished production; the variant that crossed over into UK charts during 1999-2001 | Craig David, Sweet Female Attitude, Dane Bowers, Samantha Mumba |
+| **Future Garage** | 2010s reinterpretation blending UKG rhythms with ambient textures, reverb-drenched vocals, and half-time tempos; contemplative rather than club-focused | Burial, Submerse, Sorrow |
+| **Nu-UKG** | Contemporary revival movement maintaining classic 2-step rhythms with modern production techniques; championed by dedicated labels like Kiwi Rekords | Conducta, Interplanetary Criminal, Sammy Virji, Higgo |
+| **Grime** | Aggressive MC-led offshoot that pushed UKG's pirate radio culture to its extreme, with stripped-back beats at 140 BPM and rapid-fire bars; now its own fully developed genre (see `genres/grime/`) | Wiley, Dizzee Rascal, Skepta |
+| **Dubstep** | Dark garage's logical endpoint: half-time rhythms, massive sub-bass, and minimal percussion; evolved from the same South London scenes that produced dark garage (see `genres/dubstep/`) | Skream, Benga, Digital Mystikz |
+
+## Artists
+
+| Artist | Notable Works | Era | Style Focus |
+|--------|---------------|-----|-------------|
+| **Craig David** | *Born to Do It* (2000); "Fill Me In" (UK #1), "7 Days" (UK #1), "Re-Rewind" with Artful Dodger (UK #2) | 1999-present | The voice of UK garage's pop crossover; discovered through Artful Dodger collaborations; smooth R&B vocals over 2-step rhythms |
+| **Artful Dodger** | "Re-Rewind" (1999, UK #2), "Movin' Too Fast" (2000, UK #2), "Woman Trouble" (2000, UK #6) | 1998-2003 | Mark Hill and Pete Devereux; production duo who bridged underground garage and pop charts; launched Craig David's career |
+| **MJ Cole** | *Sincere* (2000); "Sincere" (2000, UK #12), "Crazy Love" (2000, UK #10) | 1998-present | Classically trained oboist and pianist; brought musicianship and harmonic sophistication to UKG production |
+| **Todd Edwards** | *Prima Edizione* (compilation, 2001); numerous singles and remixes | 1993-present | American producer whose micro-sampled, vocal-chopping style heavily influenced the UK garage sound; key bridge between US garage house and UKG |
+| **DJ EZ** | *Pure Garage* compilation series; Kiss 100 residency; iconic Boiler Room set | 1997-present | Born Otis Roberts; widely regarded as the greatest UK garage DJ; technical mixing mastery and encyclopedic knowledge of the genre |
+| **Wookie** | *Wookie* (2000); "Battle" (2000, UK #10), "Back Up (To Me)" (2001, UK #11) | 1998-present | Jason Chue; producer and remixer whose deep, bass-driven sound bridged soulful 2-step and darker garage styles |
+| **El-B** | *The El-B Story* (2001), numerous Ghost/Bingo Beats releases | 1998-2005 | Dark garage pioneer; minimal, bass-heavy productions with haunting atmospheres; his sound directly influenced early dubstep |
+| **Tuff Jam** | Numerous remixes and white labels; Undermass/Tuff Jam productions | 1996-2001 | Matt "Jam" Lamont and Karl "Tuff Enuff" Brown; prolific remix duo who defined the 4x4 garage sound through hundreds of productions |
+| **Zed Bias** | "Neighbourhood" (2000), *Biasonic Hotsauce* (2009) | 1999-present | Dave Jones; dark garage innovator; "Neighbourhood" is a touchstone track that bridged UKG and the emerging dubstep sound |
+| **DJ Luck & MC Neat** | "A Little Bit of Luck" (1999, UK #9), "Masterblaster 2000" (UK #5) | 1999-2003 | DJ-MC partnership that epitomized the pirate radio energy of UKG's golden era; three consecutive top-ten hits |
+| **Shanks & Bigfoot** | "Sweet Like Chocolate" (1999, UK #1) | 1998-2001 | Stephen Sheraton and Danny Langsman; scored the first UK number-one garage single, opening the floodgates for mainstream crossover |
+| **Sunship** | "Try Me Out" (2000), "Cheque One-Two" (2003); Flowers remix for Sweet Female Attitude | 1998-present | Ceri Evans; versatile producer known for uplifting vocal garage and the "Flowers" remix that took Sweet Female Attitude to UK #2 |
+| **Disclosure** | *Settle* (2013, UK #1), *Caracal* (2015), *Energy* (2020) | 2010-present | Howard and Guy Lawrence; brought UKG's rhythmic DNA to global pop audiences; key catalysts of the 2010s garage revival |
+| **Conducta** | Various singles; Kiwi Rekords label; co-produced "Ladbroke Grove" with AJ Tracey (2019, UK #3) | 2017-present | Collins Nemi; founded the Kiwi Rekords label that became the hub of the nu-UKG movement; bridging classic 2-step with modern production |
+| **Interplanetary Criminal** | "B.O.T.A. (Baddest of Them All)" with Eliza Rose (2022, UK #1) | 2019-present | Zachary Bruce; scored the first UK garage number one since "Sweet Like Chocolate" with Eliza Rose; championing UKG to a new generation |
+
+## Suno Prompt Keywords
+
+```
+UK garage, UKG, 2-step, 2-step garage, speed garage, shuffled rhythm, syncopated,
+130-140 BPM, garage beat, skippy drums, chopped vocals, vocal chops, soulful,
+R&B vocals, pitched vocals, time-stretched, sub-bass, reese bass, rolling bass,
+garage bassline, shuffled hi-hats, swing beat, snare rolls, percussive,
+warm chords, organ stabs, string pad, Rhodes piano, deep bass, dark garage,
+pirate radio, MC chat, garage MC, London, UK electronic, dance floor,
+late-night, club music, 4x4 garage, bassline, vocal garage, nu-garage,
+garage house, broken beat, skip-kick, bouncy, infectious groove
+```
+
+## Reference Tracks
+
+- **Shanks & Bigfoot - "Sweet Like Chocolate"** (1999) -- The first UK garage track to reach number one on the UK Singles Chart; its warm, rolling 2-step beat and sweet vocal hook proved garage could be a pop force without losing its rhythmic identity
+
+- **Artful Dodger feat. Craig David - "Re-Rewind (The Crowd Say Bo Selecta)"** (1999) -- Reached UK #2 and launched Craig David as a household name; the track's skippy 2-step production and David's effortless vocals became the template for commercial UKG
+
+- **MJ Cole - "Sincere"** (2000) -- A classically trained musician's approach to garage; lush harmonic movement, delicate piano, and emotional depth that demonstrated UKG could be musically sophisticated without sacrificing dance floor impact
+
+- **Wookie feat. Lain - "Battle"** (2000) -- Deep, rebounding bassline anchoring soulful vocals about faith and resilience; reached UK #10 and remains one of the most recognizable garage productions ever committed to vinyl
+
+- **Craig David - "Fill Me In"** (2000) -- Debuted at UK #1; pure 2-step pop with Craig David's melodic storytelling over a tight, swinging beat; proved the garage-R&B crossover could dominate mainstream charts
+
+- **DJ Luck & MC Neat - "A Little Bit of Luck"** (1999) -- The DJ-MC dynamic captured on record; Neat's chatty, energetic vocal rides the 2-step rhythm while the production bounces with infectious optimism; reached UK #9
+
+- **Sweet Female Attitude - "Flowers" (Sunship Remix)** (2000) -- Sunship's remix took this from an album track to a UK #2 hit; dreamy vocal harmonies over crisp 2-step drums, a staple of every garage set since its release
+
+- **Todd Edwards - "Saved My Life"** (1997) -- The American producer whose micro-sampling technique -- cutting dozens of tiny vocal fragments into new melodies -- became foundational to the UK garage sound; this track exemplifies the method
+
+- **Tina Moore - "Never Gonna Let You Go" (Kelly G Remix)** (1997) -- The Kelly G Bump-N-Go remix peaked at UK #7 and is widely cited as a key bridge between speed garage and 2-step, its syncopated kick pattern pointing toward the rhythmic revolution to come
+
+- **Zed Bias feat. MC Rumpus - "Neighbourhood"** (2000) -- Dark, rolling bassline with MC Rumpus's gruff vocal delivery; a landmark in the darker end of garage that pointed directly toward what would become dubstep
+
+- **El-B - "Buck & Bury"** (2001) -- Ghostly atmospherics, sparse percussion, and oppressive sub-bass from one of dark garage's most important architects; tracks like this formed the sonic bridge between UKG and early Croydon dubstep
+
+- **Disclosure feat. Sam Smith - "Latch"** (2012) -- 2-step rhythms repackaged for a new generation; Sam Smith's falsetto over skittering garage production brought UKG's DNA back to global pop consciousness and launched two careers simultaneously
+
+- **Interplanetary Criminal & Eliza Rose - "B.O.T.A. (Baddest of Them All)"** (2022) -- Reached UK #1, the first garage track to do so since "Sweet Like Chocolate" over two decades earlier; proof that the 2-step groove retains its power to move both underground and mainstream audiences

--- a/skills/mastering-engineer/genre-presets.md
+++ b/skills/mastering-engineer/genre-presets.md
@@ -131,6 +131,20 @@ Detailed mastering settings by genre.
 - Progressive math rock (Polyphia, CHON): cleaner production, more polished; treat like modern rock mastering with emphasis on guitar clarity
 - Bass guitar often carries melodic lines -- keep it defined and present, not buried or boomy
 
+### Death Metal
+**LUFS target**: -14 LUFS
+**Dynamics**: Heavy compression; sustain the wall-of-sound density without crushing blast beats; preserve kick drum articulation through double-bass passages
+**EQ focus**: Low-end tightness (60-200 Hz), vocal presence through the distortion wall (1-4 kHz), high-mid cut to tame guitar fizz (3-5 kHz), gentle high shelf cut for cymbal wash control
+**MCP command**: `master_audio(album_slug, genre="death-metal")`
+
+**Characteristics**:
+- Growled/guttural vocals sit inside the mix, not on top -- preserve intelligibility without pushing them artificially forward
+- Blast beats generate dense high-frequency content from cymbals; gentle high shelf cut (-1 dB at 8 kHz) prevents listening fatigue
+- Double bass drum patterns need kick definition at 60-80 Hz without mud; tight low-end essential
+- Tremolo-picked guitars create a wall of harmonic content in the 1-5 kHz range; cut harshness but preserve the aggression
+- Technical/progressive death metal benefits from slightly wider dynamics to showcase rhythmic complexity
+- Old-school death metal (Morbid Angel, Death style): warmer, less polished mastering; modern (Archspire style): tighter, more clinical
+
 ### Electronic / EDM
 **LUFS target**: -10 to -12 LUFS (can go louder)
 **Dynamics**: Heavy compression, consistent energy
@@ -141,6 +155,34 @@ Detailed mastering settings by genre.
 - Massive bass
 - Sustained energy
 - Bright, polished highs
+
+### Jungle
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate compression; preserve the chopped breakbeat dynamics and rapid-fire snare rolls; avoid squashing the rhythmic complexity that defines the genre
+**EQ focus**: Sub-bass weight (30-60 Hz), breakbeat clarity (2-5 kHz), gentle high-mid cut to tame cymbal harshness from time-stretched breaks
+**MCP command**: `master_audio(album_slug, genre="jungle")`
+
+**Characteristics**:
+- Chopped Amen breaks and other breakbeats are the genre's backbone -- preserve their dynamics and attack transients
+- Sub-bass must be deep and powerful (30-60 Hz) but separate from the breakbeat energy above
+- Ragga/MC vocals sit on top of dense rhythmic layers; vocal clarity at 2-4 kHz without harshness
+- Time-stretched and pitch-shifted breaks can introduce artifacts in the 4-8 kHz range; gentle cuts as needed
+- Reese bass (detuned sawtooth) occupies a wide low-mid range; keep it defined without muddying the breaks
+- Darkside jungle: heavier, darker treatment acceptable; liquid/intelligent jungle: cleaner, more spacious mastering
+
+### UK Garage
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate compression; preserve the shuffled 2-step groove and bass bounce; avoid flattening the syncopated swing that defines the rhythm
+**EQ focus**: Bass warmth and punch (60-150 Hz), vocal clarity (2-5 kHz), crisp hi-hat and percussion detail (8-12 kHz)
+**MCP command**: `master_audio(album_slug, genre="uk-garage")`
+
+**Characteristics**:
+- 2-step rhythm is syncopated and swing-based -- over-compression destroys the bounce and groove feel
+- Bass should be warm and round, not sub-heavy like dubstep; garage bass sits higher (60-150 Hz)
+- R&B-influenced vocals need warmth and presence without harshness; pitch-shifted vocals common
+- Crisp percussion (shakers, hi-hats, rim clicks) at 8-12 kHz drives the groove; preserve transient detail
+- Organ stabs and chopped vocal samples are signature elements; keep them punchy and defined
+- Speed garage variants can push slightly louder; 2-step house leans cleaner and more spacious
 
 ### Folk / Acoustic
 **LUFS target**: -14 to -16 LUFS
@@ -302,6 +344,90 @@ Detailed mastering settings by genre.
 - Uptempo praise tracks (-13 LUFS): more compression acceptable, emphasize kick and bass punch, brighter top end for energy
 - Live worship recordings may include audience/congregation — don't over-compress those ambient elements
 - Extended bridges and vamp sections should sustain energy without fatiguing; watch for harsh buildup in layered guitars and keys
+
+### Dub
+**LUFS target**: -14 LUFS
+**Dynamics**: Light-to-moderate compression; preserve the spaciousness and echo trails that define the genre; dub is built on subtraction, so headroom and decay space are essential
+**EQ focus**: Deep bass presence (40-80 Hz), warm mid-range (200-600 Hz), high-frequency rolloff for analog warmth, echo/delay preservation
+**MCP command**: `master_audio(album_slug, genre="dub")`
+
+**Characteristics**:
+- Bass is the foundation -- deep, heavy, and felt in the chest; must be powerful without distortion or muddiness
+- Echo, delay, and reverb are compositional tools, not effects -- over-compression collapses the spatial depth that defines dub
+- Mixing desk as instrument: drops, fades, and filter sweeps are intentional; preserve dynamic contrasts
+- Drums should have room and character; snare with spring reverb, kick with weight and space
+- High-frequency content is often rolled off for analog warmth; do not brighten or add presence
+- Roots dub (King Tubby, Lee Perry): warmer, lo-fi aesthetic; modern dub (Adrian Sherwood): can be more polished but still spacious
+
+### Cumbia
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate compression; preserve the rhythmic interplay between accordion/gaita and percussion; keep the shuffling cumbia rhythm bouncy and alive
+**EQ focus**: Accordion/gaita presence (800 Hz-3 kHz), bass warmth (80-200 Hz), guacharaca/percussion clarity (4-8 kHz)
+**MCP command**: `master_audio(album_slug, genre="cumbia")`
+
+**Characteristics**:
+- The shuffling cumbia rhythm is the genre's identity -- over-compression kills the dance groove
+- Accordion or gaita melodies need clear presence in the mid-range without harshness
+- Bass (electric or tuba depending on regional style) provides the harmonic foundation; keep it warm and defined
+- Percussion (guacharaca, tambora, congas) drives the rhythm; preserve transient clarity
+- Colombian cumbia: more acoustic, warmer treatment; digital cumbia/cumbia villera: louder, more compressed acceptable
+- Cumbia sonidera and Peruvian chicha: psychedelic elements (guitar effects, synths) need space in the mix
+
+### Samba
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate compression; preserve the polyrhythmic interplay between surdo, tamborim, and cavaquinho; avoid flattening the layered percussion dynamics
+**EQ focus**: Surdo depth (60-150 Hz), cavaquinho sparkle (2-6 kHz), vocal warmth (200-500 Hz), tamborim attack (3-5 kHz)
+**MCP command**: `master_audio(album_slug, genre="samba")`
+
+**Characteristics**:
+- Polyrhythmic percussion is the genre's core -- multiple percussion layers must remain distinct and articulate
+- Surdo (bass drum) provides the rhythmic foundation; deep and resonant at 60-150 Hz without boom
+- Cavaquinho (small guitar) sits in the upper register; preserve its bright, percussive attack
+- Vocal delivery ranges from intimate pagode to powerful samba-enredo; adjust compression accordingly
+- Samba-enredo (Carnival): can push louder, more energy, massive percussion sections need headroom
+- Bossa nova-influenced samba: gentler treatment, wider dynamics, more intimate production
+
+### Highlife
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate compression; preserve the interplay between guitar melodies and rhythmic patterns; keep the groove relaxed and flowing
+**EQ focus**: Guitar clarity and warmth (800 Hz-3 kHz), bass definition (80-200 Hz), horn presence (1-4 kHz), percussion articulation (4-8 kHz)
+**MCP command**: `master_audio(album_slug, genre="highlife")`
+
+**Characteristics**:
+- Interlocking guitar patterns are the genre's signature -- preserve note separation and clarity in the mid-range
+- Bass guitar carries melodic lines alongside rhythm; keep it warm, present, and clearly defined
+- Horn sections (trumpet, saxophone) add melodic color; clarity without harshness above 3 kHz
+- Percussion (congas, shakers, bells) provides polyrhythmic texture; preserve transient detail
+- Classic highlife (E.T. Mensah style): warmer, vintage-influenced mastering; modern highlife: cleaner, more polished
+- Afrobeat-influenced highlife: treat the extended groove sections with care, preserving the hypnotic quality
+
+### J-Pop
+**LUFS target**: -14 LUFS
+**Dynamics**: Moderate-to-heavy compression; J-Pop production is dense and polished; match the loudness expectations of the market while preserving vocal clarity
+**EQ focus**: Vocal presence and brightness (2-6 kHz), synth clarity (1-4 kHz), bass punch (60-100 Hz), sparkle on top (10-14 kHz)
+**MCP command**: `master_audio(album_slug, genre="j-pop")`
+
+**Characteristics**:
+- Vocals are the centerpiece -- bright, clear, and forward; J-Pop vocal production emphasizes clarity and sweetness
+- Dense arrangements with layered synths, guitars, and strings; each element needs space in a busy mix
+- Idol pop: brighter, more compressed, radio-ready; visual kei: treat more like rock/metal mastering
+- Vocaloid tracks: synthetic vocals need careful high-frequency management to avoid digital harshness
+- Anime opening/ending themes: dramatic builds and high energy; preserve dynamic impact of key moments
+- J-Pop masters tend to be louder than Western pop averages; -14 LUFS for streaming is appropriate but the mix density is high
+
+### City Pop
+**LUFS target**: -14 LUFS
+**Dynamics**: Light-to-moderate compression; preserve the smooth, polished production aesthetic; city pop's warmth comes from dynamic headroom and analog-style mastering
+**EQ focus**: Bass warmth and groove (60-200 Hz), vocal smoothness (2-4 kHz), synth/keyboard shimmer (4-8 kHz), gentle high-frequency air
+**MCP command**: `master_audio(album_slug, genre="city-pop")`
+
+**Characteristics**:
+- Warm, analog-sounding master preferred -- city pop's 1980s production aesthetic should carry through; avoid clinical digital brightness
+- Bass guitar and synth bass are melodic and groovy (funk/boogie influence); keep them warm, round, and present
+- Vocals should be smooth and intimate, sitting naturally in the mix; avoid harsh sibilance
+- Electric piano, synth pads, and strings provide lush harmonic beds; preserve their warmth without muddiness
+- Guitar work (jazz-influenced chord voicings, funky rhythm parts) needs clarity in the mid-range
+- The internet revival aesthetic appreciates the genre's vintage warmth -- do not over-modernize the sound
 
 ### Ska
 **LUFS target**: -14 LUFS

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -24,6 +24,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+  j-pop:
+    target_lufs: -14.0
+    cut_highmid: -1.0
+    cut_highs: 0
+  city-pop:
+    target_lufs: -14.0
+    cut_highmid: -1.0
+    cut_highs: 0
   hyperpop:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -182,6 +190,10 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
+  death-metal:
+    target_lufs: -14.0
+    cut_highmid: -3.0
+    cut_highs: -1.0
   metalcore:
     target_lufs: -14.0
     cut_highmid: -3.0
@@ -219,6 +231,14 @@ genres:
   drum-and-bass:
     target_lufs: -14.0
     cut_highmid: -1.5
+    cut_highs: 0
+  jungle:
+    target_lufs: -14.0
+    cut_highmid: -1.5
+    cut_highs: 0
+  uk-garage:
+    target_lufs: -14.0
+    cut_highmid: -1.0
     cut_highs: 0
   dubstep:
     target_lufs: -14.0
@@ -393,6 +413,22 @@ genres:
   latin:
     target_lufs: -14.0
     cut_highmid: -1.0
+    cut_highs: 0
+  cumbia:
+    target_lufs: -14.0
+    cut_highmid: -1.0
+    cut_highs: 0
+  samba:
+    target_lufs: -14.0
+    cut_highmid: -1.0
+    cut_highs: 0
+  highlife:
+    target_lufs: -14.0
+    cut_highmid: -1.0
+    cut_highs: 0
+  dub:
+    target_lufs: -14.0
+    cut_highmid: -1.5
     cut_highs: 0
   afrobeats:
     target_lufs: -14.0


### PR DESCRIPTION
## Summary

Batch addition of 9 genre entries to the genre library:

- **Death Metal** (`genres/death-metal/`) — extreme metal with growled vocals and blast beats
- **Jungle** (`genres/jungle/`) — UK breakbeat with chopped Amen breaks and sub-bass
- **UK Garage** (`genres/uk-garage/`) — syncopated 2-step dance music from late 1990s UK
- **Cumbia** (`genres/cumbia/`) — Colombian-origin dance music spanning Latin America
- **Samba** (`genres/samba/`) — Afro-Brazilian rhythmic music from Rio
- **Highlife** (`genres/highlife/`) — West African guitar music covering soukous connection
- **J-Pop** (`genres/j-pop/`) — Japanese pop spanning idol pop, visual kei, Vocaloid
- **City Pop** (`genres/city-pop/`) — Japanese 1980s funk/boogie with internet revival
- **Dub** (`genres/dub/`) — Jamaican remix/production genre; bass, echo, subtraction

All include full READMEs, INDEX updates, and mastering presets. Genre count: 82 → 91.

Closes #156, closes #157, closes #158, closes #159, closes #160, closes #161, closes #162, closes #163, closes #164

## Test plan
- [ ] Verify all 9 genre READMEs follow template structure
- [ ] Verify INDEX.md has all genres in category tables and Quick Reference
- [ ] Verify mastering presets YAML parses correctly
- [ ] Run `/bitwize-music:test all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)