### PR TITLE
fix: genre-aware declick with stem-tier cubic repair (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 - Look-ahead limiter now hits its target ceiling exactly (was overshooting by ~1 dB on transients). Gain at peak samples was being sampled from the release-relaxed envelope; replaced with a rolling minimum over the lookahead window (#283)
 - QC click detector is now genre-aware: `click_peak_ratio` and `click_fail_count` are per-genre preset fields, tuned looser for genres with intentional sharp transients (electronic, IDM, breakcore, trap, metal, glitch, footwork, etc.) so musical transients no longer FAIL QC. `qc_tracks.py` accepts `--genre`, the `qc_audio` MCP tool accepts `genre`, and user `mastering-presets.yaml` overrides still apply (#285)
 - Mastering chain now adds a final true-peak guard at the output rate after downsample and SRC. `scipy.signal.resample_poly`'s polyphase FIR has passband ripple that previously reintroduced 0.1–0.9 dB inter-sample peaks above the limiter ceiling; one reactive `limit_peaks()` pass closes that gap so `ceiling_db` is hit within ~0.05 dB without the prior headroom workaround (#286)
+- Polish-stage declicker now reads `click_peak_ratio` / `click_fail_count` from
+  the mastering genre preset so polish and QC click detection stay aligned.
+  Stem passes (drums, percussion) use cubic-spline repair across ±1.5 ms of
+  clean neighbors instead of two-sample linear interpolation; full-mix fallback
+  keeps linear repair because dense mix content amplifies surgical artifacts.
+  Polish results now surface `clicks_removed` per stem and on the full-mix
+  result so operators can see whether polish acted (#289).
 
 ## [0.89.0] - 2026-04-10
 

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -1209,6 +1209,46 @@ class TestMixTrackStems:
         assert result['stems_processed'][0]['stem'] == 'drums'
         assert Path(output_path).exists()
 
+    def test_result_reports_clicks_removed_per_stem(self, tmp_path):
+        """mix_track_stems should surface clicks_removed on each stem that
+        ran the declicker."""
+        rate = 44100
+        # Build a drums-stem wav with a click at t≈0.5s.
+        # Offset by 50 samples so the click falls mid-window (not on a
+        # 10 ms window boundary) — this prevents the click's energy from
+        # being diluted across two windows, keeping peak/RMS well above 8.0.
+        # Sine amplitude of 0.10 gives peak/RMS ≈ 9.9 > electronic threshold 8.0.
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        mono = (0.10 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
+        click_idx = int(0.5 * rate) + 50  # 22100 — not on a 441-sample boundary
+        mono[click_idx] = 0.95
+        mono[click_idx + 1] = -0.95
+        drums = np.column_stack([mono, mono])
+
+        # And a clean vocal stem for completeness
+        vocal_mono = (0.1 * np.sin(2 * np.pi * 330 * t)).astype(np.float64)
+        vocals = np.column_stack([vocal_mono, vocal_mono])
+
+        drums_path = tmp_path / "drums.wav"
+        vocals_path = tmp_path / "vocals.wav"
+        sf.write(str(drums_path), drums, rate, subtype='PCM_16')
+        sf.write(str(vocals_path), vocals, rate, subtype='PCM_16')
+        out_path = tmp_path / "out.wav"
+
+        result = mix_track_stems(
+            {'drums': str(drums_path), 'vocals': str(vocals_path)},
+            out_path,
+            genre='electronic',
+        )
+
+        # Each stem entry should carry clicks_removed; drums must be > 0.
+        by_stem = {s['stem']: s for s in result['stems_processed']}
+        assert 'clicks_removed' in by_stem['drums']
+        assert by_stem['drums']['clicks_removed'] >= 1
+        # Vocals don't run the declicker, so clicks_removed should be 0
+        # or absent; assert the presence contract only for declicking stems.
+        assert by_stem['vocals'].get('clicks_removed', 0) == 0
+
 
 # ─── Tests: Stem Discovery ───────────────────────────────────────────
 

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -84,6 +84,8 @@ def _generate_noise(duration=1.0, rate=44100, amplitude=0.3, stereo=True):
 def _generate_click(duration=1.0, rate=44100, click_pos=0.5, amplitude=0.5):
     """Generate a signal with an artificial click/pop."""
     t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    # Background kept quiet (0.1x) so a 10 ms window containing the click
+    # has peak/rms > 6.0 — required by TestRemoveClicksPeakRatio tests.
     data = (amplitude * 0.1 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
     # Insert a sharp click
     click_idx = int(click_pos * rate)
@@ -467,11 +469,12 @@ class TestRemoveClicksPeakRatio:
         click_idx = int(0.5 * rate)
         assert np.abs(result[click_idx, 0]) < np.abs(data[click_idx, 0])
 
-    def test_peak_ratio_relaxed_ignores_intentional_transient(self):
-        """A genre-relaxed peak_ratio (10.0) lets moderate transients pass."""
+    def test_strict_peak_ratio_skips_moderate_click(self):
+        """A strict peak_ratio (50.0) should not flag a modest transient —
+        higher ratios demand bigger peak/rms separation before flagging."""
         data, rate = _generate_click(amplitude=0.5)
-        # Same signal as above, but the detector is asked for a stricter
-        # ratio — so it should NOT flag this modest click.
+        # peak/rms of this click in a 10 ms window is ~10.2; a strict 50.0
+        # ratio requires ~5× higher separation, so no click should fire.
         result, n_clicks = remove_clicks(data, rate, peak_ratio=50.0)
         assert n_clicks == 0
         assert np.array_equal(result, data)
@@ -521,9 +524,11 @@ class TestRemoveClicksCubicRepair:
         data, rate = _generate_click(amplitude=0.5)
         result, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="cubic")
         click_idx = int(0.5 * rate)
-        # Original click is |~0.495|; the local sine at 440 Hz, amp 0.15,
-        # at t=0.5 s is tiny (≈0). Repaired sample must be well below.
-        assert np.abs(result[click_idx, 0]) < 0.2
+        # Original click is |~0.495|; local sine at 440 Hz amp 0.05 is
+        # near zero at t=0.5s. Repaired sample should be near zero — 0.05
+        # is a generous upper bound that would still catch a regression
+        # leaving a partially-repaired click.
+        assert np.abs(result[click_idx, 0]) < 0.05
 
     def test_cubic_repair_near_buffer_edge_falls_back_to_linear(self):
         """A click within window_ms of the start should not crash; it

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -1750,13 +1750,11 @@ class TestMasterClickThresholdsThreaded:
         assert 'click_fail_count' not in settings
 
     def test_unknown_genre_does_not_raise(self):
-        # mix-only / user-added genre — helper must fail soft
+        # mix-only / user-added genre — helper must fail soft and inject
+        # nothing rather than defaulting to 6.0/3.
         settings = _get_full_mix_settings(genre='totally-invented-genre')
-        # Either the genre resolves to defaults (no click fields) or the
-        # merge yields something without them — just assert graceful.
-        assert 'click_peak_ratio' not in settings or isinstance(
-            settings['click_peak_ratio'], (int, float)
-        )
+        assert 'click_peak_ratio' not in settings
+        assert 'click_fail_count' not in settings
 
 
 # ─── Character Effects Tests ─────────────────────────────────────────

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -422,32 +422,35 @@ class TestRemoveClicks:
     def test_removes_artificial_click(self):
         """Should detect and reduce artificial clicks."""
         data, rate = _generate_click(amplitude=0.5)
-        result = remove_clicks(data, rate, threshold=4.0)
+        result, n_clicks = remove_clicks(data, rate, threshold=4.0)
         # The click sample should be reduced
         click_idx = int(0.5 * rate)
         assert np.abs(result[click_idx, 0]) < np.abs(data[click_idx, 0])
+        assert n_clicks > 0
 
     def test_clean_signal_unchanged(self):
         """Clean signal without clicks should be mostly unchanged."""
         data, rate = _generate_sine(amplitude=0.3)
-        result = remove_clicks(data, rate, threshold=6.0)
+        result, n_clicks = remove_clicks(data, rate, threshold=6.0)
         # Most samples should be identical
         diff = np.max(np.abs(result - data))
         assert diff < 0.1
+        assert n_clicks == 0
 
     def test_zero_threshold_is_passthrough(self):
         data, rate = _generate_sine()
-        result = remove_clicks(data, rate, threshold=0)
+        result, n_clicks = remove_clicks(data, rate, threshold=0)
         assert np.array_equal(result, data)
+        assert n_clicks == 0
 
     def test_mono_input(self):
         data, rate = _generate_sine(stereo=False)
-        result = remove_clicks(data, rate)
+        result, n_clicks = remove_clicks(data, rate)
         assert result.shape == data.shape
 
     def test_output_is_finite(self):
         data, rate = _generate_click()
-        result = remove_clicks(data, rate)
+        result, n_clicks = remove_clicks(data, rate)
         assert np.all(np.isfinite(result))
 
 

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -1614,6 +1614,48 @@ class TestMixTrackFull:
         assert 'post_peak' in result
         assert 'post_rms' in result
 
+    def test_full_mix_reports_clicks_removed(self, tmp_path):
+        """mix_track_full's result should include clicks_removed."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        # Quiet sine background (0.10) so the click dominates a 10ms window.
+        mono = (0.10 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
+        # Click mid-window (not on window boundary) at t≈0.5s + 50 samples.
+        click_idx = int(0.5 * rate) + 50
+        mono[click_idx] = 0.95
+        mono[click_idx + 1] = -0.95
+        data = np.column_stack([mono, mono])
+
+        in_path = tmp_path / "in.wav"
+        out_path = tmp_path / "out.wav"
+        sf.write(str(in_path), data, rate, subtype='PCM_16')
+
+        result = mix_track_full(in_path, out_path, genre='electronic')
+        assert 'clicks_removed' in result
+        # Electronic preset peak_ratio=8.0. With 0.10 background + mid-window
+        # 0.95 click, ratio is ~9.9, above the threshold.
+        assert isinstance(result['clicks_removed'], int)
+        assert result['clicks_removed'] >= 1
+
+    def test_full_mix_linear_repair_catches_obvious_click(self, tmp_path):
+        """A big click against a quiet sine should register clicks_removed>0
+        even on the legacy std-path (no genre → no peak_ratio → std default)."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        mono = (0.05 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
+        click_idx = int(0.5 * rate) + 50
+        mono[click_idx] = 0.9
+        mono[click_idx + 1] = -0.9
+        data = np.column_stack([mono, mono])
+
+        in_path = tmp_path / "in.wav"
+        out_path = tmp_path / "out.wav"
+        sf.write(str(in_path), data, rate, subtype='PCM_16')
+
+        # No genre → std path with default threshold=6.0.
+        result = mix_track_full(in_path, out_path)
+        assert result['clicks_removed'] >= 1
+
 
 # ─── Tests: Preset Loading ───────────────────────────────────────────
 

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -755,6 +755,50 @@ class TestProcessDrums:
         result = process_drums(data, rate, settings=settings)
         assert np.all(np.isfinite(result))
 
+    def test_reports_clicks_removed_when_given_report_dict(self):
+        """`process_drums` should record how many clicks it repaired when
+        a report dict is passed in."""
+        data, rate = _generate_click(amplitude=0.5)
+        report: dict[str, int] = {}
+        settings = _get_stem_settings('drums', genre='electronic')
+        result = process_drums(data, rate, settings=settings, report=report)
+        assert np.all(np.isfinite(result))
+        # Synthetic click with a high amplitude should always get flagged
+        # by the peak_ratio=8.0 detector on the electronic preset.
+        assert report.get('clicks_removed', 0) >= 1
+
+    def test_uses_cubic_repair_when_peak_ratio_is_set(self):
+        """With a `click_peak_ratio` setting, the drum processor should
+        use the cubic (stem-tier) repair, not the legacy std+linear path."""
+        data, rate = _generate_click(amplitude=0.5)
+        # Force the ratio path by passing click_peak_ratio directly.
+        settings = {
+            'click_removal': True,
+            'click_peak_ratio': 6.0,
+            'compress_threshold_db': -12.0,
+            'compress_ratio': 2.0,
+            'compress_attack_ms': 5.0,
+        }
+        # And a sibling baseline using the legacy std path.
+        baseline_settings = {
+            'click_removal': True,
+            'click_threshold': 6.0,
+            'compress_threshold_db': -12.0,
+            'compress_ratio': 2.0,
+            'compress_attack_ms': 5.0,
+        }
+        cubic = process_drums(data.copy(), rate, settings=settings)
+        linear = process_drums(data.copy(), rate, settings=baseline_settings)
+        # The *full* processor chain (compressor, saturator) runs on both,
+        # so we compare the early-pipeline sample neighborhood around the
+        # click index — must be different because repair differs.
+        click_idx = int(0.5 * rate)
+        assert not np.allclose(
+            cubic[click_idx - 1:click_idx + 2, 0],
+            linear[click_idx - 1:click_idx + 2, 0],
+            atol=1e-6,
+        )
+
 
 class TestProcessBass:
     """Tests for the bass processing chain."""
@@ -1052,6 +1096,14 @@ class TestProcessPercussion:
         }
         result = process_percussion(data, rate, settings=settings)
         assert np.all(np.isfinite(result))
+
+    def test_reports_clicks_removed_when_given_report_dict(self):
+        data, rate = _generate_click(amplitude=0.5)
+        report: dict[str, int] = {}
+        settings = _get_stem_settings('percussion', genre='electronic')
+        result = process_percussion(data, rate, settings=settings, report=report)
+        assert np.all(np.isfinite(result))
+        assert report.get('clicks_removed', 0) >= 1
 
 
 # ─── Tests: Full Pipeline (Stems) ────────────────────────────────────

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -84,7 +84,7 @@ def _generate_noise(duration=1.0, rate=44100, amplitude=0.3, stereo=True):
 def _generate_click(duration=1.0, rate=44100, click_pos=0.5, amplitude=0.5):
     """Generate a signal with an artificial click/pop."""
     t = np.linspace(0, duration, int(rate * duration), endpoint=False)
-    data = (amplitude * 0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
+    data = (amplitude * 0.1 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
     # Insert a sharp click
     click_idx = int(click_pos * rate)
     if click_idx < len(data):
@@ -452,6 +452,97 @@ class TestRemoveClicks:
         data, rate = _generate_click()
         result, n_clicks = remove_clicks(data, rate)
         assert np.all(np.isfinite(result))
+
+
+class TestRemoveClicksPeakRatio:
+    """Tests for the windowed peak/rms detection path (#289)."""
+
+    def test_peak_ratio_detects_high_peak_rms_window(self):
+        """A lone spike in an otherwise-quiet sine should register as a click."""
+        data, rate = _generate_click(amplitude=0.5)
+        # Default peak_ratio=6.0 matches QC's hard-coded default
+        result, n_clicks = remove_clicks(data, rate, peak_ratio=6.0)
+        assert n_clicks >= 1
+        # Click sample reduced in both channels
+        click_idx = int(0.5 * rate)
+        assert np.abs(result[click_idx, 0]) < np.abs(data[click_idx, 0])
+
+    def test_peak_ratio_relaxed_ignores_intentional_transient(self):
+        """A genre-relaxed peak_ratio (10.0) lets moderate transients pass."""
+        data, rate = _generate_click(amplitude=0.5)
+        # Same signal as above, but the detector is asked for a stricter
+        # ratio — so it should NOT flag this modest click.
+        result, n_clicks = remove_clicks(data, rate, peak_ratio=50.0)
+        assert n_clicks == 0
+        assert np.array_equal(result, data)
+
+    def test_peak_ratio_takes_precedence_over_threshold(self):
+        """When both `threshold` and `peak_ratio` are set, peak_ratio wins."""
+        data, rate = _generate_click(amplitude=0.5)
+        # threshold=0 would passthrough in std path; peak_ratio path must
+        # still detect the click.
+        result, n_clicks = remove_clicks(data, rate, threshold=0, peak_ratio=6.0)
+        assert n_clicks >= 1
+
+    def test_peak_ratio_on_mono(self):
+        data, rate = _generate_click(amplitude=0.5)
+        mono = data[:, 0]
+        result, n_clicks = remove_clicks(mono, rate, peak_ratio=6.0)
+        assert result.shape == mono.shape
+        assert n_clicks >= 1
+
+
+class TestRemoveClicksCubicRepair:
+    """Tests for the cubic-spline stem-tier repair path (#289)."""
+
+    def test_cubic_repair_differs_from_linear_on_stem(self):
+        """Cubic repair should produce a different signal than linear on
+        an isolated stem with a click — this is the whole point of the
+        stem-tier upgrade."""
+        data, rate = _generate_click(amplitude=0.5)
+        linear_result, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="linear")
+        cubic_result, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="cubic")
+        # Same detections, different repair — the repaired samples must differ.
+        click_idx = int(0.5 * rate)
+        assert not np.allclose(
+            linear_result[click_idx - 1:click_idx + 2, 0],
+            cubic_result[click_idx - 1:click_idx + 2, 0],
+        )
+
+    def test_cubic_repair_is_finite(self):
+        """Spline repair must never produce NaN or Inf."""
+        data, rate = _generate_click(amplitude=0.5)
+        result, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="cubic")
+        assert np.all(np.isfinite(result))
+
+    def test_cubic_repair_reduces_click_amplitude(self):
+        """Repaired click sample should be closer to the local sine value
+        than the original spike."""
+        data, rate = _generate_click(amplitude=0.5)
+        result, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="cubic")
+        click_idx = int(0.5 * rate)
+        # Original click is |~0.495|; the local sine at 440 Hz, amp 0.15,
+        # at t=0.5 s is tiny (≈0). Repaired sample must be well below.
+        assert np.abs(result[click_idx, 0]) < 0.2
+
+    def test_cubic_repair_near_buffer_edge_falls_back_to_linear(self):
+        """A click within window_ms of the start should not crash; it
+        should fall back to linear repair."""
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        mono = (0.15 * np.sin(2 * np.pi * 440 * t)).astype(np.float64)
+        # Inject a click at sample 5 (well inside the default 1.5 ms window
+        # which is ~66 samples at 44.1 kHz).
+        mono[5] = 0.95
+        data = np.column_stack([mono, mono])
+        result, n_clicks = remove_clicks(data, rate, peak_ratio=6.0, repair="cubic")
+        assert np.all(np.isfinite(result))
+        assert n_clicks >= 1
+
+    def test_invalid_repair_raises(self):
+        data, rate = _generate_click()
+        with pytest.raises(ValueError, match="repair must be"):
+            remove_clicks(data, rate, peak_ratio=6.0, repair="nearest")
 
 
 # ─── Tests: reduce_noise ─────────────────────────────────────────────

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -550,6 +550,20 @@ class TestRemoveClicksCubicRepair:
         with pytest.raises(ValueError, match="repair must be"):
             remove_clicks(data, rate, peak_ratio=6.0, repair="nearest")
 
+    def test_stem_repair_differs_from_full_mix_repair_on_isolated_stem(self):
+        """Per #289 acceptance: 'stem repair differs from full-mix repair
+        on an isolated stem with a click.' Same signal, same detection,
+        two repair strategies — they must produce distinguishable output."""
+        data, rate = _generate_click(amplitude=0.5)
+        stem_repaired, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="cubic")
+        full_repaired, _ = remove_clicks(data, rate, peak_ratio=6.0, repair="linear")
+        click_idx = int(0.5 * rate)
+        # Nontrivial difference in the repaired neighborhood
+        assert np.max(np.abs(
+            stem_repaired[click_idx - 1:click_idx + 2, 0]
+            - full_repaired[click_idx - 1:click_idx + 2, 0]
+        )) > 1e-6
+
 
 # ─── Tests: reduce_noise ─────────────────────────────────────────────
 

--- a/tests/unit/mixing/test_mix_tracks.py
+++ b/tests/unit/mixing/test_mix_tracks.py
@@ -56,6 +56,7 @@ from tools.mixing.mix_tracks import (
     discover_stems,
     _get_stem_settings,
     _get_full_mix_settings,
+    _resolve_master_click_thresholds,
 )
 
 
@@ -1726,6 +1727,36 @@ class TestOverrideMerging:
         presets = load_mix_presets()
         assert 'rock' in presets['genres']
         assert 'pop' in presets['genres']
+
+
+class TestMasterClickThresholdsThreaded:
+    """Verify polish pipeline picks up click_peak_ratio / click_fail_count
+    from the mastering genre preset so polish and QC stay aligned (#289)."""
+
+    def test_stem_settings_inherit_master_click_thresholds(self):
+        # 'electronic' is one of the mastering-tuned genres (ratio 8.0, fail 15)
+        settings = _get_stem_settings('drums', genre='electronic')
+        assert settings.get('click_peak_ratio') == 8.0
+        assert settings.get('click_fail_count') == 15
+
+    def test_full_mix_settings_inherit_master_click_thresholds(self):
+        settings = _get_full_mix_settings(genre='electronic')
+        assert settings.get('click_peak_ratio') == 8.0
+        assert settings.get('click_fail_count') == 15
+
+    def test_no_genre_leaves_click_thresholds_unset(self):
+        settings = _get_stem_settings('drums')
+        assert 'click_peak_ratio' not in settings
+        assert 'click_fail_count' not in settings
+
+    def test_unknown_genre_does_not_raise(self):
+        # mix-only / user-added genre — helper must fail soft
+        settings = _get_full_mix_settings(genre='totally-invented-genre')
+        # Either the genre resolves to defaults (no click fields) or the
+        # merge yields something without them — just assert graceful.
+        assert 'click_peak_ratio' not in settings or isinstance(
+            settings['click_peak_ratio'], (int, float)
+        )
 
 
 # ─── Character Effects Tests ─────────────────────────────────────────

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -16,7 +16,7 @@ import os
 import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import soundfile as sf
@@ -542,6 +542,7 @@ def remove_clicks(
 
     def _detect_peak_ratio(channel: Any) -> Any:
         """Windowed detection matching qc_tracks._check_clicks."""
+        assert peak_ratio is not None  # guarded by _process_channel caller
         if len(channel) < window_samples:
             return np.zeros(0, dtype=np.int64)
         indices: list[int] = []
@@ -1683,8 +1684,12 @@ def process_other(data: Any, rate: int, settings: dict[str, Any] | None = None) 
     return data
 
 
-# Stem processor dispatch
-STEM_PROCESSORS = {
+# Stem processor dispatch. Callable[..., Any] covers the signature
+# asymmetry — drums and percussion accept an extra `report` kwarg that
+# the other processors don't; callers that want to pass `report` dispatch
+# directly to `process_drums` / `process_percussion` instead of going
+# through this registry.
+STEM_PROCESSORS: dict[str, Callable[..., Any]] = {
     'vocals': process_vocals,
     'backing_vocals': process_backing_vocals,
     'drums': process_drums,
@@ -1792,10 +1797,14 @@ def mix_track_stems(stem_paths: dict[str, str | list[str]], output_path: Path | 
         if not dry_run:
             # Get settings and process
             settings = _get_stem_settings(stem_name, genre)
-            processor = STEM_PROCESSORS[stem_name]
-            if stem_name in ('drums', 'percussion'):
-                data = processor(data, rate, settings, report=stem_report)
+            # Dispatch declicking stems directly so mypy sees the
+            # `report` kwarg; other stems go through STEM_PROCESSORS.
+            if stem_name == 'drums':
+                data = process_drums(data, rate, settings, report=stem_report)
+            elif stem_name == 'percussion':
+                data = process_percussion(data, rate, settings, report=stem_report)
             else:
+                processor = STEM_PROCESSORS[stem_name]
                 data = processor(data, rate, settings)
 
             # Get remix gain

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -958,20 +958,28 @@ def _resolve_master_click_thresholds(genre: str | None) -> tuple[float | None, i
     the **mastering** genre presets, so the polish declicker uses the same
     detection semantics as the QC click detector (#285).
 
+    Every genre in the mastering preset list gets overlay values: tuned
+    genres (e.g. electronic, idm, metal) return their raised thresholds;
+    genres without explicit click fields fall back to the QC baseline
+    (6.0 / 3) via the preset defaults in `master_tracks._PRESET_DEFAULTS`.
+    This keeps polish and QC aligned for *every* genre, not just tuned
+    ones — a track polished with `genre='house'` runs the same detection
+    algorithm QC will use later.
+
     Args:
         genre: Genre name (e.g., "idm"). May be None or an empty string.
 
     Returns:
-        `(peak_ratio, fail_count)`. Both are None when `genre` is falsy or
-        when the genre is not present in the mastering preset list (polish
-        genres are a subset of mastering genres, but this stays graceful
-        for user-added mix-only genres).
+        `(peak_ratio, fail_count)`. Both are None when `genre` is falsy,
+        or when `genre` is not present in the mastering preset list at
+        all (e.g. a user-invented mix-only genre), or when the mastering
+        module fails to import.
     """
     if not genre:
         return None, None
     try:
         from tools.mastering.master_tracks import GENRE_PRESETS
-    except Exception:
+    except ImportError:
         return None, None
     preset = GENRE_PRESETS.get(genre.lower())
     if preset is None:

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -21,6 +21,7 @@ from typing import Any
 import numpy as np
 import soundfile as sf
 from scipy import signal
+from scipy.interpolate import CubicSpline
 
 try:
     import noisereduce as nr
@@ -573,7 +574,6 @@ def remove_clicks(
 
     def _repair_cubic(channel: Any, indices: Any) -> Any:
         """Cubic spline repair across ±window_ms clean neighbors."""
-        from scipy.interpolate import CubicSpline
         result = channel.copy()
         n = len(channel)
         click_set = set(int(i) for i in indices)
@@ -600,13 +600,10 @@ def remove_clicks(
             x_hi_near = _clean_at(min(hi, idx + neighbor_offset // 2), 1)
             x_hi_far = _clean_at(hi, 1)
             xs = sorted({x_lo_far, x_lo_near, x_hi_near, x_hi_far})
-            if len(xs) < 2 or idx in xs:
-                # Degenerate — fall back to linear
-                left = max(0, idx - 1)
-                right = min(n - 1, idx + 1)
-                if left != right:
-                    result[idx] = channel[left] + (channel[right] - channel[left]) * (idx - left) / (right - left)
-                continue
+            # Seeds {lo, idx±neighbor_offset//2, hi} are always distinct
+            # and never equal idx (outer guards and _clean_at's outward-
+            # only probe direction ensure this), so no degenerate-case
+            # fallback is needed here.
             ys = [float(channel[x]) for x in xs]
             spline = CubicSpline(xs, ys)
             # Repair the central sample; widen to ±1 sample so two-sample

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -953,6 +953,37 @@ def _apply_character_effects(
 # ─── Per-Stem Processing Chains ──────────────────────────────────────
 
 
+def _resolve_master_click_thresholds(genre: str | None) -> tuple[float | None, int | None]:
+    """Look up `click_peak_ratio` and `click_fail_count` for a genre from
+    the **mastering** genre presets, so the polish declicker uses the same
+    detection semantics as the QC click detector (#285).
+
+    Args:
+        genre: Genre name (e.g., "idm"). May be None or an empty string.
+
+    Returns:
+        `(peak_ratio, fail_count)`. Both are None when `genre` is falsy or
+        when the genre is not present in the mastering preset list (polish
+        genres are a subset of mastering genres, but this stays graceful
+        for user-added mix-only genres).
+    """
+    if not genre:
+        return None, None
+    try:
+        from tools.mastering.master_tracks import GENRE_PRESETS
+    except Exception:
+        return None, None
+    preset = GENRE_PRESETS.get(genre.lower())
+    if preset is None:
+        return None, None
+    peak_ratio = preset.get('click_peak_ratio')
+    fail_count = preset.get('click_fail_count')
+    return (
+        float(peak_ratio) if peak_ratio is not None else None,
+        int(fail_count) if fail_count is not None else None,
+    )
+
+
 def _get_stem_settings(stem_name: str, genre: str | None = None) -> dict[str, Any]:
     """Get processing settings for a specific stem type.
 
@@ -972,9 +1003,19 @@ def _get_stem_settings(stem_name: str, genre: str | None = None) -> dict[str, An
         genre_key = genre.lower()
         genre_presets = presets.get('genres', {}).get(genre_key, {})
         genre_stem = genre_presets.get(stem_name, {})
-        return _deep_merge(stem_defaults, genre_stem)
+        result: dict[str, Any] = _deep_merge(stem_defaults, genre_stem)
+    else:
+        result = stem_defaults.copy()
 
-    result: dict[str, Any] = stem_defaults.copy()
+    # Overlay mastering genre's click thresholds so polish and QC speak
+    # the same language (#289). Mix-preset overrides (`click_peak_ratio`
+    # under `defaults.<stem>.` or `genres.<g>.<stem>.`) win if present,
+    # so user overrides still work.
+    peak_ratio, fail_count = _resolve_master_click_thresholds(genre)
+    if peak_ratio is not None and 'click_peak_ratio' not in result:
+        result['click_peak_ratio'] = peak_ratio
+    if fail_count is not None and 'click_fail_count' not in result:
+        result['click_fail_count'] = fail_count
     return result
 
 
@@ -995,9 +1036,15 @@ def _get_full_mix_settings(genre: str | None = None) -> dict[str, Any]:
         genre_key = genre.lower()
         genre_presets = presets.get('genres', {}).get(genre_key, {})
         genre_full_mix = genre_presets.get('full_mix', {})
-        return _deep_merge(full_mix_defaults, genre_full_mix)
+        result: dict[str, Any] = _deep_merge(full_mix_defaults, genre_full_mix)
+    else:
+        result = full_mix_defaults.copy()
 
-    result: dict[str, Any] = full_mix_defaults.copy()
+    peak_ratio, fail_count = _resolve_master_click_thresholds(genre)
+    if peak_ratio is not None and 'click_peak_ratio' not in result:
+        result['click_peak_ratio'] = peak_ratio
+    if fail_count is not None and 'click_fail_count' not in result:
+        result['click_fail_count'] = fail_count
     return result
 
 

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -474,66 +474,172 @@ def gentle_compress(data: Any, rate: int, threshold_db: float = -15.0, ratio: fl
         return result
 
 
-def remove_clicks(data: Any, rate: int, threshold: float = 6.0) -> Any:
+def remove_clicks(
+    data: Any,
+    rate: int,
+    threshold: float = 6.0,
+    peak_ratio: float | None = None,
+    repair: str = "linear",
+    window_ms: float = 1.5,
+) -> tuple[Any, int]:
     """Detect and remove clicks/pops via interpolation.
 
-    Looks for sudden amplitude spikes relative to local neighborhood
-    and replaces them with linearly interpolated values.
+    Two detection modes:
+
+    - std path (default, `peak_ratio=None`): flag samples where |diff| >
+      threshold * std(diff). Backward-compatible with pre-#289 behavior.
+    - windowed peak/rms path (`peak_ratio` set): flag 10 ms windows where
+      peak/rms > peak_ratio, then locate the maximum-|sample| inside each
+      flagged window. Semantics match `qc_tracks._check_clicks` so polish
+      and QC speak the same language.
+
+    Two repair modes:
+
+    - "linear" (default): two-sample linear interpolation across the click
+      index, same as pre-#289. Safer on dense full-mix content.
+    - "cubic": fit a `scipy.interpolate.CubicSpline` through four clean
+      samples (two on each side, `window_ms` away from the click) and
+      overwrite the click region with the spline evaluated on the excised
+      sample indices. For use on isolated stems where the spline can
+      exploit the thin spectral content around the click.
 
     Args:
-        data: Audio data
-        rate: Sample rate
-        threshold: Detection threshold in standard deviations
+        data: Audio data (mono or stereo).
+        rate: Sample rate in Hz.
+        threshold: std-path detection multiplier. Ignored when `peak_ratio`
+            is set. `threshold <= 0` is a passthrough (returns input).
+        peak_ratio: Peak-to-RMS ratio over a 10 ms window above which the
+            window is flagged as a click. When None the std path is used.
+        repair: "linear" or "cubic". Cubic requires at least two clean
+            samples ±`window_ms` away from the click; falls back to linear
+            if neighbors are unavailable (near the start/end of the buffer).
+        window_ms: Half-width of the cubic repair window, in milliseconds.
 
     Returns:
-        Click-removed audio data.
+        `(repaired_data, clicks_removed)` where `clicks_removed` is the
+        number of click sites repaired (not windows flagged — coincident
+        clicks in the same window count once).
     """
-    if threshold <= 0:
-        return data
+    if threshold <= 0 and peak_ratio is None:
+        return data, 0
 
-    def _remove_clicks_channel(channel: Any) -> Any:
-        # Calculate first-order difference
+    if repair not in ("linear", "cubic"):
+        raise ValueError(f"repair must be 'linear' or 'cubic', got {repair!r}")
+
+    window_samples = max(int(rate * 0.01), 1)  # 10 ms, matches qc_tracks
+    neighbor_offset = max(int(rate * window_ms / 1000.0), 2)
+
+    def _detect_std(channel: Any) -> Any:
         diff = np.diff(channel, prepend=channel[0])
-
-        # Guard against very short audio
         if len(channel) < 3:
-            return channel
-
+            return np.zeros(0, dtype=np.int64)
         local_std = np.std(diff)
         if local_std < 1e-10:
-            return channel
+            return np.zeros(0, dtype=np.int64)
+        mask = np.abs(diff) > threshold * local_std
+        return np.where(mask)[0]
 
-        # Detect clicks: spikes above threshold * std
-        click_mask = np.abs(diff) > threshold * local_std
+    def _detect_peak_ratio(channel: Any) -> Any:
+        """Windowed detection matching qc_tracks._check_clicks."""
+        if len(channel) < window_samples:
+            return np.zeros(0, dtype=np.int64)
+        indices: list[int] = []
+        for start in range(0, len(channel) - window_samples, window_samples):
+            window = channel[start:start + window_samples]
+            rms = float(np.sqrt(np.mean(window ** 2)))
+            if rms < 1e-8:
+                continue
+            peak = float(np.max(np.abs(window)))
+            if peak > peak_ratio * rms:
+                local = int(np.argmax(np.abs(window)))
+                indices.append(start + local)
+        return np.array(indices, dtype=np.int64)
 
-        if not np.any(click_mask):
-            return channel
-
+    def _repair_linear(channel: Any, indices: Any) -> Any:
+        """Two-sample linear interp — preserves pre-#289 behavior."""
         result = channel.copy()
-        click_indices = np.where(click_mask)[0]
-
-        # Interpolate over click regions
-        for idx in click_indices:
-            # Find clean samples on either side
+        n = len(channel)
+        click_set = set(int(i) for i in indices)
+        for idx in indices:
             left = max(0, idx - 1)
-            right = min(len(channel) - 1, idx + 1)
-            while left > 0 and click_mask[left]:
+            right = min(n - 1, idx + 1)
+            while left > 0 and int(left) in click_set:
                 left -= 1
-            while right < len(channel) - 1 and click_mask[right]:
+            while right < n - 1 and int(right) in click_set:
                 right += 1
-            # Linear interpolation
             if left != right:
                 result[idx] = channel[left] + (channel[right] - channel[left]) * (idx - left) / (right - left)
-
         return result
+
+    def _repair_cubic(channel: Any, indices: Any) -> Any:
+        """Cubic spline repair across ±window_ms clean neighbors."""
+        from scipy.interpolate import CubicSpline
+        result = channel.copy()
+        n = len(channel)
+        click_set = set(int(i) for i in indices)
+        for idx in indices:
+            lo = idx - neighbor_offset
+            hi = idx + neighbor_offset
+            if lo < 0 or hi >= n:
+                # Near buffer edge — fall back to linear repair
+                left = max(0, idx - 1)
+                right = min(n - 1, idx + 1)
+                if left != right:
+                    result[idx] = channel[left] + (channel[right] - channel[left]) * (idx - left) / (right - left)
+                continue
+            # Pick four clean anchors: two each side of click, skipping
+            # any that are themselves flagged clicks.
+            def _clean_at(center: int, direction: int) -> int:
+                probe = center
+                while 0 <= probe < n and int(probe) in click_set:
+                    probe += direction
+                return probe if 0 <= probe < n else center
+
+            x_lo_far = _clean_at(lo, -1)
+            x_lo_near = _clean_at(max(lo, idx - neighbor_offset // 2), -1)
+            x_hi_near = _clean_at(min(hi, idx + neighbor_offset // 2), 1)
+            x_hi_far = _clean_at(hi, 1)
+            xs = sorted({x_lo_far, x_lo_near, x_hi_near, x_hi_far})
+            if len(xs) < 2 or idx in xs:
+                # Degenerate — fall back to linear
+                left = max(0, idx - 1)
+                right = min(n - 1, idx + 1)
+                if left != right:
+                    result[idx] = channel[left] + (channel[right] - channel[left]) * (idx - left) / (right - left)
+                continue
+            ys = [float(channel[x]) for x in xs]
+            spline = CubicSpline(xs, ys)
+            # Repair the central sample; widen to ±1 sample so two-sample
+            # fingerprints (like the `+A, -A` pair _generate_click makes)
+            # are covered.
+            for target in range(max(0, idx - 1), min(n, idx + 2)):
+                result[target] = float(spline(target))
+        return result
+
+    def _process_channel(channel: Any) -> tuple[Any, int]:
+        if peak_ratio is not None:
+            indices = _detect_peak_ratio(channel)
+        else:
+            indices = _detect_std(channel)
+        if len(indices) == 0:
+            return channel, 0
+        if repair == "cubic":
+            repaired = _repair_cubic(channel, indices)
+        else:
+            repaired = _repair_linear(channel, indices)
+        return repaired, int(len(indices))
 
     if len(data.shape) == 1:
-        return _remove_clicks_channel(data)
-    else:
-        result = np.zeros_like(data)
-        for ch in range(data.shape[1]):
-            result[:, ch] = _remove_clicks_channel(data[:, ch])
-        return result
+        repaired, n_clicks = _process_channel(data)
+        return repaired, n_clicks
+
+    result = np.zeros_like(data)
+    total_clicks = 0
+    for ch in range(data.shape[1]):
+        repaired, n_clicks = _process_channel(data[:, ch])
+        result[:, ch] = repaired
+        total_clicks += n_clicks
+    return result, total_clicks
 
 
 def enhance_stereo(data: Any, rate: int, amount: float = 0.2) -> Any:
@@ -1005,7 +1111,7 @@ def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) 
     # Click removal
     if settings.get('click_removal', True):
         click_threshold = settings.get('click_threshold', 6.0)
-        data = remove_clicks(data, rate, threshold=click_threshold)
+        data, _ = remove_clicks(data, rate, threshold=click_threshold)
 
     # Transient shaping (before compression to preserve punch)
     attack_db = settings.get('transient_attack_db', 0)
@@ -1422,7 +1528,7 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
     # Click removal
     if settings.get('click_removal', True):
         click_threshold = settings.get('click_threshold', 6.0)
-        data = remove_clicks(data, rate, threshold=click_threshold)
+        data, _ = remove_clicks(data, rate, threshold=click_threshold)
 
     # Transient shaping (before compression to preserve punch)
     attack_db = settings.get('transient_attack_db', 0)
@@ -1696,7 +1802,7 @@ def mix_track_full(input_path: Path | str, output_path: Path | str,
 
         # Click removal
         if settings.get('click_removal', True):
-            data = remove_clicks(data, rate)
+            data, _ = remove_clicks(data, rate)
 
         # Mud cut
         mud_cut_db = settings.get('mud_cut_db', -2.0)

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1863,6 +1863,7 @@ def mix_track_full(input_path: Path | str, output_path: Path | str,
             'filename': input_path.name,
             'skipped': True,
             'dry_run': dry_run,
+            'clicks_removed': 0,
         }
 
     # Handle mono

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1158,9 +1158,10 @@ def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None,
         data: Audio data
         rate: Sample rate
         settings: Dict of drum processing settings
-        report: Optional dict; when provided, this function writes
-            ``clicks_removed`` (int) into it so callers can surface how
-            many clicks were repaired.
+        report: Optional dict; when provided, this function **accumulates**
+            the repaired-click count into ``report['clicks_removed']``
+            (creating the key if absent). Pass a fresh dict per call if you
+            want per-call totals.
 
     Returns:
         Processed audio data.
@@ -1584,9 +1585,10 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
         data: Audio data
         rate: Sample rate
         settings: Dict of percussion processing settings
-        report: Optional dict; when provided, this function writes
-            ``clicks_removed`` (int) into it so callers can surface how
-            many clicks were repaired.
+        report: Optional dict; when provided, this function **accumulates**
+            the repaired-click count into ``report['clicks_removed']``
+            (creating the key if absent). Pass a fresh dict per call if you
+            want per-call totals.
 
     Returns:
         Processed audio data.
@@ -1784,11 +1786,20 @@ def mix_track_stems(stem_paths: dict[str, str | list[str]], output_path: Path | 
         pre_peak = float(np.max(np.abs(data)))
         pre_rms = float(np.sqrt(np.mean(data ** 2)))
 
+        # Only drums/percussion write clicks_removed into the report dict —
+        # keeping the per-processor kwarg asymmetric is intentional (the
+        # other 10 processors have no metric to report). The dict is
+        # initialized empty so the `get('clicks_removed', 0)` fallback in
+        # the append-below always has a value, even for non-declicking stems.
+        stem_report: dict[str, Any] = {'clicks_removed': 0}
         if not dry_run:
             # Get settings and process
             settings = _get_stem_settings(stem_name, genre)
             processor = STEM_PROCESSORS[stem_name]
-            data = processor(data, rate, settings)
+            if stem_name in ('drums', 'percussion'):
+                data = processor(data, rate, settings, report=stem_report)
+            else:
+                data = processor(data, rate, settings)
 
             # Get remix gain
             gains[stem_name] = settings.get('gain_db', 0.0)
@@ -1804,6 +1815,7 @@ def mix_track_stems(stem_paths: dict[str, str | list[str]], output_path: Path | 
             'pre_rms': pre_rms,
             'post_peak': post_peak,
             'post_rms': post_rms,
+            'clicks_removed': int(stem_report['clicks_removed']),
         })
 
     if not processed_stems:

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1150,13 +1150,17 @@ def process_backing_vocals(data: Any, rate: int, settings: dict[str, Any] | None
     return data
 
 
-def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
+def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None,
+                  report: dict[str, Any] | None = None) -> Any:
     """Process drum stem: click removal -> transient shape -> compress (fast attack) -> sat.
 
     Args:
         data: Audio data
         rate: Sample rate
         settings: Dict of drum processing settings
+        report: Optional dict; when provided, this function writes
+            ``clicks_removed`` (int) into it so callers can surface how
+            many clicks were repaired.
 
     Returns:
         Processed audio data.
@@ -1165,8 +1169,18 @@ def process_drums(data: Any, rate: int, settings: dict[str, Any] | None = None) 
 
     # Click removal
     if settings.get('click_removal', True):
-        click_threshold = settings.get('click_threshold', 6.0)
-        data, _ = remove_clicks(data, rate, threshold=click_threshold)
+        peak_ratio = settings.get('click_peak_ratio')
+        if peak_ratio is not None:
+            data, n_clicks = remove_clicks(
+                data, rate,
+                peak_ratio=float(peak_ratio),
+                repair="cubic",
+            )
+        else:
+            click_threshold = settings.get('click_threshold', 6.0)
+            data, n_clicks = remove_clicks(data, rate, threshold=click_threshold)
+        if report is not None:
+            report['clicks_removed'] = report.get('clicks_removed', 0) + int(n_clicks)
 
     # Transient shaping (before compression to preserve punch)
     attack_db = settings.get('transient_attack_db', 0)
@@ -1558,7 +1572,8 @@ def process_woodwinds(data: Any, rate: int, settings: dict[str, Any] | None = No
     return data
 
 
-def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = None) -> Any:
+def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = None,
+                       report: dict[str, Any] | None = None) -> Any:
     """Process percussion stem: highpass -> click removal -> presence -> high tame -> width -> compress -> sat.
 
     Distinct from drums — handles congas, shakers, tambourines etc. Presence at
@@ -1569,6 +1584,9 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
         data: Audio data
         rate: Sample rate
         settings: Dict of percussion processing settings
+        report: Optional dict; when provided, this function writes
+            ``clicks_removed`` (int) into it so callers can surface how
+            many clicks were repaired.
 
     Returns:
         Processed audio data.
@@ -1582,8 +1600,18 @@ def process_percussion(data: Any, rate: int, settings: dict[str, Any] | None = N
 
     # Click removal
     if settings.get('click_removal', True):
-        click_threshold = settings.get('click_threshold', 6.0)
-        data, _ = remove_clicks(data, rate, threshold=click_threshold)
+        peak_ratio = settings.get('click_peak_ratio')
+        if peak_ratio is not None:
+            data, n_clicks = remove_clicks(
+                data, rate,
+                peak_ratio=float(peak_ratio),
+                repair="cubic",
+            )
+        else:
+            click_threshold = settings.get('click_threshold', 6.0)
+            data, n_clicks = remove_clicks(data, rate, threshold=click_threshold)
+        if report is not None:
+            report['clicks_removed'] = report.get('clicks_removed', 0) + int(n_clicks)
 
     # Transient shaping (before compression to preserve punch)
     attack_db = settings.get('transient_attack_db', 0)

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1874,12 +1874,13 @@ def mix_track_full(input_path: Path | str, output_path: Path | str,
     pre_peak = float(np.max(np.abs(data)))
     pre_rms = float(np.sqrt(np.mean(data ** 2)))
 
-    result = {
+    result: dict[str, Any] = {
         'mode': 'full_mix',
         'filename': input_path.name,
         'pre_peak': pre_peak,
         'pre_rms': pre_rms,
         'dry_run': dry_run,
+        'clicks_removed': 0,
     }
 
     if not dry_run:
@@ -1895,9 +1896,22 @@ def mix_track_full(input_path: Path | str, output_path: Path | str,
         if hp_cutoff > 0:
             data = apply_highpass(data, rate, cutoff=hp_cutoff)
 
-        # Click removal
+        # Click removal — full-mix stays on linear repair per #289
+        # (dense mix content amplifies the artefacts of any deeper
+        # surgical repair). peak_ratio is preferred when the genre
+        # preset supplies one so polish and QC stay aligned.
+        clicks_removed = 0
         if settings.get('click_removal', True):
-            data, _ = remove_clicks(data, rate)
+            peak_ratio = settings.get('click_peak_ratio')
+            if peak_ratio is not None:
+                data, clicks_removed = remove_clicks(
+                    data, rate,
+                    peak_ratio=float(peak_ratio),
+                    repair="linear",
+                )
+            else:
+                data, clicks_removed = remove_clicks(data, rate)
+        result['clicks_removed'] = int(clicks_removed)
 
         # Mud cut
         mud_cut_db = settings.get('mud_cut_db', -2.0)


### PR DESCRIPTION
## Summary

- Aligns the polish-stage declicker with the QC click detector from #287 — when a genre is supplied, polish uses the same 10 ms peak/RMS detection semantics as QC, so tracks don't survive polish only to FAIL QC on residuals (or vice versa).
- Stem-tier surgical repair: drums and percussion processors use `scipy.interpolate.CubicSpline` across ±1.5 ms of clean neighbors when `click_peak_ratio` is set. Full-mix fallback stays on two-sample linear repair because dense mix content amplifies the artefacts of deeper surgical repair.
- Polish results now surface `clicks_removed` per stem (`stems_processed[i]['clicks_removed']`) and on the full-mix result (`result['clicks_removed']`, including skip-path and dry-run dicts) so operators can tell whether polish acted.
- Zero behavior change for existing callers without a genre — `remove_clicks` still defaults to std-path + linear repair, and processors fall back to the legacy `click_threshold` when `click_peak_ratio` is absent.

Closes #289.

## Test plan
- [x] `TestRemoveClicks` updated for tuple return (5 tests)
- [x] `TestRemoveClicksPeakRatio` — new (4 tests)
- [x] `TestRemoveClicksCubicRepair` — new (6 tests, including cross-repair A/B)
- [x] `TestMasterClickThresholdsThreaded` — new (4 tests)
- [x] `TestProcessDrums` / `TestProcessPercussion` — new `report`/`peak_ratio` tests (3 new)
- [x] `TestMixTrackStems::test_result_reports_clicks_removed_per_stem` — new
- [x] `TestMixTrackFull::test_full_mix_reports_clicks_removed` + obvious-click test — new
- [x] Full test suite `pytest tests/` — green
- [x] Manual: synthetic 3-click full-mix round-trips with `clicks_removed >= 1` under `genre='electronic'` — output attached below

## Manual sanity output

```
{'mode': 'full_mix', 'clicks_removed': 6, 'pre_peak': 0.95001220703125, 'post_peak': 0.6848353221399374}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)