### PR TITLE
feat: add linear-phase FIR EQ option to mastering pipeline

### DIFF
--- a/config/overrides.example/mastering-presets.yaml
+++ b/config/overrides.example/mastering-presets.yaml
@@ -24,6 +24,7 @@
 #   stereo_bass_mono_freq - Mono-sum below this frequency in Hz (0 = bypass)
 #   output_bits          - Output bit depth: 16 or 24 (default 16)
 #   dither_bits          - Dither bit depth (default: follows output_bits)
+#   eq_linear_phase      - Use linear-phase FIR EQ (0 = off, 1 = on, default 0)
 
 genres:
   # Example: override rock to be less aggressive

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -24,6 +24,7 @@ from tools.mastering.master_tracks import (
     GENRE_PRESETS,
     _BUILTIN_PRESETS_FILE,
     _PRESET_DEFAULTS,
+    _design_linear_phase_eq,
     _load_yaml_file,
     _process_one_track,
     apply_deesser,
@@ -31,6 +32,7 @@ from tools.mastering.master_tracks import (
     apply_fade_out,
     apply_high_shelf,
     apply_highpass,
+    apply_linear_phase_eq,
     apply_low_shelf,
     apply_midside_eq,
     apply_multiband_compress,
@@ -1597,3 +1599,166 @@ class TestPhase3PresetDefaults:
     def test_midside_defaults(self):
         assert _PRESET_DEFAULTS['midside_low_gain'] == 0.0
         assert _PRESET_DEFAULTS['midside_high_gain'] == 0.0
+
+
+class TestLinearPhaseEQ:
+    """Tests for linear-phase FIR EQ filters."""
+
+    def test_preset_default(self):
+        """eq_linear_phase defaults to 0 (off)."""
+        assert _PRESET_DEFAULTS['eq_linear_phase'] == 0
+
+    def test_design_returns_fir_kernel(self):
+        """FIR kernel has correct length and is real-valued."""
+        kernel = _design_linear_phase_eq(44100, 1000.0, -3.0, 1.0, 'peaking')
+        assert kernel is not None
+        assert len(kernel) == 4095
+        assert kernel.dtype in (np.float64, np.float32)
+
+    def test_design_invalid_freq_returns_none(self):
+        """Out-of-range frequency returns None."""
+        assert _design_linear_phase_eq(44100, 25000.0, -3.0, 1.0, 'peaking') is None
+        assert _design_linear_phase_eq(44100, 10.0, -3.0, 1.0, 'peaking') is None
+
+    def test_design_invalid_q_returns_none(self):
+        """Non-positive Q returns None for peaking filter."""
+        assert _design_linear_phase_eq(44100, 1000.0, -3.0, 0.0, 'peaking') is None
+
+    def test_design_unknown_type_returns_none(self):
+        """Unknown filter type returns None."""
+        assert _design_linear_phase_eq(44100, 1000.0, -3.0, 1.0, 'notch') is None
+
+    def test_design_all_types(self):
+        """All three filter types produce valid kernels."""
+        for ftype in ('peaking', 'high_shelf', 'low_shelf'):
+            kernel = _design_linear_phase_eq(44100, 1000.0, -3.0, 1.0, ftype)
+            assert kernel is not None, f"Failed for {ftype}"
+
+    def test_apply_peaking_changes_signal(self):
+        """Peaking EQ should alter the signal."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        data = np.column_stack([
+            0.5 * np.sin(2 * np.pi * 1000 * t),
+            0.5 * np.sin(2 * np.pi * 1000 * t),
+        ])
+        result = apply_linear_phase_eq(data, rate, 1000.0, -6.0, q=1.0,
+                                        filter_type='peaking')
+        assert not np.allclose(data, result)
+
+    def test_apply_low_shelf_bypass_on_zero_gain(self):
+        """Low shelf with 0 dB gain should return data unchanged."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        data = 0.5 * np.sin(2 * np.pi * 200 * t)
+        result = apply_linear_phase_eq(data, rate, 80.0, 0.0, filter_type='low_shelf')
+        assert np.array_equal(data, result)
+
+    def test_apply_mono_signal(self):
+        """Linear-phase EQ handles mono (1D) signals."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        data = 0.5 * np.sin(2 * np.pi * 1000 * t)
+        result = apply_linear_phase_eq(data, rate, 1000.0, -6.0, q=1.0,
+                                        filter_type='peaking')
+        assert result.shape == data.shape
+        assert not np.allclose(data, result)
+
+    def test_output_same_length(self):
+        """Output length matches input (fftconvolve mode='same')."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        data = np.column_stack([
+            0.5 * np.sin(2 * np.pi * 440 * t),
+            0.5 * np.sin(2 * np.pi * 440 * t),
+        ])
+        result = apply_linear_phase_eq(data, rate, 440.0, -3.0, filter_type='peaking')
+        assert result.shape == data.shape
+
+
+class TestLinearPhaseEQInMasterTrack:
+    """Test linear-phase EQ wired through master_track()."""
+
+    def test_linear_phase_produces_different_output(self, tmp_path):
+        """Linear-phase EQ should produce different output from IIR EQ."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        data = np.column_stack([
+            0.3 * np.sin(2 * np.pi * 440 * t),
+            0.3 * np.sin(2 * np.pi * 440 * t),
+        ])
+        inp = tmp_path / "in.wav"
+        out_iir = tmp_path / "out_iir.wav"
+        out_fir = tmp_path / "out_fir.wav"
+        sf.write(str(inp), data, rate)
+
+        preset_iir = {**_PRESET_DEFAULTS, 'cut_highmid': -3.0}
+        preset_fir = {**_PRESET_DEFAULTS, 'cut_highmid': -3.0, 'eq_linear_phase': 1}
+        master_track(str(inp), str(out_iir), preset=preset_iir)
+        master_track(str(inp), str(out_fir), preset=preset_fir)
+        d1, _ = sf.read(str(out_iir))
+        d2, _ = sf.read(str(out_fir))
+        assert not np.allclose(d1, d2)
+
+    def test_linear_phase_off_matches_default(self, tmp_path):
+        """eq_linear_phase=0 should match default IIR behavior (within dither noise)."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        data = np.column_stack([
+            0.3 * np.sin(2 * np.pi * 440 * t),
+            0.3 * np.sin(2 * np.pi * 440 * t),
+        ])
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        sf.write(str(inp), data, rate)
+
+        preset1 = {**_PRESET_DEFAULTS, 'cut_highmid': -3.0}
+        preset2 = {**_PRESET_DEFAULTS, 'cut_highmid': -3.0, 'eq_linear_phase': 0}
+        master_track(str(inp), str(out1), preset=preset1)
+        master_track(str(inp), str(out2), preset=preset2)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        # Allow tolerance for TPDF dither noise (random per run, ~1 LSB at 16-bit)
+        assert np.allclose(d1, d2, atol=1e-4)
+
+    def test_linear_phase_low_shelf(self, tmp_path):
+        """Linear-phase low shelf EQ should change output."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        data = np.column_stack([
+            0.3 * np.sin(2 * np.pi * 60 * t),
+            0.3 * np.sin(2 * np.pi * 60 * t),
+        ])
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        sf.write(str(inp), data, rate)
+
+        preset_off = {**_PRESET_DEFAULTS, 'eq_low_gain': -3.0}
+        preset_on = {**_PRESET_DEFAULTS, 'eq_low_gain': -3.0, 'eq_linear_phase': 1}
+        master_track(str(inp), str(out1), preset=preset_off)
+        master_track(str(inp), str(out2), preset=preset_on)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        assert not np.allclose(d1, d2)
+
+    def test_linear_phase_midside_eq(self, tmp_path):
+        """Linear-phase mid/side EQ should produce different output from IIR."""
+        rate = 44100
+        t = np.linspace(0, 3.0, int(rate * 3.0), endpoint=False)
+        left = 0.3 * np.sin(2 * np.pi * 440 * t)
+        right = 0.3 * np.sin(2 * np.pi * 440 * t + 0.3)
+        data = np.column_stack([left, right])
+        inp = tmp_path / "in.wav"
+        out1 = tmp_path / "out1.wav"
+        out2 = tmp_path / "out2.wav"
+        sf.write(str(inp), data, rate)
+
+        preset_iir = {**_PRESET_DEFAULTS, 'midside_low_gain': -6.0}
+        preset_fir = {**_PRESET_DEFAULTS, 'midside_low_gain': -6.0, 'eq_linear_phase': 1}
+        master_track(str(inp), str(out1), preset=preset_iir)
+        master_track(str(inp), str(out2), preset=preset_fir)
+        d1, _ = sf.read(str(out1))
+        d2, _ = sf.read(str(out2))
+        assert not np.allclose(d1, d2)

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -99,6 +99,7 @@ defaults:
   midside_low_freq: 300
   midside_high_gain: 0
   midside_high_freq: 8000
+  eq_linear_phase: 0
 
 genres:
   # === Pop / Mainstream ===

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -121,6 +121,7 @@ _PRESET_DEFAULTS: dict[str, float] = {
     'midside_low_freq': 300.0,
     'midside_high_gain': 0.0,
     'midside_high_freq': 8000.0,
+    'eq_linear_phase': 0,
 }
 
 
@@ -305,6 +306,121 @@ def apply_low_shelf(data: Any, rate: int, freq: float, gain_db: float) -> Any:
         result = np.zeros_like(data)
         for ch in range(data.shape[1]):
             result[:, ch] = signal.lfilter(b, a, data[:, ch])
+        return result
+
+
+def _design_linear_phase_eq(rate: int, freq: float, gain_db: float,
+                            q: float, filter_type: str,
+                            num_taps: int = 4095) -> np.ndarray | None:
+    """Design a linear-phase FIR filter equivalent to an IIR EQ filter.
+
+    Matches the magnitude response of the IIR prototype but with zero phase
+    distortion.  Returns the FIR kernel or None if the parameters are invalid.
+
+    Args:
+        rate: Sample rate in Hz
+        freq: Center/corner frequency in Hz
+        gain_db: Gain in dB
+        q: Q factor (used for peaking type only)
+        filter_type: 'peaking', 'high_shelf', or 'low_shelf'
+        num_taps: FIR filter length (must be odd for type-I linear phase)
+    """
+    nyquist = rate / 2
+    if not (20 <= freq < nyquist):
+        logger.warning("Linear-phase EQ freq %.1f Hz out of range (20–%.0f Hz), skipping",
+                       freq, nyquist)
+        return None
+
+    # Build the IIR prototype to sample its magnitude response
+    A = 10 ** (gain_db / 40)
+    w0 = 2 * np.pi * freq / rate
+    cos_w0 = np.cos(w0)
+
+    if filter_type == 'peaking':
+        if q <= 0:
+            logger.warning("Linear-phase EQ Q must be positive (got %.4f), skipping", q)
+            return None
+        alpha = np.sin(w0) / (2 * q)
+        b0 = 1 + alpha * A
+        b1 = -2 * cos_w0
+        b2 = 1 - alpha * A
+        a0 = 1 + alpha / A
+        a1 = -2 * cos_w0
+        a2 = 1 - alpha / A
+    elif filter_type == 'high_shelf':
+        alpha = np.sin(w0) / 2 * np.sqrt(2)
+        sqrt_A = np.sqrt(A)
+        b0 = A * ((A + 1) + (A - 1) * cos_w0 + 2 * sqrt_A * alpha)
+        b1 = -2 * A * ((A - 1) + (A + 1) * cos_w0)
+        b2 = A * ((A + 1) + (A - 1) * cos_w0 - 2 * sqrt_A * alpha)
+        a0 = (A + 1) - (A - 1) * cos_w0 + 2 * sqrt_A * alpha
+        a1 = 2 * ((A - 1) - (A + 1) * cos_w0)
+        a2 = (A + 1) - (A - 1) * cos_w0 - 2 * sqrt_A * alpha
+    elif filter_type == 'low_shelf':
+        alpha = np.sin(w0) / 2 * np.sqrt(2)
+        sqrt_A = np.sqrt(A)
+        b0 = A * ((A + 1) - (A - 1) * cos_w0 + 2 * sqrt_A * alpha)
+        b1 = 2 * A * ((A - 1) - (A + 1) * cos_w0)
+        b2 = A * ((A + 1) - (A - 1) * cos_w0 - 2 * sqrt_A * alpha)
+        a0 = (A + 1) + (A - 1) * cos_w0 + 2 * sqrt_A * alpha
+        a1 = -2 * ((A - 1) + (A + 1) * cos_w0)
+        a2 = (A + 1) + (A - 1) * cos_w0 - 2 * sqrt_A * alpha
+    else:
+        logger.warning("Unknown linear-phase EQ type '%s', skipping", filter_type)
+        return None
+
+    b_iir = np.array([b0 / a0, b1 / a0, b2 / a0])
+    a_iir = np.array([1, a1 / a0, a2 / a0])
+
+    # Sample the IIR magnitude response at num_taps/2+1 frequency points
+    n_freqs = num_taps // 2 + 1
+    w, h = signal.freqz(b_iir, a_iir, worN=n_freqs)
+    desired_mag = np.abs(h)
+
+    # Build a zero-phase FIR via frequency sampling (real-valued, symmetric)
+    # Construct full two-sided spectrum for irfft
+    fir_kernel = np.fft.irfft(desired_mag, n=num_taps)
+
+    # Shift to make causal and apply window to reduce Gibbs ringing
+    fir_kernel = np.roll(fir_kernel, num_taps // 2)
+    window = signal.windows.kaiser(num_taps, beta=8.0)
+    fir_kernel *= window
+
+    return fir_kernel
+
+
+def apply_linear_phase_eq(data: Any, rate: int, freq: float, gain_db: float,
+                          q: float = 1.0,
+                          filter_type: str = 'peaking') -> Any:
+    """Apply linear-phase FIR EQ to audio data.
+
+    Uses frequency-sampled FIR design to match the magnitude response of
+    the equivalent IIR filter while maintaining zero phase distortion.
+    Higher latency than IIR but irrelevant for offline mastering.
+
+    Args:
+        data: Audio data (samples x channels)
+        rate: Sample rate
+        freq: Center/corner frequency in Hz
+        gain_db: Gain in dB (negative for cut)
+        q: Q factor (for peaking type)
+        filter_type: 'peaking', 'high_shelf', or 'low_shelf'
+    """
+    if gain_db == 0 and filter_type == 'low_shelf':
+        return data
+
+    fir_kernel = _design_linear_phase_eq(rate, freq, gain_db, q, filter_type)
+    if fir_kernel is None:
+        return data
+
+    # Apply via fftconvolve for efficiency, trim to original length
+    if len(data.shape) == 1:
+        filtered = signal.fftconvolve(data, fir_kernel, mode='same')
+        return filtered.astype(data.dtype)
+    else:
+        result = np.zeros_like(data)
+        for ch in range(data.shape[1]):
+            result[:, ch] = signal.fftconvolve(data[:, ch], fir_kernel, mode='same')
         return result
 
 
@@ -721,7 +837,8 @@ def apply_multiband_compress(data: Any, rate: int,
 
 def apply_midside_eq(data: Any, rate: int,
                      low_gain: float = 0.0, low_freq: float = 300.0,
-                     high_gain: float = 0.0, high_freq: float = 8000.0) -> Any:
+                     high_gain: float = 0.0, high_freq: float = 8000.0,
+                     linear_phase: bool = False) -> Any:
     """Apply EQ to the side channel only for frequency-selective stereo management.
 
     Positive gain widens the stereo field at that frequency range;
