### PR TITLE
fix: look-ahead limiter hits ceiling exactly on transients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 - Added missing `--deess-bandwidth` CLI arg
 - Added missing CLI args for multiband ratios/thresholds and mid/side frequencies
 - Wired `eq_low_q` through to `apply_low_shelf()` (was defined but unused)
+- Look-ahead limiter now hits its target ceiling exactly (was overshooting by ~1 dB on transients). Gain at peak samples was being sampled from the release-relaxed envelope; replaced with a rolling minimum over the lookahead window (#283)
 
 ## [0.89.0] - 2026-04-10
 

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -1126,6 +1126,32 @@ class TestLookAheadLimiter:
         # They should differ because look-ahead pre-applies gain reduction
         assert not np.allclose(reactive, lookahead)
 
+    def test_respects_ceiling_on_transient(self):
+        """Regression: a transient must receive full attenuation, not a release-relaxed gain.
+
+        With the previous release-then-shift approach, gain applied at peak sample K was
+        smoothed[K + lookahead_samples] — already partially released from the attack. This
+        let peaks slip past the ceiling by ~0.9 dB on transients.
+        """
+        rate = 44100
+        t = np.linspace(0, 2.0, int(rate * 2.0), endpoint=False)
+        data = 0.3 * np.sin(2 * np.pi * 440 * t)
+        # Short transient that needs ~50% gain reduction
+        data[int(rate * 1.0):int(rate * 1.0) + 100] = 2.0
+        data = np.column_stack([data, data])
+
+        for ceiling_db in (-1.0, -1.5, -3.0):
+            result = limit_peaks_lookahead(
+                data.copy(), ceiling_db=ceiling_db,
+                lookahead_ms=5.0, release_ms=50.0, rate=rate,
+            )
+            ceiling_linear = 10 ** (ceiling_db / 20)
+            # Sample peak must sit at the ceiling (soft-clip tolerance only)
+            assert np.max(np.abs(result)) <= ceiling_linear + 0.01, (
+                f"ceiling={ceiling_db} dB: peak {np.max(np.abs(result)):.4f} "
+                f"exceeds ceiling_linear {ceiling_linear:.4f} + 0.01"
+            )
+
 
 class TestParallelCompression:
     """Tests for parallel compression (compress_mix)."""

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -20,6 +20,7 @@ import numpy as np
 import pyloudnorm as pyln
 import soundfile as sf
 from scipy import signal
+from scipy.ndimage import minimum_filter1d
 
 try:
     import yaml
@@ -658,13 +659,16 @@ def limit_peaks_lookahead(data: Any, ceiling_db: float = -1.0,
             env = release_coeff * env + (1.0 - release_coeff) * target
         smoothed[i] = env
 
-    # Shift gain envelope backward by lookahead_samples (pre-apply reduction)
-    shifted = np.ones(n_samples, dtype=np.float64)
+    # Pre-apply gain reduction across the lookahead window: at each sample i,
+    # use the minimum gain required anywhere in [i, i+lookahead_samples]. A plain
+    # backward shift would sample the release-relaxed envelope at the peak,
+    # letting peaks slip past the ceiling by release_coeff^lookahead.
     if lookahead_samples < n_samples:
-        shifted[:n_samples - lookahead_samples] = smoothed[lookahead_samples:]
-        shifted[n_samples - lookahead_samples:] = smoothed[-1]
+        window = lookahead_samples + 1
+        padded = np.concatenate([smoothed, np.ones(lookahead_samples, dtype=np.float64)])
+        shifted = minimum_filter1d(padded, size=window, origin=-(window // 2))[:n_samples]
     else:
-        shifted[:] = np.min(smoothed)
+        shifted = np.full(n_samples, float(np.min(smoothed)), dtype=np.float64)
 
     # Apply gain reduction
     if data.ndim == 1:


### PR DESCRIPTION
## Summary
- `limit_peaks_lookahead()` was overshooting its target ceiling by ~1 dB on transients because gain at peak sample K was sampled from the release-relaxed envelope (`smoothed[K + lookahead_samples]`) instead of the full attack value
- Replaced the backward shift with a rolling minimum over `[i, i + lookahead_samples]` via `scipy.ndimage.minimum_filter1d`, so peaks always receive their full pre-computed attenuation
- Added a regression test covering transient + ceiling compliance — existing steady-sine tests couldn't trigger the bug

Fixes #283

## Verification

With `processing_oversample=4` and a 100-sample transient at amplitude 2.0:

| `ceiling_db` | before | after |
|---|---|---|
| -1.0 | +0.02 dBTP (+1.02) | -1.01 dBTP (-0.01) |
| -1.5 | -0.32 dBTP (+1.18) | -1.51 dBTP (-0.01) |
| -2.5 | -1.05 dBTP (+1.45) | -2.51 dBTP (-0.01) |
| -3.0 | -1.42 dBTP (+1.58) | -3.01 dBTP (-0.01) |

Offset vs. ceiling is now within 0.01 dB across all ceiling values.

## Behaviour change

Masters produced prior to this fix had their loudest transients attenuated ~1 dB less than their preset intended. After the fix, transients hit the configured ceiling exactly — final masters will sound very slightly more limited on the loudest transients, and QC peak checks will pass where they were previously failing/warning.

No existing test behaviour changes: `test_respects_ceiling` used a steady sine (no release dynamic, so the bug didn't fire) and still passes.

## Test plan
- [x] New `test_respects_ceiling_on_transient` fails on `develop`, passes after the fix
- [x] Full mastering test suite (257 tests) passes
- [x] Full project test suite (3044 tests) passes
- [x] Pipeline end-to-end verification at `oversample=1` and `oversample=4` shows ceiling hit within 0.01 dB

🤖 Generated with [Claude Code](https://claude.com/claude-code)