### PR TITLE
feat: add multiband compression and mid/side EQ to mastering

### DIFF
--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -32,6 +32,8 @@ from tools.mastering.master_tracks import (
     apply_high_shelf,
     apply_highpass,
     apply_low_shelf,
+    apply_midside_eq,
+    apply_multiband_compress,
     apply_stereo_width,
     apply_tpdf_dither,
     limit_peaks,
@@ -1438,3 +1440,160 @@ class TestDeesserInMasterTrack:
         d1, _ = sf.read(str(out1))
         d2, _ = sf.read(str(out2))
         assert not np.allclose(d1, d2)
+
+
+class TestMultibandCompress:
+    """Tests for apply_multiband_compress()."""
+
+    def test_all_bypass_passthrough(self):
+        """All ratios=1.0 should return signal mostly unchanged."""
+        data, rate = _generate_noise(amplitude=0.3)
+        result = apply_multiband_compress(
+            data, rate, low_ratio=1.0, mid_ratio=1.0, high_ratio=1.0)
+        orig_rms = np.sqrt(np.mean(data ** 2))
+        result_rms = np.sqrt(np.mean(result ** 2))
+        assert abs(orig_rms - result_rms) / orig_rms < 0.2
+
+    def test_compression_changes_signal(self):
+        """Active compression should produce a different signal than bypass."""
+        data, rate = _generate_noise(amplitude=0.5)
+        result_bypass = apply_multiband_compress(
+            data.copy(), rate, low_ratio=1.0, mid_ratio=1.0, high_ratio=1.0)
+        result_active = apply_multiband_compress(
+            data.copy(), rate, low_ratio=3.0, mid_ratio=3.0, high_ratio=3.0,
+            low_threshold=-20.0, mid_threshold=-20.0, high_threshold=-20.0)
+        assert not np.allclose(result_bypass, result_active)
+
+    def test_preserves_shape(self):
+        """Output shape matches input."""
+        data, rate = _generate_noise(amplitude=0.3)
+        result = apply_multiband_compress(data, rate, low_ratio=2.0)
+        assert result.shape == data.shape
+
+    def test_mono_support(self):
+        """Works on mono signals."""
+        data, rate = _generate_noise(amplitude=0.3, stereo=False)
+        result = apply_multiband_compress(data, rate, mid_ratio=2.0)
+        assert result.shape == data.shape
+
+    def test_per_band_independence(self):
+        """Different band ratios should produce different results."""
+        data, rate = _generate_noise(amplitude=0.4)
+        result_low = apply_multiband_compress(
+            data.copy(), rate, low_ratio=4.0, mid_ratio=1.0, high_ratio=1.0,
+            low_threshold=-15.0)
+        result_high = apply_multiband_compress(
+            data.copy(), rate, low_ratio=1.0, mid_ratio=1.0, high_ratio=4.0,
+            high_threshold=-15.0)
+        assert not np.allclose(result_low, result_high)
+
+
+class TestMidsideEQ:
+    """Tests for apply_midside_eq()."""
+
+    def test_zero_gains_passthrough(self):
+        """Both gains=0 returns data unchanged."""
+        data, rate = _generate_sine(amplitude=0.5)
+        data[:, 1] *= 0.8
+        result = apply_midside_eq(data, rate, low_gain=0, high_gain=0)
+        np.testing.assert_array_equal(result, data)
+
+    def test_negative_low_narrows_bass(self):
+        """Negative low gain on side should narrow low-frequency stereo."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        left = 0.5 * np.sin(2 * np.pi * 100 * t)
+        right = 0.5 * np.sin(2 * np.pi * 100 * t + np.pi / 4)
+        data = np.column_stack([left, right])
+        result = apply_midside_eq(data, rate, low_gain=-6.0, low_freq=300)
+        orig_side = np.mean(np.abs(data[:, 0] - data[:, 1]))
+        result_side = np.mean(np.abs(result[:, 0] - result[:, 1]))
+        assert result_side < orig_side
+
+    def test_positive_high_widens_treble(self):
+        """Positive high gain on side should widen high-frequency stereo."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        left = 0.3 * np.sin(2 * np.pi * 10000 * t)
+        right = 0.3 * np.sin(2 * np.pi * 10000 * t + 0.3)
+        data = np.column_stack([left, right])
+        result = apply_midside_eq(data, rate, high_gain=6.0, high_freq=8000)
+        orig_side = np.mean(np.abs(data[:, 0] - data[:, 1]))
+        result_side = np.mean(np.abs(result[:, 0] - result[:, 1]))
+        assert result_side > orig_side
+
+    def test_mono_passthrough(self):
+        """Mono input returns unchanged."""
+        data, rate = _generate_sine(amplitude=0.5, stereo=False)
+        result = apply_midside_eq(data, rate, low_gain=-3.0)
+        np.testing.assert_array_equal(result, data)
+
+
+class TestMultibandInMasterTrack:
+    """Test multiband compression wired through master_track()."""
+
+    def test_multiband_produces_output(self, tmp_path):
+        """Multiband compression via preset should complete."""
+        data, rate = _generate_noise(amplitude=0.3)
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        _write_wav(inp, data, rate)
+
+        preset = {**_PRESET_DEFAULTS, 'multiband_enabled': 1}
+        result = master_track(str(inp), str(out), preset=preset)
+        assert not result.get('skipped')
+
+    def test_multiband_differs_from_singleband(self, tmp_path):
+        """Multiband should produce different output than single-band."""
+        data, rate = _generate_noise(amplitude=0.4)
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        _write_wav(inp, data, rate)
+
+        preset_single = {**_PRESET_DEFAULTS, 'compress_ratio': 2.0}
+        preset_multi = {**_PRESET_DEFAULTS, 'multiband_enabled': 1,
+                        'multiband_low_ratio': 2.0, 'multiband_mid_ratio': 2.0,
+                        'multiband_high_ratio': 2.0}
+        master_track(str(inp), str(out1), preset=preset_single)
+        master_track(str(inp), str(out2), preset=preset_multi)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        assert not np.allclose(d1, d2)
+
+
+class TestMidsideEQInMasterTrack:
+    """Test mid/side EQ wired through master_track()."""
+
+    def test_midside_eq_changes_output(self, tmp_path):
+        """Mid/side EQ via preset should change stereo field."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        left = 0.3 * np.sin(2 * np.pi * 440 * t)
+        right = 0.3 * np.sin(2 * np.pi * 440 * t + 0.3)
+        data = np.column_stack([left, right])
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        _write_wav(inp, data, rate)
+
+        preset_off = {**_PRESET_DEFAULTS}
+        preset_on = {**_PRESET_DEFAULTS, 'midside_low_gain': -6.0}
+        master_track(str(inp), str(out1), preset=preset_off)
+        master_track(str(inp), str(out2), preset=preset_on)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        assert not np.allclose(d1, d2)
+
+
+class TestPhase3PresetDefaults:
+    """Verify Phase 3 preset defaults."""
+
+    def test_multiband_defaults(self):
+        assert _PRESET_DEFAULTS['multiband_enabled'] == 0
+        assert _PRESET_DEFAULTS['multiband_low_crossover'] == 200.0
+        assert _PRESET_DEFAULTS['multiband_high_crossover'] == 5000.0
+
+    def test_midside_defaults(self):
+        assert _PRESET_DEFAULTS['midside_low_gain'] == 0.0
+        assert _PRESET_DEFAULTS['midside_high_gain'] == 0.0

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -34,6 +34,19 @@
 #   deess_threshold        - De-esser threshold in dB (default -20.0)
 #   deess_ratio            - De-esser compression ratio (default 4.0)
 #   track_gap              - Silence to prepend per track in seconds (default 0)
+#   multiband_enabled      - Enable 3-band multiband compression (0=off, 1=on, default 0)
+#   multiband_low_crossover  - Low/mid crossover in Hz (default 200)
+#   multiband_high_crossover - Mid/high crossover in Hz (default 5000)
+#   multiband_low_ratio    - Low band compression ratio (default 1.5)
+#   multiband_mid_ratio    - Mid band compression ratio (default 1.5)
+#   multiband_high_ratio   - High band compression ratio (default 1.5)
+#   multiband_low_threshold  - Low band threshold in dB (default -18)
+#   multiband_mid_threshold  - Mid band threshold in dB (default -18)
+#   multiband_high_threshold - High band threshold in dB (default -18)
+#   midside_low_gain       - Side channel low shelf gain in dB (default 0, negative = narrower bass)
+#   midside_low_freq       - Side channel low shelf frequency (default 300)
+#   midside_high_gain      - Side channel high shelf gain in dB (default 0, positive = wider highs)
+#   midside_high_freq      - Side channel high shelf frequency (default 8000)
 #
 # Override per-user: copy to {overrides}/mastering-presets.yaml and edit.
 # User overrides merge on top of these defaults (genre-level).
@@ -73,6 +86,19 @@ defaults:
   deess_threshold: -20.0
   deess_ratio: 4.0
   track_gap: 0
+  multiband_enabled: 0
+  multiband_low_crossover: 200
+  multiband_high_crossover: 5000
+  multiband_low_ratio: 1.5
+  multiband_mid_ratio: 1.5
+  multiband_high_ratio: 1.5
+  multiband_low_threshold: -18.0
+  multiband_mid_threshold: -18.0
+  multiband_high_threshold: -18.0
+  midside_low_gain: 0
+  midside_low_freq: 300
+  midside_high_gain: 0
+  midside_high_freq: 8000
 
 genres:
   # === Pop / Mainstream ===

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -108,6 +108,19 @@ _PRESET_DEFAULTS: dict[str, float] = {
     'deess_threshold': -20.0,
     'deess_ratio': 4.0,
     'track_gap': 0.0,
+    'multiband_enabled': 0,
+    'multiband_low_crossover': 200.0,
+    'multiband_high_crossover': 5000.0,
+    'multiband_low_ratio': 1.5,
+    'multiband_mid_ratio': 1.5,
+    'multiband_high_ratio': 1.5,
+    'multiband_low_threshold': -18.0,
+    'multiband_mid_threshold': -18.0,
+    'multiband_high_threshold': -18.0,
+    'midside_low_gain': 0.0,
+    'midside_low_freq': 300.0,
+    'midside_high_gain': 0.0,
+    'midside_high_freq': 8000.0,
 }
 
 
@@ -620,6 +633,142 @@ def apply_deesser(data: Any, rate: int, freq: float = 6500.0,
         return result
 
 
+def apply_multiband_compress(data: Any, rate: int,
+                             low_crossover: float = 200.0,
+                             high_crossover: float = 5000.0,
+                             low_ratio: float = 1.5, mid_ratio: float = 1.5,
+                             high_ratio: float = 1.5,
+                             low_threshold: float = -18.0,
+                             mid_threshold: float = -18.0,
+                             high_threshold: float = -18.0,
+                             attack_ms: float = 30.0,
+                             release_ms: float = 200.0) -> Any:
+    """3-band multiband compressor using Linkwitz-Riley crossovers.
+
+    Splits into low/mid/high bands, compresses each independently,
+    then recombines. Provides tighter dynamics control than single-band
+    without pumping artifacts.
+
+    Args:
+        data: Audio data
+        rate: Sample rate
+        low_crossover: Low/mid crossover frequency in Hz
+        high_crossover: Mid/high crossover frequency in Hz
+        low_ratio: Compression ratio for low band
+        mid_ratio: Compression ratio for mid band
+        high_ratio: Compression ratio for high band
+        low_threshold: Threshold for low band in dB
+        mid_threshold: Threshold for mid band in dB
+        high_threshold: Threshold for high band in dB
+        attack_ms: Compressor attack in ms (shared)
+        release_ms: Compressor release in ms (shared)
+    """
+    nyquist = rate / 2
+    if low_crossover >= high_crossover:
+        logger.warning("Multiband crossovers invalid (low=%.0f >= high=%.0f), skipping",
+                       low_crossover, high_crossover)
+        return data
+    if high_crossover >= nyquist:
+        logger.warning("High crossover %.0f Hz >= Nyquist, skipping", high_crossover)
+        return data
+
+    # Linkwitz-Riley 4th-order crossovers (two cascaded 2nd-order Butterworth)
+    low_norm = low_crossover / nyquist
+    high_norm = high_crossover / nyquist
+
+    b_lo, a_lo = signal.butter(2, low_norm, btype='low')
+    b_hi_lo, a_hi_lo = signal.butter(2, low_norm, btype='high')
+    b_hi, a_hi = signal.butter(2, high_norm, btype='high')
+    b_lo_hi, a_lo_hi = signal.butter(2, high_norm, btype='low')
+
+    def _split_and_compress_channel(channel: Any) -> Any:
+        # Split into 3 bands (LR4 = two passes of Butterworth 2nd-order)
+        low1 = signal.lfilter(b_lo, a_lo, channel)
+        low_band = signal.lfilter(b_lo, a_lo, low1)
+
+        mid_temp = signal.lfilter(b_hi_lo, a_hi_lo, channel)
+        mid_temp = signal.lfilter(b_hi_lo, a_hi_lo, mid_temp)
+        mid_lo = signal.lfilter(b_lo_hi, a_lo_hi, mid_temp)
+        mid_band = signal.lfilter(b_lo_hi, a_lo_hi, mid_lo)
+
+        high1 = signal.lfilter(b_hi, a_hi, channel)
+        high_band = signal.lfilter(b_hi, a_hi, high1)
+
+        # Compress each band independently
+        if low_ratio > 1.0:
+            low_band = gentle_compress(
+                low_band, rate, threshold_db=low_threshold,
+                ratio=low_ratio, attack_ms=attack_ms, release_ms=release_ms)
+        if mid_ratio > 1.0:
+            mid_band = gentle_compress(
+                mid_band, rate, threshold_db=mid_threshold,
+                ratio=mid_ratio, attack_ms=attack_ms, release_ms=release_ms)
+        if high_ratio > 1.0:
+            high_band = gentle_compress(
+                high_band, rate, threshold_db=high_threshold,
+                ratio=high_ratio, attack_ms=attack_ms, release_ms=release_ms)
+
+        return low_band + mid_band + high_band
+
+    if len(data.shape) == 1:
+        return _split_and_compress_channel(data)
+    else:
+        result = np.zeros_like(data)
+        for ch in range(data.shape[1]):
+            result[:, ch] = _split_and_compress_channel(data[:, ch])
+        return result
+
+
+def apply_midside_eq(data: Any, rate: int,
+                     low_gain: float = 0.0, low_freq: float = 300.0,
+                     high_gain: float = 0.0, high_freq: float = 8000.0) -> Any:
+    """Apply EQ to the side channel only for frequency-selective stereo management.
+
+    Positive gain widens the stereo field at that frequency range;
+    negative gain narrows it. Useful for mono bass (cut side lows)
+    or wider highs (boost side highs).
+
+    Args:
+        data: Stereo audio data (samples, 2)
+        rate: Sample rate
+        low_gain: Low shelf gain on side channel in dB (negative = narrower bass)
+        low_freq: Low shelf frequency in Hz
+        high_gain: High shelf gain on side channel in dB (positive = wider highs)
+        high_freq: High shelf frequency in Hz
+    """
+    if len(data.shape) == 1 or data.shape[1] != 2:
+        return data
+    if low_gain == 0 and high_gain == 0:
+        return data
+
+    # Encode to mid/side
+    mid = (data[:, 0] + data[:, 1]) / 2
+    side = (data[:, 0] - data[:, 1]) / 2
+
+    # Apply EQ to side channel only
+    if low_gain != 0:
+        side = apply_low_shelf(
+            side.reshape(-1, 1) if side.ndim == 1 else side,
+            rate, freq=low_freq, gain_db=low_gain,
+        )
+        if side.ndim == 2:
+            side = side[:, 0]
+    if high_gain != 0:
+        side = apply_high_shelf(
+            side.reshape(-1, 1) if side.ndim == 1 else side,
+            rate, freq=high_freq, gain_db=high_gain,
+        )
+        if side.ndim == 2:
+            side = side[:, 0]
+
+    # Decode back to L/R
+    result = np.zeros_like(data)
+    result[:, 0] = mid + side
+    result[:, 1] = mid - side
+
+    return result
+
+
 def apply_tpdf_dither(data: Any, target_bits: int = 16, seed: int | None = None) -> Any:
     """Apply TPDF (Triangular Probability Density Function) dithering.
 
@@ -710,6 +859,16 @@ def master_track(input_path: Path | str, output_path: Path | str,
         for freq, gain_db, q in eq_settings:
             data = apply_eq(data, rate, freq, gain_db, q)
 
+    # Mid/side EQ (frequency-selective stereo management, after regular EQ)
+    ms_low_gain = p.get('midside_low_gain', 0.0)
+    ms_high_gain = p.get('midside_high_gain', 0.0)
+    if ms_low_gain != 0 or ms_high_gain != 0:
+        data = apply_midside_eq(
+            data, rate,
+            low_gain=ms_low_gain, low_freq=p.get('midside_low_freq', 300.0),
+            high_gain=ms_high_gain, high_freq=p.get('midside_high_freq', 8000.0),
+        )
+
     # De-essing (after EQ, before dynamics)
     if p.get('deess_enabled', 0) > 0:
         data = apply_deesser(
@@ -738,17 +897,36 @@ def master_track(input_path: Path | str, output_path: Path | str,
         data = signal.resample_poly(data, up=oversample, down=1, axis=0)
         rate = original_rate * oversample
 
-    # Mastering compression — gentle safety net with parallel blend
+    # Mastering compression — single-band or multiband with parallel blend
     compress_mix = p.get('compress_mix', 1.0)
-    if compress_ratio > 1.0:
+    multiband = p.get('multiband_enabled', 0) > 0
+
+    if multiband or compress_ratio > 1.0:
         dry = data.copy() if compress_mix < 1.0 else None
-        data = gentle_compress(
-            data, rate,
-            threshold_db=p['compress_threshold'],
-            ratio=compress_ratio,
-            attack_ms=p['compress_attack'],
-            release_ms=p['compress_release'],
-        )
+
+        if multiband:
+            data = apply_multiband_compress(
+                data, rate,
+                low_crossover=p.get('multiband_low_crossover', 200.0),
+                high_crossover=p.get('multiband_high_crossover', 5000.0),
+                low_ratio=p.get('multiband_low_ratio', 1.5),
+                mid_ratio=p.get('multiband_mid_ratio', 1.5),
+                high_ratio=p.get('multiband_high_ratio', 1.5),
+                low_threshold=p.get('multiband_low_threshold', -18.0),
+                mid_threshold=p.get('multiband_mid_threshold', -18.0),
+                high_threshold=p.get('multiband_high_threshold', -18.0),
+                attack_ms=p['compress_attack'],
+                release_ms=p['compress_release'],
+            )
+        elif compress_ratio > 1.0:
+            data = gentle_compress(
+                data, rate,
+                threshold_db=p['compress_threshold'],
+                ratio=compress_ratio,
+                attack_ms=p['compress_attack'],
+                release_ms=p['compress_release'],
+            )
+
         # Makeup gain: compensate for compression gain reduction
         makeup = p.get('compress_makeup', 0.0)
         if makeup != 0:
@@ -1013,6 +1191,16 @@ Examples:
                        help='De-esser compression ratio (default: 4.0)')
     parser.add_argument('--track-gap', type=float, default=None,
                        help='Silence to prepend to each track in seconds (default: 0)')
+    parser.add_argument('--multiband', action='store_true', default=None,
+                       help='Enable 3-band multiband compression')
+    parser.add_argument('--multiband-low-crossover', type=float, default=None,
+                       help='Low/mid crossover frequency in Hz (default: 200)')
+    parser.add_argument('--multiband-high-crossover', type=float, default=None,
+                       help='Mid/high crossover frequency in Hz (default: 5000)')
+    parser.add_argument('--midside-low-gain', type=float, default=None,
+                       help='Mid/side EQ: side low shelf gain in dB (negative = narrower bass)')
+    parser.add_argument('--midside-high-gain', type=float, default=None,
+                       help='Mid/side EQ: side high shelf gain in dB (positive = wider highs)')
     parser.add_argument('-j', '--jobs', type=int, default=1,
                        help='Parallel jobs (0=auto, default: 1)')
 
@@ -1064,6 +1252,11 @@ Examples:
         'deess_threshold': args.deess_threshold,
         'deess_ratio': args.deess_ratio,
         'track_gap': args.track_gap,
+        'multiband_enabled': 1.0 if args.multiband else None,
+        'multiband_low_crossover': args.multiband_low_crossover,
+        'multiband_high_crossover': args.multiband_high_crossover,
+        'midside_low_gain': args.midside_low_gain,
+        'midside_high_gain': args.midside_high_gain,
     }
     for key, value in cli_overrides.items():
         if value is not None:


### PR DESCRIPTION
## Summary

- Implements #246 Phase 3: two mastering enhancements completing the audio enhancement issue
- **3-band multiband compression** (`multiband_enabled`) — Linkwitz-Riley crossovers split into low/mid/high bands with independent ratio and threshold per band. Prevents pumping artifacts from bass-triggered full-band gain reduction.
- **Mid/side EQ** (`midside_low_gain`, `midside_high_gain`) — applies shelving EQ to the side channel only for frequency-selective stereo management. Negative low gain = mono bass, positive high gain = wider treble.
- All defaults off — zero behavior change without explicit override
- CLI args: `--multiband`, `--multiband-low-crossover`, `--multiband-high-crossover`, `--midside-low-gain`, `--midside-high-gain`

## Test plan

- [x] 14 new unit tests for multiband compression, mid/side EQ, and preset defaults
- [x] All 148 mastering tests pass
- [x] Full suite: 2994 passed, 0 failed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)