### PR TITLE
feat: add sub-bass exciter and transient shaping to mix pipeline

### DIFF
--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -30,6 +30,8 @@ from tools.mixing.mix_tracks import (
     apply_highpass,
     apply_lowpass,
     apply_saturation,
+    apply_sub_bass_exciter,
+    apply_transient_shaper,
     gentle_compress,
     remove_clicks,
     reduce_noise,
@@ -1901,3 +1903,113 @@ class TestProcessorCharacterEffectsWiring:
         # Just verify it runs without error
         result = process_vocals(data.copy(), rate, settings)
         assert result.shape == data.shape
+
+
+# ─── Sub-Bass Exciter Tests ──────────────────────────────────────────
+
+
+class TestSubBassExciter:
+    """Tests for apply_sub_bass_exciter()."""
+
+    def test_zero_amount_passthrough(self):
+        """Amount=0 returns data unchanged."""
+        data, rate = _generate_sine(freq=60, amplitude=0.5)
+        result = apply_sub_bass_exciter(data, rate, amount=0.0)
+        np.testing.assert_array_equal(result, data)
+
+    def test_exciter_adds_harmonics(self):
+        """Exciter should add harmonic content above the crossover."""
+        data, rate = _generate_sine(freq=40, amplitude=0.5)
+        result = apply_sub_bass_exciter(data, rate, amount=0.5, freq=80)
+        # Check for new spectral energy above 80Hz
+        fft_orig = np.abs(np.fft.rfft(data[:, 0]))
+        fft_exc = np.abs(np.fft.rfft(result[:, 0]))
+        # Energy above crossover should increase
+        crossover_bin = int(80 * len(data) / rate)
+        orig_above = np.sum(fft_orig[crossover_bin:])
+        exc_above = np.sum(fft_exc[crossover_bin:])
+        assert exc_above > orig_above
+
+    def test_preserves_shape(self):
+        """Output shape matches input."""
+        data, rate = _generate_sine(freq=60, amplitude=0.5)
+        result = apply_sub_bass_exciter(data, rate, amount=0.3)
+        assert result.shape == data.shape
+
+    def test_mono_support(self):
+        """Works on mono signals."""
+        data, rate = _generate_sine(freq=60, amplitude=0.5, stereo=False)
+        result = apply_sub_bass_exciter(data, rate, amount=0.3)
+        assert result.shape == data.shape
+
+    def test_high_freq_signal_unaffected(self):
+        """Signal above crossover should be mostly unaffected."""
+        data, rate = _generate_sine(freq=1000, amplitude=0.5)
+        result = apply_sub_bass_exciter(data, rate, amount=0.5, freq=80)
+        correlation = np.corrcoef(data[:, 0], result[:, 0])[0, 1]
+        assert correlation > 0.95
+
+
+class TestTransientShaper:
+    """Tests for apply_transient_shaper()."""
+
+    def test_zero_gains_passthrough(self):
+        """Both gains=0 returns data unchanged."""
+        data, rate = _generate_noise(amplitude=0.5)
+        result = apply_transient_shaper(data, rate, attack_gain=0, sustain_gain=0)
+        np.testing.assert_array_equal(result, data)
+
+    def test_attack_boost_changes_signal(self):
+        """Positive attack gain should change the signal."""
+        data, rate = _generate_noise(amplitude=0.5)
+        result = apply_transient_shaper(data, rate, attack_gain=6.0)
+        assert not np.allclose(result, data)
+
+    def test_sustain_boost_changes_signal(self):
+        """Positive sustain gain should change the signal."""
+        data, rate = _generate_noise(amplitude=0.5)
+        result = apply_transient_shaper(data, rate, sustain_gain=3.0)
+        assert not np.allclose(result, data)
+
+    def test_preserves_shape(self):
+        """Output shape matches input."""
+        data, rate = _generate_noise(amplitude=0.5)
+        result = apply_transient_shaper(data, rate, attack_gain=3.0)
+        assert result.shape == data.shape
+
+    def test_mono_support(self):
+        """Works on mono signals."""
+        data, rate = _generate_noise(amplitude=0.5, stereo=False)
+        result = apply_transient_shaper(data, rate, attack_gain=3.0)
+        assert result.shape == data.shape
+
+
+class TestPhase2ProcessorWiring:
+    """Verify Phase 2 effects are wired into processors."""
+
+    def test_drums_transient_shaping(self):
+        """Drums applies transient shaping when attack_db != 0."""
+        data, rate = _generate_noise(amplitude=0.5)
+        settings_off = {**_get_stem_settings('drums'), 'transient_attack_db': 0}
+        settings_on = {**_get_stem_settings('drums'), 'transient_attack_db': 6.0}
+        result_off = process_drums(data.copy(), rate, settings_off)
+        result_on = process_drums(data.copy(), rate, settings_on)
+        assert not np.allclose(result_off, result_on)
+
+    def test_bass_sub_bass_exciter(self):
+        """Bass applies sub-bass exciter when amount > 0."""
+        data, rate = _generate_sine(freq=60, amplitude=0.5)
+        settings_off = {**_get_stem_settings('bass'), 'sub_bass_exciter': 0}
+        settings_on = {**_get_stem_settings('bass'), 'sub_bass_exciter': 0.3}
+        result_off = process_bass(data.copy(), rate, settings_off)
+        result_on = process_bass(data.copy(), rate, settings_on)
+        assert not np.allclose(result_off, result_on)
+
+    def test_percussion_transient_shaping(self):
+        """Percussion applies transient shaping when attack_db != 0."""
+        data, rate = _generate_noise(amplitude=0.3)
+        settings_off = {**_get_stem_settings('percussion'), 'transient_attack_db': 0}
+        settings_on = {**_get_stem_settings('percussion'), 'transient_attack_db': 4.0}
+        result_off = process_percussion(data.copy(), rate, settings_off)
+        result_on = process_percussion(data.copy(), rate, settings_on)
+        assert not np.allclose(result_off, result_on)

--- a/tools/mixing/mix-presets.yaml
+++ b/tools/mixing/mix-presets.yaml
@@ -23,6 +23,12 @@
 #   lowpass_cutoff: Hz (20000 = off, lower = darker/vintage)
 #   stereo_width: multiplier (1.0 = off, <1 = narrower, >1 = wider)
 #
+# Per-stem effects (default off):
+#   sub_bass_exciter: 0.0-1.0 (bass only, generates harmonics for small speakers)
+#   sub_bass_freq: Hz (crossover frequency, default 80)
+#   transient_attack_db: dB (drums/percussion, positive = more punch, negative = softer)
+#   transient_sustain_db: dB (drums/percussion, positive = more body, negative = tighter)
+#
 # Override per-user: copy to {overrides}/mix-presets.yaml and edit.
 # User overrides deep-merge on top of these defaults.
 
@@ -60,6 +66,8 @@ defaults:
     compress_attack_ms: 5.0
     gain_db: 0.0
     saturation_drive: 0
+    transient_attack_db: 0
+    transient_sustain_db: 0
   bass:
     highpass_cutoff: 30
     mud_cut_db: -3.0
@@ -69,6 +77,8 @@ defaults:
     compress_attack_ms: 10.0
     gain_db: 0.0
     saturation_drive: 0
+    sub_bass_exciter: 0
+    sub_bass_freq: 80
   synth:
     highpass_cutoff: 80
     mid_boost_db: 1.0
@@ -168,6 +178,8 @@ defaults:
     compress_ratio: 2.0
     compress_attack_ms: 8.0
     gain_db: 0.0
+    transient_attack_db: 0
+    transient_sustain_db: 0
     saturation_drive: 0
   other:
     noise_reduction: 0.3

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -630,6 +630,119 @@ def apply_lowpass(data: Any, rate: int, cutoff: int = 20000) -> Any:
         return result
 
 
+def apply_sub_bass_exciter(data: Any, rate: int, amount: float = 0.0,
+                           freq: float = 80.0) -> Any:
+    """Generate sub-bass harmonics for weight on large speakers and audibility on small ones.
+
+    Isolates frequencies below the crossover, applies waveshaping to generate
+    upper harmonics (2nd and 3rd), then blends back with the original.
+
+    Args:
+        data: Audio data
+        rate: Sample rate
+        amount: Exciter amount 0.0-1.0 (0 = off)
+        freq: Crossover frequency — excite below this (Hz)
+
+    Returns:
+        Audio with enhanced sub-bass harmonics.
+    """
+    if amount <= 0:
+        return data
+    amount = min(amount, 1.0)
+
+    nyquist = rate / 2
+    if freq <= 0 or freq >= nyquist:
+        return data
+
+    # Isolate sub-bass via lowpass
+    normalized = freq / nyquist
+    b, a = signal.butter(2, normalized, btype='low')
+    poles = np.roots(a)
+    if not np.all(np.abs(poles) < 1.0):
+        return data
+
+    def _excite_channel(channel: Any) -> Any:
+        sub = signal.lfilter(b, a, channel)
+        # Generate harmonics via waveshaping (tanh + squaring for 2nd harmonic)
+        harmonics = np.tanh(sub * 3.0) * 0.5 + (sub ** 2) * 0.3
+        # Highpass the harmonics to remove the fundamental (keep only generated content)
+        hp_norm = freq / nyquist
+        b_hp, a_hp = signal.butter(2, hp_norm, btype='high')
+        hp_poles = np.roots(a_hp)
+        if np.all(np.abs(hp_poles) < 1.0):
+            harmonics = signal.lfilter(b_hp, a_hp, harmonics)
+        # Blend harmonics into original
+        return channel + harmonics * amount
+
+    if len(data.shape) == 1:
+        return _excite_channel(data)
+    else:
+        result = np.zeros_like(data)
+        for ch in range(data.shape[1]):
+            result[:, ch] = _excite_channel(data[:, ch])
+        return result
+
+
+def apply_transient_shaper(data: Any, rate: int, attack_gain: float = 0.0,
+                           sustain_gain: float = 0.0,
+                           fast_attack_ms: float = 0.5,
+                           slow_attack_ms: float = 20.0) -> Any:
+    """Shape transients using dual-envelope detection.
+
+    Compares a fast envelope (tracks transients) against a slow envelope
+    (tracks sustain). The difference reveals transient events, which can
+    be boosted or cut independently of sustain.
+
+    Args:
+        data: Audio data
+        rate: Sample rate
+        attack_gain: Transient boost/cut in dB (positive = more punch, negative = softer)
+        sustain_gain: Sustain boost/cut in dB (positive = more body, negative = tighter)
+        fast_attack_ms: Fast envelope attack time (tracks transients)
+        slow_attack_ms: Slow envelope attack time (tracks sustain)
+
+    Returns:
+        Transient-shaped audio data.
+    """
+    if attack_gain == 0 and sustain_gain == 0:
+        return data
+
+    # Time constants
+    fast_attack = np.exp(-1.0 / (rate * fast_attack_ms / 1000.0))
+    fast_release = np.exp(-1.0 / (rate * 5.0 / 1000.0))  # 5ms release
+    slow_attack = np.exp(-1.0 / (rate * slow_attack_ms / 1000.0))
+    slow_release = np.exp(-1.0 / (rate * 50.0 / 1000.0))  # 50ms release
+
+    attack_linear = 10 ** (attack_gain / 20)
+    sustain_linear = 10 ** (sustain_gain / 20)
+
+    def _shape_channel(channel: Any) -> Any:
+        abs_signal = np.abs(channel)
+        # Dual envelope detection
+        fast_env = _envelope_follower(abs_signal, fast_attack, fast_release)
+        slow_env = _envelope_follower(abs_signal, slow_attack, slow_release)
+
+        # Transient component: where fast > slow (onset detected)
+        # Sustain component: where fast ≈ slow (steady state)
+        slow_safe = np.maximum(slow_env, 1e-10)
+        ratio = fast_env / slow_safe
+
+        # Gain envelope: blend attack and sustain gains based on transient ratio
+        # ratio > 1 = transient, ratio ≈ 1 = sustain
+        transient_mask = np.clip(ratio - 1.0, 0.0, 1.0)  # 0 = sustain, 1 = transient
+        gain = transient_mask * attack_linear + (1.0 - transient_mask) * sustain_linear
+
+        return channel * gain
+
+    if len(data.shape) == 1:
+        return _shape_channel(data)
+    else:
+        result = np.zeros_like(data)
+        for ch in range(data.shape[1]):
+            result[:, ch] = _shape_channel(data[:, ch])
+        return result
+
+
 def remix_stems(stems_dict: dict[str, tuple[Any, int]], gains_dict: dict[str, float] | None = None) -> tuple[Any, int]:
     """Combine processed stems into a stereo mix.
 
@@ -877,7 +990,7 @@ def process_backing_vocals(data: Any, rate: int, settings: dict[str, Any] | None
 
 
 def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process drum stem: click removal -> compress (fast attack) -> sat.
+    """Process drum stem: click removal -> transient shape -> compress (fast attack) -> sat.
 
     Args:
         data: Audio data
@@ -894,6 +1007,12 @@ def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) 
         click_threshold = settings.get('click_threshold', 6.0)
         data = remove_clicks(data, rate, threshold=click_threshold)
 
