### PR TITLE
feat: add lyric-refiner skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ At the beginning of a fresh session:
 
 ## Workflow Overview
 
-Concept → Research → Write (+Suno Prompt) → QC/Verify → Generate → [Polish] → Master → Promo Videos (optional) → Promo Copy (optional) → **Release**
+Concept → Research → Write (+Suno Prompt) → [Refine] → QC/Verify → Generate → [Polish] → Master → Promo Videos (optional) → Promo Copy (optional) → **Release**
 
 **Critical**: Research must complete before writing for source-based content. Human source verification is required before generation — never skip this gate.
 
@@ -140,6 +140,7 @@ Concept → Research → Write (+Suno Prompt) → QC/Verify → Generate → [Po
 - **Album mentioned** → `/bitwize-music:resume`
 - **"Make a new album"** → IMMEDIATELY use `/bitwize-music:new-album` BEFORE any discussion
 - **Writing lyrics** → apply `/bitwize-music:lyric-writer` expertise (auto-invokes suno-engineer)
+- **Refining/polishing lyrics** → `/bitwize-music:lyric-refiner` (post-writing multi-pass refinement)
 - **Planning album** → apply `/bitwize-music:album-conceptualizer` (7 planning phases required)
 - **Suno prompts** → apply `/bitwize-music:suno-engineer` expertise (usually auto-invoked by lyric-writer; use directly only for re-prompting)
 - **Research needed** → apply `/bitwize-music:researcher` standards

--- a/reference/SKILL_INDEX.md
+++ b/reference/SKILL_INDEX.md
@@ -31,6 +31,7 @@ Quick-reference guide for finding the right skill for any task.
 | I need to... | Use this skill |
 |--------------|----------------|
 | ...write lyrics for a track | `/lyric-writer` |
+| ...refine/polish lyrics after writing | `/lyric-refiner` |
 | ...check lyrics for pronunciation risks | `/pronunciation-specialist` |
 | ...run full QC before Suno generation | `/lyric-reviewer` |
 | ...run final pre-generation checkpoint | `/pre-generation-check` |
@@ -122,6 +123,7 @@ Quick-reference guide for finding the right skill for any task.
 | [`import-art`](/skills/import-art/SKILL.md) | Place album art in audio and content locations | Copying artwork to correct paths after creation |
 | [`import-audio`](/skills/import-audio/SKILL.md) | Move audio files to correct album location | Importing WAV files from Suno downloads |
 | [`import-track`](/skills/import-track/SKILL.md) | Move track .md files to correct album location | Importing track files from external sources |
+| [`lyric-refiner`](/skills/lyric-refiner/SKILL.md) | Multi-pass lyric refinement for tightening, cohesion, and album unity | Polishing lyrics after writing, before QC |
 | [`lyric-reviewer`](/skills/lyric-reviewer/SKILL.md) | QC gate before Suno generation (14-point checklist) | Final quality check before generating |
 | [`lyric-writer`](/skills/lyric-writer/SKILL.md) | Write or review lyrics with prosody and rhyme craft | Writing new lyrics or fixing existing ones |
 | [`mastering-engineer`](/skills/mastering-engineer/SKILL.md) | Audio mastering guidance, loudness optimization | Mastering tracks to -14 LUFS for streaming |
@@ -169,6 +171,7 @@ What to have ready before using each skill:
 | `/album-conceptualizer` | Album name and genre decided |
 | `/lyric-writer` | Track concept defined, sources captured (if documentary) |
 | `/pronunciation-specialist` | Lyrics written |
+| `/lyric-refiner` | Lyrics written (runs after lyric-writer, before QC) |
 | `/lyric-reviewer` | Lyrics complete, pronunciation checked |
 | `/voice-checker` | Lyrics written, lyric-reviewer passed |
 | `/pre-generation-check` | Lyrics written, pronunciation resolved, style prompt created (instrumental: only Style Box needed) |
@@ -194,6 +197,7 @@ What to have ready before using each skill:
 /new-album <name> <genre>
     -> /album-conceptualizer (plan concept, tracklist)
     -> /lyric-writer (for each track — auto-invokes /suno-engineer)
+    -> /lyric-refiner (optional: multi-pass refinement for tightening + album cohesion)
     -> /pronunciation-specialist (scan for risks)
     -> /lyric-reviewer (final QC)
     -> /voice-checker (advisory: flag AI-sounding patterns)
@@ -215,6 +219,7 @@ What to have ready before using each skill:
         -> /researchers-verifier (verify citations)
     -> /verify-sources (human source verification)
     -> /lyric-writer (write lyrics from sources — auto-invokes /suno-engineer)
+    -> /lyric-refiner (optional: multi-pass refinement for tightening + album cohesion)
     -> /pronunciation-specialist (names, places, acronyms)
     -> /lyric-reviewer (verify against sources)
     -> /pre-generation-check (validate all gates)
@@ -300,6 +305,7 @@ Natural pairings that complement each other:
 
 | Primary Skill | Pairs Well With | Why |
 |---------------|-----------------|-----|
+| `/lyric-writer` | `/lyric-refiner` | Refine after writing, before QC |
 | `/lyric-writer` | `/pronunciation-specialist` | Catch pronunciation issues immediately |
 | `/pronunciation-specialist` | `/lyric-reviewer` | Reviewer verifies pronunciation fixes applied correctly |
 | `/lyric-reviewer` | `/voice-checker` | Reviewer catches craft issues, voice-checker catches authenticity issues |
@@ -326,6 +332,7 @@ Redundant or conflicting combinations:
 | Avoid Combining | Reason |
 |-----------------|--------|
 | `/lyric-writer` + `/lyric-reviewer` (simultaneously) | Run separately: writer first, reviewer after pronunciation pass |
+| `/lyric-writer` + `/lyric-refiner` (simultaneously) | Run refiner after writer completes — refiner is a post-writing tool |
 | Multiple researcher specialists at once | Use `/researcher` to coordinate them instead |
 | `/mastering-engineer` before audio import | Need to generate on Suno and import audio first |
 | `/release-director` before `/mastering-engineer` | Audio must be mastered before release |
@@ -337,8 +344,9 @@ Redundant or conflicting combinations:
 
 Skills are assigned to models based on task complexity. See [model-strategy.md](model-strategy.md) for full rationale.
 
-### Opus 4.6 (Critical Creative Work — 6 skills)
+### Opus 4.6 (Critical Creative Work — 7 skills)
 - `/lyric-writer` - Core creative content
+- `/lyric-refiner` - Multi-pass lyric refinement and album cohesion
 - `/suno-engineer` - Music generation prompts
 - `/album-conceptualizer` - Album concept shapes everything downstream
 - `/lyric-reviewer` - QC gate before generation, must catch all issues

--- a/reference/model-strategy.md
+++ b/reference/model-strategy.md
@@ -7,7 +7,7 @@ This document explains the rationale for which Claude model is assigned to each 
 | Model | Strengths | Cost | When to Use |
 |-------|-----------|------|-------------|
 | **Opus 4.6** | Highest creative quality, nuanced judgment, complex synthesis | ~15x | Output directly impacts music quality; errors are costly |
-| **Sonnet 4.5** | Strong reasoning, good creativity, reliable coordination | ~5x | Most tasks; balance of capability and efficiency |
+| **Sonnet 4.6** | Strong reasoning, good creativity, reliable coordination | ~5x | Most tasks; balance of capability and efficiency |
 | **Haiku 4.5** | Fastest, pattern matching, rule-following | 1x | Simple operations; binary decisions; no judgment needed |
 
 ---
@@ -83,7 +83,7 @@ If the verifier misses something, errors reach the human reviewer or the public.
 
 ---
 
-## Sonnet 4.5 Skills (30 skills)
+## Sonnet 4.6 Skills (30 skills)
 
 These skills require reasoning and moderate creativity but follow established patterns.
 
@@ -253,7 +253,7 @@ Is it purely pattern matching, file operations, or static info?
 | Tier | Count | Percentage | Purpose |
 |------|-------|------------|---------|
 | Opus 4.6 | 7 | 13.2% | Music-defining output, high error cost |
-| Sonnet 4.5 | 30 | 58.8% | Reasoning, coordination, moderate creativity |
+| Sonnet 4.6 | 30 | 58.8% | Reasoning, coordination, moderate creativity |
 | Haiku 4.5 | 15 | 29.4% | Rule-based operations, no judgment |
 
 The plugin reserves Opus for skills where quality directly impacts the music or where errors have significant consequences. Most work happens at Sonnet tier. Haiku handles mechanical operations where speed matters more than nuance.

--- a/reference/model-strategy.md
+++ b/reference/model-strategy.md
@@ -12,7 +12,7 @@ This document explains the rationale for which Claude model is assigned to each 
 
 ---
 
-## Opus 4.5 Skills (6 skills)
+## Opus 4.5 Skills (7 skills)
 
 These skills directly impact music quality or have high error costs.
 
@@ -43,6 +43,16 @@ Bad style prompts = bad music. Every regeneration costs time. Getting it right t
 - Balancing artistic ambition with achievability
 
 A weak concept produces a weak album. Spending Opus here prevents wasted effort on a fundamentally flawed foundation.
+
+### lyric-refiner
+**Why Opus**: Multi-pass refinement requires the same creative depth as writing. This skill must:
+- Make nuanced judgment calls about what to tighten vs. preserve
+- Evaluate cross-track cohesion across an entire album's lyrics
+- Identify subtle vocabulary drift and tonal inconsistencies
+- Add callback phrases that feel organic, not forced
+- Balance competing concerns (tightening vs. preserving voice, cohesion vs. distinctiveness)
+
+Refinement is surgical — a weaker model might over-tighten, break voice consistency, or miss cohesion opportunities. The stakes are the same as writing: bad refinement degrades good lyrics.
 
 ### lyric-reviewer
 **Why Opus**: This is the quality gate before Suno generation. If issues slip through, they become embedded in the music. This skill requires:

--- a/reference/model-strategy.md
+++ b/reference/model-strategy.md
@@ -6,13 +6,13 @@ This document explains the rationale for which Claude model is assigned to each 
 
 | Model | Strengths | Cost | When to Use |
 |-------|-----------|------|-------------|
-| **Opus 4.5** | Highest creative quality, nuanced judgment, complex synthesis | ~15x | Output directly impacts music quality; errors are costly |
+| **Opus 4.6** | Highest creative quality, nuanced judgment, complex synthesis | ~15x | Output directly impacts music quality; errors are costly |
 | **Sonnet 4.5** | Strong reasoning, good creativity, reliable coordination | ~5x | Most tasks; balance of capability and efficiency |
 | **Haiku 4.5** | Fastest, pattern matching, rule-following | 1x | Simple operations; binary decisions; no judgment needed |
 
 ---
 
-## Opus 4.5 Skills (7 skills)
+## Opus 4.6 Skills (7 skills)
 
 These skills directly impact music quality or have high error costs.
 
@@ -252,7 +252,7 @@ Is it purely pattern matching, file operations, or static info?
 
 | Tier | Count | Percentage | Purpose |
 |------|-------|------------|---------|
-| Opus 4.5 | 6 | 11.8% | Music-defining output, high error cost |
+| Opus 4.6 | 7 | 13.2% | Music-defining output, high error cost |
 | Sonnet 4.5 | 30 | 58.8% | Reasoning, coordination, moderate creativity |
 | Haiku 4.5 | 15 | 29.4% | Rule-based operations, no judgment |
 

--- a/skills/lyric-refiner/SKILL.md
+++ b/skills/lyric-refiner/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: lyric-refiner
+description: Autonomous multi-pass lyric refinement for tightening, cohesion, and album unity. Use after lyrics are written to polish a track or entire album through iterative passes.
+argument-hint: <album-name | track-path> [--passes N]
+model: claude-opus-4-6
+prerequisites:
+  - lyric-writer
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - bitwize-music-mcp
+---
+
+## Your Task
+
+**Input**: $ARGUMENTS
+
+### Parse Arguments
+
+1. **Identify target scope**:
+   - If argument is an album name/slug → **album mode** (refine all tracks)
+   - If argument is a track file path → **single-track mode** (refine one track)
+2. **Parse pass count**: Look for `--passes N` (default: 3, minimum: 1, maximum: 5)
+   - If `--passes` > 5, warn: "Diminishing returns beyond 5 passes — capping at 5."
+
+### Resolve Album & Tracks
+
+1. Use `find_album(name)` MCP tool to locate the album
+2. Use `list_tracks(album_slug)` to get all tracks
+3. **Skip instrumental tracks** — check frontmatter for `instrumental: true` or Track Details for `**Instrumental** | Yes`
+4. For **album mode**: read ALL track lyrics before starting any refinement (full context needed for cohesion/unity passes)
+5. For **single-track mode**: still read all sibling tracks for cross-track context
+
+### Guard Clauses
+
+- **No lyrics found**: "No lyrics to refine — run `/lyric-writer` first."
+- **Track status `Not Started` or `Sources Pending`**: "Track isn't ready for refinement — lyrics must be written first."
+- **All tracks instrumental**: "No vocal tracks to refine."
+
+### Workflow
+
+Run all passes autonomously. No human checkpoints between passes.
+
+1. **Load override** — Call `load_override("lyric-writing-guide.md")` for user style preferences
+2. **Load album context** — Read album README (concept, motifs, themes, narrative arc)
+3. **Read all track lyrics** — Build full picture before touching anything
+4. **Execute passes** — Run each pass on every in-scope track sequentially
+5. **Report results** — Present consolidated refinement report
+
+---
+
+## Supporting Files
+
+- References lyric-writer's **[craft-reference.md](../lyric-writer/craft-reference.md)** — Refinement Pass Reference tables for tighten/strengthen/flow patterns
+- References lyric-writer's **[examples.md](../lyric-writer/examples.md)** — Before/after transformations
+
+---
+
+# Lyric Refiner Agent
+
+You are a lyric refinement specialist who polishes written lyrics through structured, iterative passes. You work autonomously — reading, refining, and reporting without stopping for approval between passes.
+
+You are NOT the lyric writer. You don't add new content, new sections, or new narrative beats. You take what exists and make it sharper, more cohesive, and more unified across the album.
+
+---
+
+## Core Principles
+
+- **Polish, don't rewrite** — The writer's voice and intent are sacred. You tighten and strengthen, never replace.
+- **Album-aware** — Every edit considers its impact on cross-track cohesion and album unity.
+- **Autonomous execution** — Run all passes without pausing. Report everything at the end.
+- **Diminishing returns awareness** — If a pass produces zero changes, stop early. Don't force edits.
+- **Respect hard limits** — Section length, word count, genre constraints, and pronunciation tables remain enforced after every edit.
+
+---
+
+## Pass Schedule
+
+Each pass has a distinct focus. Passes build on each other — tighten first, then check cohesion, then evaluate unity.
+
+### Pass 1: Tighten (Per-Track)
+
+Cut filler, compress language, eliminate redundancy. Every word must earn its place.
+
+**Focus areas:**
+- Filler phrases and throat-clearing openers
+- Redundant modifiers and double-saying
+- Passive voice → active voice
+- Pronoun-heavy lines with ambiguous references
+- Unnecessary prepositions and directional padding
+- Weak verbs → strong, specific verbs
+
+**Reference**: See lyric-writer's [craft-reference.md](../lyric-writer/craft-reference.md) → "Refinement Pass Reference → Pass 1: Tighten" for pattern tables.
+
+### Pass 2: Cohesion (Cross-Track)
+
+Ensure thematic consistency, voice continuity, and meaningful connections between tracks.
+
+**Focus areas:**
+- **Voice consistency** — POV, register, and tone should feel like the same narrator/world across tracks (unless intentional shifts are documented in the album concept)
+- **Motif reinforcement** — Check the album's Motifs & Threads table. Are established motifs being used effectively? Are there missed callback opportunities?
+- **Vocabulary drift** — Flag when tracks use contradictory language for the same concept (e.g., track 3 calls it "the signal" but track 7 says "the broadcast" for the same thing)
+- **Thematic progression** — Does each track advance the album's narrative or thematic arc? Flag tracks that feel disconnected from the album's throughline
+- **Callback quality** — Review existing cross-references. Are they subtle and earned, or heavy-handed? (See lyric-writer's Cross-Track Referencing rules)
+- **Tense/timeline consistency** — If the album follows a chronological narrative, verify tense usage aligns with timeline position
+
+**This pass may add or adjust callbacks** — this is the ONE exception to "no new content." Callbacks are connective tissue, not new ideas. Keep them to single phrases woven into existing lines, never new lines or sections.
+
+### Pass 3: Album Unity (Holistic)
+
+Step back and evaluate the album as a single body of work.
+
+**Focus areas:**
+- **Tonal arc** — Does the album's emotional trajectory make sense? Flag tracks that break the arc without justification
+- **Vocabulary palette** — Is the album's word choice cohesive? A cybercrime album shouldn't suddenly use pastoral imagery (unless intentional contrast)
+- **Hook distinctiveness** — Are all choruses/hooks distinct from each other? Flag any two hooks that are too similar in structure or phrasing
+- **Energy pacing** — Does the tracklist flow? Flag consecutive tracks with identical energy levels (all high-energy or all reflective with no variation)
+- **Opening/closing bookend** — Does the final track echo or resolve something from track 1? If not, flag the opportunity
+- **Repetition across tracks** — Flag any phrase, rhyme pair, or image that appears in multiple tracks unintentionally (intentional callbacks documented in Motifs & Threads are exempt)
+
+### Additional Passes (4–5, if requested)
+
+If the user requests more than 3 passes:
+
+| Pass | Focus | Goal |
+|------|-------|------|
+| 4 — Strengthen | Upgrade weak imagery, sharpen sensory detail, replace generic with specific | Lines that stick |
+| 5 — Flow & Ear | Read-aloud test, smooth transitions, singability at target BPM | Sounds right when sung |
+
+**Reference**: See lyric-writer's [craft-reference.md](../lyric-writer/craft-reference.md) → "Refinement Pass Reference → Pass 2: Strengthen" and "Pass 3: Flow & Ear" for pattern tables.
+
+---
+
+## Per-Pass Rules
+
+Every pass must follow these rules:
+
+1. **Run the 13-point quality check** (from lyric-writer) on every track after modifications. If new violations are introduced, fix them before moving to the next pass.
+2. **Preserve pronunciation table enforcement** — Never revert a phonetic spelling back to standard spelling. If editing a line with phonetic words, keep them phonetic.
+3. **Respect section length limits** — Edits must not push any section over its genre maximum.
+4. **Respect word count targets** — Track word count must stay within genre range for target duration.
+5. **Respect override preferences** — User's lyric-writing-guide.md preferences take precedence.
+6. **Early exit** — If a pass produces zero changes across all in-scope tracks, skip remaining passes and report: "Early exit after pass N — no further improvements found."
+
+---
+
+## Single-Track Mode
+
+When refining a single track:
+
+- Still read all sibling tracks for cross-track context (passes 2 and 3 need it)
+- Only modify the target track
+- Cohesion pass checks the target track's relationship to its siblings but doesn't edit siblings
+- Unity pass evaluates the target track's role in the album but doesn't edit siblings
+- Report focuses on the single track, with notes about album-level observations
+
+---
+
+## Album Mode
+
+When refining an entire album:
+
+- Read ALL tracks before starting any edits
+- Process tracks in order (01, 02, 03...) within each pass
+- Complete one full pass across all tracks before starting the next pass
+- Cross-reference changes made to earlier tracks when processing later tracks in the same pass
+- The cohesion and unity passes may flag issues that require changes to previously-processed tracks in the current pass — go back and fix them
+
+---
+
+## Refinement Report Format
+
+After all passes complete, present this consolidated report:
+
+```markdown
+# Lyric Refinement Report
+
+**Album**: [name]
+**Tracks refined**: X of Y (Z instrumental skipped)
+**Passes completed**: N of M requested
+**Date**: YYYY-MM-DD
+
+---
+
+## Summary
+
+- **Total changes**: X
+- **Pass 1 (Tighten)**: X changes across Y tracks
+- **Pass 2 (Cohesion)**: X changes across Y tracks
+- **Pass 3 (Unity)**: X changes across Y tracks
+- **Early exit**: Yes/No (after pass N)
+
+---
+
+## Pass 1: Tighten
+
+### Track 01: [title]
+| Line | Before | After | Reason |
+|------|--------|-------|--------|
+| V1 L3 | "He stood up and spoke the words" | "He said" | Filler phrase |
+| C L2 | "completely shattered apart" | "shattered" | Redundant modifier |
+
+### Track 02: [title]
+(no changes)
+
+---
+
+## Pass 2: Cohesion
+
+### Cross-Track Observations
+- Vocabulary drift: Track 03 uses "signal" but Track 07 uses "broadcast" for the same concept → standardized to "signal"
+- Added callback in Track 06 V2 referencing Track 02's "red door" motif
+
+### Track 03: [title]
+| Line | Before | After | Reason |
+|------|--------|-------|--------|
+| V2 L1 | "The broadcast faded out" | "The signal faded out" | Vocabulary consistency with Track 03 |
+
+### Track 06: [title]
+| Line | Before | After | Reason |
+|------|--------|-------|--------|
+| V2 L4 | "Another hallway, another lock" | "Another red door, another lock" | Callback to Track 02 motif |
+
+---
+
+## Pass 3: Unity
+
+### Album-Level Observations
+- Tonal arc: Tracks 04–06 all share reflective energy — consider if Track 05 could shift (flagged, not changed)
+- Bookend: Final track now echoes Track 01's opening image
+- No unintentional cross-track repetition found
+
+### Track 10: [title]
+| Line | Before | After | Reason |
+|------|--------|-------|--------|
+| C L1 | "Where it started, where it ends" | "Back to where the signal starts" | Bookend callback to Track 01 |
+
+---
+
+## Quality Check Results
+
+All tracks pass the 13-point quality check after refinement.
+
+(or: Track 03 has 1 warning — [details])
+```
+
+---
+
+## Override Support
+
+### Loading Override
+1. Call `load_override("lyric-writing-guide.md")` — returns override content if found
+2. If found: apply user preferences during all passes (vocabulary preferences, style rules, theme constraints)
+3. If not found: use base guidelines only
+
+Override preferences take precedence during refinement — if the user prefers "direct, simple language," don't strengthen imagery into elaborate metaphors.
+
+---
+
+## Integration Points
+
+### Before This Skill
+- `lyric-writer` — lyrics must exist before refinement
+- `suno-engineer` — style prompts should be written (refinement may affect lyrics that the style prompt references)
+
+### After This Skill
+- `pronunciation-specialist` — re-check pronunciation after refinement (edits may introduce new pronunciation risks)
+- `lyric-reviewer` — run QC to verify refinement didn't introduce issues
+- `pre-generation-check` — final gate before Suno generation
+
+### Workflow Position
+```
+lyric-writer (WRITES) → suno-engineer (STYLE) → lyric-refiner (POLISHES) → pronunciation-specialist → lyric-reviewer → pre-generation-check
+```
+
+---
+
+## Remember
+
+1. **Load override first** — Call `load_override("lyric-writing-guide.md")` at invocation
+2. **Read everything before editing anything** — Full album context is required for cohesion and unity passes
+3. **Polish, don't rewrite** — The writer's voice is sacred. Tighten and connect, never replace
+4. **Run autonomously** — No human checkpoints between passes. Report everything at the end
+5. **Early exit is good** — Zero changes means the lyrics are already tight. Don't force edits
+6. **Callbacks are the exception** — Pass 2 may add brief callback phrases. This is connective tissue, not new content
+7. **13-point check every pass** — Never let refinement introduce new quality violations
+8. **Pronunciation is untouchable** — Never revert phonetic spellings. If editing a line, keep phonetics intact
+9. **Album mode: order matters** — Process tracks in tracklist order, complete each pass fully before starting the next
+10. **Your deliverable**: Refined lyrics + consolidated refinement report showing every change and why


### PR DESCRIPTION
## Summary
- Adds new `lyric-refiner` skill for autonomous multi-pass lyric refinement (tighten → cohesion → album unity)
- Defaults to 3 passes, overridable up to 5 via `--passes N`
- Supports single-track and full-album modes, both with cross-track context awareness
- Updates SKILL_INDEX.md, model-strategy.md, and CLAUDE.md routing rules

## Test plan
- [ ] Verify skill appears in `/help` output
- [ ] Test single-track mode on an in-progress track
- [ ] Test album mode on an album with multiple written tracks
- [ ] Verify `--passes` override works (e.g., `--passes 1`, `--passes 5`)
- [ ] Confirm early exit behavior when no changes are found
- [ ] Run `/bitwize-music:test all` for full plugin validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)