### PR TITLE
refactor: extract hardcoded mastering params into configurable presets

### DIFF
--- a/config/overrides.example/mastering-presets.yaml
+++ b/config/overrides.example/mastering-presets.yaml
@@ -5,9 +5,20 @@
 # Only specify fields you want to change — unset fields inherit from built-in.
 #
 # Fields per genre:
-#   target_lufs  - Loudness target in LUFS (e.g., -14.0)
-#   cut_highmid  - EQ cut in dB at 3.5kHz (negative = cut, 0 = none)
-#   cut_highs    - High shelf cut in dB at 8kHz (negative = cut, 0 = none)
+#   target_lufs        - Loudness target in LUFS (e.g., -14.0)
+#   cut_highmid        - EQ cut in dB at eq_highmid_freq (negative = cut, 0 = none)
+#   cut_highs          - High shelf cut in dB at eq_highs_freq (negative = cut, 0 = none)
+#   compress_ratio     - Compression ratio (1.0 = bypass, default 1.5)
+#   compress_threshold - Compression threshold in dB (default -18.0)
+#   compress_attack    - Compression attack in ms (default 30.0)
+#   compress_release   - Compression release in ms (default 200.0)
+#   eq_highmid_freq    - High-mid EQ center frequency in Hz (default 3500.0)
+#   eq_highmid_q       - High-mid EQ Q factor (default 1.5)
+#   eq_highs_freq      - High shelf frequency in Hz (default 8000.0)
+#   eq_highs_q         - High shelf Q factor (default 0.7)
+#
+# dither_bits can only be set in defaults (not per-genre):
+#   dither_bits        - Output bit depth (default 16)
 
 genres:
   # Example: override rock to be less aggressive
@@ -24,8 +35,15 @@ genres:
   # ambient:
   #   target_lufs: -18.0       # Override default -16
 
+  # Example: tweak compression for a genre
+  # hip-hop:
+  #   compress_ratio: 2.5      # Heavier compression
+  #   compress_threshold: -15.0
+  #   compress_attack: 10.0    # Faster attack for punch
+
 # Default settings (applied when no genre is specified)
 # defaults:
 #   target_lufs: -14.0         # Streaming standard
 #   cut_highmid: 0
 #   cut_highs: 0
+#   dither_bits: 24            # 24-bit output for archival

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -249,15 +249,15 @@ async def master_audio(
                 "error": f"Unknown genre: {genre}",
                 "available_genres": sorted(presets.keys()),
             })
-        preset_lufs, preset_highmid, preset_highs, preset_compress = presets[genre_key]
+        preset = presets[genre_key]
         # Genre preset provides defaults; explicit non-default args override
         if target_lufs == -14.0:
-            effective_lufs = preset_lufs
+            effective_lufs = preset['target_lufs']
         if cut_highmid == 0.0:
-            effective_highmid = preset_highmid
+            effective_highmid = preset['cut_highmid']
         if cut_highs == 0.0:
-            effective_highs = preset_highs
-        effective_compress = preset_compress
+            effective_highs = preset['cut_highs']
+        effective_compress = preset['compress_ratio']
         genre_applied = genre_key
 
     # Build EQ settings
@@ -657,14 +657,14 @@ async def master_album(
                     "available_genres": sorted(presets.keys()),
                 },
             })
-        preset_lufs, preset_highmid, preset_highs, preset_compress = presets[genre_key]
+        preset = presets[genre_key]
         if target_lufs == -14.0:
-            effective_lufs = preset_lufs
+            effective_lufs = preset['target_lufs']
         if cut_highmid == 0.0:
-            effective_highmid = preset_highmid
+            effective_highmid = preset['cut_highmid']
         if cut_highs == 0.0:
