### PR TITLE
feat: codec preview and mono fold-down QC artifacts (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Added
+- **Mastering samples — codec preview + mono fold-down QC artifacts** — `master_album` now writes operator-listening artifacts to a sibling `mastering_samples/` directory after verification, so `mastered/` stays byte-identical to the streaming upload. Each track gets a 128 kbps `.aac.m4a` AAC encode (Bluetooth-path audition), a `.mono.wav` mono fold sample (phone-speaker / Echo audition), and a `.MONO_FOLD.md` per-band delta report. A >6 dB band drop in the mono fold hard-fails the pipeline with the offending frequency surfaced (phase cancellation guard). New standalone tools `render_codec_preview` and `mono_fold_check` run the same checks independently. Thresholds and on/off flags configurable in `genre-presets.yaml` defaults; `reset_mastering` accepts `mastering_samples` (#296)
 - **Mastering pipeline overhaul** — 30+ new configurable parameters across the full mastering chain:
   - DC offset removal (subsonic HPF)
   - Low shelf EQ with configurable Q factor

--- a/servers/bitwize-music-server/handlers/maintenance.py
+++ b/servers/bitwize-music-server/handlers/maintenance.py
@@ -16,7 +16,7 @@ logger = logging.getLogger("bitwize-music-state")
 # Constants
 # ---------------------------------------------------------------------------
 
-_RESET_ALLOWED_SUBFOLDERS = {"mastered", "polished"}
+_RESET_ALLOWED_SUBFOLDERS = {"mastered", "polished", "mastering_samples"}
 
 _LEGACY_VENV_DIRS = ["mastering-env", "promotion-env", "cloud-env"]
 
@@ -31,10 +31,10 @@ async def reset_mastering(
     subfolders: list[str] = ["mastered"],  # noqa: B006 — MCP tool default, not mutated
     dry_run: bool = True,
 ) -> str:
-    """Remove mastered/ and/or polished/ subfolders so the mastering pipeline can be re-run.
+    """Remove mastered/, polished/, and/or mastering_samples/ subfolders.
 
-    Only 'mastered' and 'polished' are allowed — originals/ and stems/ are
-    protected and cannot be deleted through this tool.
+    Only 'mastered', 'polished', and 'mastering_samples' are allowed —
+    originals/ and stems/ are protected and cannot be deleted through this tool.
 
     Default is dry_run=True: reports what would be deleted without removing anything.
     Set dry_run=False to actually delete.
@@ -53,7 +53,7 @@ async def reset_mastering(
         return _safe_json({
             "error": f"Disallowed subfolders: {rejected}",
             "allowed": sorted(_RESET_ALLOWED_SUBFOLDERS),
-            "hint": "Only 'mastered' and 'polished' can be reset. "
+            "hint": "Only 'mastered', 'polished', and 'mastering_samples' can be reset. "
                     "originals/ and stems/ are protected.",
         })
 

--- a/servers/bitwize-music-server/handlers/processing/__init__.py
+++ b/servers/bitwize-music-server/handlers/processing/__init__.py
@@ -24,7 +24,9 @@ from handlers.processing.audio import (  # noqa: F401
     master_album,
     master_audio,
     master_with_reference,
+    mono_fold_check,
     qc_audio,
+    render_codec_preview,
 )
 
 # Sheet music tools

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -1053,6 +1053,148 @@ async def master_album(
         verification_stage["auto_recovered"] = auto_recovered
     stages["verification"] = verification_stage
 
+    # --- Stage 5.5: Mastering samples (codec preview + mono fold-down QC) ---
+    # Issue #296. Writes .aac.m4a and .MONO_FOLD.md sidecars to the
+    # mastering_samples/ sibling directory so mastered/ stays WAV-only. A
+    # mono-fold hard-fail short-circuits the pipeline; codec preview never blocks.
+    from tools.mastering.master_tracks import GENRE_PRESETS, _PRESET_DEFAULTS
+
+    sample_cfg: dict[str, Any] = (
+        GENRE_PRESETS.get(genre.lower())
+        if genre and genre.lower() in GENRE_PRESETS
+        else dict(_PRESET_DEFAULTS)
+    )
+
+    codec_enabled = bool(int(sample_cfg.get("codec_preview_enabled", 1)))
+    codec_bitrate = int(sample_cfg.get("codec_preview_bitrate_kbps", 128))
+    monofold_enabled = bool(int(sample_cfg.get("mono_fold_enabled", 1)))
+    monofold_write_audio = bool(int(sample_cfg.get("mono_fold_write_audio", 1)))
+    monofold_thresholds = {
+        "band_drop_fail_db": float(sample_cfg.get("mono_fold_band_drop_fail_db", 6.0)),
+        "lufs_warn_db": float(sample_cfg.get("mono_fold_lufs_warn_db", 3.0)),
+        "vocal_warn_db": float(sample_cfg.get("mono_fold_vocal_warn_db", 2.0)),
+        "correlation_warn": float(sample_cfg.get("mono_fold_correlation_warn", 0.3)),
+    }
+
+    samples_dir = audio_dir / "mastering_samples"
+    samples_stage: dict[str, Any] = {
+        "status": "pass",
+        "codec_preview_enabled": codec_enabled,
+        "mono_fold_enabled": monofold_enabled,
+        "output_dir": str(samples_dir),
+    }
+
+    if codec_enabled or monofold_enabled:
+        samples_dir.mkdir(exist_ok=True)
+
+    # Codec preview — never blocks
+    if codec_enabled:
+        from tools.mastering.codec_preview import (
+            CodecPreviewError,
+            render_aac_preview,
+        )
+
+        codec_results: list[dict[str, Any]] = []
+        codec_errors: list[str] = []
+        for wav in mastered_files:
+            out_path = samples_dir / f"{wav.stem}.aac.m4a"
+            try:
+                info = await loop.run_in_executor(
+                    None, render_aac_preview, wav, out_path, codec_bitrate
+                )
+                codec_results.append({
+                    "track": wav.name,
+                    "output_path": info["output_path"],
+                    "bitrate_kbps": info["bitrate_kbps"],
+                })
+            except CodecPreviewError as e:
+                codec_errors.append(f"{wav.name}: {e}")
+                warnings.append(f"Codec preview {wav.name}: {e}")
+
+        samples_stage["codec_previews"] = codec_results
+        if codec_errors:
+            samples_stage["codec_errors"] = codec_errors
+
+    # Mono fold-down QC — hard-fails the pipeline on band drop
+    if monofold_enabled:
+        import soundfile as sf
+        from tools.mastering.mono_fold import mono_fold_metrics
+        from tools.mastering.mono_fold_report import render_mono_fold_markdown
+
+        def _do_mono_fold(wav_path: Path) -> dict[str, Any]:
+            data, rate = sf.read(str(wav_path))
+            import numpy as _np
+            if data.ndim == 1:
+                data = _np.column_stack([data, data])
+            metrics = mono_fold_metrics(data, rate, thresholds=monofold_thresholds)
+
+            stem = wav_path.stem
+            sample_filename = f"{stem}.mono.wav" if monofold_write_audio else None
+            if sample_filename:
+                sf.write(str(samples_dir / sample_filename), metrics["mono_audio"], rate, subtype="PCM_24")
+
+            md = render_mono_fold_markdown(stem, metrics, sample_filename)
+            (samples_dir / f"{stem}.MONO_FOLD.md").write_text(md, encoding="utf-8")
+
+            return {
+                "track": wav_path.name,
+                "verdict": metrics["verdict"],
+                "band_drop_fail": metrics["band_drop_fail"],
+                "worst_band": metrics["worst_band"],
+                "lufs_delta_db": metrics["lufs"]["delta_db"],
+                "vocal_delta_db": metrics["vocal_rms"]["delta_db"],
+                "stereo_correlation": metrics["stereo_correlation"],
+                "report_path": str(samples_dir / f"{stem}.MONO_FOLD.md"),
+            }
+
+        mono_results = []
+        for wav in mastered_files:
+            mono_results.append(await loop.run_in_executor(None, _do_mono_fold, wav))
+
+        mono_passed = sum(1 for r in mono_results if r["verdict"] == "PASS")
+        mono_warned = sum(1 for r in mono_results if r["verdict"] == "WARN")
+        mono_failed = sum(1 for r in mono_results if r["verdict"] == "FAIL")
+
+        for r in mono_results:
+            if r["verdict"] == "WARN":
+                warnings.append(
+                    f"Mono fold {r['track']}: WARN — see {Path(r['report_path']).name}"
+                )
+
+        samples_stage["mono_fold"] = {
+            "tracks": mono_results,
+            "passed": mono_passed,
+            "warned": mono_warned,
+            "failed": mono_failed,
+        }
+
+        if mono_failed > 0:
+            failed_tracks = [r for r in mono_results if r["verdict"] == "FAIL"]
+            samples_stage["status"] = "fail"
+            stages["mastering_samples"] = samples_stage
+            return _safe_json({
+                "album_slug": album_slug,
+                "stage_reached": "mastering_samples",
+                "stages": stages,
+                "settings": settings,
+                "warnings": warnings,
+                "failed_stage": "mastering_samples",
+                "failure_detail": {
+                    "reason": "Mono fold-down hard-fail (phase cancellation)",
+                    "tracks_failed": [r["track"] for r in failed_tracks],
+                    "details": [
+                        {
+                            "track": r["track"],
+                            "worst_band": r["worst_band"],
+                            "report": r["report_path"],
+                        }
+                        for r in failed_tracks
+                    ],
+                },
+            })
+
+    stages["mastering_samples"] = samples_stage
+
     # --- Stage 6: Post-QC ---
     post_qc_results = []
     for wav in mastered_files:
@@ -1225,6 +1367,195 @@ async def master_album(
     })
 
 
+async def render_codec_preview(
+    album_slug: str,
+    subfolder: str = "mastered",
+    bitrate_kbps: int = 128,
+) -> str:
+    """Render a 128 kbps AAC preview of each mastered track.
+
+    The `.aac.m4a` files are written to `mastering_samples/` next to
+    (never inside) `mastered/`, so streaming uploads stay WAV-only. The
+    previews exist so the operator can audition how the album sounds over
+    Bluetooth before release (issue #296).
+
+    Args:
+        album_slug: Album slug (e.g., "my-album")
+        subfolder: Source subfolder relative to the audio dir (default "mastered")
+        bitrate_kbps: AAC bitrate in kbps (default 128)
+
+    Returns:
+        JSON with per-track preview info and a summary.
+    """
+    err, audio_dir = _helpers._resolve_audio_dir(album_slug)
+    if err:
+        return err
+    assert audio_dir is not None
+
+    source_dir = audio_dir / subfolder
+    if not source_dir.is_dir():
+        return _safe_json({
+            "error": f"Source subfolder not found: {source_dir}",
+            "hint": "Run master_audio or master_album first to populate mastered/.",
+        })
+
+    wav_files = sorted(
+        f for f in source_dir.iterdir()
+        if f.suffix.lower() == ".wav" and "venv" not in str(f)
+    )
+    if not wav_files:
+        return _safe_json({"error": f"No WAV files in {source_dir}"})
+
+    from tools.mastering.codec_preview import CodecPreviewError, render_aac_preview
+
+    output_dir = audio_dir / "mastering_samples"
+    output_dir.mkdir(exist_ok=True)
+
+    loop = asyncio.get_running_loop()
+    previews: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for wav in wav_files:
+        out_path = output_dir / f"{wav.stem}.aac.m4a"
+        try:
+            info = await loop.run_in_executor(
+                None, render_aac_preview, wav, out_path, bitrate_kbps
+            )
+            previews.append({
+                "input": wav.name,
+                "output_path": info["output_path"],
+                "bitrate_kbps": info["bitrate_kbps"],
+                "output_bytes": info["output_bytes"],
+            })
+        except CodecPreviewError as e:
+            errors.append(f"{wav.name}: {e}")
+
+    if not previews and errors:
+        return _safe_json({"error": "All previews failed", "details": errors})
+
+    return _safe_json({
+        "previews": previews,
+        "summary": {
+            "count": len(previews),
+            "total_bytes": sum(p["output_bytes"] for p in previews),
+            "output_dir": str(output_dir),
+            "errors": errors or None,
+        },
+    })
+
+
+async def mono_fold_check(
+    album_slug: str,
+    subfolder: str = "mastered",
+    write_audio: bool = True,
+) -> str:
+    """Run the mono fold-down QC gate on every mastered track.
+
+    For each WAV in `{audio_dir}/mastered/`, sum stereo to mono, measure
+    per-band deltas, LUFS delta, vocal-band RMS delta, and stereo correlation,
+    then write a `{track}.MONO_FOLD.md` report (and optionally a
+    `{track}.mono.wav` listenable sample) to `mastering_samples/`. See
+    issue #296.
+
+    Args:
+        album_slug: Album slug.
+        subfolder: Source subfolder relative to the audio dir (default "mastered")
+        write_audio: If True (default), write a .mono.wav sibling sample so
+            the operator can audition cancellation on a phone speaker.
+
+    Returns:
+        JSON with per-track deltas, the offending band on any FAIL, and a
+        summary verdict.
+    """
+    dep_err = _helpers._check_mastering_deps()
+    if dep_err:
+        return _safe_json({"error": dep_err})
+
+    err, audio_dir = _helpers._resolve_audio_dir(album_slug)
+    if err:
+        return err
+    assert audio_dir is not None
+
+    source_dir = audio_dir / subfolder
+    if not source_dir.is_dir():
+        return _safe_json({
+            "error": f"Source subfolder not found: {source_dir}",
+            "hint": "Run master_audio or master_album first to populate mastered/.",
+        })
+
+    wav_files = sorted(
+        f for f in source_dir.iterdir()
+        if f.suffix.lower() == ".wav" and "venv" not in str(f)
+    )
+    if not wav_files:
+        return _safe_json({"error": f"No WAV files in {source_dir}"})
+
+    import soundfile as sf
+    from tools.mastering.mono_fold import mono_fold_metrics
+    from tools.mastering.mono_fold_report import render_mono_fold_markdown
+
+    output_dir = audio_dir / "mastering_samples"
+    output_dir.mkdir(exist_ok=True)
+
+    loop = asyncio.get_running_loop()
+
+    def _analyze(wav_path: Path) -> dict[str, Any]:
+        data, rate = sf.read(str(wav_path))
+        import numpy as _np
+        if data.ndim == 1:
+            data = _np.column_stack([data, data])
+        metrics = mono_fold_metrics(data, rate)
+
+        stem = wav_path.stem
+        sample_filename: str | None = None
+        if write_audio:
+            sample_filename = f"{stem}.mono.wav"
+            mono = metrics["mono_audio"]
+            sf.write(str(output_dir / sample_filename), mono, rate, subtype="PCM_24")
+
+        md = render_mono_fold_markdown(stem, metrics, sample_filename)
+        (output_dir / f"{stem}.MONO_FOLD.md").write_text(md, encoding="utf-8")
+
+        return {
+            "track": wav_path.name,
+            "verdict": metrics["verdict"],
+            "band_drop_fail": metrics["band_drop_fail"],
+            "worst_band": metrics["worst_band"],
+            "lufs_delta_db": metrics["lufs"]["delta_db"],
+            "vocal_delta_db": metrics["vocal_rms"]["delta_db"],
+            "stereo_correlation": metrics["stereo_correlation"],
+            "report_path": str(output_dir / f"{stem}.MONO_FOLD.md"),
+            "sample_path": str(output_dir / sample_filename) if sample_filename else None,
+        }
+
+    tracks: list[dict[str, Any]] = []
+    for wav in wav_files:
+        tracks.append(await loop.run_in_executor(None, _analyze, wav))
+
+    passed = sum(1 for t in tracks if t["verdict"] == "PASS")
+    warned = sum(1 for t in tracks if t["verdict"] == "WARN")
+    failed = sum(1 for t in tracks if t["verdict"] == "FAIL")
+
+    if failed > 0:
+        verdict = "FAIL"
+    elif warned > 0:
+        verdict = "WARN"
+    else:
+        verdict = "PASS"
+
+    return _safe_json({
+        "tracks": tracks,
+        "summary": {
+            "count": len(tracks),
+            "passed": passed,
+            "warned": warned,
+            "failed": failed,
+            "output_dir": str(output_dir),
+        },
+        "verdict": verdict,
+    })
+
+
 def register(mcp: Any) -> None:
     """Register audio mastering tools."""
     mcp.tool()(analyze_audio)
@@ -1233,3 +1564,5 @@ def register(mcp: Any) -> None:
     mcp.tool()(fix_dynamic_track)
     mcp.tool()(master_with_reference)
     mcp.tool()(master_album)
+    mcp.tool()(render_codec_preview)
+    mcp.tool()(mono_fold_check)

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -1072,11 +1072,10 @@ async def master_album(
     # mono-fold hard-fail short-circuits the pipeline; codec preview never blocks.
     from tools.mastering.master_tracks import GENRE_PRESETS, _PRESET_DEFAULTS
 
-    sample_cfg: dict[str, Any] = (
-        GENRE_PRESETS.get(genre.lower())
-        if genre and genre.lower() in GENRE_PRESETS
-        else dict(_PRESET_DEFAULTS)
-    )
+    if genre and genre.lower() in GENRE_PRESETS:
+        sample_cfg: dict[str, Any] = dict(GENRE_PRESETS[genre.lower()])
+    else:
+        sample_cfg = dict(_PRESET_DEFAULTS)
 
     codec_enabled = bool(int(sample_cfg.get("codec_preview_enabled", 1)))
     codec_bitrate = int(sample_cfg.get("codec_preview_bitrate_kbps", 128))

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -490,12 +490,14 @@ from handlers.processing import (  # noqa: F401
     master_album,
     master_audio,
     master_with_reference,
+    mono_fold_check,
     polish_album,
     polish_and_master_album,
     polish_audio,
     prepare_singles,
     publish_sheet_music,
     qc_audio,
+    render_codec_preview,
     transcribe_audio,
 )
 

--- a/skills/mastering-engineer/SKILL.md
+++ b/skills/mastering-engineer/SKILL.md
@@ -284,6 +284,48 @@ If a track has excessive dynamic range and won't reach target LUFS:
 fix_dynamic_track(album_slug, track_filename="05-problem-track.wav")
 ```
 
+### Step 6.5: Real-listener QC artifacts (`mastering_samples/`)
+
+After verification, `master_album` writes operator-listening artifacts to a
+sibling directory so `mastered/` stays byte-identical to what gets uploaded
+to streaming platforms:
+
+```
+{audio_root}/.../[album]/
+├── mastered/                         # Final masters — UPLOAD THIS
+│   ├── 01-track.wav
+│   └── ...
+└── mastering_samples/                # Operator QA only — DO NOT UPLOAD
+    ├── 01-track.aac.m4a              # 128 kbps AAC for Bluetooth listening
+    ├── 01-track.mono.wav             # Mono fold-down sample
+    └── 01-track.MONO_FOLD.md         # Per-band delta report + verdict
+```
+
+**Two automated checks run here**:
+- **Codec preview** — renders each master to 128 kbps AAC. Audition on
+  AirPods / car Bluetooth before release; compressed playback exposes
+  warbly sibilance, lost sub-bass, and pumping that the full-resolution
+  master hides.
+- **Mono fold-down** — sums stereo to mono, measures per-band drops vs.
+  stereo. A >6 dB drop in any band hard-fails the pipeline (phase
+  cancellation). Listen to `.mono.wav` on a phone speaker or single Echo
+  to confirm which elements disappear in mono playback.
+
+Standalone tools (run independently of the full pipeline):
+```
+render_codec_preview(album_slug)        # writes .aac.m4a files
+mono_fold_check(album_slug)             # writes .MONO_FOLD.md + .mono.wav
+```
+
+Re-run cleanup (regenerable artifacts):
+```
+reset_mastering(album_slug, subfolders=["mastering_samples"], dry_run=False)
+```
+
+Configurable thresholds live in `tools/mastering/genre-presets.yaml`
+under `defaults:` (`mono_fold_band_drop_fail_db`, etc.) — override per-user
+in `~/.bitwize-music/overrides/mastering-presets.yaml`.
+
 ---
 
 ## MCP Tools Reference
@@ -298,6 +340,8 @@ All mastering operations are available as MCP tools. **Use these instead of runn
 | `master_with_reference` | Match mastering to a reference track |
 | `fix_dynamic_track` | Fix tracks with extreme dynamic range |
 | `master_album` | End-to-end pipeline — all steps in one call |
+| `render_codec_preview` | Render 128 kbps AAC previews to `mastering_samples/` |
+| `mono_fold_check` | Mono fold-down QC: per-band deltas, sample audio, MD report |
 
 ---
 

--- a/tests/unit/mastering/test_codec_preview.py
+++ b/tests/unit/mastering/test_codec_preview.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/mastering/codec_preview.py — AAC preview rendering."""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.codec_preview import (
+    CodecPreviewError,
+    render_aac_preview,
+)
+
+
+def _write_test_wav(path: Path, freq: float = 440.0, duration: float = 1.5, rate: int = 44100) -> None:
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    mono = 0.3 * np.sin(2 * np.pi * freq * t)
+    stereo = np.column_stack([mono, mono]).astype(np.float32)
+    sf.write(str(path), stereo, rate, subtype="PCM_16")
+
+
+ffmpeg_available = shutil.which("ffmpeg") is not None
+skip_if_no_ffmpeg = pytest.mark.skipif(
+    not ffmpeg_available, reason="ffmpeg not installed"
+)
+
+
+class TestRenderAacPreview:
+    @skip_if_no_ffmpeg
+    def test_writes_m4a_at_output_path(self, tmp_path):
+        in_wav = tmp_path / "in.wav"
+        out_m4a = tmp_path / "out.aac.m4a"
+        _write_test_wav(in_wav)
+
+        result = render_aac_preview(in_wav, out_m4a, bitrate_kbps=128)
+
+        assert out_m4a.exists()
+        assert out_m4a.stat().st_size > 0
+        assert result["output_path"] == str(out_m4a)
+        assert result["bitrate_kbps"] == 128
+
+    @skip_if_no_ffmpeg
+    def test_output_is_valid_aac_container(self, tmp_path):
+        in_wav = tmp_path / "in.wav"
+        out_m4a = tmp_path / "out.aac.m4a"
+        _write_test_wav(in_wav)
+        render_aac_preview(in_wav, out_m4a, bitrate_kbps=128)
+
+        # ffprobe should identify it as AAC audio in an MP4 container
+        probe = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries", "stream=codec_name",
+             "-of", "default=noprint_wrappers=1:nokey=1", str(out_m4a)],
+            capture_output=True, text=True,
+        )
+        assert probe.returncode == 0
+        assert "aac" in probe.stdout.strip().lower()
+
+    @skip_if_no_ffmpeg
+    def test_custom_bitrate_honored(self, tmp_path):
+        """Higher bitrate should produce a larger file for the same source."""
+        in_wav = tmp_path / "in.wav"
+        lo = tmp_path / "lo.aac.m4a"
+        hi = tmp_path / "hi.aac.m4a"
+        _write_test_wav(in_wav, duration=3.0)
+
+        render_aac_preview(in_wav, lo, bitrate_kbps=64)
+        render_aac_preview(in_wav, hi, bitrate_kbps=256)
+
+        assert hi.stat().st_size > lo.stat().st_size
+
+    def test_missing_input_raises(self, tmp_path):
+        out = tmp_path / "out.aac.m4a"
+        with pytest.raises(CodecPreviewError, match="does not exist"):
+            render_aac_preview(tmp_path / "nope.wav", out)
+
+    def test_creates_output_directory(self, tmp_path):
+        in_wav = tmp_path / "in.wav"
+        nested_out = tmp_path / "deep" / "nested" / "out.aac.m4a"
+        _write_test_wav(in_wav)
+        if not ffmpeg_available:
+            pytest.skip("ffmpeg not installed")
+        render_aac_preview(in_wav, nested_out, bitrate_kbps=128)
+        assert nested_out.exists()
+        assert nested_out.parent.is_dir()
+
+    def test_rejects_invalid_bitrate(self, tmp_path):
+        in_wav = tmp_path / "in.wav"
+        out = tmp_path / "out.aac.m4a"
+        _write_test_wav(in_wav)
+        with pytest.raises(CodecPreviewError, match="bitrate"):
+            render_aac_preview(in_wav, out, bitrate_kbps=0)
+        with pytest.raises(CodecPreviewError, match="bitrate"):
+            render_aac_preview(in_wav, out, bitrate_kbps=-64)

--- a/tests/unit/mastering/test_mono_fold.py
+++ b/tests/unit/mastering/test_mono_fold.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/mastering/mono_fold.py — mono fold-down QC analysis."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.mono_fold import (
+    DEFAULT_THRESHOLDS,
+    fold_to_mono,
+    mono_fold_metrics,
+)
+
+
+def _stereo_sine(freq=1000.0, duration=3.0, rate=44100, amplitude=0.3,
+                 right_scale=1.0, right_phase=0.0):
+    """Generate a stereo sine with configurable right-channel scale/phase."""
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    left = amplitude * np.sin(2 * np.pi * freq * t)
+    right = right_scale * amplitude * np.sin(2 * np.pi * freq * t + right_phase)
+    return np.column_stack([left, right]).astype(np.float64), rate
+
+
+class TestFoldToMono:
+    def test_returns_1d_array_same_length(self):
+        data, _ = _stereo_sine()
+        mono = fold_to_mono(data)
+        assert mono.ndim == 1
+        assert len(mono) == len(data)
+
+    def test_mean_downmix_convention(self):
+        """Codebase uses np.mean(data, axis=1) for stereo→mono."""
+        data = np.array([[1.0, 3.0], [2.0, 4.0]])
+        mono = fold_to_mono(data)
+        np.testing.assert_allclose(mono, [2.0, 3.0])
+
+    def test_mono_input_passthrough(self):
+        """1-D input should be returned unchanged."""
+        data = np.array([0.1, 0.2, 0.3])
+        mono = fold_to_mono(data)
+        np.testing.assert_allclose(mono, data)
+
+
+class TestMonoFoldMetrics:
+    def test_in_phase_correlated_signal_passes(self):
+        """Identical L/R channels fold perfectly — PASS."""
+        data, rate = _stereo_sine(right_scale=1.0)
+        metrics = mono_fold_metrics(data, rate)
+        assert metrics["verdict"] == "PASS"
+        assert metrics["band_drop_fail"] is False
+
+    def test_inverted_channels_hard_fail_with_band_info(self):
+        """L = -R cancels completely in mono — FAIL with offending band reported."""
+        data, rate = _stereo_sine(right_scale=-1.0)
+        metrics = mono_fold_metrics(data, rate)
+        assert metrics["verdict"] == "FAIL"
+        assert metrics["band_drop_fail"] is True
+        # The signal is at 1000 Hz, which lives in the "mid" band (500-2000)
+        assert metrics["worst_band"]["name"] == "mid"
+        # Drop should exceed the 6 dB threshold
+        assert metrics["worst_band"]["delta_db"] < -6.0
+
+    def test_returned_mono_audio_is_sample_ready(self):
+        """Metrics should return the mono audio data for writing as a .mono.wav sample."""
+        data, rate = _stereo_sine()
+        metrics = mono_fold_metrics(data, rate)
+        mono_audio = metrics["mono_audio"]
+        assert mono_audio.ndim == 1
+        assert len(mono_audio) == len(data)
+
+    def test_per_band_deltas_cover_all_bands(self):
+        """Result should include delta_db for every band in DEFAULT_THRESHOLDS."""
+        data, rate = _stereo_sine()
+        metrics = mono_fold_metrics(data, rate)
+        band_deltas = metrics["band_deltas"]
+        for band in ("sub_bass", "bass", "low_mid", "mid", "high_mid", "high", "air"):
+            assert band in band_deltas
+            entry = band_deltas[band]
+            assert "delta_db" in entry
+            assert "hz_low" in entry
+            assert "hz_high" in entry
+
+    def test_lufs_delta_reported(self):
+        """LUFS stereo/mono/delta should be present in the result."""
+        data, rate = _stereo_sine()
+        metrics = mono_fold_metrics(data, rate)
+        assert "lufs" in metrics
+        assert "stereo" in metrics["lufs"]
+        assert "mono" in metrics["lufs"]
+        assert "delta_db" in metrics["lufs"]
+
+    def test_vocal_rms_delta_reported(self):
+        """Vocal band (1-4 kHz) RMS delta should be present."""
+        data, rate = _stereo_sine()
+        metrics = mono_fold_metrics(data, rate)
+        assert "vocal_rms" in metrics
+        assert "delta_db" in metrics["vocal_rms"]
+
+    def test_stereo_correlation_reported(self):
+        """Stereo correlation coefficient should be present."""
+        data, rate = _stereo_sine()
+        metrics = mono_fold_metrics(data, rate)
+        assert "stereo_correlation" in metrics
+        corr = metrics["stereo_correlation"]
+        # In-phase identical channels should correlate near 1.0
+        assert corr > 0.9
+
+    def test_inverted_channels_correlation_near_minus_one(self):
+        data, rate = _stereo_sine(right_scale=-1.0)
+        metrics = mono_fold_metrics(data, rate)
+        assert metrics["stereo_correlation"] < -0.9
+
+    def test_custom_thresholds_respected(self):
+        """Thresholds gate the verdict — extreme ones suppress the fail."""
+        data_inv, rate_inv = _stereo_sine(right_scale=-1.0)
+        # 100 dB threshold is wider than the noise-floor cancellation bound,
+        # so even a phase-inverted signal won't trip band_drop_fail.
+        loose = dict(DEFAULT_THRESHOLDS)
+        loose["band_drop_fail_db"] = 100.0
+        loose_metrics = mono_fold_metrics(data_inv, rate_inv, thresholds=loose)
+        assert loose_metrics["band_drop_fail"] is False
+
+        # Default threshold (6 dB) catches the same cancellation as FAIL.
+        default_metrics = mono_fold_metrics(data_inv, rate_inv)
+        assert default_metrics["band_drop_fail"] is True
+
+    def test_wide_stereo_low_correlation_warns(self):
+        """Uncorrelated L/R (random noise) should WARN on correlation."""
+        rate = 44100
+        rng = np.random.default_rng(42)
+        left = 0.3 * rng.standard_normal(rate * 3)
+        right = 0.3 * rng.standard_normal(rate * 3)
+        data = np.column_stack([left, right])
+        metrics = mono_fold_metrics(data, rate)
+        # Uncorrelated noise ≈ 0 correlation — below 0.3 threshold
+        assert metrics["stereo_correlation"] < 0.3
+        assert metrics["verdict"] in ("WARN", "FAIL")
+
+    def test_verdict_is_worst_status(self):
+        """If any sub-check is FAIL, overall verdict is FAIL."""
+        data, rate = _stereo_sine(right_scale=-1.0)
+        metrics = mono_fold_metrics(data, rate)
+        assert metrics["verdict"] == "FAIL"
+
+    def test_silent_signal_degrades_gracefully(self):
+        """Silent stereo should not crash and should not claim a band-drop fail."""
+        rate = 44100
+        data = np.zeros((rate * 2, 2), dtype=np.float64)
+        metrics = mono_fold_metrics(data, rate)
+        # No signal = no drop to measure
+        assert metrics["band_drop_fail"] is False

--- a/tests/unit/mastering/test_mono_fold_report.py
+++ b/tests/unit/mastering/test_mono_fold_report.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unit tests for mono_fold report markdown rendering."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.mono_fold import DEFAULT_THRESHOLDS
+from tools.mastering.mono_fold_report import render_mono_fold_markdown
+
+
+def _pass_metrics() -> dict:
+    return {
+        "lufs": {"stereo": -14.0, "mono": -14.4, "delta_db": -0.4},
+        "vocal_rms": {"stereo_db": -20.0, "mono_db": -20.3, "delta_db": -0.3},
+        "stereo_correlation": 0.72,
+        "worst_band": {"name": "mid", "delta_db": -0.5},
+        "band_drop_fail": False,
+        "verdict": "PASS",
+        "thresholds": dict(DEFAULT_THRESHOLDS),
+        "band_deltas": {
+            "sub_bass": {"delta_db": -0.2, "hz_low": 20.0, "hz_high": 60.0, "stereo_db": -35.0, "mono_db": -35.2},
+            "bass":     {"delta_db": -0.4, "hz_low": 60.0, "hz_high": 250.0, "stereo_db": -25.0, "mono_db": -25.4},
+            "low_mid":  {"delta_db": -0.3, "hz_low": 250.0, "hz_high": 500.0, "stereo_db": -22.0, "mono_db": -22.3},
+            "mid":      {"delta_db": -0.5, "hz_low": 500.0, "hz_high": 2000.0, "stereo_db": -18.0, "mono_db": -18.5},
+            "high_mid": {"delta_db": -0.4, "hz_low": 2000.0, "hz_high": 6000.0, "stereo_db": -22.0, "mono_db": -22.4},
+            "high":     {"delta_db": -0.3, "hz_low": 6000.0, "hz_high": 12000.0, "stereo_db": -28.0, "mono_db": -28.3},
+            "air":      {"delta_db": -0.2, "hz_low": 12000.0, "hz_high": 20000.0, "stereo_db": -35.0, "mono_db": -35.2},
+        },
+    }
+
+
+def _fail_metrics() -> dict:
+    m = _pass_metrics()
+    m["verdict"] = "FAIL"
+    m["band_drop_fail"] = True
+    m["worst_band"] = {"name": "mid", "delta_db": -96.0}
+    m["band_deltas"]["mid"]["delta_db"] = -96.0
+    m["band_deltas"]["mid"]["mono_db"] = None
+    return m
+
+
+def test_includes_track_name_in_header():
+    md = render_mono_fold_markdown("01-test-track", _pass_metrics(), sample_filename="01-test-track.mono.wav")
+    assert "01-test-track" in md
+
+
+def test_pass_verdict_rendered():
+    md = render_mono_fold_markdown("track", _pass_metrics(), sample_filename="track.mono.wav")
+    assert "PASS" in md
+    assert "FAIL" not in md.split("\n")[0:5][0]  # header line shouldn't claim FAIL
+
+
+def test_fail_verdict_rendered():
+    md = render_mono_fold_markdown("track", _fail_metrics(), sample_filename="track.mono.wav")
+    assert "FAIL" in md
+
+
+def test_all_bands_appear_in_table():
+    md = render_mono_fold_markdown("track", _pass_metrics(), sample_filename="track.mono.wav")
+    for band in ("sub_bass", "bass", "low_mid", "mid", "high_mid", "high", "air"):
+        assert band in md
+
+
+def test_lufs_and_vocal_and_correlation_present():
+    md = render_mono_fold_markdown("track", _pass_metrics(), sample_filename="track.mono.wav")
+    assert "LUFS" in md
+    assert "Vocal" in md or "vocal" in md
+    assert "correl" in md.lower()
+
+
+def test_sample_filename_linked_in_notes():
+    md = render_mono_fold_markdown("track", _pass_metrics(), sample_filename="track.mono.wav")
+    assert "track.mono.wav" in md
+
+
+def test_no_sample_filename_when_omitted():
+    md = render_mono_fold_markdown("track", _pass_metrics(), sample_filename=None)
+    assert ".mono.wav" not in md
+
+
+def test_thresholds_reflected_in_report():
+    metrics = _pass_metrics()
+    metrics["thresholds"]["band_drop_fail_db"] = 9.0
+    md = render_mono_fold_markdown("track", metrics, sample_filename="track.mono.wav")
+    assert "9" in md  # custom threshold surfaces somewhere
+
+
+def test_worst_band_highlighted_on_fail():
+    md = render_mono_fold_markdown("track", _fail_metrics(), sample_filename="track.mono.wav")
+    # Should call out the offending band frequency range in the fail message
+    assert "500" in md or "2000" in md or "mid" in md

--- a/tests/unit/state/test_server_mastering_samples.py
+++ b/tests/unit/state/test_server_mastering_samples.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Tests for render_codec_preview and mono_fold_check MCP tools (issue #296)."""
+from __future__ import annotations
+
+import asyncio
+import copy
+import importlib.util
+import json
+import shutil
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_ms", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers.processing import _helpers as _processing_helpers
+from handlers import _shared as _shared_mod
+
+
+SAMPLE_STATE = {
+    "version": 2,
+    "config": {
+        "content_root": "/tmp/test-content",
+        "audio_root": "/tmp/test-audio",
+        "documents_root": "/tmp/test-docs",
+        "artist_name": "test-artist",
+        "overrides_path": "/tmp/test-content/overrides",
+        "ideas_file": "/tmp/test-content/IDEAS.md",
+    },
+    "albums": {
+        "test-album": {
+            "title": "Test Album",
+            "status": "In Progress",
+            "genre": "electronic",
+            "path": "/tmp/test-content/artists/test-artist/albums/electronic/test-album",
+            "track_count": 2,
+            "tracks": {
+                "01-first": {"title": "First", "status": "Generated", "mtime": 1.0},
+                "02-second": {"title": "Second", "status": "Generated", "mtime": 2.0},
+            },
+            "mtime": 1234567890.0,
+        },
+    },
+    "ideas": {"total": 0, "by_status": {}, "items": []},
+    "session": {
+        "last_album": None,
+        "last_track": None,
+        "last_phase": None,
+        "pending_actions": [],
+        "updated_at": None,
+    },
+    "meta": {"rebuilt_at": "2026-01-01T00:00:00Z", "plugin_version": "0.50.0"},
+}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _fresh_state():
+    return copy.deepcopy(SAMPLE_STATE)
+
+
+class MockStateCache:
+    def __init__(self, state=None):
+        self._state = state if state is not None else _fresh_state()
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+    def rebuild(self):
+        return self._state
+
+
+def _write_stereo_wav(path: Path, freq=1000.0, duration=1.0, rate=44100,
+                     right_scale=1.0, amplitude=0.3):
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    left = amplitude * np.sin(2 * np.pi * freq * t)
+    right = right_scale * amplitude * np.sin(2 * np.pi * freq * t)
+    data = np.column_stack([left, right]).astype(np.float32)
+    sf.write(str(path), data, rate, subtype="PCM_16")
+
+
+def _make_mastered_album(tmp_path: Path, right_scale=1.0):
+    """Build a minimal audio dir with mastered/ containing 2 WAVs."""
+    audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+    mastered = audio_dir / "mastered"
+    mastered.mkdir(parents=True)
+    _write_stereo_wav(mastered / "01-first.wav", right_scale=right_scale)
+    _write_stereo_wav(mastered / "02-second.wav", right_scale=right_scale)
+    state = _fresh_state()
+    state["config"]["audio_root"] = str(tmp_path)
+    return audio_dir, state
+
+
+ffmpeg_available = shutil.which("ffmpeg") is not None
+skip_if_no_ffmpeg = pytest.mark.skipif(not ffmpeg_available, reason="ffmpeg not installed")
+
+
+class TestRenderCodecPreview:
+    @skip_if_no_ffmpeg
+    def test_writes_aac_m4a_to_mastering_samples(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.render_codec_preview("test-album")))
+        assert "error" not in result
+        samples_dir = audio_dir / "mastering_samples"
+        assert samples_dir.is_dir()
+        assert (samples_dir / "01-first.aac.m4a").exists()
+        assert (samples_dir / "02-second.aac.m4a").exists()
+        # Does NOT touch mastered/
+        assert sorted(p.name for p in (audio_dir / "mastered").iterdir()) == [
+            "01-first.wav", "02-second.wav",
+        ]
+
+    @skip_if_no_ffmpeg
+    def test_returns_per_track_summary(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.render_codec_preview("test-album")))
+        assert "previews" in result
+        assert len(result["previews"]) == 2
+        for entry in result["previews"]:
+            assert "input" in entry
+            assert "output_path" in entry
+            assert "bitrate_kbps" in entry
+
+    def test_no_mastered_dir_returns_error(self, tmp_path):
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        audio_dir.mkdir(parents=True)
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.render_codec_preview("test-album")))
+        assert "error" in result
+
+
+class TestMonoFoldCheck:
+    def test_in_phase_album_returns_pass_verdict(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path, right_scale=1.0)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.mono_fold_check("test-album")))
+        assert "error" not in result
+        assert result["verdict"] == "PASS"
+        assert result["summary"]["failed"] == 0
+
+    def test_writes_report_and_sample_to_mastering_samples(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path, right_scale=1.0)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            _run(server.mono_fold_check("test-album"))
+        samples_dir = audio_dir / "mastering_samples"
+        assert (samples_dir / "01-first.MONO_FOLD.md").exists()
+        assert (samples_dir / "02-second.MONO_FOLD.md").exists()
+        assert (samples_dir / "01-first.mono.wav").exists()
+        assert (samples_dir / "02-second.mono.wav").exists()
+
+    def test_mastered_dir_remains_wav_only(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path, right_scale=1.0)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            _run(server.mono_fold_check("test-album"))
+        mastered_files = sorted(p.name for p in (audio_dir / "mastered").iterdir())
+        assert mastered_files == ["01-first.wav", "02-second.wav"]
+
+    def test_inverted_channels_hard_fail_with_offending_band(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path, right_scale=-1.0)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.mono_fold_check("test-album")))
+        assert result["verdict"] == "FAIL"
+        assert result["summary"]["failed"] == 2
+        # Each failed track should surface the offending band with its Hz range
+        failing = [t for t in result["tracks"] if t["verdict"] == "FAIL"]
+        assert len(failing) == 2
+        for track in failing:
+            assert track["worst_band"]["name"] is not None
+            assert track["worst_band"]["delta_db"] < -6.0
+
+    def test_skip_sample_audio_when_disabled(self, tmp_path):
+        audio_dir, state = _make_mastered_album(tmp_path, right_scale=1.0)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            _run(server.mono_fold_check("test-album", write_audio=False))
+        samples_dir = audio_dir / "mastering_samples"
+        # Report still written
+        assert (samples_dir / "01-first.MONO_FOLD.md").exists()
+        # But no .mono.wav
+        assert not (samples_dir / "01-first.mono.wav").exists()
+
+    def test_no_mastered_dir_returns_error(self, tmp_path):
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        audio_dir.mkdir(parents=True)
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.mono_fold_check("test-album")))
+        assert "error" in result

--- a/tests/unit/state/test_server_qc.py
+++ b/tests/unit/state/test_server_qc.py
@@ -553,7 +553,7 @@ class TestMasterAlbumPipeline:
             return self._mock_qc_result(Path(filepath).name)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,

--- a/tests/unit/state/test_server_qc.py
+++ b/tests/unit/state/test_server_qc.py
@@ -18,7 +18,42 @@ import types
 from pathlib import Path
 from unittest.mock import patch
 
+import numpy as np
 import pytest
+import soundfile as sf
+
+
+def _write_tiny_stereo_wav(path) -> None:
+    """Write a 1-second 44.1k 16-bit stereo sine WAV via raw bytes.
+
+    Bypasses soundfile so tests that patch `soundfile.write` still get a
+    real file on disk that downstream code can read. Duration ≥0.4 s to
+    satisfy pyloudnorm's integrated-loudness block size.
+    """
+    import struct
+    rate = 44100
+    duration = 1.0
+    n_samples = int(rate * duration)
+    t = np.linspace(0, duration, n_samples, endpoint=False)
+    mono = (0.2 * np.sin(2 * np.pi * 440 * t)) * 32767
+    int16 = mono.astype(np.int16)
+    interleaved = np.column_stack([int16, int16]).flatten().tobytes()
+
+    n_channels = 2
+    bits_per_sample = 16
+    byte_rate = rate * n_channels * bits_per_sample // 8
+    block_align = n_channels * bits_per_sample // 8
+    data_size = len(interleaved)
+    fmt_chunk = struct.pack(
+        "<4sIHHIIHH",
+        b"fmt ", 16, 1, n_channels, rate, byte_rate, block_align, bits_per_sample,
+    )
+    data_chunk = struct.pack("<4sI", b"data", data_size) + interleaved
+    riff_size = 4 + len(fmt_chunk) + len(data_chunk)
+    riff = struct.pack("<4sI4s", b"RIFF", riff_size, b"WAVE") + fmt_chunk + data_chunk
+
+    with open(str(path), "wb") as f:
+        f.write(riff)
 
 # Ensure project root is on sys.path for imports
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -537,7 +572,7 @@ class TestMasterAlbumPipeline:
 
         def mock_master(input_path, output_path, **kwargs):
             master_called[0] = True
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -575,7 +610,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -615,7 +650,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -684,7 +719,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -755,7 +790,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -813,7 +848,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -845,7 +880,7 @@ class TestMasterAlbumPipeline:
         state["albums"]["test-album"]["tracks"] = {}
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -877,7 +912,7 @@ class TestMasterAlbumPipeline:
         state["albums"]["test-album"]["tracks"] = {}
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -923,7 +958,7 @@ class TestMasterAlbumPipeline:
             return self._mock_analyze(name, lufs=-14.0, tinniness=tinniness)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -950,7 +985,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1021,7 +1056,7 @@ class TestMasterAlbumPipeline:
         }
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1056,7 +1091,7 @@ class TestMasterAlbumPipeline:
 
         def mock_master(input_path, output_path, **kwargs):
             captured_kwargs.append(kwargs)
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -13.0,
@@ -1093,7 +1128,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1153,7 +1188,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1192,7 +1227,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1237,7 +1272,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1306,7 +1341,7 @@ class TestMasterAlbumPipeline:
 
         def mock_master(input_path, output_path, **kwargs):
             captured_kwargs.append(kwargs)
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1335,7 +1370,7 @@ class TestMasterAlbumPipeline:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1642,7 +1677,7 @@ class TestMasterAlbumStaging:
             if call_count[0] >= 3:
                 raise RuntimeError("simulated mastering crash")
             # Write to the output path that was given (staging dir)
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1677,7 +1712,7 @@ class TestMasterAlbumStaging:
         mock_cache = MockStateCache(state)
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1720,7 +1755,7 @@ class TestMasterAlbumStaging:
         stale_file.write_bytes(b"stale")
 
         def mock_master(input_path, output_path, **kwargs):
-            Path(output_path).write_bytes(b"")
+            _write_tiny_stereo_wav(output_path)
             return {
                 "original_lufs": -20.0,
                 "final_lufs": -14.0,
@@ -1768,3 +1803,131 @@ class TestMasterAlbumStaging:
 
         staging_dir = audio_dir / ".mastering_staging"
         assert not staging_dir.exists(), ".mastering_staging was not cleaned up on silent-track failure"
+
+
+# =============================================================================
+# Tests for stage 5.5 — codec preview + mono fold-down (issue #296)
+# =============================================================================
+
+
+def _write_inverted_phase_wav(path) -> None:
+    """1-second 44.1k stereo where R = -L — guaranteed mono fold-down FAIL."""
+    import struct
+    rate = 44100
+    duration = 1.0
+    n_samples = int(rate * duration)
+    t = np.linspace(0, duration, n_samples, endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * 1000 * t)) * 32767
+    left = mono.astype(np.int16)
+    right = (-mono).astype(np.int16)
+    interleaved = np.column_stack([left, right]).flatten().tobytes()
+
+    n_channels, bits = 2, 16
+    byte_rate = rate * n_channels * bits // 8
+    block_align = n_channels * bits // 8
+    fmt = struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, n_channels, rate, byte_rate, block_align, bits)
+    data = struct.pack("<4sI", b"data", len(interleaved)) + interleaved
+    riff = struct.pack("<4sI4s", b"RIFF", 4 + len(fmt) + len(data), b"WAVE") + fmt + data
+    with open(str(path), "wb") as f:
+        f.write(riff)
+
+
+class TestMasterAlbumMasteringSamplesStage:
+    """Stage 5.5: codec preview and mono fold-down QC artifacts."""
+
+    def _make_audio_dir(self, tmp_path, num_tracks=2):
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        audio_dir.mkdir(parents=True)
+        for i in range(num_tracks):
+            (audio_dir / f"{i+1:02d}-track-{i+1}.wav").write_bytes(b"")
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        state["config"]["artist_name"] = "test-artist"
+        return audio_dir, state
+
+    def _mock_analyze(self, filename, lufs=-14.0, peak_db=-1.5):
+        return {
+            "filename": filename, "duration": 180.0, "sample_rate": 44100,
+            "lufs": lufs, "peak_db": peak_db, "rms_db": -18.0, "dynamic_range": 17.0,
+            "band_energy": {"sub_bass": 5, "bass": 20, "low_mid": 15,
+                            "mid": 30, "high_mid": 20, "high": 8, "air": 2},
+            "tinniness_ratio": 0.3,
+        }
+
+    def _mock_qc(self, filename):
+        return {
+            "filename": filename,
+            "checks": {
+                "format": {"status": "PASS", "value": "ok", "detail": "ok"},
+                "mono": {"status": "PASS", "value": "0", "detail": "ok"},
+            },
+            "verdict": "PASS",
+        }
+
+    def test_stage_runs_and_writes_to_mastering_samples_dir(self, tmp_path):
+        """In-phase mastered output → mastering_samples populated, mastered/ untouched."""
+        audio_dir, state = self._make_audio_dir(tmp_path, 2)
+        mock_cache = MockStateCache(state)
+
+        def mock_master(input_path, output_path, **kwargs):
+            _write_tiny_stereo_wav(output_path)
+            return {"original_lufs": -20.0, "final_lufs": -14.0,
+                    "gain_applied": 6.0, "final_peak": -1.5}
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \
+             patch("tools.mastering.master_tracks.load_genre_presets", return_value={}), \
+             patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
+             patch("tools.mastering.analyze_tracks.analyze_track",
+                   side_effect=lambda f: self._mock_analyze(Path(f).name)), \
+             patch("tools.mastering.qc_tracks.qc_track",
+                   side_effect=lambda f, c=None: self._mock_qc(Path(f).name)), \
+             patch.object(server, "write_state"):
+            result = json.loads(_run(server.master_album("test-album")))
+
+        assert result["failed_stage"] is None
+        assert "mastering_samples" in result["stages"]
+        samples_stage = result["stages"]["mastering_samples"]
+        assert samples_stage["status"] == "pass"
+        assert samples_stage["mono_fold"]["passed"] == 2
+        assert samples_stage["mono_fold"]["failed"] == 0
+
+        samples_dir = audio_dir / "mastering_samples"
+        assert (samples_dir / "01-track-1.MONO_FOLD.md").exists()
+        assert (samples_dir / "01-track-1.mono.wav").exists()
+
+        # mastered/ stays WAV-only
+        mastered_files = sorted(p.name for p in (audio_dir / "mastered").iterdir())
+        assert mastered_files == ["01-track-1.wav", "02-track-2.wav"]
+
+    def test_phase_inversion_short_circuits_pipeline_with_failed_stage(self, tmp_path):
+        """When mock_master writes inverted-phase audio, stage 5.5 hard-fails."""
+        audio_dir, state = self._make_audio_dir(tmp_path, 1)
+        mock_cache = MockStateCache(state)
+
+        def mock_master(input_path, output_path, **kwargs):
+            _write_inverted_phase_wav(output_path)
+            return {"original_lufs": -20.0, "final_lufs": -14.0,
+                    "gain_applied": 6.0, "final_peak": -1.5}
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \
+             patch("tools.mastering.master_tracks.load_genre_presets", return_value={}), \
+             patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
+             patch("tools.mastering.analyze_tracks.analyze_track",
+                   side_effect=lambda f: self._mock_analyze(Path(f).name)), \
+             patch("tools.mastering.qc_tracks.qc_track",
+                   side_effect=lambda f, c=None: self._mock_qc(Path(f).name)), \
+             patch.object(server, "write_state"):
+            result = json.loads(_run(server.master_album("test-album")))
+
+        assert result["failed_stage"] == "mastering_samples"
+        assert result["stage_reached"] == "mastering_samples"
+        # Post-QC and status_update should NOT have run
+        assert "post_qc" not in result["stages"]
+        assert "status_update" not in result["stages"]
+        # Failure detail surfaces the offending band
+        detail = result["failure_detail"]
+        assert "phase cancellation" in detail["reason"].lower()
+        assert "01-track-1.wav" in detail["tracks_failed"]
+        assert detail["details"][0]["worst_band"]["name"] is not None

--- a/tools/mastering/codec_preview.py
+++ b/tools/mastering/codec_preview.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Render a 128 kbps (configurable) AAC preview from a mastered WAV.
+
+The output `.aac.m4a` is for operator Bluetooth-path listening only — it is
+never uploaded to DistroKid. See issue #296.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class CodecPreviewError(RuntimeError):
+    """Raised when the codec preview cannot be produced."""
+
+
+def render_aac_preview(
+    input_wav: Path | str,
+    output_m4a: Path | str,
+    bitrate_kbps: int = 128,
+) -> dict[str, Any]:
+    """Encode a WAV to AAC/M4A at the given bitrate using ffmpeg.
+
+    Args:
+        input_wav: Path to a source WAV (typically from `mastered/`).
+        output_m4a: Destination `.aac.m4a` path. Parent directory is created.
+        bitrate_kbps: AAC bitrate in kbps. Must be > 0.
+
+    Returns:
+        Dict with output_path (str), bitrate_kbps (int), output_bytes (int).
+
+    Raises:
+        CodecPreviewError: on missing ffmpeg, missing input, invalid bitrate,
+            or a failed ffmpeg invocation.
+    """
+    if bitrate_kbps <= 0:
+        raise CodecPreviewError(f"Invalid bitrate {bitrate_kbps} — must be > 0 kbps")
+
+    in_path = Path(input_wav)
+    out_path = Path(output_m4a)
+
+    if not in_path.exists():
+        raise CodecPreviewError(f"Input WAV does not exist: {in_path}")
+
+    if shutil.which("ffmpeg") is None:
+        raise CodecPreviewError("ffmpeg not found on PATH — install it first")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-hide_banner",
+        "-loglevel", "error",
+        "-i", str(in_path),
+        "-c:a", "aac",
+        "-b:a", f"{bitrate_kbps}k",
+        str(out_path),
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0 or not out_path.exists():
+        raise CodecPreviewError(
+            f"ffmpeg failed encoding {in_path.name}: {result.stderr.strip()}"
+        )
+
+    return {
+        "output_path": str(out_path),
+        "bitrate_kbps": int(bitrate_kbps),
+        "output_bytes": out_path.stat().st_size,
+    }

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -52,6 +52,21 @@
 #                            sharp transients (e.g., 8.0–10.0 for electronic/IDM/metal).
 #   click_fail_count       - QC click detector: absolute click count above which clicks FAIL
 #                            (default 3). Raise alongside peak_ratio for dense-transient genres.
+#   codec_preview_enabled  - Render a 128 kbps AAC .aac.m4a next to each master in
+#                            mastering_samples/ for operator Bluetooth audition (issue #296).
+#                            1 = on (default), 0 = off.
+#   codec_preview_bitrate_kbps - AAC bitrate for the preview (default 128).
+#   mono_fold_enabled      - Run the mono fold-down QC gate during mastering (issue #296).
+#                            Writes {track}.MONO_FOLD.md + {track}.mono.wav sample to
+#                            mastering_samples/. 1 = on (default), 0 = off.
+#   mono_fold_write_audio  - Write the .mono.wav sample alongside the report (1 = on,
+#                            default). Set to 0 for report-only.
+#   mono_fold_band_drop_fail_db - Hard-fail threshold for per-band drop (stereo vs. mono)
+#                            in dB. Default 6.0 — raise to 8–10 for ambient/cinematic
+#                            genres that intentionally use wide-stereo cancellation.
+#   mono_fold_lufs_warn_db - Warn threshold for integrated LUFS delta (default 3.0 dB).
+#   mono_fold_vocal_warn_db - Warn threshold for vocal-band (1–4 kHz) RMS delta (default 2.0 dB).
+#   mono_fold_correlation_warn - Warn threshold for stereo correlation coefficient (default 0.3).
 #
 # Override per-user: copy to {overrides}/mastering-presets.yaml and edit.
 # User overrides merge on top of these defaults (genre-level).
@@ -107,6 +122,14 @@ defaults:
   eq_linear_phase: 0
   click_peak_ratio: 6.0
   click_fail_count: 3
+  codec_preview_enabled: 1
+  codec_preview_bitrate_kbps: 128
+  mono_fold_enabled: 1
+  mono_fold_write_audio: 1
+  mono_fold_band_drop_fail_db: 6.0
+  mono_fold_lufs_warn_db: 3.0
+  mono_fold_vocal_warn_db: 2.0
+  mono_fold_correlation_warn: 0.3
 
 genres:
   # === Pop / Mainstream ===

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -126,6 +126,15 @@ _PRESET_DEFAULTS: dict[str, float] = {
     # QC thresholds (consumed by tools/mastering/qc_tracks.py)
     'click_peak_ratio': 6.0,
     'click_fail_count': 3,
+    # Mastering-samples QC artifacts (issue #296, consumed by handlers/processing/audio.py)
+    'codec_preview_enabled': 1,
+    'codec_preview_bitrate_kbps': 128,
+    'mono_fold_enabled': 1,
+    'mono_fold_write_audio': 1,
+    'mono_fold_band_drop_fail_db': 6.0,
+    'mono_fold_lufs_warn_db': 3.0,
+    'mono_fold_vocal_warn_db': 2.0,
+    'mono_fold_correlation_warn': 0.3,
 }
 
 

--- a/tools/mastering/mono_fold.py
+++ b/tools/mastering/mono_fold.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Mono fold-down QC analysis — sum stereo to mono, measure per-band deltas.
+
+Used to surface phase-cancellation and phantom-center issues that the full
+stereo master hides but a mono playback (phone speaker, Echo, club mono sum)
+exposes. See issue #296.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pyloudnorm as pyln
+from scipy import signal
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+logger = logging.getLogger(__name__)
+
+
+# Frequency bands — identical layout to tools/mastering/analyze_tracks.py so
+# operators comparing reports aren't surprised by band boundaries.
+FREQUENCY_BANDS: dict[str, tuple[float, float]] = {
+    "sub_bass": (20.0, 60.0),
+    "bass": (60.0, 250.0),
+    "low_mid": (250.0, 500.0),
+    "mid": (500.0, 2000.0),
+    "high_mid": (2000.0, 6000.0),
+    "high": (6000.0, 12000.0),
+    "air": (12000.0, 20000.0),
+}
+
+VOCAL_BAND_HZ: tuple[float, float] = (1000.0, 4000.0)
+
+# Bands with energy below this (relative to total) are ignored for band-drop
+# checks — silence-fold artifacts shouldn't trigger a FAIL.
+_BAND_MIN_PRESENT_DB = -60.0
+
+DEFAULT_THRESHOLDS: dict[str, float] = {
+    "band_drop_fail_db": 6.0,
+    "lufs_warn_db": 3.0,
+    "vocal_warn_db": 2.0,
+    "correlation_warn": 0.3,
+}
+
+
+def fold_to_mono(data: np.ndarray) -> np.ndarray:
+    """Downmix stereo to mono via simple mean — codebase convention.
+
+    A 1-D input is returned unchanged.
+    """
+    if data.ndim == 1:
+        return data
+    return np.mean(data, axis=1)
+
+
+def _ensure_stereo(data: np.ndarray) -> np.ndarray:
+    if data.ndim == 1:
+        return np.column_stack([data, data])
+    return data
+
+
+def _integrated_lufs(samples: np.ndarray, rate: int) -> float | None:
+    stereo = _ensure_stereo(samples)
+    meter = pyln.Meter(rate)
+    try:
+        lufs = meter.integrated_loudness(stereo)
+    except ValueError:
+        return None  # audio shorter than the analysis block — treat as unmeasurable
+    return float(lufs) if np.isfinite(lufs) else None
+
+
+def _band_energy_db(samples: np.ndarray, rate: int) -> dict[str, float]:
+    """Return per-band energy in dB. Silent bands are -inf."""
+    if np.max(np.abs(samples)) < 1e-12:
+        return {name: float("-inf") for name in FREQUENCY_BANDS}
+    freqs, psd = signal.welch(samples, rate, nperseg=8192)
+    out: dict[str, float] = {}
+    for name, (low, high) in FREQUENCY_BANDS.items():
+        mask = (freqs >= low) & (freqs < high)
+        energy = float(np.sum(psd[mask]))
+        out[name] = 10 * np.log10(energy) if energy > 0 else float("-inf")
+    return out
+
+
+def _bandlimited_rms_db(samples: np.ndarray, rate: int, low_hz: float, high_hz: float) -> float:
+    if np.max(np.abs(samples)) < 1e-12:
+        return float("-inf")
+    freqs, psd = signal.welch(samples, rate, nperseg=8192)
+    mask = (freqs >= low_hz) & (freqs < high_hz)
+    energy = float(np.sum(psd[mask]))
+    return 10 * np.log10(energy) if energy > 0 else float("-inf")
+
+
+def _average_channel_band_energy(data: np.ndarray, rate: int) -> dict[str, float]:
+    """For stereo input, average per-band energy across channels (in linear domain)."""
+    if data.ndim < 2:
+        return _band_energy_db(data, rate)
+    per_ch = [_band_energy_db(data[:, ch], rate) for ch in range(data.shape[1])]
+    out: dict[str, float] = {}
+    for name in FREQUENCY_BANDS:
+        linear_vals = [10 ** (p[name] / 10) for p in per_ch if np.isfinite(p[name])]
+        if linear_vals:
+            out[name] = 10 * np.log10(float(np.mean(linear_vals)))
+        else:
+            out[name] = float("-inf")
+    return out
+
+
+def _average_channel_bandlimited_rms_db(
+    data: np.ndarray, rate: int, low_hz: float, high_hz: float
+) -> float:
+    if data.ndim < 2:
+        return _bandlimited_rms_db(data, rate, low_hz, high_hz)
+    per_ch = [_bandlimited_rms_db(data[:, ch], rate, low_hz, high_hz) for ch in range(data.shape[1])]
+    linear_vals = [10 ** (d / 10) for d in per_ch if np.isfinite(d)]
+    if not linear_vals:
+        return float("-inf")
+    return float(10 * np.log10(float(np.mean(linear_vals))))
+
+
+def _stereo_correlation(data: np.ndarray) -> float:
+    if data.ndim < 2 or data.shape[1] < 2:
+        return 1.0
+    left = data[:, 0]
+    right = data[:, 1]
+    if np.std(left) < 1e-12 or np.std(right) < 1e-12:
+        return 1.0
+    corr = np.corrcoef(left, right)[0, 1]
+    return float(corr) if np.isfinite(corr) else 0.0
+
+
+def mono_fold_metrics(
+    data: np.ndarray,
+    rate: int,
+    thresholds: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Measure mono fold-down deltas.
+
+    Args:
+        data: Audio samples. Stereo (N, 2) or mono (N,).
+        rate: Sample rate in Hz.
+        thresholds: Optional override for DEFAULT_THRESHOLDS.
+
+    Returns:
+        Dict with mono_audio, lufs, vocal_rms, band_deltas, stereo_correlation,
+        worst_band, band_drop_fail, verdict, thresholds.
+    """
+    active = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
+
+    mono = fold_to_mono(data)
+
+    stereo_lufs = _integrated_lufs(data, rate)
+    mono_lufs = _integrated_lufs(mono, rate)
+    lufs_delta: float | None
+    if stereo_lufs is not None and mono_lufs is not None:
+        lufs_delta = mono_lufs - stereo_lufs
+    else:
+        lufs_delta = None
+
+    stereo_vocal_db = _average_channel_bandlimited_rms_db(data, rate, *VOCAL_BAND_HZ)
+    mono_vocal_db = _bandlimited_rms_db(mono, rate, *VOCAL_BAND_HZ)
+    vocal_delta: float | None
+    if np.isfinite(stereo_vocal_db) and np.isfinite(mono_vocal_db):
+        vocal_delta = float(mono_vocal_db - stereo_vocal_db)
+    else:
+        vocal_delta = None
+
+    stereo_bands = _average_channel_band_energy(data, rate)
+    mono_bands = _band_energy_db(mono, rate)
+
+    band_deltas: dict[str, dict[str, Any]] = {}
+    worst = {"name": None, "delta_db": 0.0}
+    any_hard_fail = False
+
+    # When the mono fold is silent in a band but stereo had real energy, report
+    # the drop bounded to the 16-bit noise floor — below this nothing is audible,
+    # and it keeps JSON/markdown finite. A caller can still suppress the fail
+    # with a threshold wider than this bound.
+    _CANCEL_DROP_DB = -96.0
+
+    for name, (hz_low, hz_high) in FREQUENCY_BANDS.items():
+        s = stereo_bands[name]
+        m = mono_bands[name]
+        stereo_present = np.isfinite(s) and s > _BAND_MIN_PRESENT_DB
+        if np.isfinite(s) and np.isfinite(m):
+            delta = float(m - s)
+        elif stereo_present and not np.isfinite(m):
+            delta = _CANCEL_DROP_DB
+        else:
+            delta = 0.0
+
+        band_deltas[name] = {
+            "delta_db": delta,
+            "hz_low": hz_low,
+            "hz_high": hz_high,
+            "stereo_db": float(s) if np.isfinite(s) else None,
+            "mono_db": float(m) if np.isfinite(m) else None,
+        }
+
+        if stereo_present:
+            if delta < worst["delta_db"]:
+                worst = {"name": name, "delta_db": delta}
+            if delta < -active["band_drop_fail_db"]:
+                any_hard_fail = True
+
+    corr = _stereo_correlation(data)
+
+    verdict = "PASS"
+    if any_hard_fail:
+        verdict = "FAIL"
+    else:
+        if lufs_delta is not None and abs(lufs_delta) > active["lufs_warn_db"]:
+            verdict = "WARN"
+        if vocal_delta is not None and abs(vocal_delta) > active["vocal_warn_db"]:
+            verdict = "WARN"
+        if corr < active["correlation_warn"]:
+            verdict = "WARN"
+
+    return {
+        "mono_audio": mono,
+        "lufs": {
+            "stereo": stereo_lufs,
+            "mono": mono_lufs,
+            "delta_db": lufs_delta,
+        },
+        "vocal_rms": {
+            "stereo_db": float(stereo_vocal_db) if np.isfinite(stereo_vocal_db) else None,
+            "mono_db": float(mono_vocal_db) if np.isfinite(mono_vocal_db) else None,
+            "delta_db": vocal_delta,
+        },
+        "band_deltas": band_deltas,
+        "stereo_correlation": corr,
+        "worst_band": worst,
+        "band_drop_fail": any_hard_fail,
+        "verdict": verdict,
+        "thresholds": active,
+    }

--- a/tools/mastering/mono_fold.py
+++ b/tools/mastering/mono_fold.py
@@ -56,7 +56,7 @@ def fold_to_mono(data: np.ndarray) -> np.ndarray:
     """
     if data.ndim == 1:
         return data
-    return np.mean(data, axis=1)
+    return np.asarray(np.mean(data, axis=1))
 
 
 def _ensure_stereo(data: np.ndarray) -> np.ndarray:
@@ -175,7 +175,7 @@ def mono_fold_metrics(
     mono_bands = _band_energy_db(mono, rate)
 
     band_deltas: dict[str, dict[str, Any]] = {}
-    worst = {"name": None, "delta_db": 0.0}
+    worst: dict[str, Any] = {"name": None, "delta_db": 0.0}
     any_hard_fail = False
 
     # When the mono fold is silent in a band but stereo had real energy, report

--- a/tools/mastering/mono_fold_report.py
+++ b/tools/mastering/mono_fold_report.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Render a MONO_FOLD.md markdown report from mono_fold_metrics() output."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+_BAND_ORDER = ("sub_bass", "bass", "low_mid", "mid", "high_mid", "high", "air")
+
+
+def _verdict_badge(verdict: str) -> str:
+    return {
+        "PASS": "PASS",
+        "WARN": "WARN",
+        "FAIL": "FAIL",
+    }.get(verdict, verdict)
+
+
+def _fmt_db(value: float | None, digits: int = 1) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.{digits}f}"
+
+
+def _band_status(delta_db: float | None, band_fail_db: float) -> str:
+    if delta_db is None:
+        return "—"
+    if delta_db <= -band_fail_db:
+        return "FAIL"
+    if delta_db <= -(band_fail_db / 2.0):
+        return "WARN"
+    return "PASS"
+
+
+def render_mono_fold_markdown(
+    track_name: str,
+    metrics: dict[str, Any],
+    sample_filename: str | None,
+) -> str:
+    """Produce the MONO_FOLD.md content for a single track.
+
+    Args:
+        track_name: Stem/slug of the track (e.g., "01-opening").
+        metrics: The dict returned by mono_fold_metrics().
+        sample_filename: Filename of the `.mono.wav` sibling sample, or None
+            if the audio sample was not written.
+
+    Returns:
+        Markdown string (no trailing newline guaranteed).
+    """
+    verdict = metrics.get("verdict", "PASS")
+    badge = _verdict_badge(verdict)
+    thresholds = metrics.get("thresholds", {})
+    band_fail_db = float(thresholds.get("band_drop_fail_db", 6.0))
+    lufs_warn = float(thresholds.get("lufs_warn_db", 3.0))
+    vocal_warn = float(thresholds.get("vocal_warn_db", 2.0))
+    corr_warn = float(thresholds.get("correlation_warn", 0.3))
+
+    lufs = metrics.get("lufs", {})
+    vocal = metrics.get("vocal_rms", {})
+    corr = metrics.get("stereo_correlation")
+    worst = metrics.get("worst_band", {}) or {}
+
+    lines: list[str] = []
+    lines.append(f"# Mono Fold-Down Report — {track_name}")
+    lines.append("")
+    lines.append(f"**Generated**: {datetime.now(timezone.utc).isoformat(timespec='seconds')}")
+    lines.append(f"**Source**: `mastered/{track_name}.wav`")
+    lines.append(f"**Verdict**: {badge} ({verdict})")
+    lines.append("")
+
+    # Summary deltas
+    lines.append("## Deltas (mono − stereo)")
+    lines.append("")
+    lines.append("| Metric | Stereo | Mono | Delta | Threshold | Status |")
+    lines.append("|---|---|---|---|---|---|")
+
+    lufs_delta = lufs.get("delta_db")
+    lufs_status = (
+        "PASS" if lufs_delta is None or abs(lufs_delta) <= lufs_warn else "WARN"
+    )
+    lines.append(
+        f"| Integrated LUFS | {_fmt_db(lufs.get('stereo'))} LU | "
+        f"{_fmt_db(lufs.get('mono'))} LU | {_fmt_db(lufs_delta)} dB | "
+        f"warn ±{lufs_warn:.1f} dB | {lufs_status} |"
+    )
+
+    vocal_delta = vocal.get("delta_db")
+    vocal_status = (
+        "PASS" if vocal_delta is None or abs(vocal_delta) <= vocal_warn else "WARN"
+    )
+    lines.append(
+        f"| Vocal RMS (1–4 kHz) | {_fmt_db(vocal.get('stereo_db'))} dB | "
+        f"{_fmt_db(vocal.get('mono_db'))} dB | {_fmt_db(vocal_delta)} dB | "
+        f"warn ±{vocal_warn:.1f} dB | {vocal_status} |"
+    )
+
+    corr_status = (
+        "PASS" if corr is None or corr >= corr_warn else "WARN"
+    )
+    corr_str = _fmt_db(corr, digits=2) if corr is not None else "—"
+    lines.append(
+        f"| Stereo correlation | {corr_str} | — | — | warn <{corr_warn:.2f} | {corr_status} |"
+    )
+    lines.append("")
+
+    # Per-band table
+    lines.append("## Per-band deltas")
+    lines.append("")
+    lines.append(
+        f"Threshold: any band drop > **{band_fail_db:.1f} dB** → hard FAIL."
+    )
+    lines.append("")
+    lines.append("| Band | Hz range | Stereo dB | Mono dB | Delta dB | Status |")
+    lines.append("|---|---|---|---|---|---|")
+    band_deltas = metrics.get("band_deltas", {})
+    for band in _BAND_ORDER:
+        entry = band_deltas.get(band)
+        if not entry:
+            continue
+        delta = entry.get("delta_db")
+        status = _band_status(delta, band_fail_db)
+        hz_low = entry.get("hz_low", 0.0)
+        hz_high = entry.get("hz_high", 0.0)
+        lines.append(
+            f"| `{band}` | {hz_low:.0f}–{hz_high:.0f} | "
+            f"{_fmt_db(entry.get('stereo_db'))} | {_fmt_db(entry.get('mono_db'))} | "
+            f"{_fmt_db(delta)} | {status} |"
+        )
+    lines.append("")
+
+    # Worst band / fail call-out
+    if metrics.get("band_drop_fail"):
+        worst_name = worst.get("name") or "unknown"
+        worst_delta = worst.get("delta_db")
+        worst_entry = band_deltas.get(worst_name, {})
+        hz_low = worst_entry.get("hz_low", 0.0)
+        hz_high = worst_entry.get("hz_high", 0.0)
+        lines.append("## Phase cancellation detected")
+        lines.append("")
+        lines.append(
+            f"Band `{worst_name}` ({hz_low:.0f}–{hz_high:.0f} Hz) dropped "
+            f"{_fmt_db(worst_delta)} dB when folded to mono — above the "
+            f"{band_fail_db:.1f} dB hard-fail threshold. Listen to the "
+            f".mono sample on a phone speaker or Echo to confirm which "
+            f"elements disappear."
+        )
+        lines.append("")
+
+    # Notes
+    lines.append("## Notes")
+    lines.append("")
+    if sample_filename:
+        lines.append(f"- Audio sample: `{sample_filename}`")
+    lines.append("- Audition on a phone speaker, single Echo, or a club mono sum.")
+    lines.append("- This file is QC-only — not uploaded to streaming platforms.")
+
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- New sibling `mastering_samples/` directory keeps `mastered/` byte-identical to the streaming upload while collecting operator-listening QC artifacts: a 128 kbps `.aac.m4a` (Bluetooth audition), a `.mono.wav` mono fold-down sample, and a `.MONO_FOLD.md` per-band delta report.
- Mono fold-down is a hard-fail QC gate: any band drop > 6 dB short-circuits the pipeline with the offending frequency surfaced (phase cancellation guard). Codec preview never blocks.
- Two new standalone MCP tools (`render_codec_preview`, `mono_fold_check`) plus integration as stage 5.5 in `master_album` between verification and post-QC. All thresholds configurable via `genre-presets.yaml` defaults; user overrides honored. `reset_mastering` accepts `mastering_samples`.

Closes #296.

## Layout
```
{audio_root}/.../[album]/
├── mastered/                         # Final masters — UPLOAD THIS (WAV-only)
│   ├── 01-track.wav
│   └── ...
└── mastering_samples/                # Operator QA — DO NOT UPLOAD
    ├── 01-track.aac.m4a              # 128 kbps AAC (Bluetooth path)
    ├── 01-track.mono.wav             # Mono fold-down sample
    └── 01-track.MONO_FOLD.md         # Per-band deltas + verdict
```

## Test plan
- [x] 30 new unit tests across `tools/mastering/mono_fold.py`, `codec_preview.py`, `mono_fold_report.py`, the two new MCP tools, and the pipeline stage (in-phase PASS + phase-inversion short-circuit)
- [x] Full unit suite: 3116 passed, 2 xfailed
- [x] Plugin suite: 245 passed
- [ ] Manual: run `master_album` on a real album, verify `mastered/` stays WAV-only and `mastering_samples/` has the three artifact types per track
- [ ] Manual: AirPods-over-Bluetooth playback of an `.aac.m4a` to confirm the audition workflow
- [ ] Manual: phone-speaker playback of a `.mono.wav` to confirm cancellation surfacing
- [ ] Manual: synthetic phase-cancellation track (R = -L) hard-fails with the offending band in the error

🤖 Generated with [Claude Code](https://claude.com/claude-code)