### PR TITLE
fix: detect stale plugin cache with missing/ghost skill registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,11 +74,14 @@ At the beginning of a fresh session:
    - If MCP missing → **Stop immediately** and suggest: `/bitwize-music:setup mcp`
    - If config missing → suggest: `/bitwize-music:configure`
    - Don't proceed with session start until setup is complete
-1.5. **Check venv health** — Use `check_venv_health` MCP tool:
-   - `status: "ok"` → continue silently
-   - `status: "stale"` → warn with mismatches and fix command, continue session
-   - `status: "no_venv"` → **stop** and suggest `/bitwize-music:setup`
-   - `status: "error"` → warn and continue
+1.5. **Health check** — Use `health_check` MCP tool (checks venv + skill registration):
+   - Venv `status: "ok"` → continue silently
+   - Venv `status: "stale"` → warn with mismatches and fix command, continue session
+   - Venv `status: "no_venv"` → **stop** and suggest `/bitwize-music:setup`
+   - Venv `status: "error"` → warn and continue
+   - Skills `status: "ok"` → continue silently
+   - Skills `status: "stale"` → warn with missing/ghost skill names and fix message, continue session
+   - Skills `status: "no_cache"` → warn (plugin may not be installed via marketplace), continue
 2. **Load config** — Read `~/.bitwize-music/config.yaml`. If missing, tell user to run `/bitwize-music:configure`.
 3. **Load overrides** — Check `paths.overrides` (default: `{content_root}/overrides`):
    - `{overrides}/CLAUDE.md` → incorporate instructions
@@ -97,7 +100,9 @@ At the beginning of a fresh session:
    - If versions match → no action
 5. _(Removed — run `/bitwize-music:skill-model-updater check` manually when new models are released)_
 6. **Report from MCP state**:
-   - Venv health warnings (from step 1.5 — omit if ok, warn if stale: "⚠️ Venv has N outdated package(s): pkg1 (1.0.0 → 1.1.0), ... Run: `~/.bitwize-music/venv/bin/pip install -r .../requirements.txt`")
+   - Health warnings (from step 1.5 — omit if ok):
+     - Venv stale: "⚠️ Venv has N outdated package(s): pkg1 (1.0.0 → 1.1.0), ... Run: `~/.bitwize-music/venv/bin/pip install -r .../requirements.txt`"
+     - Skills stale: "⚠️ N skill(s) missing from Claude Code, N ghost — run: `claude plugin update bitwize-music`"
    - Album ideas (from `get_ideas`)
    - In-progress albums (status: "In Progress", "Research Complete", "Complete")
    - Pending source verifications (from `get_pending_verifications(summary_only=True)`)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Then run `/bitwize-music:setup` to detect your environment and install dependenc
 
 This is where the engineering lives. The plugin is a case study in how far you can push Claude Code's plugin system.
 
-### Skill System (52 Skills)
+### Skill System (53 Skills)
 
 Each skill is a self-contained markdown file with a YAML frontmatter that declares its model, description, and when it should activate. Skills range from simple clipboard operations to multi-step creative workflows. Claude routes to skills automatically based on context, or you invoke them directly with `/bitwize-music:<name>`.
 

--- a/reference/SKILL_INDEX.md
+++ b/reference/SKILL_INDEX.md
@@ -13,6 +13,7 @@ Quick-reference guide for finding the right skill for any task.
 | ...set up the plugin for the first time | `/configure` |
 | ...learn how to use this plugin | `/tutorial` |
 | ...see what skills are available | `/help` |
+| ...check plugin health (venv, skill registration) | `/health-check` |
 | ...learn about the plugin creator | `/about` |
 
 ### Album Lifecycle
@@ -119,6 +120,7 @@ Quick-reference guide for finding the right skill for any task.
 | [`document-hunter`](/skills/document-hunter/SKILL.md) | Automated browser-based document search from free archives | Finding court docs for true-story albums |
 | [`explicit-checker`](/skills/explicit-checker/SKILL.md) | Scan lyrics for explicit content, verify flags | Ensuring explicit flags match actual content |
 | [`genre-creator`](/skills/genre-creator/SKILL.md) | Create new genre documentation with consistent structure | Adding a new genre to the genre library |
