### PR TITLE
feat: add DC offset removal, de-essing, sample rate conversion, and track gaps

### DIFF
--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -26,6 +26,7 @@ from tools.mastering.master_tracks import (
     _PRESET_DEFAULTS,
     _load_yaml_file,
     _process_one_track,
+    apply_deesser,
     apply_eq,
     apply_fade_out,
     apply_high_shelf,
@@ -1271,3 +1272,169 @@ class TestPresetDefaultsComplete:
         assert _PRESET_DEFAULTS['compress_makeup'] == 0.0
         assert _PRESET_DEFAULTS['processing_oversample'] == 1
         assert _PRESET_DEFAULTS['target_lra'] == 0.0
+
+    def test_new_pipeline_defaults(self):
+        """New pipeline preset defaults should exist."""
+        assert _PRESET_DEFAULTS['dc_filter_freq'] == 5.0
+        assert _PRESET_DEFAULTS['output_sample_rate'] == 0
+        assert _PRESET_DEFAULTS['deess_enabled'] == 0
+        assert _PRESET_DEFAULTS['deess_freq'] == 6500.0
+        assert _PRESET_DEFAULTS['deess_bandwidth'] == 4000.0
+        assert _PRESET_DEFAULTS['deess_threshold'] == -20.0
+        assert _PRESET_DEFAULTS['deess_ratio'] == 4.0
+        assert _PRESET_DEFAULTS['track_gap'] == 0.0
+
+
+class TestDeesser:
+    """Tests for apply_deesser()."""
+
+    def test_ratio_1_passthrough(self):
+        """Ratio <= 1.0 returns data unchanged."""
+        data, rate = _generate_sine(freq=6500, amplitude=0.5)
+        result = apply_deesser(data, rate, ratio=1.0)
+        np.testing.assert_array_equal(result, data)
+
+    def test_reduces_sibilance_band(self):
+        """De-esser reduces energy in the sibilance frequency range."""
+        # Generate signal at de-esser center frequency (high amplitude)
+        data, rate = _generate_sine(freq=6500, amplitude=0.5)
+        result = apply_deesser(data, rate, freq=6500, threshold_db=-30.0, ratio=4.0)
+        # RMS should decrease
+        orig_rms = np.sqrt(np.mean(data ** 2))
+        result_rms = np.sqrt(np.mean(result ** 2))
+        assert result_rms < orig_rms
+
+    def test_preserves_low_frequencies(self):
+        """De-esser should not affect frequencies outside sibilance band."""
+        data, rate = _generate_sine(freq=200, amplitude=0.5)
+        result = apply_deesser(data, rate, freq=6500, threshold_db=-30.0, ratio=4.0)
+        correlation = np.corrcoef(data[:, 0], result[:, 0])[0, 1]
+        assert correlation > 0.95
+
+    def test_mono_support(self):
+        """De-esser works on mono signals."""
+        data, rate = _generate_sine(freq=6500, amplitude=0.5, stereo=False)
+        result = apply_deesser(data, rate, freq=6500, threshold_db=-30.0, ratio=4.0)
+        assert result.shape == data.shape
+
+    def test_below_threshold_passthrough(self):
+        """Signal below threshold is mostly unaffected."""
+        data, rate = _generate_sine(freq=6500, amplitude=0.01)
+        result = apply_deesser(data, rate, freq=6500, threshold_db=-10.0, ratio=4.0)
+        np.testing.assert_allclose(result, data, atol=0.001)
+
+
+class TestDCOffsetRemoval:
+    """Tests for DC offset removal in master_track()."""
+
+    def test_dc_filter_applied(self, tmp_path):
+        """DC offset removal should run without error."""
+        data, rate = _generate_sine(amplitude=0.3)
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        _write_wav(inp, data, rate)
+
+        preset = {**_PRESET_DEFAULTS, 'dc_filter_freq': 5.0}
+        result = master_track(str(inp), str(out), preset=preset)
+        assert not result.get('skipped')
+
+    def test_dc_filter_bypass(self, tmp_path):
+        """dc_filter_freq=0 should bypass DC removal."""
+        data, rate = _generate_sine(amplitude=0.3)
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        _write_wav(inp, data, rate)
+
+        preset = {**_PRESET_DEFAULTS, 'dc_filter_freq': 0.0}
+        result = master_track(str(inp), str(out), preset=preset)
+        assert not result.get('skipped')
+
+
+class TestSampleRateConversion:
+    """Tests for sample rate conversion."""
+
+    def test_output_preserves_rate_by_default(self, tmp_path):
+        """output_sample_rate=0 preserves input rate."""
+        data, rate = _generate_sine(amplitude=0.3)
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        _write_wav(inp, data, rate)
+
+        preset = {**_PRESET_DEFAULTS, 'output_sample_rate': 0}
+        master_track(str(inp), str(out), preset=preset)
+        info = sf.info(str(out))
+        assert info.samplerate == rate
+
+    def test_downsample_to_22050(self, tmp_path):
+        """Downsampling to 22050 should produce correct sample rate."""
+        data, rate = _generate_sine(amplitude=0.3, duration=3.0)
+        assert rate == 44100
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        _write_wav(inp, data, rate)
+
+        preset = {**_PRESET_DEFAULTS, 'output_sample_rate': 22050}
+        master_track(str(inp), str(out), preset=preset)
+        info = sf.info(str(out))
+        assert info.samplerate == 22050
+
+
+class TestInterTrackGap:
+    """Tests for inter-track gap insertion."""
+
+    def test_no_gap_by_default(self, tmp_path):
+        """track_gap=0 should not add silence."""
+        data, rate = _generate_sine(amplitude=0.3)
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        _write_wav(inp, data, rate)
+
+        preset_no_gap = {**_PRESET_DEFAULTS, 'track_gap': 0.0}
+        preset_gap = {**_PRESET_DEFAULTS, 'track_gap': 2.0}
+        master_track(str(inp), str(out1), preset=preset_no_gap)
+        master_track(str(inp), str(out2), preset=preset_gap)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        # Gap version should be longer
+        assert d2.shape[0] > d1.shape[0]
+
+    def test_gap_is_silence(self, tmp_path):
+        """Prepended gap should be silence."""
+        data, rate = _generate_sine(amplitude=0.3)
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        _write_wav(inp, data, rate)
+
+        gap_seconds = 1.0
+        preset = {**_PRESET_DEFAULTS, 'track_gap': gap_seconds}
+        master_track(str(inp), str(out), preset=preset)
+        d, r = sf.read(str(out))
+        gap_samples = int(r * gap_seconds)
+        # First gap_samples should be near-silent (dither noise only)
+        gap_rms = np.sqrt(np.mean(d[:gap_samples] ** 2))
+        assert gap_rms < 0.001
+
+
+class TestDeesserInMasterTrack:
+    """Test de-esser wired through master_track()."""
+
+    def test_deess_changes_output(self, tmp_path):
+        """Enabling de-esser should change the output."""
+        # Create signal with sibilance-frequency content
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        data = 0.3 * np.sin(2 * np.pi * 440 * t) + 0.2 * np.sin(2 * np.pi * 6500 * t)
+        data = np.column_stack([data, data])
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        _write_wav(inp, data, rate)
+
+        preset_off = {**_PRESET_DEFAULTS, 'deess_enabled': 0}
+        preset_on = {**_PRESET_DEFAULTS, 'deess_enabled': 1, 'deess_threshold': -30.0}
+        master_track(str(inp), str(out1), preset=preset_off)
+        master_track(str(inp), str(out2), preset=preset_on)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        assert not np.allclose(d1, d2)

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -26,6 +26,14 @@
 #   compress_makeup        - Compression makeup gain in dB (0 = off, default 0)
 #   processing_oversample  - Oversample factor for nonlinear stages (1/2/4, default 1)
 #   target_lra             - Target loudness range in LU (0 = disable, default 0)
+#   dc_filter_freq         - DC offset HPF frequency in Hz (0 = bypass, default 5.0)
+#   output_sample_rate     - Target sample rate (0 = preserve input, e.g., 44100)
+#   deess_enabled          - Enable de-esser (0 = off, 1 = on, default 0)
+#   deess_freq             - De-esser center frequency in Hz (default 6500)
+#   deess_bandwidth        - De-esser bandwidth in Hz (default 4000)
+#   deess_threshold        - De-esser threshold in dB (default -20.0)
+#   deess_ratio            - De-esser compression ratio (default 4.0)
+#   track_gap              - Silence to prepend per track in seconds (default 0)
 #
 # Override per-user: copy to {overrides}/mastering-presets.yaml and edit.
 # User overrides merge on top of these defaults (genre-level).
@@ -57,6 +65,14 @@ defaults:
   compress_makeup: 0
   processing_oversample: 1
   target_lra: 0
+  dc_filter_freq: 5.0
+  output_sample_rate: 0
+  deess_enabled: 0
+  deess_freq: 6500
+  deess_bandwidth: 4000
+  deess_threshold: -20.0
+  deess_ratio: 4.0
+  track_gap: 0
 
 genres:
   # === Pop / Mainstream ===

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -100,6 +100,14 @@ _PRESET_DEFAULTS: dict[str, float] = {
     'compress_makeup': 0.0,
     'processing_oversample': 1,
     'target_lra': 0.0,
+    'dc_filter_freq': 5.0,
+    'output_sample_rate': 0,
+    'deess_enabled': 0,
+    'deess_freq': 6500.0,
+    'deess_bandwidth': 4000.0,
+    'deess_threshold': -20.0,
+    'deess_ratio': 4.0,
+    'track_gap': 0.0,
 }
 
 
@@ -537,6 +545,81 @@ def limit_peaks_lookahead(data: Any, ceiling_db: float = -1.0,
     return soft_clip(result, ceiling_linear)
 
 
+def apply_deesser(data: Any, rate: int, freq: float = 6500.0,
+                  bandwidth: float = 4000.0, threshold_db: float = -20.0,
+                  ratio: float = 4.0) -> Any:
+    """Frequency-selective de-esser for sibilance reduction.
+
+    Isolates a sibilance band, detects energy exceeding threshold,
+    and applies gain reduction only to that band.
+
+    Args:
+        data: Audio data
+        rate: Sample rate
+        freq: Center frequency for sibilance detection (Hz)
+        bandwidth: Detection bandwidth in Hz
+        threshold_db: Threshold for sibilance reduction (dB)
+        ratio: Compression ratio for sibilant regions
+    """
+    if ratio <= 1.0:
+        return data
+
+    nyquist = rate / 2
+    low_freq = max(20, freq - bandwidth / 2)
+    high_freq = min(nyquist - 1, freq + bandwidth / 2)
+
+    if low_freq >= high_freq or high_freq >= nyquist:
+        return data
+
+    # Design bandpass filter for sibilance detection
+    low_norm = low_freq / nyquist
+    high_norm = high_freq / nyquist
+    b_bp, a_bp = signal.butter(2, [low_norm, high_norm], btype='band')
+
+    poles = np.roots(a_bp)
+    if not np.all(np.abs(poles) < 1.0):
+        logger.warning("Unstable de-esser bandpass at %.0f Hz, skipping", freq)
+        return data
+
+    threshold_linear = 10 ** (threshold_db / 20)
+
+    def _deess_channel(channel: Any) -> Any:
+        # Extract sibilance band
+        sibilance = signal.lfilter(b_bp, a_bp, channel)
+        # Envelope of sibilance band
+        env = np.abs(sibilance)
+        # Smooth envelope (fast attack, medium release)
+        attack_coeff = np.exp(-1.0 / (rate * 0.001))  # 1ms attack
+        release_coeff = np.exp(-1.0 / (rate * 0.020))  # 20ms release
+        smoothed = np.empty_like(env)
+        val = 0.0
+        for i in range(len(env)):
+            if env[i] > val:
+                val = attack_coeff * val + (1.0 - attack_coeff) * env[i]
+            else:
+                val = release_coeff * val + (1.0 - release_coeff) * env[i]
+            smoothed[i] = val
+        # Gain reduction only where sibilance exceeds threshold
+        gain = np.ones_like(channel)
+        above = smoothed > threshold_linear
+        if np.any(above):
+            env_db = np.where(above, 20 * np.log10(np.maximum(smoothed, 1e-10)), 0)
+            thresh_db_val = 20 * np.log10(max(threshold_linear, 1e-10))
+            excess_db = np.where(above, env_db - thresh_db_val, 0)
+            gain_reduction_db = excess_db * (1 - 1 / ratio)
+            gain = np.where(above, 10 ** (-gain_reduction_db / 20), 1.0)
+        # Apply gain reduction only to sibilance band, keep rest unchanged
+        return channel - sibilance + sibilance * gain
+
+    if len(data.shape) == 1:
+        return _deess_channel(data)
+    else:
+        result = np.zeros_like(data)
+        for ch in range(data.shape[1]):
+            result[:, ch] = _deess_channel(data[:, ch])
+        return result
+
+
 def apply_tpdf_dither(data: Any, target_bits: int = 16, seed: int | None = None) -> Any:
     """Apply TPDF (Triangular Probability Density Function) dithering.
 
@@ -607,6 +690,11 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if was_mono:
         data = np.column_stack([data, data])
 
+    # DC offset removal (first processing stage)
+    dc_freq = p.get('dc_filter_freq', 5.0)
+    if dc_freq > 0:
+        data = apply_highpass(data, rate, cutoff=int(dc_freq))
+
     # Sub-bass rumble removal (before any EQ)
     sub_cut = int(p.get('eq_sub_cut_freq', 0))
     if sub_cut > 0:
@@ -621,6 +709,16 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if eq_settings:
         for freq, gain_db, q in eq_settings:
             data = apply_eq(data, rate, freq, gain_db, q)
+
+    # De-essing (after EQ, before dynamics)
+    if p.get('deess_enabled', 0) > 0:
+        data = apply_deesser(
+            data, rate,
+            freq=p.get('deess_freq', 6500.0),
+            bandwidth=p.get('deess_bandwidth', 4000.0),
+            threshold_db=p.get('deess_threshold', -20.0),
+            ratio=p.get('deess_ratio', 4.0),
+        )
 
     # Stereo width adjustment (after EQ, before compression)
     stereo_w = p.get('stereo_width', 1.0)
@@ -740,11 +838,30 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if was_mono:
         data = data[:, 0]
 
+    # Sample rate conversion (after processing, before dither)
+    output_sr = int(p.get('output_sample_rate', 0))
+    if output_sr > 0 and output_sr != rate:
+        # Use rational resampling via polyphase FIR
+        from math import gcd
+        g = gcd(output_sr, rate)
+        data = signal.resample_poly(data, up=output_sr // g, down=rate // g, axis=0)
+        rate = output_sr
+
     # Resolve output bit depth: output_bits controls the format,
     # dither_bits follows output_bits by default but can be overridden
     output_bits = int(p.get('output_bits', 16))
     dither_bits = int(p.get('dither_bits', output_bits))
     data = apply_tpdf_dither(data, target_bits=dither_bits)
+
+    # Inter-track gap insertion (after dither, before write)
+    track_gap = p.get('track_gap', 0.0)
+    if track_gap > 0:
+        gap_samples = int(rate * track_gap)
+        if data.ndim == 1:
+            silence = np.zeros(gap_samples, dtype=data.dtype)
+        else:
+            silence = np.zeros((gap_samples, data.shape[1]), dtype=data.dtype)
+        data = np.concatenate([silence, data], axis=0)
 
     # Write output
     subtype = 'PCM_16' if output_bits <= 16 else 'PCM_24'
@@ -882,6 +999,20 @@ Examples:
                        help='Oversample factor for nonlinear stages (1/2/4, default: 1)')
     parser.add_argument('--target-lra', type=float, default=None,
                        help='Target loudness range in LU (0 = disable, default: 0)')
+    parser.add_argument('--dc-filter-freq', type=float, default=None,
+                       help='DC offset removal HPF frequency in Hz (0 = bypass, default: 5.0)')
+    parser.add_argument('--output-sample-rate', type=int, default=None,
+                       help='Target sample rate (0 = preserve input, e.g., 44100)')
+    parser.add_argument('--deess', action='store_true', default=None,
+                       help='Enable de-esser')
+    parser.add_argument('--deess-freq', type=float, default=None,
+                       help='De-esser center frequency in Hz (default: 6500)')
+    parser.add_argument('--deess-threshold', type=float, default=None,
+                       help='De-esser threshold in dB (default: -20.0)')
+    parser.add_argument('--deess-ratio', type=float, default=None,
+                       help='De-esser compression ratio (default: 4.0)')
+    parser.add_argument('--track-gap', type=float, default=None,
+                       help='Silence to prepend to each track in seconds (default: 0)')
     parser.add_argument('-j', '--jobs', type=int, default=1,
                        help='Parallel jobs (0=auto, default: 1)')
 
@@ -926,6 +1057,13 @@ Examples:
         'compress_makeup': args.compress_makeup,
         'processing_oversample': float(args.processing_oversample) if args.processing_oversample is not None else None,
         'target_lra': args.target_lra,
+        'dc_filter_freq': args.dc_filter_freq,
+        'output_sample_rate': float(args.output_sample_rate) if args.output_sample_rate is not None else None,
+        'deess_enabled': 1.0 if args.deess else None,
+        'deess_freq': args.deess_freq,
+        'deess_threshold': args.deess_threshold,
+        'deess_ratio': args.deess_ratio,
+        'track_gap': args.track_gap,
     }
     for key, value in cli_overrides.items():
         if value is not None:


### PR DESCRIPTION
## Summary

- Implements core per-track items from #254: four new mastering pipeline stages
- **DC offset removal** (`dc_filter_freq`, default 5Hz) — subsonic HPF as first processing stage, removes DC bias
- **De-esser** (`deess_enabled/freq/bandwidth/threshold/ratio`) — frequency-selective compression for sibilance reduction
- **Sample rate conversion** (`output_sample_rate`) — rational resampling via polyphase FIR for platform compatibility
- **Inter-track gap** (`track_gap`) — prepends silence for album sequencing or CD master prep
- All defaults preserve existing behavior (DC filter at 5Hz is the only always-on addition)
- Remaining #254 items (album consistency, linear phase EQ, QC metering) are follow-up scope

## Test plan

- [x] 13 new unit tests for de-esser, DC offset, sample rate conversion, track gap, and preset defaults
- [x] All 134 mastering tests pass
- [x] Full suite: 2967 passed, 0 failed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)