+    # Transient shaping (before compression to preserve punch)
+    attack_db = settings.get('transient_attack_db', 0)
+    sustain_db = settings.get('transient_sustain_db', 0)
+    if attack_db != 0 or sustain_db != 0:
+        data = apply_transient_shaper(data, rate, attack_gain=attack_db, sustain_gain=sustain_db)
+
     # Compression with fast attack for transient preservation
     comp_threshold = settings.get('compress_threshold_db', -12.0)
     comp_ratio = settings.get('compress_ratio', 2.0)
@@ -909,7 +1028,7 @@ def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) 
 
 
 def process_bass(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
-    """Process bass stem: highpass -> mud cut -> compress -> sat.
+    """Process bass stem: highpass -> mud cut -> compress -> sub-bass exciter -> sat.
 
     Args:
         data: Audio data
@@ -939,6 +1058,12 @@ def process_bass(data: Any, rate: int, settings: dict[str, Any] | None = None) -
     if comp_ratio > 1.0:
         data = gentle_compress(data, rate, threshold_db=comp_threshold,
                                ratio=comp_ratio, attack_ms=comp_attack)
+
+    # Sub-bass harmonic exciter (post-compression for consistent level)
+    exciter_amount = settings.get('sub_bass_exciter', 0)
+    if exciter_amount > 0:
+        exciter_freq = settings.get('sub_bass_freq', 80)
+        data = apply_sub_bass_exciter(data, rate, amount=exciter_amount, freq=exciter_freq)
 
     # Character effects (post-compression)
     data = _apply_character_effects(data, rate, settings, saturation=True)
@@ -1298,6 +1423,12 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
     if settings.get('click_removal', True):
         click_threshold = settings.get('click_threshold', 6.0)
         data = remove_clicks(data, rate, threshold=click_threshold)
+
+    # Transient shaping (before compression to preserve punch)
+    attack_db = settings.get('transient_attack_db', 0)
+    sustain_db = settings.get('transient_sustain_db', 0)
+    if attack_db != 0 or sustain_db != 0:
+        data = apply_transient_shaper(data, rate, attack_gain=attack_db, sustain_gain=sustain_db)
 
     # Presence boost (~4 kHz) — shakers/tambourines
     presence_db = settings.get('presence_boost_db', 1.0)


### PR DESCRIPTION
## Summary

- Implements #246 Phase 2: two new per-stem effects
- **Sub-bass harmonic exciter** (bass stem) — generates upper harmonics from sub-bass content via waveshaping, making bass audible on small speakers. New fields: `sub_bass_exciter` (0-1), `sub_bass_freq` (Hz)
- **Transient shaper** (drums/percussion stems) — dual-envelope detection using existing numba-accelerated envelope follower. Independently boosts/cuts attack punch and sustain body. New fields: `transient_attack_db`, `transient_sustain_db`
- All defaults are off — zero behavior change without explicit preset override

## Test plan

- [x] 13 new unit tests for sub-bass exciter, transient shaper, and processor wiring
- [x] All 173 mixing tests pass
- [x] Full suite: 2980 passed, 0 failed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)