### PR TITLE
fix: make QC click thresholds genre-aware (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 - Added missing CLI args for multiband ratios/thresholds and mid/side frequencies
 - Wired `eq_low_q` through to `apply_low_shelf()` (was defined but unused)
 - Look-ahead limiter now hits its target ceiling exactly (was overshooting by ~1 dB on transients). Gain at peak samples was being sampled from the release-relaxed envelope; replaced with a rolling minimum over the lookahead window (#283)
+- QC click detector is now genre-aware: `click_peak_ratio` and `click_fail_count` are per-genre preset fields, tuned looser for genres with intentional sharp transients (electronic, IDM, breakcore, trap, metal, glitch, footwork, etc.) so musical transients no longer FAIL QC. `qc_tracks.py` accepts `--genre`, the `qc_audio` MCP tool accepts `genre`, and user `mastering-presets.yaml` overrides still apply (#285)
 
 ## [0.89.0] - 2026-04-10
 

--- a/config/overrides.example/mastering-presets.yaml
+++ b/config/overrides.example/mastering-presets.yaml
@@ -52,6 +52,12 @@
 #   midside_high_gain    - Side channel high shelf gain in dB (default 0)
 #   midside_high_freq    - Side channel high shelf frequency in Hz (default 8000)
 #   eq_linear_phase      - Use linear-phase FIR EQ (0 = off, 1 = on, default 0)
+#   click_peak_ratio     - QC click detector: peak-to-RMS ratio above which a 10ms
+#                          window counts as a click (default 6.0). Raise for genres
+#                          with intentional sharp transients (e.g., 8.0–10.0).
+#   click_fail_count     - QC click detector: click count above which clicks FAIL
+#                          (default 3). Raise alongside click_peak_ratio for
+#                          dense-transient genres.
 
 genres:
   # Example: override rock to be less aggressive

--- a/reference/mastering/mastering-workflow.md
+++ b/reference/mastering/mastering-workflow.md
@@ -416,9 +416,15 @@ Technical audio QC with 7 automated checks:
 ```bash
 python3 {plugin_root}/tools/mastering/qc_tracks.py {audio_path}/
 python3 {plugin_root}/tools/mastering/qc_tracks.py {audio_path}/ --checks mono,phase,clipping
+python3 {plugin_root}/tools/mastering/qc_tracks.py {audio_path}/ --genre idm
 ```
 
-Also available as the `qc_audio` MCP tool for use from skills.
+The `--genre` flag loads per-genre click detector thresholds so intentional sharp
+transients in electronic/metal/IDM don't FAIL QC. User overrides in
+`{overrides}/mastering-presets.yaml` (`click_peak_ratio`, `click_fail_count`)
+take precedence over the built-in per-genre defaults.
+
+Also available as the `qc_audio` MCP tool (with an optional `genre` argument) for use from skills.
 
 ### reference_master.py
 

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -99,7 +99,12 @@ async def analyze_audio(album_slug: str, subfolder: str = "") -> str:
     })
 
 
-async def qc_audio(album_slug: str, subfolder: str = "", checks: str = "") -> str:
+async def qc_audio(
+    album_slug: str,
+    subfolder: str = "",
+    checks: str = "",
+    genre: str = "",
+) -> str:
     """Run technical QC checks on audio tracks.
 
     Scans WAV files for mono compatibility, phase correlation, clipping,
@@ -110,6 +115,9 @@ async def qc_audio(album_slug: str, subfolder: str = "", checks: str = "") -> st
         subfolder: Optional subfolder within audio dir (e.g., "mastered")
         checks: Comma-separated checks to run (default: all).
                 Options: mono, phase, clipping, clicks, silence, format, spectral
+        genre: Optional genre preset name. When set, the click detector uses
+                genre-tuned peak/RMS thresholds so intentional sharp transients
+                in electronic/metal/IDM don't FAIL QC.
 
     Returns:
         JSON with per-track QC results, summary, and verdicts
@@ -123,7 +131,7 @@ async def qc_audio(album_slug: str, subfolder: str = "", checks: str = "") -> st
         return err
     assert audio_dir is not None
 
-    from tools.mastering.qc_tracks import ALL_CHECKS, qc_track
+    from tools.mastering.qc_tracks import ALL_CHECKS, _resolve_click_thresholds, qc_track
 
     source_dir = _find_wav_source_dir(audio_dir) if not subfolder else audio_dir
     wav_files = sorted(source_dir.glob("*.wav"))
@@ -145,10 +153,19 @@ async def qc_audio(album_slug: str, subfolder: str = "", checks: str = "") -> st
                 "valid_checks": ALL_CHECKS,
             })
 
+    genre_arg = genre.strip() or None
+    if genre_arg is not None:
+        try:
+            _resolve_click_thresholds(genre_arg)
+        except ValueError as e:
+            return _safe_json({"error": str(e)})
+
     loop = asyncio.get_running_loop()
     results = []
     for wav in wav_files:
-        result = await loop.run_in_executor(None, qc_track, str(wav), active_checks)
+        result = await loop.run_in_executor(
+            None, qc_track, str(wav), active_checks, genre_arg
+        )
         results.append(result)
 
     # Build summary

--- a/tests/unit/mastering/test_qc_tracks.py
+++ b/tests/unit/mastering/test_qc_tracks.py
@@ -292,6 +292,68 @@ class TestCheckClicks:
         assert "0 found" not in result["value"]
 
 
+class TestCheckClicksGenreThresholds:
+    """Tests for configurable per-genre click detection thresholds (#285)."""
+
+    def test_default_call_fails_on_dense_transients(self, clicks_wav):
+        """Default thresholds (6.0, 3) flag clicks_wav's 5 strong spikes as FAIL."""
+        data, rate = sf.read(clicks_wav)
+        result = _check_clicks(data, rate)
+        assert result["status"] == "FAIL"
+
+    def test_relaxed_peak_ratio_passes_dense_transients(self, clicks_wav):
+        """A high peak_ratio lets strong musical transients through."""
+        data, rate = sf.read(clicks_wav)
+        # clicks_wav spikes at peak/rms ~16.5; ratio=20 should detect nothing.
+        result = _check_clicks(data, rate, peak_ratio=20.0)
+        assert result["status"] == "PASS"
+        assert "0 found" in result["value"]
+
+    def test_relaxed_fail_count_downgrades_fail_to_warn(self, clicks_wav):
+        """Raising fail_count turns a FAIL count into a WARN."""
+        data, rate = sf.read(clicks_wav)
+        result = _check_clicks(data, rate, peak_ratio=6.0, fail_count=10)
+        # 5 clicks <= fail_count=10 => WARN
+        assert result["status"] == "WARN"
+
+    def test_stricter_peak_ratio_flags_moderate_spikes(self):
+        """Lowering peak_ratio catches smaller transients missed by default."""
+        rate = 44100
+        duration = 3.0
+        t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+        mono = (0.1 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
+        # Spikes at 0.3 over 0.1 sine yield peak/rms ~4.2 — below default 6
+        for i in range(5):
+            idx = 10000 + i * 20000
+            mono[idx] = 0.3
+        data = np.column_stack([mono, mono])
+        # Default (6.0) misses them
+        default_result = _check_clicks(data, rate)
+        assert default_result["status"] == "PASS"
+        # Strict (3.0) catches them
+        strict_result = _check_clicks(data, rate, peak_ratio=3.0, fail_count=3)
+        assert strict_result["status"] == "FAIL"
+
+
+class TestQcTrackGenre:
+    """Tests that qc_track applies genre-preset click thresholds (#285)."""
+
+    def test_no_genre_matches_default_behavior(self, clicks_wav):
+        """Without a genre kwarg, click check uses the default 6.0/3 thresholds."""
+        result = qc_track(clicks_wav, checks=["clicks"])
+        assert result["checks"]["clicks"]["status"] == "FAIL"
+
+    def test_genre_with_relaxed_thresholds_does_not_fail(self, clicks_wav):
+        """A dense-transient genre (idm) should not FAIL on intentional spikes."""
+        result = qc_track(clicks_wav, checks=["clicks"], genre="idm")
+        assert result["checks"]["clicks"]["status"] != "FAIL"
+
+    def test_unknown_genre_raises(self, normal_wav):
+        """Unknown genre should raise a clear error."""
+        with pytest.raises(ValueError, match="Unknown genre"):
+            qc_track(normal_wav, checks=["clicks"], genre="nonexistent-genre-xyz")
+
+
 class TestCheckSilence:
     """Tests for the silence detection check."""
 

--- a/tests/unit/state/test_server_qc.py
+++ b/tests/unit/state/test_server_qc.py
@@ -278,7 +278,7 @@ class TestQcAudioComprehensive:
 
         call_count = []
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             name = Path(filepath).name
             call_count.append(name)
             return self._mock_qc_result(name)
@@ -297,7 +297,7 @@ class TestQcAudioComprehensive:
         audio_dir, state = self._make_audio_dir(tmp_path, 2)
         mock_cache = MockStateCache(state)
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             return self._mock_qc_result(Path(filepath).name, verdict="PASS")
 
         with patch.object(_shared_mod, "cache", mock_cache), \
@@ -316,7 +316,7 @@ class TestQcAudioComprehensive:
 
         call_idx = [0]
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             idx = call_idx[0]
             call_idx[0] += 1
             if idx == 0:
@@ -339,7 +339,7 @@ class TestQcAudioComprehensive:
         audio_dir, state = self._make_audio_dir(tmp_path, 1)
         mock_cache = MockStateCache(state)
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             return self._mock_qc_result(
                 Path(filepath).name, verdict="WARN", spectral_status="WARN"
             )
@@ -363,7 +363,7 @@ class TestQcAudioComprehensive:
         state["config"]["artist_name"] = "test-artist"
         mock_cache = MockStateCache(state)
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             return self._mock_qc_result(Path(filepath).name)
 
         with patch.object(_shared_mod, "cache", mock_cache), \
@@ -381,7 +381,7 @@ class TestQcAudioComprehensive:
 
         captured_checks = []
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             captured_checks.append(checks)
             return self._mock_qc_result(Path(filepath).name)
 
@@ -505,7 +505,7 @@ class TestMasterAlbumPipeline:
 
         call_idx = [0]
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             idx = call_idx[0]
             call_idx[0] += 1
             name = Path(filepath).name
@@ -628,7 +628,7 @@ class TestMasterAlbumPipeline:
 
         qc_call_idx = [0]
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             idx = qc_call_idx[0]
             qc_call_idx[0] += 1
             name = Path(filepath).name
@@ -695,7 +695,7 @@ class TestMasterAlbumPipeline:
         def mock_analyze(filepath):
             return self._mock_analyze(Path(filepath).name, lufs=-14.0)
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             return self._mock_qc_result(Path(filepath).name)
 
         with patch.object(_shared_mod, "cache", mock_cache), \
@@ -885,7 +885,7 @@ class TestMasterAlbumPipeline:
                 "final_peak": -1.5,
             }
 
-        def mock_qc(filepath, checks=None):
+        def mock_qc(filepath, checks=None, genre=None):
             name = Path(filepath).name
             r = self._mock_qc_result(name)
             r["checks"]["spectral"]["status"] = "WARN"

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -47,6 +47,11 @@
 #   midside_low_freq       - Side channel low shelf frequency (default 300)
 #   midside_high_gain      - Side channel high shelf gain in dB (default 0, positive = wider highs)
 #   midside_high_freq      - Side channel high shelf frequency (default 8000)
+#   click_peak_ratio       - QC click detector: peak-to-RMS ratio above which a 10ms window
+#                            counts as a click (default 6.0). Raise for genres with intentional
+#                            sharp transients (e.g., 8.0–10.0 for electronic/IDM/metal).
+#   click_fail_count       - QC click detector: absolute click count above which clicks FAIL
+#                            (default 3). Raise alongside peak_ratio for dense-transient genres.
 #
 # Override per-user: copy to {overrides}/mastering-presets.yaml and edit.
 # User overrides merge on top of these defaults (genre-level).
@@ -100,6 +105,8 @@ defaults:
   midside_high_gain: 0
   midside_high_freq: 8000
   eq_linear_phase: 0
+  click_peak_ratio: 6.0
+  click_fail_count: 3
 
 genres:
   # === Pop / Mainstream ===
@@ -131,6 +138,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   dream-pop:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -175,6 +184,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   jangle-pop:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -225,14 +236,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   drill:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   phonk:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   grime:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -277,6 +294,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   mumble-rap:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -453,6 +472,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   britpop:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -523,18 +544,26 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   crust-punk:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   d-beat:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   powerviolence:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   screamo:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -577,14 +606,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   thrash-metal:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   black-metal:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   doom-metal:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -593,10 +628,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   metalcore:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   nu-metal:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -617,14 +656,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   grindcore:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   groove-metal:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   sludge-metal:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -637,14 +682,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   djent:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   industrial:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   hair-metal:
     target_lufs: -14.0
     cut_highmid: -2.0
@@ -687,10 +738,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   edm:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   eurodance:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -719,6 +774,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   trance:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -727,10 +784,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   jungle:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   uk-garage:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -739,6 +800,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   synthwave:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -755,6 +818,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   electro:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -763,6 +828,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -2.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   electroswing:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -787,6 +854,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -2.0
     cut_highs: 0
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   nightcore:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -795,18 +864,26 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.0
     cut_highs: -1.0
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   pc-music:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   speedcore:
     target_lufs: -12.0
     cut_highmid: -2.0
     cut_highs: -1.0
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   riddim:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   wave:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -823,6 +900,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   vocal-trance:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -839,6 +918,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -2.0
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   dub-techno:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -847,14 +928,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: -1.0
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   glitch-hop:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   glitch-pop:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   moombahton:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -863,6 +950,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   witch-house:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -871,6 +960,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.0
     cut_highs: -1.0
+    click_peak_ratio: 8.0
+    click_fail_count: 15
   ebm:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -907,6 +998,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   baile-funk:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -1053,6 +1146,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   new-age:
     target_lufs: -16.0
     cut_highmid: -1.0

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -123,6 +123,9 @@ _PRESET_DEFAULTS: dict[str, float] = {
     'midside_high_gain': 0.0,
     'midside_high_freq': 8000.0,
     'eq_linear_phase': 0,
+    # QC thresholds (consumed by tools/mastering/qc_tracks.py)
+    'click_peak_ratio': 6.0,
+    'click_fail_count': 3,
 }
 
 

--- a/tools/mastering/qc_tracks.py
+++ b/tools/mastering/qc_tracks.py
@@ -209,8 +209,21 @@ def _check_truepeak(data: Any, rate: int, ceiling_db: float = -1.0) -> dict[str,
     }
 
 
-def _check_clicks(data: Any, rate: int) -> dict[str, str]:
-    """Detect clicks/pops using sliding RMS window comparison."""
+def _check_clicks(
+    data: Any,
+    rate: int,
+    peak_ratio: float = 6.0,
+    fail_count: int = 3,
+) -> dict[str, str]:
+    """Detect clicks/pops using sliding RMS window comparison.
+
+    Args:
+        data: Audio samples (mono or stereo).
+        rate: Sample rate in Hz.
+        peak_ratio: Window peak-to-RMS ratio above which a window counts as a click.
+            Raise for genres with intentional sharp transients (electronic, metal, IDM).
+        fail_count: Click count above which the status is FAIL (inclusive WARN below).
+    """
     # Work with mono sum for detection
     if data.ndim > 1:
         mono = np.mean(data, axis=1)
@@ -229,12 +242,12 @@ def _check_clicks(data: Any, rate: int) -> dict[str, str]:
             continue
 
         peak = np.max(np.abs(window))
-        if peak > 6.0 * rms:
+        if peak > peak_ratio * rms:
             click_count += 1
 
     if click_count == 0:
         status = "PASS"
-    elif click_count <= 3:
+    elif click_count <= fail_count:
         status = "WARN"
     else:
         status = "FAIL"
@@ -374,13 +387,42 @@ def _check_spectral(data: Any, rate: int) -> dict[str, str]:
     }
 
 
-def qc_track(filepath: Path | str, checks: list[str] | None = None) -> dict[str, Any]:
+def _resolve_click_thresholds(genre: str | None) -> tuple[float, int]:
+    """Look up click_peak_ratio and click_fail_count for a genre preset.
+
+    Falls back to the hardcoded defaults (6.0, 3) if no genre is given.
+    Raises ValueError for an unknown genre name.
+    """
+    if genre is None:
+        return 6.0, 3
+
+    from tools.mastering.master_tracks import GENRE_PRESETS
+
+    key = genre.lower()
+    if key not in GENRE_PRESETS:
+        raise ValueError(
+            f"Unknown genre: {genre}. "
+            f"Available: {', '.join(sorted(GENRE_PRESETS.keys()))}"
+        )
+    preset = GENRE_PRESETS[key]
+    return float(preset.get('click_peak_ratio', 6.0)), int(preset.get('click_fail_count', 3))
+
+
+def qc_track(
+    filepath: Path | str,
+    checks: list[str] | None = None,
+    genre: str | None = None,
+) -> dict[str, Any]:
     """Run QC checks on a single audio track.
 
     Args:
         filepath: Path to WAV file.
         checks: List of check names to run (default: all).
             Options: format, mono, phase, clipping, clicks, silence, spectral
+        genre: Optional genre preset name (e.g., "idm", "metal"). When set,
+            the click detector reads `click_peak_ratio` and `click_fail_count`
+            from the matching genre preset so intentional sharp transients
+            don't FAIL QC. Unknown names raise ValueError.
 
     Returns:
         Dict with filename, per-check results, and overall verdict.
@@ -388,6 +430,8 @@ def qc_track(filepath: Path | str, checks: list[str] | None = None) -> dict[str,
     filepath = str(filepath)
     basename = os.path.basename(filepath)
     active_checks = checks or ALL_CHECKS
+
+    click_peak_ratio, click_fail_count = _resolve_click_thresholds(genre)
 
     info = sf.info(filepath)
     data, rate = sf.read(filepath)
@@ -414,7 +458,11 @@ def qc_track(filepath: Path | str, checks: list[str] | None = None) -> dict[str,
         results["truepeak"] = _check_truepeak(data, rate)
 
     if "clicks" in active_checks:
-        results["clicks"] = _check_clicks(data, rate)
+        results["clicks"] = _check_clicks(
+            data, rate,
+            peak_ratio=click_peak_ratio,
+            fail_count=click_fail_count,
+        )
 
     if "silence" in active_checks:
         results["silence"] = _check_silence(data, rate)
@@ -457,6 +505,13 @@ def main() -> None:
         default="",
         help=f"Comma-separated checks to run (default: all). Options: {', '.join(ALL_CHECKS)}",
     )
+    parser.add_argument(
+        "--genre",
+        type=str,
+        default="",
+        help="Genre preset name — loads click detector thresholds so intentional "
+             "sharp transients in electronic/metal/IDM don't FAIL QC.",
+    )
     args = parser.parse_args()
 
     setup_logging(__name__, verbose=args.verbose, quiet=args.quiet)
@@ -481,6 +536,14 @@ def main() -> None:
             logger.error("Unknown checks: %s. Valid: %s", ", ".join(invalid), ", ".join(ALL_CHECKS))
             sys.exit(1)
 
+    genre = args.genre.strip() or None
+    if genre is not None:
+        try:
+            _resolve_click_thresholds(genre)
+        except ValueError as e:
+            logger.error("%s", e)
+            sys.exit(1)
+
     print("=" * 90)
     print("AUDIO QC CHECKS")
     print("=" * 90)
@@ -493,14 +556,14 @@ def main() -> None:
         results = []
         for wav_file in filterable:
             progress.update(wav_file.name)
-            result = qc_track(str(wav_file), checks=active_checks)
+            result = qc_track(str(wav_file), checks=active_checks, genre=genre)
             results.append(result)
     else:
         logger.info("Using %d parallel workers", workers)
         ordered = {}
         with ProcessPoolExecutor(max_workers=workers) as executor:
             futures = {
-                executor.submit(qc_track, str(wf), active_checks): i
+                executor.submit(qc_track, str(wf), active_checks, genre): i
                 for i, wf in enumerate(filterable)
             }
             for future in as_completed(futures):


### PR DESCRIPTION
## Summary

- `_check_clicks()` used a single hardcoded peak-to-RMS ratio (6.0) and fail count (3) for every genre, causing electronic/IDM/breakcore/trap/metal/glitch work to FAIL QC on intentional musical transients.
- Promoted `click_peak_ratio` and `click_fail_count` into `genre-presets.yaml` defaults and added tuned overrides for dense-transient genres. Tier 1 (8.0, 15) covers electronic/metal/trap/industrial/etc.; tier 2 (10.0, 30) covers IDM/breakcore/glitch/footwork/speedcore/gabber.
- `qc_tracks.py` accepts `--genre`; the `qc_audio` MCP tool accepts an optional `genre` argument. User overrides in `{overrides}/mastering-presets.yaml` still merge on top via the existing `load_genre_presets` path.

Closes #285.

## Test plan
- [x] New per-genre click threshold tests in `tests/unit/mastering/test_qc_tracks.py` (5 tests) pass
- [x] `tests/unit/mastering/test_qc_tracks.py` (all 38 tests) pass
- [x] `tests/unit/state/test_server_qc.py` (48 tests) pass after updating mocks to accept `genre`
- [x] Full test suite: 3051 passed, 2 skipped
- [x] CLI smoke test: default FAILs 5-click synthetic WAV, `--genre idm` WARNs it, `--genre nonexistent` errors with available list

🤖 Generated with [Claude Code](https://claude.com/claude-code)