### PR TITLE
feat: add per-genre exclude styles guidance

### DIFF
--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -324,6 +324,7 @@ Only mark track as "Generated" when output meets:
 - [ ] Mix balance (vocals not buried)
 - [ ] Structure follows tags
 - [ ] No awkward cuts or loops
+- [ ] No unwanted instruments/elements present (verify exclusions were effective)
 
 ---
 

--- a/skills/suno-engineer/genre-practices.md
+++ b/skills/suno-engineer/genre-practices.md
@@ -22,6 +22,10 @@ Male rapper, clear delivery, storytelling flow. Boom-bap hip-hop,
 - Piano, strings, vocal samples
 - Minimal (let vocals breathe)
 
+### Exclude Styles
+- Boom-bap: `no autotune, no synths`
+- Lo-fi: `no live drums, no electric guitar`
+
 ---
 
 ## Alternative Rock
@@ -42,6 +46,10 @@ Modern production with live energy.
 - Electric guitar (clean/distorted), bass, drums
 - Organ, keys (optional)
 - Live feel, energy
+
+### Exclude Styles
+- Acoustic version: `no electric guitar, no drums`
+- Stripped-down: `no synths, no backing vocals`
 
 ---
 
@@ -64,6 +72,10 @@ Atmospheric production, spacious reverb.
 - Programmed drums, sub-bass
 - Layers, textures, effects
 
+### Exclude Styles
+- Ambient: `no drums, no vocals`
+- Minimal: `no vocals, no acoustic instruments`
+
 ---
 
 ## Folk/Indie
@@ -85,6 +97,11 @@ Natural room sound, minimal production.
 - Upright bass, light percussion
 - Organic, room ambience
 
+### Exclude Styles
+- Sparse/intimate: `no drums, no electric instruments`
+- Solo acoustic: `no drums, no electric instruments, no harmony vocals`
+- Full band: `no synths, no electric guitar`
+
 ---
 
 ## Country
@@ -104,6 +121,10 @@ steel guitar, acoustic rhythm, walking bass. Classic Nashville production.
 - Steel guitar, fiddle, acoustic
 - Walking bass, light drums
 - Warm, organic
+
+### Exclude Styles
+- Traditional: `no electric instruments, no synths`
+- Acoustic: `no drums, no electric instruments`
 
 ---
 

--- a/skills/suno-engineer/genre-practices.md
+++ b/skills/suno-engineer/genre-practices.md
@@ -1,6 +1,6 @@
 # Genre-Specific Best Practices
 
-Detailed prompting strategies for each major genre.
+Example prompting strategies for common genres. These are starting points, not exhaustive rules — adapt to the track's specific arrangement, mood, and concept. Genres not listed here should be prompted using the same principles from SKILL.md.
 
 ---
 

--- a/skills/suno-engineer/genre-practices.md
+++ b/skills/suno-engineer/genre-practices.md
@@ -1,6 +1,6 @@
 # Genre-Specific Best Practices
 
-Example prompting strategies for common genres. These are starting points, not exhaustive rules — adapt to the track's specific arrangement, mood, and concept. Genres not listed here should be prompted using the same principles from SKILL.md.
+Example prompting strategies for common genres. These are starting points, not exhaustive rules — adapt to the track's specific arrangement, mood, and concept.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add "### Exclude Styles" subsections to all 5 genres in `genre-practices.md` with concrete instrument/element exclusions organized by arrangement type
- Add output-focused quality checklist item to `SKILL.md`: "No unwanted instruments/elements present (verify exclusions were effective)"

Closes #232

## Test plan

- [x] Verified existing negative prompting sections in SKILL.md unchanged (no duplication)
- [x] Exclusions use concrete instrument names, not abstract style preferences
- [x] Checklist item is output-focused to match existing checklist context

🤖 Generated with [Claude Code](https://claude.com/claude-code)