### PR TITLE
feat: add album loudness consistency and extended loudness metering

### DIFF
--- a/tests/unit/mastering/test_analyze_tracks.py
+++ b/tests/unit/mastering/test_analyze_tracks.py
@@ -104,6 +104,7 @@ class TestAnalyzeTrackBasic:
             'filename', 'duration', 'sample_rate', 'lufs',
             'peak_db', 'rms_db', 'dynamic_range',
             'band_energy', 'tinniness_ratio',
+            'max_short_term_lufs', 'max_momentary_lufs', 'short_term_range',
         }
         assert expected_keys == set(result.keys())
 

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -78,6 +78,36 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
     # Crest factor (peak to RMS as linear ratio)
     _crest_factor = peak_linear / rms if rms > 0 else 0.0
 
+    # Short-term and momentary loudness dynamics
+    max_short_term = float('-inf')
+    min_short_term = float('inf')
+    max_momentary = float('-inf')
+
+    # Short-term: 3s window, 1s hop (EBU R128)
+    st_window = int(3.0 * rate)
+    st_hop = int(1.0 * rate)
+    if data.shape[0] > st_window:
+        for start in range(0, data.shape[0] - st_window, st_hop):
+            chunk = data[start:start + st_window]
+            st_lufs = pyln.Meter(rate).integrated_loudness(chunk)
+            if np.isfinite(st_lufs):
+                max_short_term = max(max_short_term, st_lufs)
+                min_short_term = min(min_short_term, st_lufs)
+
+    # Momentary: 400ms window, 100ms hop
+    mom_window = int(0.4 * rate)
+    mom_hop = int(0.1 * rate)
+    if data.shape[0] > mom_window:
+        for start in range(0, data.shape[0] - mom_window, mom_hop):
+            chunk = data[start:start + mom_window]
+            mom_lufs = pyln.Meter(rate).integrated_loudness(chunk)
+            if np.isfinite(mom_lufs):
+                max_momentary = max(max_momentary, mom_lufs)
+
+    short_term_range = (max_short_term - min_short_term
+                        if np.isfinite(max_short_term) and np.isfinite(min_short_term)
+                        else 0.0)
+
     return {
         'filename': os.path.basename(filepath),
         'duration': len(mono) / rate,
@@ -88,6 +118,9 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
         'dynamic_range': dynamic_range,
         'band_energy': band_energy,
         'tinniness_ratio': tinniness_ratio,
+        'max_short_term_lufs': max_short_term if np.isfinite(max_short_term) else None,
+        'max_momentary_lufs': max_momentary if np.isfinite(max_momentary) else None,
+        'short_term_range': short_term_range,
     }
 
 def main() -> None:
@@ -156,6 +189,23 @@ def main() -> None:
     print("-" * 65)
     print(f"{'Average':<35} {avg_lufs:>8.1f}")
     print()
+
+    # Loudness dynamics table
+    has_dynamics = any(r.get('max_short_term_lufs') is not None for r in results)
+    if has_dynamics:
+        print("=" * 80)
+        print("LOUDNESS DYNAMICS (short-term=3s, momentary=400ms)")
+        print("=" * 80)
+        print(f"{'Track':<35} {'MaxST':>8} {'MaxMom':>8} {'STRange':>8}")
+        print("-" * 65)
+        for r in results:
+            st = r.get('max_short_term_lufs')
+            mom = r.get('max_momentary_lufs')
+            st_range = r.get('short_term_range', 0)
+            st_str = f"{st:.1f}" if st is not None else "N/A"
+            mom_str = f"{mom:.1f}" if mom is not None else "N/A"
+            print(f"{r['filename'][:34]:<35} {st_str:>8} {mom_str:>8} {st_range:>7.1f}dB")
+        print()
 
     print("=" * 80)
     print("SPECTRAL BALANCE (% energy per band)")

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -1201,6 +1201,8 @@ Examples:
                        help='Mid/side EQ: side low shelf gain in dB (negative = narrower bass)')
     parser.add_argument('--midside-high-gain', type=float, default=None,
                        help='Mid/side EQ: side high shelf gain in dB (positive = wider highs)')
