### PR TITLE
fix: post-downsample true-peak guard closes SRC ripple overshoot (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 - Wired `eq_low_q` through to `apply_low_shelf()` (was defined but unused)
 - Look-ahead limiter now hits its target ceiling exactly (was overshooting by ~1 dB on transients). Gain at peak samples was being sampled from the release-relaxed envelope; replaced with a rolling minimum over the lookahead window (#283)
 - QC click detector is now genre-aware: `click_peak_ratio` and `click_fail_count` are per-genre preset fields, tuned looser for genres with intentional sharp transients (electronic, IDM, breakcore, trap, metal, glitch, footwork, etc.) so musical transients no longer FAIL QC. `qc_tracks.py` accepts `--genre`, the `qc_audio` MCP tool accepts `genre`, and user `mastering-presets.yaml` overrides still apply (#285)
+- Mastering chain now adds a final true-peak guard at the output rate after downsample and SRC. `scipy.signal.resample_poly`'s polyphase FIR has passband ripple that previously reintroduced 0.1–0.9 dB inter-sample peaks above the limiter ceiling; one reactive `limit_peaks()` pass closes that gap so `ceiling_db` is hit within ~0.05 dB without the prior headroom workaround (#286)
 
 ## [0.89.0] - 2026-04-10
 

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -1266,6 +1266,109 @@ class TestOversampling:
         assert not np.allclose(d1, d2, atol=1e-3)
 
 
+class TestPostDownsampleTruePeakGuard:
+    """Tests for the final true-peak guard that closes SRC/downsample ripple overshoot (#286)."""
+
+    def _write_transient_signal(self, path, rate=44100, duration=4.0):
+        """Dense transient content that stresses the limiter + downsample chain.
+
+        Low-level carrier (-34 dBFS) with a cluster of sharp HF bursts. Loud-
+        ness comes out around -30 LUFS so -14 LUFS mastering applies ~+16 dB
+        gain. At high gain, the look-ahead limiter hits the ceiling exactly
+        at the oversampled rate, but the downsample polyphase FIR's passband
+        ripple reintroduces sub-dB inter-sample peaks above the ceiling.
+        """
+        t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+        base = 0.02 * np.sin(2 * np.pi * 220 * t)
+        # Add HF transient bursts every ~40 ms
+        burst_interval = int(rate * 0.04)
+        burst_len = 30
+        for start in range(0, len(base) - burst_len, burst_interval):
+            base[start:start + burst_len] += 0.8 * np.sin(
+                2 * np.pi * 7000 * np.arange(burst_len) / rate
+            )
+        base = np.clip(base, -0.9, 0.9)
+        data = np.column_stack([base, base])
+        _write_wav(path, data, rate)
+        return rate
+
+    def test_output_true_peak_within_005_db_of_ceiling(self, tmp_path):
+        """After mastering, output-rate true peak must not exceed the ceiling by more than 0.05 dB."""
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        rate = self._write_transient_signal(inp)
+
+        ceiling = -1.0
+        preset = {
+            **_PRESET_DEFAULTS,
+            'processing_oversample': 2,
+            'limiter_lookahead_ms': 5.0,
+        }
+        result = master_track(
+            str(inp), str(out),
+            ceiling_db=ceiling,
+            target_lufs=-14.0,
+            preset=preset,
+        )
+        assert not result.get('skipped')
+
+        out_data, out_rate = sf.read(str(out))
+        tp_linear = measure_true_peak(out_data, out_rate)
+        tp_db = 20 * np.log10(tp_linear) if tp_linear > 0 else float('-inf')
+
+        assert tp_db <= ceiling + 0.05, (
+            f"Output-rate true peak {tp_db:.3f} dBTP exceeds ceiling "
+            f"{ceiling} dBTP by more than 0.05 dB"
+        )
+
+    def test_reported_final_peak_matches_output_rate(self, tmp_path):
+        """Returned final_peak should reflect the post-guard peak at the output rate."""
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        self._write_transient_signal(inp)
+
+        ceiling = -1.0
+        preset = {
+            **_PRESET_DEFAULTS,
+            'processing_oversample': 2,
+            'limiter_lookahead_ms': 5.0,
+        }
+        result = master_track(
+            str(inp), str(out),
+            ceiling_db=ceiling,
+            target_lufs=-14.0,
+            preset=preset,
+        )
+        assert result['final_peak'] <= ceiling + 0.05
+
+    def test_guard_active_after_src(self, tmp_path):
+        """When SRC is configured, output-rate peaks still stay within 0.05 dB of ceiling."""
+        inp = tmp_path / "in.wav"
+        out = tmp_path / "out.wav"
+        self._write_transient_signal(inp, rate=44100)
+
+        ceiling = -1.0
+        preset = {
+            **_PRESET_DEFAULTS,
+            'processing_oversample': 2,
+            'limiter_lookahead_ms': 5.0,
+            'output_sample_rate': 48000,
+        }
+        result = master_track(
+            str(inp), str(out),
+            ceiling_db=ceiling,
+            target_lufs=-14.0,
+            preset=preset,
+        )
+        assert not result.get('skipped')
+
+        out_data, out_rate = sf.read(str(out))
+        assert out_rate == 48000
+        tp_linear = measure_true_peak(out_data, out_rate)
+        tp_db = 20 * np.log10(tp_linear) if tp_linear > 0 else float('-inf')
+        assert tp_db <= ceiling + 0.05
+
+
 class TestLookaheadInMasterTrack:
     """Test look-ahead limiter wired through master_track()."""
 

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -1236,10 +1236,10 @@ def master_track(input_path: Path | str, output_path: Path | str,
         data = signal.resample_poly(data, up=1, down=oversample, axis=0)
         rate = original_rate
 
-    # Verify final loudness and measure true peak
+    # Measure final loudness at the processing rate before SRC. LUFS is
+    # invariant under rate conversion so this is authoritative, and it
+    # keeps us on a pyln-supported rate.
     final_lufs = meter.integrated_loudness(data)
-    true_peak_linear = measure_true_peak(data, rate)
-    final_peak = 20 * np.log10(true_peak_linear) if true_peak_linear > 0 else float('-inf')
 
     # Convert back to mono if input was mono
     if was_mono:
@@ -1253,6 +1253,18 @@ def master_track(input_path: Path | str, output_path: Path | str,
         g = gcd(output_sr, rate)
         data = signal.resample_poly(data, up=output_sr // g, down=rate // g, axis=0)
         rate = output_sr
+
+    # Final true-peak guard at the output rate. The look-ahead limiter
+    # hit the ceiling exactly at the oversampled rate, but the
+    # downsample/SRC polyphase FIRs have passband ripple that
+    # reintroduces sub-dB inter-sample peaks. One reactive pass is
+    # sufficient: gain = ceiling / true_peak is exact for the measured
+    # peak and soft_clip absorbs any tiny residual.
+    data = limit_peaks(data, ceiling_db)
+
+    # Measure final true peak at the output rate for the returned result.
+    true_peak_linear = measure_true_peak(data, rate)
+    final_peak = 20 * np.log10(true_peak_linear) if true_peak_linear > 0 else float('-inf')
 
     # Resolve output bit depth: output_bits controls the format,
     # dither_bits follows output_bits by default but can be overridden


### PR DESCRIPTION
## Summary

- The look-ahead limiter from #284 hits the target ceiling exactly at the oversampled rate, but `scipy.signal.resample_poly`'s polyphase FIR (used on both the 2×/4× downsample and the optional `output_sample_rate` SRC) has passband ripple that re-introduces 0.1–0.9 dB inter-sample peaks above the ceiling at the output rate. In practice peaks on a 10-track electronic album land up to ~0.9 dB over the limiter ceiling, forcing a manual -0.5 to -1.0 dB headroom workaround.
- Add one reactive `limit_peaks()` pass after SRC and before dither. Single pass is sufficient because `gain = ceiling / true_peak` is exact for the measured peak and `soft_clip()` absorbs any tiny residual. `final_lufs` stays measured at the processing rate (authoritative and pyln-supported); `final_peak` is now measured at the output rate after the guard so the returned value matches what was written to disk.

Closes #286.

## Test plan
- [x] New regression suite `TestPostDownsampleTruePeakGuard` (3 tests) covers: output-rate TP ≤ ceiling + 0.05 dB on a transient-heavy synthetic signal at 44.1 kHz oversample ×2; returned `final_peak` matches; SRC (44.1 → 48 kHz) path still clean.
- [x] Without the fix: the synthetic signal overshoots the ceiling by ~0.1 dB at 48 kHz (0.05 dB tolerance triggers the failure).
- [x] With the fix: all three new tests pass; full suite `tests/` passes (3054 passed, 2 skipped).
- [x] Manual: `ceiling_db` now means what it says — no 0.5–1.0 dB headroom workaround needed in genre presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)