### PR TITLE
fix: harden _normalize_slug against path traversal and fix CI injection

### DIFF
--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -20,8 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify PR source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          HEAD_REF="${{ github.head_ref }}"
           echo "PR source branch: $HEAD_REF"
           echo "PR target branch: main"
 

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -105,8 +105,22 @@ def _is_path_confined(base: Path, user_component: str) -> bool:
 
 
 def _normalize_slug(name: str) -> str:
-    """Normalize input to slug format."""
-    return name.lower().replace(" ", "-").replace("_", "-")
+    """Normalize input to slug format.
+
+    Raises:
+        ValueError: If *name* contains path separators (``/``, ``\\``),
+            null bytes, or traversal sequences (``..``).
+    """
+    if "/" in name or "\\" in name or "\0" in name:
+        raise ValueError(
+            f"Invalid name: contains path separator or null byte: {name!r}"
+        )
+    slug = name.lower().replace(" ", "-").replace("_", "-")
+    if ".." in slug:
+        raise ValueError(
+            f"Invalid name: contains path traversal sequence: {name!r}"
+        )
+    return slug
 
 
 def _safe_json(data: Any) -> str:

--- a/servers/bitwize-music-server/handlers/album_ops.py
+++ b/servers/bitwize-music-server/handlers/album_ops.py
@@ -19,6 +19,7 @@ from handlers._shared import (
     _extract_markdown_section,
     _find_album_or_error,
     _find_wav_source_dir,
+    _is_path_confined,
     _normalize_slug,
     _safe_json,
 )
@@ -373,7 +374,11 @@ async def create_album_structure(
                     "generation.additional_genres in config.",
         })
 
-    album_path = Path(content_root) / "artists" / artist / "albums" / genre_slug / normalized
+    albums_base = Path(content_root) / "artists" / artist / "albums" / genre_slug
+    # Defense-in-depth: verify slug stays within the genre directory
+    if not _is_path_confined(albums_base, normalized):
+        return _safe_json({"error": "Invalid album slug: would escape album directory"})
+    album_path = albums_base / normalized
     tracks_path = album_path / "tracks"
     assert _shared.PLUGIN_ROOT is not None
     templates_path = _shared.PLUGIN_ROOT / "templates"

--- a/servers/bitwize-music-server/handlers/core.py
+++ b/servers/bitwize-music-server/handlers/core.py
@@ -625,9 +625,15 @@ async def resolve_path(path_type: str, album_slug: str, genre: str = "") -> str:
         "audio": audio_root,
         "documents": documents_root,
     }
+    root_dir = Path(root_map[path_type]).resolve()
     base = Path(root_map[path_type]) / "artists" / artist / "albums" / genre / normalized
     if path_type == "tracks":
         base = base / "tracks"