-            effective_highs = preset_highs
-        effective_compress = preset_compress
+            effective_highs = preset['cut_highs']
+        effective_compress = preset['compress_ratio']
         genre_applied = genre_key
 
     settings = {

--- a/skills/mastering-engineer/SKILL.md
+++ b/skills/mastering-engineer/SKILL.md
@@ -91,26 +91,32 @@ Check for custom mastering presets:
 
 genres:
   dark-electronic:
-    cut_highmid: -3  # More aggressive cut
-    boost_sub: 2     # More sub bass
-    target_lufs: -12 # Louder master
+    cut_highmid: -3         # More aggressive cut
+    target_lufs: -12        # Louder master
+    compress_ratio: 2.0     # Heavier compression
+    compress_attack: 15.0   # Faster attack
 
   ambient:
-    cut_highmid: -1  # Gentle cut
-    boost_sub: 0     # Natural bass
-    target_lufs: -16 # Quieter, more dynamic
+    cut_highmid: -1         # Gentle cut
+    target_lufs: -16        # Quieter, more dynamic
+    compress_ratio: 1.2     # Very light compression
+
+defaults:
+  dither_bits: 24           # 24-bit output for archival
 ```
+
+**Available preset fields:** `target_lufs`, `cut_highmid`, `cut_highs`, `compress_ratio`, `compress_threshold`, `compress_attack`, `compress_release`, `eq_highmid_freq`, `eq_highmid_q`, `eq_highs_freq`, `eq_highs_q`, `dither_bits`
 
 ### How to Use Override
 1. Load at invocation start
 2. Check for genre-specific presets when mastering
-3. Override presets take precedence over base genre presets
-4. Use override target_lufs instead of default -14
+3. Override presets take precedence over base genre presets (field-level merge)
+4. Only specify fields you want to change — unset fields inherit from built-in
 
 **Example:**
 - Mastering "dark-electronic" genre
 - Override has custom preset
-- Result: Apply -3 highmid cut, +2 sub boost, target -12 LUFS
+- Result: Apply -3 highmid cut, 2.0:1 compression with 15ms attack, target -12 LUFS
 
 ---
 

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -451,6 +451,34 @@ class TestMasterTrack:
         assert len(data) > 0
         assert np.all(np.isfinite(data))
 
+    def test_mastering_with_preset_dict(self, noise_wav, output_path):
+        """master_track should accept a preset dict for all parameters."""
+        preset = {
+            'target_lufs': -16.0,
+            'cut_highmid': -2.0,
+            'cut_highs': -1.0,
+            'compress_ratio': 2.0,
+            'compress_threshold': -15.0,
+            'compress_attack': 20.0,
+            'compress_release': 150.0,
+            'eq_highmid_freq': 4000.0,
+            'eq_highmid_q': 2.0,
+            'eq_highs_freq': 9000.0,
+            'eq_highs_q': 0.5,
+            'dither_bits': 16,
+        }
+        result = master_track(noise_wav, output_path, preset=preset)
+        assert not result.get('skipped', False)
+        assert Path(output_path).exists()
+        assert abs(result['final_lufs'] - (-16.0)) < 2.0
+
+    def test_preset_dict_overrides_defaults(self, noise_wav, output_path):
+        """Partial preset dict should merge with defaults."""
+        preset = {'target_lufs': -18.0}
+        result = master_track(noise_wav, output_path, preset=preset)
+        assert not result.get('skipped', False)
+        assert abs(result['final_lufs'] - (-18.0)) < 2.0
+
 
 # ─── Tests: Genre Presets ──────────────────────────────────────────────
 
@@ -794,3 +822,13 @@ class TestProcessOneTrack:
             ceiling_db=-1.0, dry_run=True,
         )
         assert result is None
+
+    def test_preset_dict_passthrough(self, sine_wav, output_path):
+        """_process_one_track should accept and pass through a preset dict."""
+        preset = {'target_lufs': -16.0, 'compress_ratio': 1.0}
+        name, result = _process_one_track(
+            Path(sine_wav), Path(output_path),
+            preset=preset, ceiling_db=-1.0, dry_run=False,
+        )
+        assert result is not None
+        assert Path(output_path).exists()

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -23,6 +23,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from tools.mastering.master_tracks import (
     GENRE_PRESETS,
     _BUILTIN_PRESETS_FILE,
+    _PRESET_DEFAULTS,
     _load_yaml_file,
     _process_one_track,
     apply_eq,
@@ -832,3 +833,35 @@ class TestProcessOneTrack:
         )
         assert result is not None
         assert Path(output_path).exists()
+
+
+# ─── Tests: Preset Resolution ───────────────────────────────────────────
+
+
+class TestPresetResolution:
+    """Tests for preset dict construction from genre presets and CLI overrides."""
+
+    def test_genre_preset_is_complete_dict(self):
+        """Each genre preset should have all keys from _PRESET_DEFAULTS."""
+        for genre, preset in GENRE_PRESETS.items():
+            for key in _PRESET_DEFAULTS:
+                assert key in preset, f"Genre '{genre}' missing key '{key}'"
+
+    def test_genre_preset_values_are_floats(self):
+        """All preset values should be floats."""
+        for genre, preset in GENRE_PRESETS.items():
+            for key, value in preset.items():
+                assert isinstance(value, float), (
+                    f"Genre '{genre}' key '{key}' is {type(value).__name__}, expected float"
+                )
+
+    def test_default_preset_matches_hardcoded_defaults(self):
+        """_PRESET_DEFAULTS should match the previously hardcoded values."""
+        assert _PRESET_DEFAULTS['compress_threshold'] == -18.0
+        assert _PRESET_DEFAULTS['compress_attack'] == 30.0
+        assert _PRESET_DEFAULTS['compress_release'] == 200.0
+        assert _PRESET_DEFAULTS['eq_highmid_freq'] == 3500.0
+        assert _PRESET_DEFAULTS['eq_highmid_q'] == 1.5
+        assert _PRESET_DEFAULTS['eq_highs_freq'] == 8000.0
+        assert _PRESET_DEFAULTS['eq_highs_q'] == 0.7
+        assert _PRESET_DEFAULTS['dither_bits'] == 16

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -572,6 +572,19 @@ class TestYamlPresetLoading:
             assert 'cut_highmid' in settings, f"Genre '{genre}' missing cut_highmid"
             assert 'cut_highs' in settings, f"Genre '{genre}' missing cut_highs"
 
+    def test_builtin_yaml_has_all_default_keys(self):
+        """Built-in YAML defaults should include all preset keys."""
+        data = _load_yaml_file(_BUILTIN_PRESETS_FILE)
+        defaults = data['defaults']
+        expected_keys = [
+            'target_lufs', 'cut_highmid', 'cut_highs', 'compress_ratio',
+            'compress_threshold', 'compress_attack', 'compress_release',
+            'eq_highmid_freq', 'eq_highmid_q', 'eq_highs_freq', 'eq_highs_q',
+            'dither_bits',
+        ]
+        for key in expected_keys:
+            assert key in defaults, f"Default key '{key}' missing from genre-presets.yaml"
+
     def test_loaded_presets_match_yaml(self):
         """GENRE_PRESETS dict should match what's in the YAML file."""
         data = _load_yaml_file(_BUILTIN_PRESETS_FILE)

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -458,19 +458,23 @@ class TestMasterTrack:
 class TestGenrePresets:
     """Tests for genre preset configuration."""
 
-    def test_all_presets_are_4_tuples(self):
+    def test_all_presets_are_dicts(self):
         for genre, preset in GENRE_PRESETS.items():
-            assert len(preset) == 4, f"Genre '{genre}' preset should be a 4-tuple"
+            assert isinstance(preset, dict), f"Genre '{genre}' preset should be a dict"
+            assert 'target_lufs' in preset, f"Genre '{genre}' missing target_lufs"
+            assert 'cut_highmid' in preset, f"Genre '{genre}' missing cut_highmid"
+            assert 'cut_highs' in preset, f"Genre '{genre}' missing cut_highs"
+            assert 'compress_ratio' in preset, f"Genre '{genre}' missing compress_ratio"
 
     def test_all_presets_have_negative_lufs(self):
-        for genre, (lufs, _, _, _) in GENRE_PRESETS.items():
-            assert lufs < 0, f"Genre '{genre}' LUFS should be negative"
+        for genre, preset in GENRE_PRESETS.items():
+            assert preset['target_lufs'] < 0, f"Genre '{genre}' LUFS should be negative"
 
     def test_all_presets_have_nonpositive_eq(self):
         """EQ values should be cuts (negative) or zero."""
-        for genre, (_, highmid, highs, _) in GENRE_PRESETS.items():
-            assert highmid <= 0, f"Genre '{genre}' high-mid should be <= 0"
-            assert highs <= 0, f"Genre '{genre}' highs should be <= 0"
+        for genre, preset in GENRE_PRESETS.items():
+            assert preset['cut_highmid'] <= 0, f"Genre '{genre}' high-mid should be <= 0"
+            assert preset['cut_highs'] <= 0, f"Genre '{genre}' highs should be <= 0"
 
     def test_common_genres_exist(self):
         for genre in ['pop', 'rock', 'hip-hop', 'electronic', 'jazz', 'classical', 'folk', 'country', 'metal']:
@@ -478,13 +482,13 @@ class TestGenrePresets:
 
     def test_preset_with_mastering(self, noise_wav, output_path):
         """Apply a genre preset through the full mastering chain."""
-        lufs, highmid, highs, _compress = GENRE_PRESETS['rock']
+        preset = GENRE_PRESETS['rock']
         eq = []
-        if highmid != 0:
-            eq.append((3500, highmid, 1.5))
-        if highs != 0:
-            eq.append((8000, highs, 0.7))
-        result = master_track(noise_wav, output_path, target_lufs=lufs, eq_settings=eq)
+        if preset['cut_highmid'] != 0:
+            eq.append((preset['eq_highmid_freq'], preset['cut_highmid'], preset['eq_highmid_q']))
+        if preset['cut_highs'] != 0:
+            eq.append((preset['eq_highs_freq'], preset['cut_highs'], preset['eq_highs_q']))
+        result = master_track(noise_wav, output_path, target_lufs=preset['target_lufs'], eq_settings=eq)
         assert not result.get('skipped', False)
 
 
@@ -571,18 +575,17 @@ class TestYamlPresetLoading:
     def test_loaded_presets_match_yaml(self):
         """GENRE_PRESETS dict should match what's in the YAML file."""
         data = _load_yaml_file(_BUILTIN_PRESETS_FILE)
-        defaults = data.get('defaults', {})
-        default_compress = float(defaults.get('compress_ratio', 1.5))
         for genre, settings in data['genres'].items():
             assert genre in GENRE_PRESETS, f"Genre '{genre}' in YAML but not in GENRE_PRESETS"
-            expected = (
-                float(settings['target_lufs']),
-                float(settings['cut_highmid']),
-                float(settings['cut_highs']),
-                float(settings.get('compress_ratio', default_compress)),
+            preset = GENRE_PRESETS[genre]
+            assert preset['target_lufs'] == float(settings['target_lufs']), (
+                f"Genre '{genre}' target_lufs mismatch"
             )
-            assert GENRE_PRESETS[genre] == expected, (
-                f"Genre '{genre}': YAML={expected}, loaded={GENRE_PRESETS[genre]}"
+            assert preset['cut_highmid'] == float(settings['cut_highmid']), (
+                f"Genre '{genre}' cut_highmid mismatch"
+            )
+            assert preset['cut_highs'] == float(settings['cut_highs']), (
+                f"Genre '{genre}' cut_highs mismatch"
             )
 
     def test_load_yaml_file_missing(self, tmp_path):
@@ -622,11 +625,11 @@ class TestYamlPresetLoading:
 
         presets = load_genre_presets()
         # Rock should have overridden cut_highmid but keep other fields
-        lufs, highmid, highs, compress = presets['rock']
-        assert highmid == -1.0  # Overridden
-        assert lufs == -14.0    # Inherited from built-in
-        assert highs == 0       # Inherited from built-in
-        assert compress == 1.5  # Default compress_ratio
+        preset = presets['rock']
+        assert preset['cut_highmid'] == -1.0  # Overridden
+        assert preset['target_lufs'] == -14.0  # Inherited from built-in
+        assert preset['cut_highs'] == 0        # Inherited from built-in
+        assert preset['compress_ratio'] == 1.5  # Default
 
     def test_override_adds_new_genre(self, tmp_path, monkeypatch):
         """User override can add entirely new genres."""
@@ -646,7 +649,11 @@ class TestYamlPresetLoading:
 
         presets = load_genre_presets()
         assert 'dark-electronic' in presets
-        assert presets['dark-electronic'] == (-12.0, -3.0, -1.0, 1.5)
+        preset = presets['dark-electronic']
+        assert preset['target_lufs'] == -12.0
+        assert preset['cut_highmid'] == -3.0
+        assert preset['cut_highs'] == -1.0
+        assert preset['compress_ratio'] == 1.5
 
     def test_override_defaults(self, tmp_path, monkeypatch):
         """User can override default settings."""
@@ -665,10 +672,10 @@ class TestYamlPresetLoading:
         monkeypatch.setattr(mt, '_get_overrides_path', lambda: override_dir)
 
         presets = load_genre_presets()
-        lufs, highmid, highs, compress = presets['custom-genre']
-        assert lufs == -12.0    # From overridden defaults
-        assert highmid == -2.0  # From genre entry
-        assert compress == 1.5  # Default compress_ratio
+        preset = presets['custom-genre']
+        assert preset['target_lufs'] == -12.0    # From overridden defaults
+        assert preset['cut_highmid'] == -2.0     # From genre entry
+        assert preset['compress_ratio'] == 1.5   # Default
 
     def test_no_override_dir_works(self, monkeypatch):
         """When no override directory exists, built-in presets load fine."""

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -12140,7 +12140,7 @@ class TestMasterAudioComprehensive:
                 "final_peak": -1.0,
             }
 
-        presets = {"hip-hop": (-13.0, -3.0, -1.0, 2.0)}
+        presets = {"hip-hop": {"target_lufs": -13.0, "cut_highmid": -3.0, "cut_highs": -1.0, "compress_ratio": 2.0}}
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \
@@ -12166,7 +12166,7 @@ class TestMasterAudioComprehensive:
                 "final_peak": -1.0,
             }
 
-        presets = {"hip-hop": (-13.0, -3.0, -1.0, 2.0)}
+        presets = {"hip-hop": {"target_lufs": -13.0, "cut_highmid": -3.0, "cut_highs": -1.0, "compress_ratio": 2.0}}
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \

--- a/tests/unit/state/test_server_qc.py
+++ b/tests/unit/state/test_server_qc.py
@@ -856,7 +856,7 @@ class TestMasterAlbumPipeline:
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \
              patch("tools.mastering.master_tracks.load_genre_presets",
-                   return_value={"rock": (-14.0, -2.5, 0.0, 1.5)}), \
+                   return_value={"rock": {"target_lufs": -14.0, "cut_highmid": -2.5, "cut_highs": 0.0, "compress_ratio": 1.5}}), \
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
@@ -1064,7 +1064,7 @@ class TestMasterAlbumPipeline:
                 "final_peak": -1.5,
             }
 
-        presets = {"country": (-14.0, -2.0, 0.0, 1.5)}
+        presets = {"country": {"target_lufs": -14.0, "cut_highmid": -2.0, "cut_highs": 0.0, "compress_ratio": 1.5}}
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -1,9 +1,18 @@
 # Genre-Specific Mastering Presets
 #
-# Each genre defines:
-#   target_lufs  - Loudness target (streaming standard: -14, dynamic genres: -16 to -18)
-#   cut_highmid  - EQ cut in dB at 3.5kHz to tame harshness (negative = cut, 0 = none)
-#   cut_highs    - High shelf cut in dB at 8kHz for overly bright mixes (negative = cut, 0 = none)
+# Each genre defines (all optional — unset fields inherit from defaults):
+#   target_lufs        - Loudness target (streaming standard: -14, dynamic genres: -16 to -18)
+#   cut_highmid        - EQ cut in dB at eq_highmid_freq to tame harshness (negative = cut, 0 = none)
+#   cut_highs          - High shelf cut in dB at eq_highs_freq (negative = cut, 0 = none)
+#   compress_ratio     - Compression ratio (1.0 = bypass, default 1.5 = gentle glue)
+#   compress_threshold - Compression threshold in dB (default -18.0)
+#   compress_attack    - Compression attack in ms (default 30.0)
+#   compress_release   - Compression release in ms (default 200.0)
+#   eq_highmid_freq    - High-mid EQ center frequency in Hz (default 3500.0)
+#   eq_highmid_q       - High-mid EQ Q factor (default 1.5)
+#   eq_highs_freq      - High shelf frequency in Hz (default 8000.0)
+#   eq_highs_q         - High shelf Q factor (default 0.7)
+#   dither_bits        - Output bit depth for TPDF dither (default 16)
 #
 # Override per-user: copy to {overrides}/mastering-presets.yaml and edit.
 # User overrides merge on top of these defaults (genre-level).
@@ -13,6 +22,15 @@ defaults:
   target_lufs: -14.0
   cut_highmid: 0
   cut_highs: 0
+  compress_ratio: 1.5
+  compress_threshold: -18.0
+  compress_attack: 30.0
+  compress_release: 200.0
+  eq_highmid_freq: 3500.0
+  eq_highmid_q: 1.5
+  eq_highs_freq: 8000.0
+  eq_highs_q: 0.7
+  dither_bits: 16
 
 genres:
   # === Pop / Mainstream ===

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -363,19 +363,36 @@ def master_track(input_path: Path | str, output_path: Path | str,
                  target_lufs: float = -14.0,
                  eq_settings: list[tuple[float, float, float]] | None = None,
                  ceiling_db: float = -1.0, fade_out: float | None = None,
-                 compress_ratio: float = 1.5) -> dict[str, Any]:
+                 compress_ratio: float = 1.5,
+                 preset: dict[str, float] | None = None) -> dict[str, Any]:
     """Master a single track.
 
     Args:
         input_path: Path to input wav file
         output_path: Path for output wav file
-        target_lufs: Target integrated loudness
-        eq_settings: List of (freq, gain_db, q) tuples for EQ
+        target_lufs: Target integrated loudness (ignored if preset provided)
+        eq_settings: List of (freq, gain_db, q) tuples for EQ (ignored if preset provided)
         ceiling_db: True peak ceiling in dB
         fade_out: Optional fade-out duration in seconds.
             None or <= 0 disables fade-out.
-        compress_ratio: Compression ratio (1.0 = bypass, 1.5 = gentle glue)
+        compress_ratio: Compression ratio (ignored if preset provided)
+        preset: Full preset dict. When provided, target_lufs, eq_settings,
+            and compress_ratio are read from the preset instead.
     """
+    # Resolve parameters from preset or legacy args
+    p = {**_PRESET_DEFAULTS}
+    if preset is not None:
+        p.update(preset)
+        target_lufs = p['target_lufs']
+        compress_ratio = p['compress_ratio']
+        # Build EQ settings from preset
+        eq_settings = []
+        if p['cut_highmid'] != 0:
+            eq_settings.append((p['eq_highmid_freq'], p['cut_highmid'], p['eq_highmid_q']))
+        if p['cut_highs'] != 0:
+            eq_settings.append((p['eq_highs_freq'], p['cut_highs'], p['eq_highs_q']))
+        eq_settings = eq_settings or None
+
     # Read audio
     data, rate = sf.read(input_path)
 
@@ -398,10 +415,11 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if compress_ratio > 1.0:
         data = gentle_compress(
             data, rate,
-            threshold_db=-18.0, ratio=compress_ratio,
-            attack_ms=30.0, release_ms=200.0,
+            threshold_db=p['compress_threshold'],
+            ratio=compress_ratio,
+            attack_ms=p['compress_attack'],
+            release_ms=p['compress_release'],
         )
-
 
     # Measure current loudness
     meter = pyln.Meter(rate)
@@ -438,10 +456,12 @@ def master_track(input_path: Path | str, output_path: Path | str,
         data = data[:, 0]
 
     # Apply TPDF dither as the final step before quantization
-    data = apply_tpdf_dither(data, target_bits=16)
+    dither_bits = int(p['dither_bits'])
+    data = apply_tpdf_dither(data, target_bits=dither_bits)
 
     # Write output (same format as input)
-    sf.write(output_path, data, rate, subtype='PCM_16')
+    subtype = 'PCM_16' if dither_bits <= 16 else 'PCM_24'
+    sf.write(output_path, data, rate, subtype=subtype)
 
     return {
         'original_lufs': current_lufs,
@@ -451,10 +471,12 @@ def master_track(input_path: Path | str, output_path: Path | str,
     }
 
 def _process_one_track(wav_file: Path | str, output_path: Path | str,
-                       target_lufs: float,
-                       eq_settings: list[tuple[float, float, float]] | None,
-                       ceiling_db: float, dry_run: bool,
-                       compress_ratio: float = 1.5) -> tuple[str, dict[str, Any] | None]:
+                       target_lufs: float = -14.0,
+                       eq_settings: list[tuple[float, float, float]] | None = None,
+                       ceiling_db: float = -1.0, dry_run: bool = False,
+                       compress_ratio: float = 1.5,
+                       preset: dict[str, float] | None = None,
+                       ) -> tuple[str, dict[str, Any] | None]:
     """Process a single track (used by both sequential and parallel paths).
 
     Returns (wav_file_name, result_dict) or (wav_file_name, None) if skipped.
@@ -464,13 +486,16 @@ def _process_one_track(wav_file: Path | str, output_path: Path | str,
         if len(data.shape) == 1:
             data = np.column_stack([data, data])
         meter = pyln.Meter(rate)
+        effective_lufs = target_lufs
+        if preset is not None:
+            effective_lufs = preset.get('target_lufs', target_lufs)
         current_lufs = meter.integrated_loudness(data)
         if not np.isfinite(current_lufs):
             return (str(wav_file), None)
-        gain = target_lufs - current_lufs
+        gain = effective_lufs - current_lufs
         result = {
             'original_lufs': current_lufs,
-            'final_lufs': target_lufs,
+            'final_lufs': effective_lufs,
             'gain_applied': gain,
             'final_peak': -1.0,
         }
@@ -482,6 +507,7 @@ def _process_one_track(wav_file: Path | str, output_path: Path | str,
             eq_settings=eq_settings,
             ceiling_db=ceiling_db,
             compress_ratio=compress_ratio,
+            preset=preset,
         )
 
     if result.get('skipped'):

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -73,16 +73,39 @@ def _get_overrides_path() -> Path | None:
     return None
 
 
-def load_genre_presets() -> dict[str, tuple[float, float, float, float]]:
+# All recognized preset keys and their defaults
+_PRESET_DEFAULTS: dict[str, float] = {
+    'target_lufs': -14.0,
+    'cut_highmid': 0.0,
+    'cut_highs': 0.0,
+    'compress_ratio': 1.5,
+    'compress_threshold': -18.0,
+    'compress_attack': 30.0,
+    'compress_release': 200.0,
+    'eq_highmid_freq': 3500.0,
+    'eq_highmid_q': 1.5,
+    'eq_highs_freq': 8000.0,
+    'eq_highs_q': 0.7,
+    'dither_bits': 16,
+}
+
+
+def load_genre_presets() -> dict[str, dict[str, float]]:
     """Load genre presets from YAML, merging built-in with user overrides.
 
     Returns:
-        Dict mapping genre name to (target_lufs, cut_highmid, cut_highs, compress_ratio) tuples.
+        Dict mapping genre name to a dict of preset parameters.
     """
     # Load built-in presets
     builtin = _load_yaml_file(_BUILTIN_PRESETS_FILE)
     builtin_genres = builtin.get('genres', {})
-    defaults = builtin.get('defaults', {})
+    defaults = {**_PRESET_DEFAULTS}
+
+    # Merge YAML defaults on top of hardcoded defaults
+    yaml_defaults = builtin.get('defaults', {})
+    for key in defaults:
+        if key in yaml_defaults:
+            defaults[key] = float(yaml_defaults[key])
 
     # Load user overrides
     overrides_dir = _get_overrides_path()
@@ -93,26 +116,21 @@ def load_genre_presets() -> dict[str, tuple[float, float, float, float]]:
         override_genres = override_data.get('genres', {})
         override_defaults = override_data.get('defaults', {})
         if override_defaults:
-            defaults.update(override_defaults)
-
-    default_lufs = float(defaults.get('target_lufs', -14.0))
-    default_highmid = float(defaults.get('cut_highmid', 0))
-    default_highs = float(defaults.get('cut_highs', 0))
-    default_compress_ratio = float(defaults.get('compress_ratio', 1.5))
+            for key in defaults:
+                if key in override_defaults:
+                    defaults[key] = float(override_defaults[key])
 
     # Merge: built-in genres + override genres (override wins per-field)
     all_genre_names = set(builtin_genres.keys()) | set(override_genres.keys())
-    presets = {}
+    presets: dict[str, dict[str, float]] = {}
     for genre in all_genre_names:
         base = builtin_genres.get(genre, {})
         over = override_genres.get(genre, {})
         merged = {**base, **over}
-        presets[genre] = (
-            float(merged.get('target_lufs', default_lufs)),
-            float(merged.get('cut_highmid', default_highmid)),
-            float(merged.get('cut_highs', default_highs)),
-            float(merged.get('compress_ratio', default_compress_ratio)),
-        )
+        presets[genre] = {
+            key: float(merged.get(key, default))
+            for key, default in defaults.items()
+        }
 
     return presets
 
@@ -521,16 +539,16 @@ Examples:
             logger.error("Unknown genre: %s", args.genre)
             logger.error("Available: %s", ', '.join(sorted(GENRE_PRESETS.keys())))
             return
-        preset_lufs, preset_highmid, preset_highs, preset_compress = GENRE_PRESETS[genre_key]
+        genre_preset = GENRE_PRESETS[genre_key]
         # Genre preset provides defaults, but explicit args override
         if args.target_lufs is None:
-            args.target_lufs = preset_lufs
+            args.target_lufs = genre_preset['target_lufs']
         if args.cut_highmid is None:
-            args.cut_highmid = preset_highmid
+            args.cut_highmid = genre_preset['cut_highmid']
         if args.cut_highs is None:
-            args.cut_highs = preset_highs
+            args.cut_highs = genre_preset['cut_highs']
         if args.compress_ratio is None:
-            args.compress_ratio = preset_compress
+            args.compress_ratio = genre_preset['compress_ratio']
 
     # Apply defaults if no genre and no explicit value
     if args.target_lufs is None:

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -538,9 +538,9 @@ Examples:
     parser.add_argument('--ceiling', type=float, default=-1.0,
                        help='True peak ceiling in dB (default: -1.0)')
     parser.add_argument('--cut-highmid', type=float, default=None,
-                       help='High-mid cut in dB at 3.5kHz (e.g., -2 for 2dB cut)')
+                       help='High-mid cut in dB at eq_highmid_freq (e.g., -2 for 2dB cut)')
     parser.add_argument('--cut-highs', type=float, default=None,
-                       help='High shelf cut in dB at 8kHz')
+                       help='High shelf cut in dB at eq_highs_freq')
     parser.add_argument('--output-dir', type=str, default='mastered',
                        help='Output directory (default: mastered)')
     parser.add_argument('--dry-run', action='store_true',
@@ -551,6 +551,22 @@ Examples:
                        help='Show only warnings and errors')
     parser.add_argument('--compress-ratio', type=float, default=None,
                        help='Mastering compression ratio (1.0=bypass, default: genre preset or 1.5)')
+    parser.add_argument('--compress-threshold', type=float, default=None,
+                       help='Compression threshold in dB (default: -18.0)')
+    parser.add_argument('--compress-attack', type=float, default=None,
+                       help='Compression attack in ms (default: 30.0)')
+    parser.add_argument('--compress-release', type=float, default=None,
+                       help='Compression release in ms (default: 200.0)')
+    parser.add_argument('--eq-highmid-freq', type=float, default=None,
+                       help='High-mid EQ center frequency in Hz (default: 3500.0)')
+    parser.add_argument('--eq-highmid-q', type=float, default=None,
+                       help='High-mid EQ Q factor (default: 1.5)')
+    parser.add_argument('--eq-highs-freq', type=float, default=None,
+                       help='High shelf frequency in Hz (default: 8000.0)')
+    parser.add_argument('--eq-highs-q', type=float, default=None,
+                       help='High shelf Q factor (default: 0.7)')
+    parser.add_argument('--dither-bits', type=int, default=None,
+                       help='Output bit depth for TPDF dither (default: 16)')
     parser.add_argument('-j', '--jobs', type=int, default=1,
                        help='Parallel jobs (0=auto, default: 1)')
 
@@ -558,33 +574,35 @@ Examples:
 
     setup_logging(__name__, verbose=args.verbose, quiet=args.quiet)
 
-    # Apply genre preset if specified
+    # Build preset dict: start with defaults, layer genre preset, then CLI overrides
+    preset = {**_PRESET_DEFAULTS}
+
     if args.genre:
         genre_key = args.genre.lower()
         if genre_key not in GENRE_PRESETS:
             logger.error("Unknown genre: %s", args.genre)
             logger.error("Available: %s", ', '.join(sorted(GENRE_PRESETS.keys())))
             return
-        genre_preset = GENRE_PRESETS[genre_key]
-        # Genre preset provides defaults, but explicit args override
-        if args.target_lufs is None:
-            args.target_lufs = genre_preset['target_lufs']
-        if args.cut_highmid is None:
-            args.cut_highmid = genre_preset['cut_highmid']
-        if args.cut_highs is None:
-            args.cut_highs = genre_preset['cut_highs']
-        if args.compress_ratio is None:
-            args.compress_ratio = genre_preset['compress_ratio']
+        preset.update(GENRE_PRESETS[genre_key])
 
-    # Apply defaults if no genre and no explicit value
-    if args.target_lufs is None:
-        args.target_lufs = -14.0
-    if args.cut_highmid is None:
-        args.cut_highmid = 0
-    if args.cut_highs is None:
-        args.cut_highs = 0
-    if args.compress_ratio is None:
-        args.compress_ratio = 1.5
+    # CLI overrides (only apply if explicitly set)
+    cli_overrides = {
+        'target_lufs': args.target_lufs,
+        'cut_highmid': args.cut_highmid,
+        'cut_highs': args.cut_highs,
+        'compress_ratio': args.compress_ratio,
+        'compress_threshold': args.compress_threshold,
+        'compress_attack': args.compress_attack,
+        'compress_release': args.compress_release,
+        'eq_highmid_freq': args.eq_highmid_freq,
+        'eq_highmid_q': args.eq_highmid_q,
+        'eq_highs_freq': args.eq_highs_freq,
+        'eq_highs_q': args.eq_highs_q,
+        'dither_bits': float(args.dither_bits) if args.dither_bits is not None else None,
+    }
+    for key, value in cli_overrides.items():
+        if value is not None:
+            preset[key] = float(value)
 
     # Setup
     input_dir = Path(args.path).expanduser().resolve()
@@ -614,29 +632,23 @@ Examples:
                        if f.suffix.lower() == '.wav'
                        and 'venv' not in str(f)])
 
-    # Build EQ settings
-    eq_settings: list[tuple[float, float, float]] = []
-    if args.cut_highmid != 0:
-        eq_settings.append((3500.0, args.cut_highmid, 1.5))  # 3.5kHz with moderate Q
-    if args.cut_highs != 0:
-        # For high shelf, we'd need different handling - simplified here
-        eq_settings.append((8000.0, args.cut_highs, 0.7))
-
     print("=" * 70)
     print("MASTERING SESSION")
     print("=" * 70)
     if args.genre:
         print(f"Genre preset: {args.genre}")
-    print(f"Target LUFS: {args.target_lufs}")
+    print(f"Target LUFS: {preset['target_lufs']}")
     print(f"Peak ceiling: {args.ceiling} dBTP")
-    if args.cut_highmid != 0:
-        print(f"EQ: High-mid cut: {args.cut_highmid}dB at 3.5kHz")
-    if args.cut_highs != 0:
-        print(f"EQ: High shelf cut: {args.cut_highs}dB at 8kHz")
-    if args.compress_ratio > 1.0:
-        print(f"Compression: {args.compress_ratio}:1")
+    if preset['cut_highmid'] != 0:
+        print(f"EQ: High-mid cut: {preset['cut_highmid']}dB at {preset['eq_highmid_freq']}Hz (Q={preset['eq_highmid_q']})")
+    if preset['cut_highs'] != 0:
+        print(f"EQ: High shelf cut: {preset['cut_highs']}dB at {preset['eq_highs_freq']}Hz (Q={preset['eq_highs_q']})")
+    if preset['compress_ratio'] > 1.0:
+        print(f"Compression: {preset['compress_ratio']}:1 (threshold={preset['compress_threshold']}dB, attack={preset['compress_attack']}ms, release={preset['compress_release']}ms)")
     else:
         print("Compression: bypass")
+    if int(preset['dither_bits']) != 16:
+        print(f"Dither: {int(preset['dither_bits'])}-bit")
     print(f"Output: {output_dir}/")
     print("=" * 70)
     print()
@@ -649,7 +661,6 @@ Examples:
     print("-" * 70)
 
     workers = args.jobs if args.jobs > 0 else os.cpu_count()
-    eq = eq_settings if eq_settings else None
 
     # Build list of (wav_file, output_path) pairs
     tasks = [(wf, output_dir / wf.name) for wf in wav_files]
@@ -662,8 +673,10 @@ Examples:
         for wav_file, output_path in tasks:
             progress.update(wav_file.name)
             _, result = _process_one_track(
-                wav_file, output_path, args.target_lufs, eq, args.ceiling,
-                args.dry_run, compress_ratio=args.compress_ratio,
+                wav_file, output_path,
+                ceiling_db=args.ceiling,
+                dry_run=args.dry_run,
+                preset=preset,
             )
             if result is None:
                 continue
@@ -678,8 +691,10 @@ Examples:
         with ProcessPoolExecutor(max_workers=workers) as executor:
             futures = {
                 executor.submit(
-                    _process_one_track, wf, op, args.target_lufs, eq, args.ceiling,
-                    args.dry_run, args.compress_ratio,
+                    _process_one_track, wf, op,
+                    ceiling_db=args.ceiling,
+                    dry_run=args.dry_run,
+                    preset=preset,
                 ): i
                 for i, (wf, op) in enumerate(tasks)
             }


### PR DESCRIPTION
## Summary

- Refactors `load_genre_presets()` from `dict[str, tuple]` to `dict[str, dict[str, float]]` with a central `_PRESET_DEFAULTS` dict containing all 12 preset keys
- Extracts 7 previously hardcoded mastering parameters (compression threshold/attack/release, EQ freq/Q for both bands) into the genre preset system and CLI
- Adds `compress_ratio` and `dither_bits` to YAML defaults (closing the compress_ratio gap where it was handled in code but missing from the YAML)
- Threads a single `preset: dict` through the call chain (`main()` → `_process_one_track()` → `master_track()`) instead of individual kwargs — future parameter additions are a YAML-only change

## Test plan

- [x] All 86 mastering tests pass (including 7 new tests for dict structure, preset resolution, and preset dict passthrough)
- [x] All 160 mixing tests pass — no regressions from the `gentle_compress()` import
- [x] CLI `--help` shows all 8 new args (`--compress-threshold`, `--compress-attack`, `--compress-release`, `--eq-highmid-freq`, `--eq-highmid-q`, `--eq-highs-freq`, `--eq-highs-q`, `--dither-bits`)
- [x] Legacy positional args still work (backward compatible)
- [x] Override merging tested: genre overrides, new genre addition, default overrides all pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)