### PR TITLE
fix: analyze every stem per track in analyze_mix_issues stems mode (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 - Look-ahead limiter now hits its target ceiling exactly (was overshooting by ~1 dB on transients). Gain at peak samples was being sampled from the release-relaxed envelope; replaced with a rolling minimum over the lookahead window (#283)
 - QC click detector is now genre-aware: `click_peak_ratio` and `click_fail_count` are per-genre preset fields, tuned looser for genres with intentional sharp transients (electronic, IDM, breakcore, trap, metal, glitch, footwork, etc.) so musical transients no longer FAIL QC. `qc_tracks.py` accepts `--genre`, the `qc_audio` MCP tool accepts `genre`, and user `mastering-presets.yaml` overrides still apply (#285)
 - Mastering chain now adds a final true-peak guard at the output rate after downsample and SRC. `scipy.signal.resample_poly`'s polyphase FIR has passband ripple that previously reintroduced 0.1–0.9 dB inter-sample peaks above the limiter ceiling; one reactive `limit_peaks()` pass closes that gap so `ceiling_db` is hit within ~0.05 dB without the prior headroom workaround (#286)
+- `analyze_mix_issues` in stems mode now analyzes every stem per track and reports per-stem diagnostics under `tracks[].stems[stem_name]`, rather than sampling only the alphabetically first stem. Issues in specific stems (muddy bass, harsh vocals, etc.) are no longer missed, and per-track issue rollups are the union across stems (#272)
 
 ## [0.89.0] - 2026-04-10
 

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -187,24 +187,24 @@ async def analyze_mix_issues(
     ])
 
     # If no root WAVs, check stems/ for per-track directories and analyze
-    # the first stem from each track (gives representative analysis).
+    # every stem in each track (per-stem diagnostics).
     stems_mode = False
+    stem_track_map: list[tuple[str, list[Path]]] = []
     if not wav_files:
         stems_dir = audio_dir / "stems"
         if stems_dir.is_dir():
             track_dirs = sorted([d for d in stems_dir.iterdir() if d.is_dir()])
             for td in track_dirs:
-                # Pick the first WAV in each track dir as representative
                 stem_wavs = sorted([
                     f for f in td.iterdir()
                     if f.suffix.lower() == ".wav"
                 ])
                 if stem_wavs:
-                    wav_files.append(stem_wavs[0])
-            if wav_files:
+                    stem_track_map.append((td.name, stem_wavs))
+            if stem_track_map:
                 stems_mode = True
 
-    if not wav_files:
+    if not wav_files and not stem_track_map:
         return _safe_json({"error": f"No WAV files found in {audio_dir}"})
 
     def _analyze_one(wav_path: Path) -> dict[str, Any]:
@@ -276,10 +276,27 @@ async def analyze_mix_issues(
 
         return result
 
-    track_analyses = []
-    for wav_file in wav_files:
-        analysis = await loop.run_in_executor(None, _analyze_one, wav_file)
-        track_analyses.append(analysis)
+    track_analyses: list[dict[str, Any]] = []
+    if stems_mode:
+        for track_name, stem_wavs in stem_track_map:
+            stems_result: dict[str, dict[str, Any]] = {}
+            track_issues: set[str] = set()
+            for stem_wav in stem_wavs:
+                stem_name = stem_wav.stem
+                analysis = await loop.run_in_executor(None, _analyze_one, stem_wav)
+                stems_result[stem_name] = analysis
+                track_issues.update(
+                    i for i in analysis["issues"] if i != "none_detected"
+                )
+            track_analyses.append({
+                "track": track_name,
+                "stems": stems_result,
+                "issues": sorted(track_issues) if track_issues else ["none_detected"],
+            })
+    else:
+        for wav_file in wav_files:
+            analysis = await loop.run_in_executor(None, _analyze_one, wav_file)
+            track_analyses.append(analysis)
 
     # Album-level summary
     all_issues: set[str] = set()

--- a/tests/unit/state/test_handlers_mixing.py
+++ b/tests/unit/state/test_handlers_mixing.py
@@ -282,6 +282,22 @@ class TestAnalyzeMixIssues:
         assert result["album_summary"]["tracks_analyzed"] >= 1
         assert result["album_summary"]["source_mode"] == "stems"
 
+    def test_stems_mode_analyzes_every_stem_per_track(self, tmp_path):
+        """Each stem in a track gets its own analysis, not just the first alphabetically."""
+        audio_dir = _setup_stems_dir(tmp_path)
+        with patch.object(_helpers_mod, "_check_mixing_deps", return_value=None), \
+             patch.object(_helpers_mod, "_resolve_audio_dir", return_value=(None, audio_dir)):
+            raw = _run(_mixing_mod.analyze_mix_issues("test"))
+        result = json.loads(raw)
+        assert result["album_summary"]["tracks_analyzed"] == 1
+        track = result["tracks"][0]
+        assert track["track"] == "01-test-track"
+        assert set(track["stems"].keys()) == {"vocals", "bass"}
+        for stem_name, stem_analysis in track["stems"].items():
+            assert "peak" in stem_analysis
+            assert "issues" in stem_analysis
+        assert "issues" in track
+
 
 # ---------------------------------------------------------------------------
 # Tests: polish_album (3-stage pipeline)


### PR DESCRIPTION
## Summary
- Fixes #272 — `analyze_mix_issues` in stems mode previously sampled only the alphabetically first stem per track, missing issues in other stems.
- Now iterates every stem; output shape in stems mode is `tracks[].stems[stem_name]` with per-track `issues` aggregated as the union across stems.
- Full-mix mode output unchanged.

## Test plan
- [x] `pytest tests/unit/state/test_handlers_mixing.py` — 21 passed (includes new `test_stems_mode_analyzes_every_stem_per_track`)
- [x] `mypy` clean on changed module
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)