+
+    # Defense-in-depth: verify resolved path stays within its root directory
+    if not base.resolve().is_relative_to(root_dir):
+        return _safe_json({"error": "Resolved path escapes root directory"})
+
     resolved = str(base)
 
     return _safe_json({

--- a/servers/bitwize-music-server/handlers/rename.py
+++ b/servers/bitwize-music-server/handlers/rename.py
@@ -14,6 +14,7 @@ from handlers._shared import (
     _derive_title_from_slug,
     _find_album_or_error,
     _find_track_or_error,
+    _is_path_confined,
     _normalize_slug,
     _safe_json,
 )
@@ -42,8 +43,11 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     """
     from tools.state.indexer import write_state
 
-    normalized_old = _normalize_slug(old_slug)
-    normalized_new = _normalize_slug(new_slug)
+    try:
+        normalized_old = _normalize_slug(old_slug)
+        normalized_new = _normalize_slug(new_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
 
     if normalized_old == normalized_new:
         return _safe_json({"error": "Old and new slugs are the same after normalization."})
@@ -86,6 +90,11 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     audio_dir_new = Path(audio_root) / "artists" / artist / "albums" / genre / normalized_new
     docs_dir_old = Path(documents_root) / "artists" / artist / "albums" / genre / normalized_old
     docs_dir_new = Path(documents_root) / "artists" / artist / "albums" / genre / normalized_new
+
+    # Defense-in-depth: verify new paths stay within their root directories
+    albums_content_base = Path(content_root) / "artists" / artist / "albums" / genre
+    if not _is_path_confined(albums_content_base, normalized_new):
+        return _safe_json({"error": "Invalid new slug: would escape album directory"})
 
     # Content directory MUST exist
     if not content_dir_old.is_dir():
@@ -205,15 +214,21 @@ async def rename_track(
     assert album is not None
 
     tracks = album.get("tracks", {})
-    normalized_new = _normalize_slug(new_track_slug)
+    try:
+        normalized_new = _normalize_slug(new_track_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
 
     matched_slug, track_data, error = _find_track_or_error(tracks, old_track_slug, album_slug)
     if error:
         return error
     assert track_data is not None
 
-    if _normalize_slug(old_track_slug) == normalized_new:
-        return _safe_json({"error": "Old and new track slugs are the same after normalization."})
+    try:
+        if _normalize_slug(old_track_slug) == normalized_new:
+            return _safe_json({"error": "Old and new track slugs are the same after normalization."})
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
 
     # Check new slug doesn't already exist
     if normalized_new in tracks:
@@ -227,7 +242,9 @@ async def rename_track(
             "error": f"Track file not found on disk: {old_path}",
         })
 
-    # Build new path
+    # Build new path — verify it stays within the tracks directory
+    if not _is_path_confined(old_path.parent, f"{normalized_new}.md"):
+        return _safe_json({"error": "Invalid new track slug: would escape tracks directory"})
     new_path = old_path.parent / f"{normalized_new}.md"
 
     # Derive title

--- a/servers/bitwize-music-server/handlers/text_analysis.py
+++ b/servers/bitwize-music-server/handlers/text_analysis.py
@@ -553,7 +553,10 @@ async def extract_links(
 
     # Determine file path
     file_path = None
-    normalized_file = _normalize_slug(file_name)
+    try:
+        normalized_file = _normalize_slug(file_name)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
 
     # Check if it's a track slug
     tracks = album.get("tracks", {})

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -11368,6 +11368,55 @@ class TestPathTraversalGuards:
 
 
 # =============================================================================
+# Tests for _normalize_slug path traversal rejection
+# =============================================================================
+
+
+class TestNormalizeSlugPathTraversal:
+    """Verify _normalize_slug rejects path traversal characters."""
+
+    def test_forward_slash_rejected(self):
+        with pytest.raises(ValueError, match="path separator"):
+            server._normalize_slug("../../etc/passwd")
+
+    def test_backslash_rejected(self):
+        with pytest.raises(ValueError, match="path separator"):
+            server._normalize_slug("..\\..\\etc")
+
+    def test_null_byte_rejected(self):
+        with pytest.raises(ValueError, match="path separator"):
+            server._normalize_slug("album\x00evil")
+
+    def test_dot_dot_rejected(self):
+        with pytest.raises(ValueError, match="traversal"):
+            server._normalize_slug("album..escape")
+
+    def test_single_dot_allowed(self):
+        """A single dot (e.g., 'v2.0') is fine — only '..' is blocked."""
+        assert server._normalize_slug("v2.0") == "v2.0"
+
+    def test_normal_slug_unaffected(self):
+        assert server._normalize_slug("my-album-name") == "my-album-name"
+
+    def test_spaces_still_normalized(self):
+        assert server._normalize_slug("my album name") == "my-album-name"
+
+    def test_underscores_still_normalized(self):
+        assert server._normalize_slug("my_album_name") == "my-album-name"
+
+    def test_mixed_case_still_lowered(self):
+        assert server._normalize_slug("My Album") == "my-album"
+
+    def test_double_dot_in_underscored_name(self):
+        """Underscores become hyphens before '..' check, but '..' in raw name is caught."""
+        with pytest.raises(ValueError, match="traversal"):
+            server._normalize_slug("a..b")
+
+    def test_empty_string_still_works(self):
+        assert server._normalize_slug("") == ""
+
+
+# =============================================================================
 # Tests for dependency checker helpers
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- **`_normalize_slug()` now rejects path traversal characters** (`/`, `\`, `\0`, `..`) with `ValueError` — this single-point fix closes path traversal vectors across all ~50 call sites, including `rename_album`, `rename_track`, `resolve_path`, and `create_album_structure`
- **Defense-in-depth**: added `_is_path_confined()` checks in `rename_album`, `rename_track`, and `create_album_structure` before any `shutil.move()` or `mkdir` operations
- **Fixed GitHub Actions injection** in `pr-target-check.yml`: moved `github.head_ref` from inline `${{ }}` interpolation to an `env:` block, preventing shell injection via malicious fork branch names
- Handlers that pass user input through `_normalize_slug` (`extract_links`, `rename_album`, `rename_track`) now catch `ValueError` and return proper JSON error responses

## Context

Full codebase security audit identified these as the top two priority fixes:
1. `_normalize_slug` allowed `/`, `\`, `..` through — enabling path traversal in handlers that build filesystem paths from slugs
2. `github.head_ref` inline interpolation allowed arbitrary command execution from fork PRs

Related: #275 (env var credential support — intentional design, tracked as enhancement)

## Test plan

- [x] 11 new tests in `TestNormalizeSlugPathTraversal` — verifies rejection of `/`, `\`, `\0`, `..` and confirms normal slugs unaffected
- [x] All 40 existing path traversal guard tests pass (including `extract_links` which now gets a JSON error instead of uncaught ValueError)
- [x] Full suite: 3036 passed, 3 skipped, 2 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)