+| [`health-check`](/skills/health-check/SKILL.md) | Run plugin health checks (venv packages and skill registration) | Troubleshooting missing skills or stale packages |
 | [`help`](/skills/help/SKILL.md) | Show available skills and common workflows | Quick reference for what skills exist |
 | [`import-art`](/skills/import-art/SKILL.md) | Place album art in audio and content locations | Copying artwork to correct paths after creation |
 | [`import-audio`](/skills/import-audio/SKILL.md) | Move audio files to correct album location | Importing WAV files from Suno downloads |
@@ -379,10 +381,11 @@ Skills are assigned to models based on task complexity. See [model-strategy.md](
 - `/verify-sources` - Human verification gate
 - `/voice-checker` - Advisory review for AI-sounding patterns
 
-### Haiku 4.5 (Pattern Matching — 15 skills)
+### Haiku 4.5 (Pattern Matching — 16 skills)
 - `/about` - Static information
 - `/album-dashboard` - Progress dashboard
 - `/clipboard` - Copy to clipboard
+- `/health-check` - Plugin health checks
 - `/help` - Display information
 - `/import-art` - File operations
 - `/import-audio` - File operations

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -85,7 +85,7 @@ def _find_plugin_cache_dir() -> Path | None:
     return candidates[0]
 
 
-def _check_skill_registration() -> dict:
+def _check_skill_registration() -> dict[str, Any]:
     """Compare on-disk skills against the Claude Code plugin cache.
 
     Scans ``{PLUGIN_ROOT}/skills/*/SKILL.md`` for the canonical set of
@@ -138,7 +138,7 @@ def _check_skill_registration() -> dict:
 
     status = "ok" if not missing and not ghost else "stale"
 
-    result: dict = {
+    result: dict[str, Any] = {
         "status": status,
         "source_count": len(source_skills),
         "cached_count": len(cached_skills),

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -57,6 +57,107 @@ def _parse_requirements(path: Path) -> dict[str, str]:
     return result
 
 
+def _find_plugin_cache_dir() -> Path | None:
+    """Locate the Claude Code plugin cache directory for bitwize-music.
+
+    Scans ``~/.claude/plugins/cache/bitwize-music/`` for versioned
+    subdirectories and returns the one with the highest version number.
+    Returns ``None`` if no cache directory exists.
+    """
+    cache_base = Path.home() / ".claude" / "plugins" / "cache" / "bitwize-music"
+    if not cache_base.is_dir():
+        return None
+
+    # Walk one level: each child may be an org/name dir containing version dirs
+    candidates: list[Path] = []
+    for org_or_name in cache_base.iterdir():
+        if not org_or_name.is_dir():
+            continue
+        for version_dir in org_or_name.iterdir():
+            if version_dir.is_dir() and (version_dir / "skills").is_dir():
+                candidates.append(version_dir)
+
+    if not candidates:
+        return None
+
+    # Sort by directory name descending (version-ish sort) and pick latest
+    candidates.sort(key=lambda p: p.name, reverse=True)
+    return candidates[0]
+
+
+def _check_skill_registration() -> dict:
+    """Compare on-disk skills against the Claude Code plugin cache.
+
+    Scans ``{PLUGIN_ROOT}/skills/*/SKILL.md`` for the canonical set of
+    skill names, then compares against the cached copy at
+    ``~/.claude/plugins/cache/bitwize-music/*/skills/*/SKILL.md``.
+
+    Returns:
+        dict with status ("ok", "stale", "no_cache"), missing skills,
+        ghost skills, counts, cached version, and fix message.
+    """
+    assert _shared.PLUGIN_ROOT is not None
+
+    # Canonical skills from the plugin source
+    source_skills = {
+        p.parent.name
+        for p in (_shared.PLUGIN_ROOT / "skills").glob("*/SKILL.md")
+    }
+
+    # Find the plugin cache
+    cache_dir = _find_plugin_cache_dir()
+    if cache_dir is None:
+        return {
+            "status": "no_cache",
+            "message": "No Claude Code plugin cache found for bitwize-music",
+            "source_count": len(source_skills),
+            "fix_message": (
+                "Install or update the plugin: claude plugin update bitwize-music "
+                "— or use --plugin-dir for local development"
+            ),
+        }
+
+    cached_skills = {
+        p.parent.name
+        for p in (cache_dir / "skills").glob("*/SKILL.md")
+    }
+
+    missing = sorted(source_skills - cached_skills)
+    ghost = sorted(cached_skills - source_skills)
+    ok_count = len(source_skills & cached_skills)
+
+    # Read cached version from plugin.json
+    cached_version = None
+    cached_plugin_json = cache_dir / ".claude-plugin" / "plugin.json"
+    try:
+        if cached_plugin_json.exists():
+            data = json.loads(cached_plugin_json.read_text(encoding="utf-8"))
+            cached_version = data.get("version")
+    except (json.JSONDecodeError, OSError):
+        pass
+
+    status = "ok" if not missing and not ghost else "stale"
+
+    result: dict = {
+        "status": status,
+        "source_count": len(source_skills),
+        "cached_count": len(cached_skills),
+        "ok_count": ok_count,
+        "missing": missing,
+        "ghost": ghost,
+        "cached_version": cached_version,
+        "cache_path": str(cache_dir),
+    }
+
+    if status == "stale":
+        result["fix_message"] = (
+            "Plugin cache is stale — run: claude plugin update bitwize-music "
+            "— or use --plugin-dir for local development"
+        )
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Tool functions
 # ---------------------------------------------------------------------------
