### PR TITLE
feat: default mastering routing to polish-then-master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Concept → Research → Write (+Suno Prompt) → [Refine] → QC/Verify → Gen
 - **Suno prompts** → apply `/bitwize-music:suno-engineer` expertise (usually auto-invoked by lyric-writer; use directly only for re-prompting)
 - **Research needed** → apply `/bitwize-music:researcher` standards
 - **Polishing audio / fixing Suno artifacts** → apply `/bitwize-music:mix-engineer` expertise
-- **Mastering audio** → apply `/bitwize-music:mastering-engineer` standards
+- **Mastering audio** → polish first via `/bitwize-music:mix-engineer`, then apply `/bitwize-music:mastering-engineer` standards. Skip polish only if: (a) user says "master only", "skip polish", or "already polished"; or (b) polished audio already exists at `{audio_root}/artists/[artist]/albums/[genre]/[album]/polished/`. Applies equally to single-track and whole-album mastering.
 - **Album art** → apply `/bitwize-music:album-art-director`
 - **Writing promo copy** → apply `/bitwize-music:promo-writer` expertise
 - **Releasing** → apply `/bitwize-music:release-director`


### PR DESCRIPTION
## Summary

- Updates the `Mastering audio` routing rule in `CLAUDE.md` so "master the album" polishes first by default, then hands off to `mastering-engineer`.
- Adds explicit opt-outs: user phrases ("master only", "skip polish", "already polished") or state-based (polished audio already exists at `{audio_root}/.../polished/`).
- Applies equally to single-track and whole-album mastering requests.

Closes #280. Related: #269 (backend MCP tool for the combined pipeline).

## Test plan

- [ ] Fresh session, say "let's master [album]" — confirm Claude runs polish first, then mastering
- [ ] Fresh session, say "master only [album]" — confirm polish is skipped
- [ ] With existing `polished/` audio present, say "master [album]" — confirm polish is skipped
- [ ] Single track: "master this track" — same rules apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)