+    parser.add_argument('--album-consistency', type=float, default=0,
+                       help='Max LUFS spread across album in dB (0=disable, 1.0=recommended)')
     parser.add_argument('-j', '--jobs', type=int, default=1,
                        help='Parallel jobs (0=auto, default: 1)')
 
@@ -1324,6 +1326,44 @@ Examples:
         logger.info("DRY RUN - No files will be written")
         print()
 
+    # Album consistency: two-pass mastering
+    # Pass 1: measure source LUFS to compute per-track target adjustments
+    per_track_presets: dict[str, dict[str, float]] = {}
+    album_consistency = args.album_consistency
+
+    if album_consistency > 0 and wav_files:
+        print("Pass 1: Analyzing source loudness...")
+        source_lufs: dict[str, float] = {}
+        for wf in wav_files:
+            d, r = sf.read(str(wf))
+            if len(d.shape) == 1:
+                d = np.column_stack([d, d])
+            lufs = pyln.Meter(r).integrated_loudness(d)
+            if np.isfinite(lufs):
+                source_lufs[wf.name] = lufs
+
+        if len(source_lufs) >= 2:
+            avg_lufs = np.mean(list(source_lufs.values()))
+            half_spread = album_consistency / 2
+            base_target = preset['target_lufs']
+
+            print(f"  Source average: {avg_lufs:.1f} LUFS")
+            print(f"  Max spread: ±{half_spread:.1f} dB from average")
+
+            for name, src_lufs in source_lufs.items():
+                # How far is this track from the average source loudness?
+                deviation = src_lufs - avg_lufs
+                # Adjust target: quieter sources get slightly higher target,
+                # louder sources get slightly lower target
+                adjusted_target = base_target - np.clip(deviation, -half_spread, half_spread)
+                track_preset = {**preset, 'target_lufs': adjusted_target}
+                per_track_presets[name] = track_preset
+                if abs(adjusted_target - base_target) > 0.05:
+                    print(f"  {name[:34]}: target adjusted to {adjusted_target:.1f} LUFS "
+                          f"({adjusted_target - base_target:+.1f})")
+
+            print()
+
     print(f"{'Track':<35} {'Before':>8} {'After':>8} {'Gain':>8} {'Peak':>8}")
     print("-" * 70)
 
@@ -1339,11 +1379,12 @@ Examples:
         # Sequential (existing behavior)
         for wav_file, output_path in tasks:
             progress.update(wav_file.name)
+            track_preset = per_track_presets.get(wav_file.name, preset)
             _, result = _process_one_track(
                 wav_file, output_path,
                 ceiling_db=args.ceiling,
                 dry_run=args.dry_run,
-                preset=preset,
+                preset=track_preset,
             )
             if result is None:
                 continue
@@ -1361,7 +1402,7 @@ Examples:
                     _process_one_track, wf, op,
                     ceiling_db=args.ceiling,
                     dry_run=args.dry_run,
-                    preset=preset,
+                    preset=per_track_presets.get(wf.name, preset),
                 ): i
                 for i, (wf, op) in enumerate(tasks)
             }


### PR DESCRIPTION
## Summary

- Completes remaining #254 items (linear phase EQ deferred as low-priority)
- **Album-level loudness consistency** (`--album-consistency`): two-pass mastering that measures source LUFS across all tracks, then adjusts per-track targets to keep spread within tolerance
- **Extended loudness metering**: adds short-term (3s) and momentary (400ms) LUFS measurements per EBU R128 to `analyze_track()` output — reports max short-term, max momentary, and short-term range

## Test plan

- [x] Updated expected keys in analyze_tracks test
- [x] Full suite: 2994 passed, 0 failed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)