@@ -164,6 +265,78 @@ async def check_venv_health() -> str:
         )
 
     return _safe_json(result)
+
+
+async def health_check() -> str:
+    """Run startup health checks: venv packages and skill registration.
+
+    Combines check_venv_health and skill registration checks into a
+    single call for session startup. Use this instead of calling
+    check_venv_health directly during session start.
+
+    Returns:
+        JSON with overall status ("ok", "warn", "fail"), per-check
+        summaries, and raw results for venv and skills.
+    """
+    checks: list[dict[str, Any]] = []
+
+    # --- Venv check ---
+    venv_raw = json.loads(await check_venv_health())
+    venv_status = venv_raw.get("status", "error")
+    if venv_status == "ok":
+        checks.append({"name": "venv", "status": "ok",
+                        "detail": f"{venv_raw.get('checked', 0)} packages verified"})
+    elif venv_status == "stale":
+        parts = []
+        if venv_raw.get("mismatches"):
+            parts.append(f"{len(venv_raw['mismatches'])} outdated")
+        if venv_raw.get("missing"):
+            parts.append(f"{len(venv_raw['missing'])} missing")
+        checks.append({"name": "venv", "status": "warn",
+                        "detail": ", ".join(parts),
+                        "fix": venv_raw.get("fix_command")})
+    elif venv_status == "no_venv":
+        checks.append({"name": "venv", "status": "fail",
+                        "detail": "Venv not found at ~/.bitwize-music/venv"})
+    else:
+        checks.append({"name": "venv", "status": "fail",
+                        "detail": venv_raw.get("message", venv_status)})
+
+    # --- Skill registration check ---
+    skills_raw = _check_skill_registration()
+    skills_status = skills_raw.get("status", "error")
+    if skills_status == "ok":
+        checks.append({"name": "skills", "status": "ok",
+                        "detail": f"{skills_raw.get('ok_count', 0)} skills registered"})
+    elif skills_status == "stale":
+        parts = []
+        if skills_raw.get("missing"):
+            parts.append(f"{len(skills_raw['missing'])} missing: {', '.join(skills_raw['missing'])}")
+        if skills_raw.get("ghost"):
+            parts.append(f"{len(skills_raw['ghost'])} ghost: {', '.join(skills_raw['ghost'])}")
+        checks.append({"name": "skills", "status": "warn",
+                        "detail": "; ".join(parts),
+                        "fix": skills_raw.get("fix_message")})
+    elif skills_status == "no_cache":
+        checks.append({"name": "skills", "status": "warn",
+                        "detail": "No plugin cache found",
+                        "fix": skills_raw.get("fix_message")})
+
+    # --- Overall status ---
+    statuses = [c["status"] for c in checks]
+    if "fail" in statuses:
+        overall = "fail"
+    elif "warn" in statuses:
+        overall = "warn"
+    else:
+        overall = "ok"
+
+    return _safe_json({
+        "status": overall,
+        "checks": checks,
+        "venv": venv_raw,
+        "skills": skills_raw,
+    })
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +529,25 @@ async def diagnose() -> str:
         checks.append({"name": "venv", "status": "fail",
                         "detail": venv_result.get("message", venv_status)})
 
