### PR TITLE
fix: harden optional module import helpers and callers

### DIFF
--- a/servers/bitwize-music-server/handlers/processing/_helpers.py
+++ b/servers/bitwize-music-server/handlers/processing/_helpers.py
@@ -8,8 +8,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
 from handlers import _shared
 from handlers._shared import _normalize_slug
 from handlers._shared import _resolve_audio_dir as _resolve_audio_dir  # noqa: F401
@@ -95,23 +93,23 @@ def _import_sheet_music_module(module_name: str) -> Any:
     import importlib.util
     assert _shared.PLUGIN_ROOT is not None
     module_path = _shared.PLUGIN_ROOT / "tools" / "sheet-music" / f"{module_name}.py"
-    try:
-        spec = importlib.util.spec_from_file_location(
-            f"sheet_music_{module_name}", str(module_path)
+    spec = importlib.util.spec_from_file_location(
+        f"sheet_music_{module_name}", str(module_path)
+    )
+    if spec is None or spec.loader is None:
+        logger.warning(
+            "Optional module %s not available: Could not load import spec for %s",
+            module_name,
+            module_path,
         )
-        if spec is None or spec.loader is None:
-            logger.warning(
-                "Optional module %s not available: Could not load import spec for %s",
-                module_name,
-                module_path,
-            )
-            return None
+        return None
+    try:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return mod
-    except Exception as e:
-        logger.warning("Optional module %s not available: %s", module_name, e)
-        raise
+    except (ImportError, OSError) as exc:
+        logger.warning("Optional sheet-music module %r not available: %s", module_name, exc)
+        return None
+    return mod
 
 
 def _import_cloud_module(module_name: str) -> Any:
@@ -119,23 +117,23 @@ def _import_cloud_module(module_name: str) -> Any:
     import importlib.util
     assert _shared.PLUGIN_ROOT is not None
     module_path = _shared.PLUGIN_ROOT / "tools" / "cloud" / f"{module_name}.py"
-    try:
-        spec = importlib.util.spec_from_file_location(
-            f"cloud_{module_name}", str(module_path)
+    spec = importlib.util.spec_from_file_location(
+        f"cloud_{module_name}", str(module_path)
+    )
+    if spec is None or spec.loader is None:
+        logger.warning(
+            "Optional module %s not available: Could not load import spec for %s",
+            module_name,
+            module_path,
         )
-        if spec is None or spec.loader is None:
-            logger.warning(
-                "Optional module %s not available: Could not load import spec for %s",
-                module_name,
-                module_path,
-            )
-            return None
+        return None
+    try:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return mod
-    except Exception as e:
-        logger.warning("Optional module %s not available: %s", module_name, e)
-        raise
+    except (ImportError, OSError) as exc:
+        logger.warning("Optional cloud module %r not available: %s", module_name, exc)
+        return None
+    return mod
 
 
 def _check_cloud_enabled() -> str | None:
@@ -162,26 +160,28 @@ def _check_cloud_enabled() -> str | None:
 
 def _check_anthemscore() -> str | None:
     """Return error message if AnthemScore not found, else None."""
-    try:
-        transcribe_mod = _import_sheet_music_module("transcribe")
-        if transcribe_mod.find_anthemscore() is None:
-            return (
-                "AnthemScore not found. Install from: https://www.lunaverus.com/ "
-                "(Professional edition recommended for CLI support)"
-            )
-    except (ImportError, OSError, AttributeError) as exc:
-        logger.warning("AnthemScore module check failed, falling back to path search: %s", exc)
-        # Fall back to path search
-        paths = [
-            "/Applications/AnthemScore.app/Contents/MacOS/AnthemScore",
-            "/usr/bin/anthemscore",
-            "/usr/local/bin/anthemscore",
-        ]
-        if not any(Path(p).exists() for p in paths) and not shutil.which("anthemscore"):
-            return (
-                "AnthemScore not found. Install from: https://www.lunaverus.com/ "
-                "(Professional edition recommended for CLI support)"
-            )
+    transcribe_mod = _import_sheet_music_module("transcribe")
+    if transcribe_mod is not None:
+        try:
+            if transcribe_mod.find_anthemscore() is None:
+                return (
+                    "AnthemScore not found. Install from: https://www.lunaverus.com/ "
+                    "(Professional edition recommended for CLI support)"
+                )
+            return None
+        except (ImportError, OSError) as exc:
+            logger.warning("AnthemScore check failed, falling back to path search: %s", exc)
+    # Fall back to path search
+    paths = [
+        "/Applications/AnthemScore.app/Contents/MacOS/AnthemScore",
+        "/usr/bin/anthemscore",
+        "/usr/local/bin/anthemscore",
+    ]
+    if not any(Path(p).exists() for p in paths) and not shutil.which("anthemscore"):
+        return (
+            "AnthemScore not found. Install from: https://www.lunaverus.com/ "
+            "(Professional edition recommended for CLI support)"
+        )
     return None
 
 

--- a/servers/bitwize-music-server/handlers/processing/sheet_music.py
+++ b/servers/bitwize-music-server/handlers/processing/sheet_music.py
@@ -61,6 +61,8 @@ async def transcribe_audio(
     assert audio_dir is not None
 
     transcribe_mod = _helpers._import_sheet_music_module("transcribe")
+    if transcribe_mod is None:
+        return _safe_json({"error": "Sheet music transcription module not available."})
     find_anthemscore = transcribe_mod.find_anthemscore
     transcribe_track = transcribe_mod.transcribe_track
 
@@ -262,6 +264,8 @@ async def prepare_singles(
     singles_dir = audio_dir / "sheet-music" / "singles"
 
     prepare_mod = _helpers._import_sheet_music_module("prepare_singles")
+    if prepare_mod is None:
+        return _safe_json({"error": "Sheet music prepare_singles module not available."})
     _prepare_singles = prepare_mod.prepare_singles
 
     musescore = None
@@ -270,6 +274,8 @@ async def prepare_singles(
 
     # Get artist, cover art, and footer URL for title pages
     songbook_mod = _helpers._import_sheet_music_module("create_songbook")
+    if songbook_mod is None:
+        return _safe_json({"error": "Sheet music create_songbook module not available."})
     auto_detect_cover_art = songbook_mod.auto_detect_cover_art
     get_footer_url_from_config = songbook_mod.get_footer_url_from_config
 
@@ -371,6 +377,8 @@ async def create_songbook(
             })
 
     songbook_mod = _helpers._import_sheet_music_module("create_songbook")
+    if songbook_mod is None:
+        return _safe_json({"error": "Sheet music create_songbook module not available."})
     _create_songbook = songbook_mod.create_songbook
     auto_detect_cover_art = songbook_mod.auto_detect_cover_art
     get_website_from_config = songbook_mod.get_website_from_config
@@ -524,11 +532,10 @@ async def publish_sheet_music(
         })
 
     # Import cloud module and upload
-    try:
-        cloud_mod = _helpers._import_cloud_module("upload_to_cloud")
-    except Exception as e:
+    cloud_mod = _helpers._import_cloud_module("upload_to_cloud")
+    if cloud_mod is None:
         return _safe_json({
-            "error": f"Failed to import cloud module: {e}",
+            "error": "Cloud upload module not available.",
             "suggestion": "Ensure boto3 is installed: pip install boto3",
         })
 

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -12151,10 +12151,10 @@ class TestImportSheetMusicModule:
         assert hasattr(mod, "create_songbook")
         assert hasattr(mod, "auto_detect_cover_art")
 
-    def test_nonexistent_module_raises(self):
-        """Should raise on a module that doesn't exist."""
-        with pytest.raises(Exception):
-            _processing_helpers._import_sheet_music_module("nonexistent_module")
+    def test_nonexistent_module_returns_none(self):
+        """Should return None and log a warning for a module that doesn't exist."""
+        result = _processing_helpers._import_sheet_music_module("nonexistent_module")
+        assert result is None
 
     def test_logs_warning_when_spec_missing(self, caplog):
         """Should warn before raising if the import spec cannot be created."""
@@ -12166,8 +12166,8 @@ class TestImportSheetMusicModule:
         assert mod is None
         assert "Optional module transcribe not available" in caplog.text
 
-    def test_logs_warning_when_exec_fails(self, caplog):
-        """Should warn before raising if module execution fails."""
+    def test_returns_none_when_exec_fails(self, caplog):
+        """Should warn and return None if module execution fails."""
         caplog.set_level("WARNING", logger="bitwize-music-state")
         mock_loader = MagicMock()
         mock_loader.exec_module.side_effect = ImportError("missing optional dep")
@@ -12175,10 +12175,11 @@ class TestImportSheetMusicModule:
 
         with patch("importlib.util.spec_from_file_location", return_value=mock_spec), \
              patch("importlib.util.module_from_spec", return_value=MagicMock()):
-            with pytest.raises(ImportError, match="missing optional dep"):
-                _processing_helpers._import_sheet_music_module("transcribe")
+            result = _processing_helpers._import_sheet_music_module("transcribe")
 
-        assert "Optional module transcribe not available: missing optional dep" in caplog.text
+        assert result is None
+        assert "Optional sheet-music module" in caplog.text
+        assert "missing optional dep" in caplog.text
 
 
 class TestImportCloudModule:
@@ -12194,8 +12195,8 @@ class TestImportCloudModule:
         assert mod is None
         assert "Optional module upload_to_cloud not available" in caplog.text
 
-    def test_logs_warning_when_exec_fails(self, caplog):
-        """Should warn before raising if module execution fails."""
+    def test_returns_none_when_exec_fails(self, caplog):
+        """Should warn and return None if module execution fails."""
         caplog.set_level("WARNING", logger="bitwize-music-state")
         mock_loader = MagicMock()
         mock_loader.exec_module.side_effect = ImportError("missing boto3")
@@ -12203,10 +12204,11 @@ class TestImportCloudModule:
 
         with patch("importlib.util.spec_from_file_location", return_value=mock_spec), \
              patch("importlib.util.module_from_spec", return_value=MagicMock()):
-            with pytest.raises(ImportError, match="missing boto3"):
-                _processing_helpers._import_cloud_module("upload_to_cloud")
+            result = _processing_helpers._import_cloud_module("upload_to_cloud")
 
-        assert "Optional module upload_to_cloud not available: missing boto3" in caplog.text
+        assert result is None
+        assert "Optional cloud module" in caplog.text
+        assert "missing boto3" in caplog.text
 
 
 # =============================================================================

--- a/tests/unit/state/test_silent_exceptions.py
+++ b/tests/unit/state/test_silent_exceptions.py
@@ -298,25 +298,23 @@ class TestHelpersCloudConfigWarning:
 
 
 class TestHelpersAnthemScoreWarning:
-    """Verify that AnthemScore module check failure logs a warning."""
+    """Verify that AnthemScore module check failure falls back to path search."""
 
-    def test_anthemscore_module_failure_logs_warning(self, caplog):
-        """When _import_sheet_music_module raises ImportError, a warning is logged."""
+    def test_anthemscore_module_failure_falls_back(self):
+        """When _import_sheet_music_module returns None, fall back to path search."""
         from handlers.processing import _helpers as helpers_mod
 
         with (
             patch.object(
                 helpers_mod,
                 "_import_sheet_music_module",
-                side_effect=ImportError("transcribe not found"),
+                return_value=None,
             ),
             # Ensure no anthemscore binary found on this system either
             patch("shutil.which", return_value=None),
             patch.object(Path, "exists", return_value=False),
-            caplog.at_level("WARNING", logger="handlers.processing._helpers"),
         ):
             result = helpers_mod._check_anthemscore()
 
-        assert any(
-            "AnthemScore module check failed" in r.message for r in caplog.records
-        ), f"Expected AnthemScore warning. Records: {[r.message for r in caplog.records]}"
+        assert result is not None
+        assert "AnthemScore not found" in result


### PR DESCRIPTION
## Summary
- Narrow `except Exception` to `(ImportError, OSError)` in `_import_sheet_music_module`, `_import_cloud_module`, and `publish_sheet_music` so unexpected bugs propagate instead of being masked as "module not available"
- Restructure `_check_anthemscore` to check for `None` return before falling back to path search, eliminating double-logging
- Add `None` guards at all four call sites in `sheet_music.py` that dereference the import return value without checking

Closes #277

## Test plan
- [x] All 3036 existing tests pass
- [x] Updated `test_nonexistent_module_raises` → `test_nonexistent_module_returns_none` to match new return-None behavior
- [x] Updated `test_anthemscore_module_failure_logs_warning` → `test_anthemscore_module_failure_falls_back` to verify path-search fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)