@@ -735,6 +852,7 @@ def apply_midside_eq(data: Any, rate: int,
         low_freq: Low shelf frequency in Hz
         high_gain: High shelf gain on side channel in dB (positive = wider highs)
         high_freq: High shelf frequency in Hz
+        linear_phase: Use linear-phase FIR filters instead of minimum-phase IIR
     """
     if len(data.shape) == 1 or data.shape[1] != 2:
         return data
@@ -747,19 +865,21 @@ def apply_midside_eq(data: Any, rate: int,
 
     # Apply EQ to side channel only
     if low_gain != 0:
-        side = apply_low_shelf(
-            side.reshape(-1, 1) if side.ndim == 1 else side,
-            rate, freq=low_freq, gain_db=low_gain,
-        )
-        if side.ndim == 2:
-            side = side[:, 0]
+        side_2d = side.reshape(-1, 1) if side.ndim == 1 else side
+        if linear_phase:
+            side_2d = apply_linear_phase_eq(side_2d, rate, freq=low_freq,
+                                            gain_db=low_gain, filter_type='low_shelf')
+        else:
+            side_2d = apply_low_shelf(side_2d, rate, freq=low_freq, gain_db=low_gain)
+        side = side_2d[:, 0] if side_2d.ndim == 2 else side_2d
     if high_gain != 0:
-        side = apply_high_shelf(
-            side.reshape(-1, 1) if side.ndim == 1 else side,
-            rate, freq=high_freq, gain_db=high_gain,
-        )
-        if side.ndim == 2:
-            side = side[:, 0]
+        side_2d = side.reshape(-1, 1) if side.ndim == 1 else side
+        if linear_phase:
+            side_2d = apply_linear_phase_eq(side_2d, rate, freq=high_freq,
+                                            gain_db=high_gain, filter_type='high_shelf')
+        else:
+            side_2d = apply_high_shelf(side_2d, rate, freq=high_freq, gain_db=high_gain)
+        side = side_2d[:, 0] if side_2d.ndim == 2 else side_2d
 
     # Decode back to L/R
     result = np.zeros_like(data)
@@ -850,14 +970,23 @@ def master_track(input_path: Path | str, output_path: Path | str,
         data = apply_highpass(data, rate, cutoff=sub_cut)
 
     # Low shelf EQ (bass shaping)
+    use_linear_phase = p.get('eq_linear_phase', 0) > 0
     low_gain = p.get('eq_low_gain', 0.0)
     if low_gain != 0:
-        data = apply_low_shelf(data, rate, freq=p['eq_low_freq'], gain_db=low_gain)
+        if use_linear_phase:
+            data = apply_linear_phase_eq(data, rate, freq=p['eq_low_freq'],
+                                         gain_db=low_gain, filter_type='low_shelf')
+        else:
+            data = apply_low_shelf(data, rate, freq=p['eq_low_freq'], gain_db=low_gain)
 
     # Apply high-mid/highs EQ if specified
     if eq_settings:
         for freq, gain_db, q in eq_settings:
-            data = apply_eq(data, rate, freq, gain_db, q)
+            if use_linear_phase:
+                data = apply_linear_phase_eq(data, rate, freq, gain_db, q,
+                                             filter_type='peaking')
+            else:
+                data = apply_eq(data, rate, freq, gain_db, q)
 
     # Mid/side EQ (frequency-selective stereo management, after regular EQ)
     ms_low_gain = p.get('midside_low_gain', 0.0)
@@ -867,6 +996,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
             data, rate,
             low_gain=ms_low_gain, low_freq=p.get('midside_low_freq', 300.0),
             high_gain=ms_high_gain, high_freq=p.get('midside_high_freq', 8000.0),
+            linear_phase=use_linear_phase,
         )
 
     # De-essing (after EQ, before dynamics)
@@ -1201,6 +1331,8 @@ Examples:
                        help='Mid/side EQ: side low shelf gain in dB (negative = narrower bass)')
     parser.add_argument('--midside-high-gain', type=float, default=None,
                        help='Mid/side EQ: side high shelf gain in dB (positive = wider highs)')
+    parser.add_argument('--linear-phase-eq', action='store_true', default=None,
+                       help='Use linear-phase FIR filters for EQ (zero phase distortion)')
     parser.add_argument('--album-consistency', type=float, default=0,
                        help='Max LUFS spread across album in dB (0=disable, 1.0=recommended)')
     parser.add_argument('-j', '--jobs', type=int, default=1,
@@ -1259,6 +1391,7 @@ Examples:
         'multiband_high_crossover': args.multiband_high_crossover,
         'midside_low_gain': args.midside_low_gain,
         'midside_high_gain': args.midside_high_gain,
+        'eq_linear_phase': 1.0 if args.linear_phase_eq else None,
     }
     for key, value in cli_overrides.items():
         if value is not None:


### PR DESCRIPTION
## Summary

- Implements the final item from #254: linear-phase EQ option (`eq_linear_phase` preset flag)
- Designs FIR kernels by sampling the IIR prototype's magnitude response with Kaiser-windowed frequency sampling — matches the magnitude curve of existing IIR filters but with zero phase distortion
- Supports all three EQ types: peaking, high shelf, low shelf
- Wired into `master_track()` for low shelf, parametric (high-mid/highs), and mid/side EQ stages
- `apply_midside_eq()` extended with `linear_phase` parameter
- New preset field `eq_linear_phase` (default 0 = off), CLI flag `--linear-phase-eq`
- All defaults preserve existing behavior — opt-in only

## Test plan

- [x] 14 new tests: FIR kernel design, edge cases (invalid freq/Q/type), all filter types, mono/stereo, output length, master_track integration
- [x] All 162 mastering tests pass
- [x] Full suite: 3008 passed, 0 failed
- [ ] CI passes

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)