+    # Add skill registration check
+    skills_result = _check_skill_registration()
+    skills_status = skills_result.get("status", "error")
+    if skills_status == "ok":
+        checks.append({"name": "skills", "status": "ok",
+                        "detail": f"{skills_result.get('ok_count', 0)} skills registered"})
+    elif skills_status == "stale":
+        parts = []
+        if skills_result.get("missing"):
+            parts.append(f"{len(skills_result['missing'])} missing")
+        if skills_result.get("ghost"):
+            parts.append(f"{len(skills_result['ghost'])} ghost")
+        checks.append({"name": "skills", "status": "warn",
+                        "detail": ", ".join(parts),
+                        "fix": skills_result.get("fix_message")})
+    else:
+        checks.append({"name": "skills", "status": "warn",
+                        "detail": skills_result.get("message", skills_status)})
+
     # Add version check
     version_result = json.loads(await get_plugin_version())
     if version_result.get("needs_upgrade"):
@@ -389,7 +581,8 @@ async def diagnose() -> str:
 # ---------------------------------------------------------------------------
 
 def register(mcp: Any) -> None:
-    """Register plugin version, venv health, and diagnostic tools."""
+    """Register plugin version, health check, venv, and diagnostic tools."""
     mcp.tool()(get_plugin_version)
     mcp.tool()(check_venv_health)
+    mcp.tool()(health_check)
     mcp.tool()(diagnose)

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -454,6 +454,7 @@ from handlers.health import (  # noqa: F401
     check_venv_health,
     diagnose,
     get_plugin_version,
+    health_check,
 )
 
 # Ideas tools

--- a/skills/about/SKILL.md
+++ b/skills/about/SKILL.md
@@ -18,4 +18,6 @@ I'm bitwize—a hacker who loves music and experimenting with new technology. Wh
 
 **Behind the Music:** https://www.bitwizemusic.com/behind-the-music/
 
