### PR TITLE
feat: wire saturation, lowpass, and stereo width into mix pipeline

### DIFF
--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -28,10 +28,13 @@ from tools.mixing.mix_tracks import (
     apply_eq,
     apply_high_shelf,
     apply_highpass,
+    apply_lowpass,
+    apply_saturation,
     gentle_compress,
     remove_clicks,
     reduce_noise,
     enhance_stereo,
+    _apply_character_effects,
     remix_stems,
     process_vocals,
     process_backing_vocals,
@@ -1622,3 +1625,279 @@ class TestOverrideMerging:
         presets = load_mix_presets()
         assert 'rock' in presets['genres']
         assert 'pop' in presets['genres']
+
+
+# ─── Character Effects Tests ─────────────────────────────────────────
+
+
+class TestApplySaturation:
+    """Tests for apply_saturation()."""
+
+    def test_zero_drive_passthrough(self):
+        """Drive=0 returns data unchanged."""
+        data, rate = _generate_sine(amplitude=0.5)
+        result = apply_saturation(data, rate, drive=0.0)
+        np.testing.assert_array_equal(result, data)
+
+    def test_negative_drive_passthrough(self):
+        """Negative drive returns data unchanged."""
+        data, rate = _generate_sine(amplitude=0.5)
+        result = apply_saturation(data, rate, drive=-0.5)
+        np.testing.assert_array_equal(result, data)
+
+    def test_saturation_changes_signal(self):
+        """Non-zero drive produces a different signal."""
+        data, rate = _generate_sine(amplitude=0.5)
+        result = apply_saturation(data, rate, drive=0.2)
+        assert not np.allclose(result, data)
+
+    def test_saturation_preserves_shape(self):
+        """Output shape matches input shape."""
+        data, rate = _generate_sine(amplitude=0.5)
+        result = apply_saturation(data, rate, drive=0.3)
+        assert result.shape == data.shape
+
+    def test_saturation_mono(self):
+        """Saturation works on mono signals."""
+        data, rate = _generate_sine(amplitude=0.5, stereo=False)
+        result = apply_saturation(data, rate, drive=0.2)
+        assert result.shape == data.shape
+        assert not np.allclose(result, data)
+
+    def test_saturation_adds_harmonics(self):
+        """Saturation adds harmonic content (broadens spectrum)."""
+        data, rate = _generate_sine(freq=440, amplitude=0.5)
+        result = apply_saturation(data, rate, drive=0.3)
+        # Check that spectral energy outside the fundamental increases
+        fft_orig = np.abs(np.fft.rfft(data[:, 0]))
+        fft_sat = np.abs(np.fft.rfft(result[:, 0]))
+        # Fundamental bin
+        fund_bin = int(440 * len(data) / rate)
+        # Sum energy outside ±5 bins of fundamental
+        mask = np.ones(len(fft_orig), dtype=bool)
+        mask[max(0, fund_bin - 5):fund_bin + 6] = False
+        orig_sideband = np.sum(fft_orig[mask])
+        sat_sideband = np.sum(fft_sat[mask])
+        assert sat_sideband > orig_sideband
+
+    def test_saturation_drive_clamped(self):
+        """Drive > 1.0 is clamped to 1.0 (no explosion)."""
+        data, rate = _generate_sine(amplitude=0.8)
+        result = apply_saturation(data, rate, drive=5.0)
+        assert np.all(np.abs(result) <= 1.0)
+
+    def test_higher_drive_more_effect(self):
+        """Higher drive produces more deviation from original."""
+        data, rate = _generate_sine(amplitude=0.5)
+        low = apply_saturation(data, rate, drive=0.1)
+        high = apply_saturation(data, rate, drive=0.5)
+        diff_low = np.mean(np.abs(low - data))
+        diff_high = np.mean(np.abs(high - data))
+        assert diff_high > diff_low
+
+
+class TestApplyLowpass:
+    """Tests for apply_lowpass()."""
+
+    def test_high_cutoff_passthrough(self):
+        """Cutoff >= Nyquist returns data unchanged."""
+        data, rate = _generate_sine(freq=440, amplitude=0.5)
+        result = apply_lowpass(data, rate, cutoff=rate // 2)
+        np.testing.assert_array_equal(result, data)
+
+    def test_zero_cutoff_passthrough(self):
+        """Cutoff=0 returns data unchanged (invalid, skip)."""
+        data, rate = _generate_sine(freq=440, amplitude=0.5)
+        result = apply_lowpass(data, rate, cutoff=0)
+        np.testing.assert_array_equal(result, data)
+
+    def test_lowpass_attenuates_highs(self):
+        """Lowpass at 1000 Hz attenuates a 5000 Hz signal."""
+        data, rate = _generate_sine(freq=5000, amplitude=0.5)
+        result = apply_lowpass(data, rate, cutoff=1000)
+        # RMS should drop significantly
+        orig_rms = np.sqrt(np.mean(data ** 2))
+        result_rms = np.sqrt(np.mean(result ** 2))
+        assert result_rms < orig_rms * 0.5
+
+    def test_lowpass_preserves_lows(self):
+        """Lowpass at 5000 Hz preserves a 200 Hz signal."""
+        data, rate = _generate_sine(freq=200, amplitude=0.5)
+        result = apply_lowpass(data, rate, cutoff=5000)
+        # Signal should be mostly unchanged (small filter ripple OK)
+        correlation = np.corrcoef(data[:, 0], result[:, 0])[0, 1]
+        assert correlation > 0.95
+
+    def test_lowpass_preserves_shape(self):
+        """Output shape matches input shape."""
+        data, rate = _generate_sine(amplitude=0.5)
+        result = apply_lowpass(data, rate, cutoff=8000)
+        assert result.shape == data.shape
+
+    def test_lowpass_mono(self):
+        """Lowpass works on mono signals."""
+        data, rate = _generate_sine(freq=5000, amplitude=0.5, stereo=False)
+        result = apply_lowpass(data, rate, cutoff=1000)
+        assert result.shape == data.shape
+        assert np.sqrt(np.mean(result ** 2)) < np.sqrt(np.mean(data ** 2)) * 0.5
+
+
+class TestApplyCharacterEffects:
+    """Tests for _apply_character_effects() helper."""
+
+    def test_no_effects_passthrough(self):
+        """All effects disabled returns data unchanged."""
+        data, rate = _generate_sine(amplitude=0.5)
+        settings = {'saturation_drive': 0, 'lowpass_cutoff': 20000, 'stereo_width': 1.0}
+        result = _apply_character_effects(data, rate, settings)
+        np.testing.assert_array_equal(result, data)
+
+    def test_saturation_flag(self):
+        """saturation=True applies saturation when drive > 0."""
+        data, rate = _generate_sine(amplitude=0.5)
+        settings = {'saturation_drive': 0.2}
+        result = _apply_character_effects(data, rate, settings, saturation=True)
+        assert not np.allclose(result, data)
+
+    def test_saturation_flag_off(self):
+        """saturation=False skips saturation even with drive > 0."""
+        data, rate = _generate_sine(amplitude=0.5)
+        settings = {'saturation_drive': 0.2}
+        result = _apply_character_effects(data, rate, settings, saturation=False)
+        np.testing.assert_array_equal(result, data)
+
+    def test_lowpass_flag(self):
+        """lowpass=True applies lowpass when cutoff < 20000."""
+        data, rate = _generate_sine(freq=5000, amplitude=0.5)
+        settings = {'lowpass_cutoff': 1000}
+        result = _apply_character_effects(data, rate, settings, lowpass=True)
+        assert not np.allclose(result, data)
+
+    def test_stereo_flag(self):
+        """stereo=True applies width when stereo_width != 1.0."""
+        data, rate = _generate_sine(amplitude=0.5)
+        # Make left and right slightly different for stereo effect
+        data[:, 1] *= 0.8
+        settings = {'stereo_width': 1.3}
+        result = _apply_character_effects(data, rate, settings, stereo=True)
+        assert not np.allclose(result, data)
+
+    def test_stereo_width_narrowing(self):
+        """stereo_width < 1.0 narrows the stereo field."""
+        data, rate = _generate_sine(amplitude=0.5)
+        data[:, 1] *= 0.7  # Create stereo difference
+        settings = {'stereo_width': 0.9}
+        result = _apply_character_effects(data, rate, settings, stereo=True)
+        # Side signal should be reduced
+        orig_side = np.mean(np.abs(data[:, 0] - data[:, 1]))
+        result_side = np.mean(np.abs(result[:, 0] - result[:, 1]))
+        assert result_side < orig_side
+
+
+class TestProcessorCharacterEffectsWiring:
+    """Verify that processors apply character effects when settings are non-default."""
+
+    def test_vocals_saturation(self):
+        """Vocals applies saturation when drive > 0."""
+        data, rate = _generate_sine(amplitude=0.5)
+        settings_off = _get_stem_settings('vocals')
+        settings_on = {**settings_off, 'saturation_drive': 0.2}
+        result_off = process_vocals(data.copy(), rate, settings_off)
+        result_on = process_vocals(data.copy(), rate, settings_on)
+        assert not np.allclose(result_off, result_on)
+
+    def test_vocals_lowpass(self):
+        """Vocals applies lowpass when cutoff < 20000."""
+        data, rate = _generate_sine(freq=5000, amplitude=0.5)
+        settings_off = _get_stem_settings('vocals')
+        settings_on = {**settings_off, 'lowpass_cutoff': 2000}
+        result_off = process_vocals(data.copy(), rate, settings_off)
+        result_on = process_vocals(data.copy(), rate, settings_on)
+        assert not np.allclose(result_off, result_on)
+
+    def test_backing_vocals_stereo_width(self):
+        """Backing vocals applies stereo width."""
+        data, rate = _generate_sine(amplitude=0.5)
+        data[:, 1] *= 0.8
+        settings = {**_get_stem_settings('backing_vocals'), 'stereo_width': 1.5}
+        result_wide = process_backing_vocals(data.copy(), rate, settings)
+        settings_narrow = {**settings, 'stereo_width': 1.0}
+        result_narrow = process_backing_vocals(data.copy(), rate, settings_narrow)
+        assert not np.allclose(result_wide, result_narrow)
+
+    def test_drums_saturation(self):
+        """Drums applies saturation when drive > 0."""
+        data, rate = _generate_noise(amplitude=0.5)
+        settings_off = _get_stem_settings('drums')
+        settings_on = {**settings_off, 'saturation_drive': 0.15}
+        result_off = process_drums(data.copy(), rate, settings_off)
+        result_on = process_drums(data.copy(), rate, settings_on)
+        assert not np.allclose(result_off, result_on)
+
+    def test_guitar_all_character_effects(self):
+        """Guitar applies stereo, saturation, and lowpass."""
+        data, rate = _generate_sine(freq=1200, amplitude=0.5)
+        data[:, 1] *= 0.9
+        settings = {
+            **_get_stem_settings('guitar'),
+            'stereo_width': 1.2,
+            'saturation_drive': 0.15,
+            'lowpass_cutoff': 8000,
+        }
+        settings_off = {
+            **_get_stem_settings('guitar'),
+            'stereo_width': 1.0,
+            'saturation_drive': 0,
+            'lowpass_cutoff': 20000,
+        }
+        result_on = process_guitar(data.copy(), rate, settings)
+        result_off = process_guitar(data.copy(), rate, settings_off)
+        assert not np.allclose(result_on, result_off)
+
+    def test_strings_no_saturation(self):
+        """Strings does NOT apply saturation (per YAML chain)."""
+        data, rate = _generate_sine(amplitude=0.5)
+        settings = {**_get_stem_settings('strings'), 'saturation_drive': 0.3}
+        # Both should be the same because strings doesn't wire saturation
+        result = process_strings(data.copy(), rate, settings)
+        settings_zero = {**settings, 'saturation_drive': 0}
+        result_zero = process_strings(data.copy(), rate, settings_zero)
+        np.testing.assert_array_equal(result, result_zero)
+
+    def test_percussion_stereo_and_saturation(self):
+        """Percussion applies stereo width and saturation but not lowpass."""
+        data, rate = _generate_noise(amplitude=0.3)
+        settings = {
+            **_get_stem_settings('percussion'),
+            'stereo_width': 1.2,
+            'saturation_drive': 0.1,
+            'lowpass_cutoff': 5000,  # should be ignored
+        }
+        settings_off = {
+            **settings,
+            'stereo_width': 1.0,
+            'saturation_drive': 0,
+        }
+        result_on = process_percussion(data.copy(), rate, settings)
+        result_off = process_percussion(data.copy(), rate, settings_off)
+        assert not np.allclose(result_on, result_off)
+
+    def test_other_lowpass_only(self):
+        """Other stem applies lowpass but not saturation or stereo."""
+        data, rate = _generate_sine(freq=5000, amplitude=0.3)
+        settings = {**_get_stem_settings('other'), 'lowpass_cutoff': 2000}
+        settings_off = {**settings, 'lowpass_cutoff': 20000}
+        result_on = process_other(data.copy(), rate, settings)
+        result_off = process_other(data.copy(), rate, settings_off)
+        assert not np.allclose(result_on, result_off)
+
+    def test_default_settings_unchanged_behavior(self):
+        """With default settings (drive=0, cutoff=20000, width=1.0), processors behave as before."""
+        data, rate = _generate_sine(amplitude=0.5)
+        # Default settings have all character effects off
+        settings = _get_stem_settings('vocals')
+        assert settings.get('saturation_drive', 0) == 0
+        assert settings.get('lowpass_cutoff', 20000) == 20000
+        # Just verify it runs without error
+        result = process_vocals(data.copy(), rate, settings)
+        assert result.shape == data.shape

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -537,28 +537,29 @@ def remove_clicks(data: Any, rate: int, threshold: float = 6.0) -> Any:
 
 
 def enhance_stereo(data: Any, rate: int, amount: float = 0.2) -> Any:
-    """Enhance stereo width using mid-side processing.
+    """Adjust stereo width using mid-side processing.
 
     Args:
         data: Stereo audio data (samples, 2)
         rate: Sample rate (unused, kept for API consistency)
-        amount: Width enhancement amount (0.0 = no change, 1.0 = max)
+        amount: Width adjustment (-1.0 to 1.0). Positive widens, negative narrows,
+            0.0 = no change.
 
     Returns:
-        Width-enhanced stereo audio data.
+        Width-adjusted stereo audio data.
     """
     if len(data.shape) == 1 or data.shape[1] != 2:
         return data
-    if amount <= 0:
+    if amount == 0:
         return data
 
-    amount = min(amount, 1.0)
+    amount = max(-1.0, min(amount, 1.0))
 
     # Mid-side encoding
     mid = (data[:, 0] + data[:, 1]) / 2
     side = (data[:, 0] - data[:, 1]) / 2
 
-    # Enhance side signal
+    # Adjust side signal (positive = widen, negative = narrow)
     side = side * (1 + amount)
 
     # Decode back to L/R
@@ -567,6 +568,66 @@ def enhance_stereo(data: Any, rate: int, amount: float = 0.2) -> Any:
     result[:, 1] = mid - side
 
     return result
+
+
+def apply_saturation(data: Any, rate: int, drive: float = 0.0) -> Any:
+    """Apply tanh soft saturation for harmonic warmth.
+
+    Args:
+        data: Audio data
+        rate: Sample rate (unused, kept for API consistency)
+        drive: Saturation amount 0.0-1.0 (0 = off, higher = more harmonics)
+
+    Returns:
+        Saturated audio data with preserved peak level.
+    """
+    if drive <= 0:
+        return data
+    drive = min(drive, 1.0)
+
+    # Pre-gain maps drive 0.1-1.0 to 1.5x-6.0x
+    gain = 1.0 + drive * 5.0
+    saturated = np.tanh(data * gain)
+    # Normalize so that a full-scale sine doesn't change peak level
+    normalizer = np.tanh(gain)
+    if normalizer > 0:
+        saturated = saturated / normalizer
+
+    return saturated
+
+
+def apply_lowpass(data: Any, rate: int, cutoff: int = 20000) -> Any:
+    """Apply Butterworth lowpass filter for dark/vintage character.
+
+    Args:
+        data: Audio data
+        rate: Sample rate
+        cutoff: Cutoff frequency in Hz (20000 = effectively off)
+
+    Returns:
+        Lowpass-filtered audio data.
+    """
+    nyquist = rate / 2
+    if cutoff <= 0 or cutoff >= nyquist:
+        return data
+
+    normalized_cutoff = cutoff / nyquist
+    # 2nd order Butterworth
+    b, a = signal.butter(2, normalized_cutoff, btype='low')
+
+    # Verify stability
+    poles = np.roots(a)
+    if not np.all(np.abs(poles) < 1.0):
+        logger.warning("Unstable lowpass filter at %d Hz, skipping", cutoff)
+        return data
+
+    if len(data.shape) == 1:
+        return signal.lfilter(b, a, data)
+    else:
+        result = np.zeros_like(data)
+        for ch in range(data.shape[1]):
+            result[:, ch] = signal.lfilter(b, a, data[:, ch])
+        return result
 
 
 def remix_stems(stems_dict: dict[str, tuple[Any, int]], gains_dict: dict[str, float] | None = None) -> tuple[Any, int]:
@@ -629,6 +690,47 @@ def remix_stems(stems_dict: dict[str, tuple[Any, int]], gains_dict: dict[str, fl
     return mixed, rate
 
 
+# ─── Character Effects Helper ────────────────────────────────────────
+
+
+def _apply_character_effects(
+    data: Any, rate: int, settings: dict[str, Any],
+    *, stereo: bool = False, saturation: bool = False, lowpass: bool = False,
+) -> Any:
+    """Apply character effects (stereo width, saturation, lowpass) in standard order.
+
+    Call this at the appropriate point in each processor's chain:
+    - stereo_width: call BEFORE compression
+    - saturation + lowpass: call AFTER compression
+
+    Args:
+        data: Audio data
+        rate: Sample rate
+        settings: Stem settings dict (reads stereo_width, saturation_drive, lowpass_cutoff)
+        stereo: Whether to apply stereo width enhancement
+        saturation: Whether to apply saturation
+        lowpass: Whether to apply lowpass filter
+    """
+    if stereo:
+        width = settings.get('stereo_width', 1.0)
+        if width != 1.0:
+            # Convert width multiplier to enhancement amount
+            # width 1.3 → amount 0.3, width 0.9 → amount -0.1
+            data = enhance_stereo(data, rate, amount=width - 1.0)
+
+    if saturation:
+        drive = settings.get('saturation_drive', 0)
+        if drive > 0:
+            data = apply_saturation(data, rate, drive=drive)
+
+    if lowpass:
+        cutoff = settings.get('lowpass_cutoff', 20000)
+        if cutoff < 20000:
+            data = apply_lowpass(data, rate, cutoff=cutoff)
+
+    return data
+
+
 # ─── Per-Stem Processing Chains ──────────────────────────────────────
 
 
@@ -681,7 +783,7 @@ def _get_full_mix_settings(genre: str | None = None) -> dict[str, Any]:
 
 
 def process_vocals(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process vocal stem: noise reduction -> presence boost -> high tame -> compress.
+    """Process vocal stem: noise reduction -> presence boost -> high tame -> compress -> sat -> lp.
 
     Args:
         data: Audio data
@@ -718,11 +820,14 @@ def process_vocals(data: Any, rate: int, settings: dict[str, Any] | None = None)
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
+
     return data
 
 
 def process_backing_vocals(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process backing vocal stem: noise reduction -> presence boost -> high tame -> width -> compress.
+    """Process backing vocal stem: noise reduction -> presence boost -> high tame -> width -> compress -> sat -> lp.
 
     Lighter presence than lead vocals so backing sits behind. Wider stereo
     spread and slightly more aggressive high tame for de-essing.
@@ -754,6 +859,9 @@ def process_backing_vocals(data: Any, rate: int, settings: dict[str, Any] | None
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
 
+    # Stereo width (pre-compression)
+    data = _apply_character_effects(data, rate, settings, stereo=True)
+
     # Compression — tighter than lead
     comp_threshold = settings.get('compress_threshold_db', -14.0)
     comp_ratio = settings.get('compress_ratio', 3.0)
@@ -762,11 +870,14 @@ def process_backing_vocals(data: Any, rate: int, settings: dict[str, Any] | None
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
+
     return data
 
 
 def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process drum stem: click removal -> compress (fast attack).
+    """Process drum stem: click removal -> compress (fast attack) -> sat.
 
     Args:
         data: Audio data
@@ -791,11 +902,14 @@ def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) 
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True)
+
     return data
 
 
 def process_bass(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process bass stem: highpass -> mud cut -> compress.
+    """Process bass stem: highpass -> mud cut -> compress -> sat.
 
     Args:
         data: Audio data
@@ -826,11 +940,14 @@ def process_bass(data: Any, rate: int, settings: dict[str, Any] | None = None) -
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True)
+
     return data
 
 
 def process_synth(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process synth stem: highpass -> mid boost -> high tame -> width -> compress.
+    """Process synth stem: highpass -> mid boost -> high tame -> width -> compress -> sat -> lp.
 
     Highpass avoids bass competition. Mid boost adds body/presence.
     Light compression preserves dynamics.
@@ -862,6 +979,9 @@ def process_synth(data: Any, rate: int, settings: dict[str, Any] | None = None) 
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
 
+    # Stereo width (pre-compression)
+    data = _apply_character_effects(data, rate, settings, stereo=True)
+
     # Compression — light, preserve dynamics
     comp_threshold = settings.get('compress_threshold_db', -16.0)
     comp_ratio = settings.get('compress_ratio', 2.0)
@@ -869,6 +989,9 @@ def process_synth(data: Any, rate: int, settings: dict[str, Any] | None = None) 
     if comp_ratio > 1.0:
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
+
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
 
     return data
 
@@ -912,6 +1035,9 @@ def process_guitar(data: Any, rate: int, settings: dict[str, Any] | None = None)
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
 
+    # Stereo width (pre-compression)
+    data = _apply_character_effects(data, rate, settings, stereo=True)
+
     # Compression — moderate, preserve dynamics
     comp_threshold = settings.get('compress_threshold_db', -14.0)
     comp_ratio = settings.get('compress_ratio', 2.5)
@@ -919,6 +1045,9 @@ def process_guitar(data: Any, rate: int, settings: dict[str, Any] | None = None)
     if comp_ratio > 1.0:
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
+
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
 
     return data
 
@@ -962,6 +1091,9 @@ def process_keyboard(data: Any, rate: int, settings: dict[str, Any] | None = Non
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
 
+    # Stereo width (pre-compression)
+    data = _apply_character_effects(data, rate, settings, stereo=True)
+
     # Compression — light, preserve dynamics
     comp_threshold = settings.get('compress_threshold_db', -16.0)
     comp_ratio = settings.get('compress_ratio', 2.0)
@@ -969,6 +1101,9 @@ def process_keyboard(data: Any, rate: int, settings: dict[str, Any] | None = Non
     if comp_ratio > 1.0:
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
+
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
 
     return data
 
@@ -1013,6 +1148,9 @@ def process_strings(data: Any, rate: int, settings: dict[str, Any] | None = None
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
 
+    # Stereo width (pre-compression)
+    data = _apply_character_effects(data, rate, settings, stereo=True)
+
     # Compression — very gentle, preserve orchestral dynamics
     comp_threshold = settings.get('compress_threshold_db', -18.0)
     comp_ratio = settings.get('compress_ratio', 1.5)
@@ -1020,6 +1158,9 @@ def process_strings(data: Any, rate: int, settings: dict[str, Any] | None = None
     if comp_ratio > 1.0:
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
+
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, lowpass=True)
 
     return data
 
@@ -1072,6 +1213,9 @@ def process_brass(data: Any, rate: int, settings: dict[str, Any] | None = None) 
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
+
     return data
 
 
@@ -1122,6 +1266,9 @@ def process_woodwinds(data: Any, rate: int, settings: dict[str, Any] | None = No
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True, lowpass=True)
+
     return data
 
 
@@ -1164,6 +1311,9 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
 
+    # Stereo width (pre-compression)
+    data = _apply_character_effects(data, rate, settings, stereo=True)
+
     # Compression
     comp_threshold = settings.get('compress_threshold_db', -15.0)
     comp_ratio = settings.get('compress_ratio', 2.0)
@@ -1172,11 +1322,14 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
 
+    # Character effects (post-compression)
+    data = _apply_character_effects(data, rate, settings, saturation=True)
+
     return data
 
 
 def process_other(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process 'other' stem (instruments, synths): noise reduction -> mud cut -> high tame.
+    """Process 'other' stem (instruments, synths): noise reduction -> mud cut -> high tame -> lp.
 
     Args:
         data: Audio data
@@ -1204,6 +1357,9 @@ def process_other(data: Any, rate: int, settings: dict[str, Any] | None = None) 
     high_tame_freq = settings.get('high_tame_freq', 8000)
     if high_tame_db != 0:
         data = apply_high_shelf(data, rate, freq=high_tame_freq, gain_db=high_tame_db)
+
+    # Character effects
+    data = _apply_character_effects(data, rate, settings, lowpass=True)
 
     return data
 
@@ -1435,6 +1591,9 @@ def mix_track_full(input_path: Path | str, output_path: Path | str,
         if comp_ratio > 1.0:
             data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                    ratio=comp_ratio)
+
+        # Character effects (post-compression)
+        data = _apply_character_effects(data, rate, settings, lowpass=True)
 
         # Convert back to mono if input was mono
         if was_mono:


### PR DESCRIPTION
## Summary

- Implements Phase 1 of #246: wires existing dead preset fields (`saturation_drive`, `lowpass_cutoff`, `stereo_width`) that were tuned across 120+ genre entries but never had implementation code
- Adds `apply_saturation()` (tanh soft saturation), `apply_lowpass()` (Butterworth), and `_apply_character_effects()` helper
- Updates `enhance_stereo()` to support narrowing (width < 1.0)
- Wires effects into all 12 stem processors + full_mix per YAML chain spec
- All defaults are off — zero behavior change unless a genre preset overrides

## Test plan

- [x] 28 new unit tests covering `apply_saturation`, `apply_lowpass`, `_apply_character_effects`, and processor wiring
- [x] All 160 mixing tests pass
- [x] All 167 mastering tests pass (no regressions)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)