+**Discord:** https://discord.gg/dMURByGF
+
 **Share What You Make:** Tag [@bitwizemusic](https://x.com/bitwizemusic) on X/Twitter with anything interesting you create!

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -14,7 +14,7 @@ Run the `health_check` MCP tool and report results to the user.
 
 ## Workflow
 
-1. Call the `health_check` MCP tool
+1. Call the `health_check` MCP tool via the bitwize-music-mcp tool interface — do NOT use Bash, python, or any CLI command
 2. Report results clearly using the format below
 
 ## Report Format

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -3,6 +3,7 @@ name: health-check
 description: Runs plugin health checks (venv packages and skill registration). Use when the user asks to check plugin health, verify setup, or troubleshoot missing skills.
 model: claude-haiku-4-5-20251001
 allowed-tools:
+  - ToolSearch
   - bitwize-music-mcp
 ---
 
@@ -14,8 +15,11 @@ Run the `health_check` MCP tool and report results to the user.
 
 ## Workflow
 
-1. Call the `health_check` MCP tool via the bitwize-music-mcp tool interface — do NOT use Bash, python, or any CLI command
-2. Report results clearly using the format below
+**IMPORTANT: Do NOT use Bash for any step. Use only the tools listed below.**
+
+1. Use the `ToolSearch` tool with query `select:mcp__plugin_bitwize-music_bitwize-music-mcp__health_check` to load the MCP tool schema
+2. Call `mcp__plugin_bitwize-music_bitwize-music-mcp__health_check` (the MCP tool, not a CLI command)
+3. Report results clearly using the format below
 
 ## Report Format
 

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: health-check
+description: Runs plugin health checks (venv packages and skill registration). Use when the user asks to check plugin health, verify setup, or troubleshoot missing skills.
+model: claude-haiku-4-5-20251001
+allowed-tools:
+  - bitwize-music-mcp
+---
+
+# Health Check
+
+## Your Task
+
+Run the `health_check` MCP tool and report results to the user.
+
+## Workflow
+
+1. Call the `health_check` MCP tool
+2. Report results clearly using the format below
+
+## Report Format
+
+### All OK
+
+```
+HEALTH CHECK: OK
+  Venv: N packages verified
+  Skills: N skills registered
+```
+
+### Warnings
+
+```
+HEALTH CHECK: WARN
+
+VENV [warn]
+  N outdated: pkg1 (1.0 -> 1.1), pkg2 (2.0 -> 2.1)
+  N missing: pkg3, pkg4
+  Fix: ~/.bitwize-music/venv/bin/pip install -r .../requirements.txt
+
+SKILLS [warn]
+  N missing from Claude Code: skill-a, skill-b
+  N ghost (deleted but cached): skill-c
+  Fix: claude plugin update bitwize-music
+
+For comprehensive diagnostics, run the `diagnose` MCP tool.
+```
+
+### Failure
+
+```
+HEALTH CHECK: FAIL
+
+VENV [fail]
+  Venv not found at ~/.bitwize-music/venv
+  Fix: /bitwize-music:setup
+```
+
+## Remember
+
+1. **Be concise** — this is a status report
+2. **Show fix commands** — always include the fix command when status is not ok
+3. **Suggest diagnose** — if warnings are found, mention `diagnose` MCP tool for deeper checks

--- a/skills/session-start/SKILL.md
+++ b/skills/session-start/SKILL.md
@@ -36,6 +36,21 @@ Quick dependency check:
 - If config missing (`~/.bitwize-music/config.yaml` doesn't exist): suggest `/bitwize-music:configure`
 - Don't proceed until setup is complete
 
+## Step 1.5: Health Check
+
+Use the `health_check` MCP tool (checks venv packages + skill registration in one call):
+
+**Venv results** (from `result.venv`):
+- `status: "ok"` → continue silently
+- `status: "stale"` → warn with mismatches and fix command, continue session
+- `status: "no_venv"` → **stop** and suggest `/bitwize-music:setup`
+- `status: "error"` → warn and continue
+
+**Skill registration results** (from `result.skills`):
+- `status: "ok"` → continue silently
+- `status: "stale"` → warn: list missing and ghost skill names, show fix message
+- `status: "no_cache"` → warn that plugin cache not found, continue
+
 ## Step 2: Load Config
 
 Read `~/.bitwize-music/config.yaml`.
@@ -138,6 +153,7 @@ SESSION START
 =============
 
 Setup: MCP ready, config loaded
+Health: [venv ok, skills ok | warnings listed]
 Overrides: [loaded from {path} | not found (optional)]
 State: [loaded | rebuilt | error]
 

--- a/tests/plugin/test_skills.py
+++ b/tests/plugin/test_skills.py
@@ -314,3 +314,73 @@ class TestSkillIndex:
                 missing.append(skill_name)
 
         assert not missing, f"Skills not in SKILL_INDEX.md: {', '.join(missing)}"
+
+
+class TestSkillRegistrationIntegrity:
+    """On-disk skills must match the Claude Code plugin cache (#234)."""
+
+    @pytest.mark.xfail(reason="Stale plugin cache — run: claude plugin update bitwize-music (#234)", strict=False)
+    def test_no_ghost_skills_in_cache(self, skills_dir):
+        """Skills in plugin cache but not on disk are ghost registrations."""
+        from pathlib import Path
+        cache_base = Path.home() / ".claude" / "plugins" / "cache" / "bitwize-music"
+        if not cache_base.is_dir():
+            pytest.skip("No plugin cache found (plugin not installed via marketplace)")
+
+        source_skills = {
+            p.parent.name for p in skills_dir.glob("*/SKILL.md")
+        }
+
+        # Find all cached version directories
+        ghost = set()
+        for org_or_name in cache_base.iterdir():
+            if not org_or_name.is_dir():
+                continue
+            for version_dir in org_or_name.iterdir():
+                cache_skills_dir = version_dir / "skills"
+                if not cache_skills_dir.is_dir():
+                    continue
+                cached = {p.parent.name for p in cache_skills_dir.glob("*/SKILL.md")}
+                ghost |= cached - source_skills
+
+        assert not ghost, (
+            f"Ghost skills in plugin cache (deleted but still cached): "
+            f"{', '.join(sorted(ghost))} — run: claude plugin update bitwize-music"
+        )
+
+    @pytest.mark.xfail(reason="Stale plugin cache — run: claude plugin update bitwize-music (#234)", strict=False)
+    def test_no_missing_skills_in_cache(self, skills_dir):
+        """Skills on disk must also be present in the plugin cache."""
+        from pathlib import Path
+        cache_base = Path.home() / ".claude" / "plugins" / "cache" / "bitwize-music"
+        if not cache_base.is_dir():
+            pytest.skip("No plugin cache found (plugin not installed via marketplace)")
+
+        source_skills = {
+            p.parent.name for p in skills_dir.glob("*/SKILL.md")
+        }
+
+        # Find the latest cached version
+        candidates = []
+        for org_or_name in cache_base.iterdir():
+            if not org_or_name.is_dir():
+                continue
+            for version_dir in org_or_name.iterdir():
+                if version_dir.is_dir() and (version_dir / "skills").is_dir():
+                    candidates.append(version_dir)
+
+        if not candidates:
+            pytest.skip("No cached plugin versions found")
+
+        candidates.sort(key=lambda p: p.name, reverse=True)
+        latest_cache = candidates[0]
+        cached_skills = {
+            p.parent.name
+            for p in (latest_cache / "skills").glob("*/SKILL.md")
+        }
+
+        missing = source_skills - cached_skills
+        assert not missing, (
+            f"Skills on disk but missing from plugin cache (v{latest_cache.name}): "
+            f"{', '.join(sorted(missing))} — run: claude plugin update bitwize-music"
+        )

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -7048,6 +7048,266 @@ class TestCheckVenvHealth:
 
 
 # =============================================================================
+# Tests for _check_skill_registration
+# =============================================================================
+
+
+class TestCheckSkillRegistration:
+    """Tests for the _check_skill_registration() helper."""
+
+    def _setup_skills(self, tmp_path, source_skills, cached_skills,
+                      cached_version="0.89.0"):
+        """Create source and cache skill directories for testing."""
+        # Source skills in PLUGIN_ROOT
+        plugin_root = tmp_path / "plugin"
+        skills_dir = plugin_root / "skills"
+        skills_dir.mkdir(parents=True)
+        for name in source_skills:
+            skill_dir = skills_dir / name
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        # Cache directory
+        cache_dir = (tmp_path / "fakehome" / ".claude" / "plugins" / "cache"
+                     / "bitwize-music" / "bitwize-music" / cached_version)
+        cache_skills_dir = cache_dir / "skills"
+        cache_skills_dir.mkdir(parents=True)
+        for name in cached_skills:
+            skill_dir = cache_skills_dir / name
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        # Write plugin.json in cache
+        plugin_json_dir = cache_dir / ".claude-plugin"
+        plugin_json_dir.mkdir(parents=True)
+        (plugin_json_dir / "plugin.json").write_text(
+            json.dumps({"version": cached_version})
+        )
+
+        return plugin_root
+
+    def test_all_match_returns_ok(self, tmp_path):
+        """All skills matching returns status ok."""
+        skills = ["lyric-writer", "resume", "test"]
+        plugin_root = self._setup_skills(tmp_path, skills, skills)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = _health_mod._check_skill_registration()
+        assert result["status"] == "ok"
+        assert result["ok_count"] == 3
+        assert result["missing"] == []
+        assert result["ghost"] == []
+
+    def test_missing_skills_returns_stale(self, tmp_path):
+        """Skills on disk but not in cache are reported as missing."""
+        source = ["lyric-writer", "lyric-refiner", "voice-checker"]
+        cached = ["lyric-writer"]
+        plugin_root = self._setup_skills(tmp_path, source, cached)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = _health_mod._check_skill_registration()
+        assert result["status"] == "stale"
+        assert "lyric-refiner" in result["missing"]
+        assert "voice-checker" in result["missing"]
+        assert result["ok_count"] == 1
+
+    def test_ghost_skills_returns_stale(self, tmp_path):
+        """Skills in cache but not on disk are reported as ghost."""
+        source = ["lyric-writer"]
+        cached = ["lyric-writer", "ship"]
+        plugin_root = self._setup_skills(tmp_path, source, cached)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = _health_mod._check_skill_registration()
+        assert result["status"] == "stale"
+        assert result["ghost"] == ["ship"]
+        assert result["ok_count"] == 1
+
+    def test_mixed_missing_and_ghost(self, tmp_path):
+        """Both missing and ghost skills detected."""
+        source = ["lyric-writer", "voice-checker"]
+        cached = ["lyric-writer", "ship"]
+        plugin_root = self._setup_skills(tmp_path, source, cached)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = _health_mod._check_skill_registration()
+        assert result["status"] == "stale"
+        assert result["missing"] == ["voice-checker"]
+        assert result["ghost"] == ["ship"]
+        assert result["ok_count"] == 1
+
+    def test_no_cache_returns_no_cache(self, tmp_path):
+        """No plugin cache directory returns no_cache status."""
+        plugin_root = tmp_path / "plugin"
+        skills_dir = plugin_root / "skills"
+        skills_dir.mkdir(parents=True)
+        skill_dir = skills_dir / "test-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+
+        # fakehome with no .claude directory
+        fakehome = tmp_path / "fakehome"
+        fakehome.mkdir()
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome):
+            result = _health_mod._check_skill_registration()
+        assert result["status"] == "no_cache"
+        assert result["source_count"] == 1
+
+    def test_cached_version_reported(self, tmp_path):
+        """Cached plugin version is included in result."""
+        skills = ["test-skill"]
+        plugin_root = self._setup_skills(tmp_path, skills, skills,
+                                         cached_version="0.69.0")
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = _health_mod._check_skill_registration()
+        assert result["cached_version"] == "0.69.0"
+
+    def test_fix_message_on_stale(self, tmp_path):
+        """Stale result includes a fix message."""
+        source = ["lyric-writer", "new-skill"]
+        cached = ["lyric-writer"]
+        plugin_root = self._setup_skills(tmp_path, source, cached)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = _health_mod._check_skill_registration()
+        assert "fix_message" in result
+        assert "claude plugin update" in result["fix_message"]
+
+
+# =============================================================================
+# Tests for health_check
+# =============================================================================
+
+
+class TestHealthCheck:
+    """Tests for the health_check() MCP tool."""
+
+    def test_all_ok(self, tmp_path):
+        """Both venv and skills ok returns overall ok."""
+        # Set up matching skills
+        plugin_root = tmp_path / "plugin"
+        skills_dir = plugin_root / "skills"
+        skills_dir.mkdir(parents=True)
+        skill_dir = skills_dir / "test-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+
+        cache_dir = (tmp_path / "fakehome" / ".claude" / "plugins" / "cache"
+                     / "bitwize-music" / "bitwize-music" / "1.0.0")
+        cache_skills_dir = cache_dir / "skills" / "test-skill"
+        cache_skills_dir.mkdir(parents=True)
+        (cache_skills_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+        pj = cache_dir / ".claude-plugin"
+        pj.mkdir(parents=True)
+        (pj / "plugin.json").write_text('{"version": "1.0.0"}')
+
+        # Set up venv
+        req = plugin_root / "requirements.txt"
+        req.write_text("requests==2.31.0\n")
+        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "python3").touch()
+
+        def mock_version(pkg):
+            if pkg == "requests":
+                return "2.31.0"
+            raise importlib.metadata.PackageNotFoundError(pkg)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch("importlib.metadata.version", side_effect=mock_version), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["status"] == "ok"
+        assert len(result["checks"]) == 2
+        assert result["checks"][0]["name"] == "venv"
+        assert result["checks"][0]["status"] == "ok"
+        assert result["checks"][1]["name"] == "skills"
+        assert result["checks"][1]["status"] == "ok"
+
+    def test_stale_skills_returns_warn(self, tmp_path):
+        """Stale skills with ok venv returns overall warn."""
+        # Source has extra skill not in cache
+        plugin_root = tmp_path / "plugin"
+        skills_dir = plugin_root / "skills"
+        for name in ("existing", "new-skill"):
+            d = skills_dir / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        cache_dir = (tmp_path / "fakehome" / ".claude" / "plugins" / "cache"
+                     / "bitwize-music" / "bitwize-music" / "1.0.0")
+        cache_skill = cache_dir / "skills" / "existing"
+        cache_skill.mkdir(parents=True)
+        (cache_skill / "SKILL.md").write_text("---\nname: existing\n---\n")
+        pj = cache_dir / ".claude-plugin"
+        pj.mkdir(parents=True)
+        (pj / "plugin.json").write_text('{"version": "1.0.0"}')
+
+        # Venv ok
+        req = plugin_root / "requirements.txt"
+        req.write_text("requests==2.31.0\n")
+        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "python3").touch()
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch("importlib.metadata.version", return_value="2.31.0"), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["status"] == "warn"
+        skills_check = result["checks"][1]
+        assert skills_check["status"] == "warn"
+        assert "new-skill" in skills_check["detail"]
+
+    def test_no_venv_returns_fail(self, tmp_path):
+        """Missing venv returns overall fail."""
+        plugin_root = tmp_path / "plugin"
+        skills_dir = plugin_root / "skills"
+        skills_dir.mkdir(parents=True)
+
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+        # No venv
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["status"] == "fail"
+        assert result["checks"][0]["name"] == "venv"
+        assert result["checks"][0]["status"] == "fail"
+
+    def test_raw_results_included(self, tmp_path):
+        """Raw venv and skills results are included for direct access."""
+        plugin_root = tmp_path / "plugin"
+        skills_dir = plugin_root / "skills"
+        skills_dir.mkdir(parents=True)
+
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert "venv" in result
+        assert "skills" in result
+        assert "status" in result["venv"]
+        assert "status" in result["skills"]
+
+
+# =============================================================================
 # Tests for create_idea
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Closes #234

- Add `health_check` MCP tool that combines venv health + skill registration checks into a single session-start call
- Add `_check_skill_registration()` helper that compares on-disk `skills/*/SKILL.md` against `~/.claude/plugins/cache/bitwize-music/*/skills/` to detect missing and ghost skills
- Integrate skill registration check into `diagnose()` comprehensive health check
- Update session-start skill and CLAUDE.md to use `health_check` instead of standalone `check_venv_health`
- Add 11 unit tests (7 for skill registration, 4 for health_check) — all pass
- Add 2 plugin-level tests for cache integrity (`xfail` since cache is external state)

## Root cause

Claude Code caches plugins at install time. The cached version (0.69.0) was missing 3 skills added after install (`lyric-refiner`, `voice-checker`, `genre-creator`) and still had 1 deleted skill (`ship`). The plugin had no mechanism to detect this drift.

## Test plan

- [x] `pytest tests/unit/state/test_server.py -k "TestCheckSkillRegistration or TestHealthCheck"` — 11 passed
- [x] `pytest tests/plugin/test_skills.py -k "TestSkillRegistrationIntegrity"` — 2 xfailed (correctly detects stale cache)
- [x] `pytest tests/` — 2838 passed, 2 xfailed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)