### PR TITLE
feat: multi-metric signature foundation (#290 phase 1b)

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -792,6 +792,11 @@ sheet_music:
 #   #   48000 — broadcast standard; still below Apple Hi-Res threshold.
 #   #   96000 — unlocks Apple Hi-Res Lossless + Tidal Max badges.
 #   #
+#   # Disk-usage note: at 24-bit / 96 kHz, mastered WAVs are roughly
+#   # ~33 MB per stereo minute (vs. ~10 MB at 44.1 kHz). A 12-track
+#   # album averages ~1.5 GB of mastered/ output before archival; enable
+#   # archival only when you have headroom for an extra ~3x of that.
+#   #
 #   # delivery_sample_rate: 96000
 #
 #   # ---------------------------

--- a/docs/superpowers/plans/2026-04-13-phase-1b-multi-metric-signature.md
+++ b/docs/superpowers/plans/2026-04-13-phase-1b-multi-metric-signature.md
@@ -1,0 +1,1136 @@
+# Phase 1b — Multi-Metric Signature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `analyze_track()` with three signature metrics — STL-95, low-RMS (STL-95-windowed, 20–200 Hz), and vocal-RMS (polished stem when present, 1–4 kHz band fallback) — plus a `signature_meta` provenance dict, as the input for Phase 2 anchor selection and coherence checking.
+
+**Architecture:** Additive extension of `tools/mastering/analyze_tracks.py`. Reuses the existing short-term LUFS loop; adds Butterworth bandpass helpers for low-RMS and vocal-band fallback; adds stem auto-resolve walking one directory up from the input. No pipeline stages change; MCP handler unchanged (new fields flow through existing JSON serialization). No consumers wired in this phase.
+
+**Tech Stack:** Python 3.11, `numpy`, `scipy.signal` (already imported), `pyloudnorm`, `soundfile` — all existing deps. Tests use `pytest` + `tmp_path` fixtures, modeled on `tests/unit/mastering/test_analyze_tracks.py`.
+
+---
+
+## File Structure
+
+**Create:**
+- `tests/unit/mastering/test_signature_metrics.py` — unit tests for STL-95, low-RMS, vocal-RMS (stem + fallback + auto-resolve).
+
+**Modify:**
+- `tools/mastering/analyze_tracks.py` — extend `analyze_track()`; add three private helpers (`_bandpass_sos`, `_read_vocal_stem`, `_auto_resolve_vocal_stem`).
+- `config/config.example.yaml` — fold in E2 review item: disk-usage note on `delivery_sample_rate` comment.
+
+**Not modified:**
+- `servers/bitwize-music-server/handlers/processing/audio.py` — handler picks up new fields through existing serialization; no code changes.
+
+**Module responsibilities:**
+- `analyze_tracks.py` owns signal math and stem resolution. Pure Python; no MCP coupling.
+- Helpers stay private (underscore prefix) — they are implementation details of `analyze_track()`.
+
+---
+
+## Task 1: STL-95 — collect ST-LUFS values and compute 95th percentile
+
+**Files:**
+- Create: `tests/unit/mastering/test_signature_metrics.py`
+- Modify: `tools/mastering/analyze_tracks.py`
+
+- [ ] **Step 1: Write the failing test for constant-level STL-95**
+
+Create `tests/unit/mastering/test_signature_metrics.py` with shared fixtures and the first test:
+
+```python
+#!/usr/bin/env python3
+"""Unit tests for Phase 1b signature metrics (STL-95, low-RMS, vocal-RMS)."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.analyze_tracks import analyze_track
+
+
+def _write_wav(path, data, rate):
+    sf.write(str(path), data, rate, subtype='PCM_16')
+
+
+def _sine(freq, duration, rate, amplitude):
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    return (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+@pytest.fixture
+def long_constant_wav(tmp_path):
+    """60 s constant-level stereo sine at ~-14 LUFS."""
+    rate = 48000
+    mono = _sine(440, duration=60.0, rate=rate, amplitude=0.3)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "constant.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
+class TestShortTerm95:
+    def test_constant_level_stl_95_close_to_lufs(self, long_constant_wav):
+        result = analyze_track(long_constant_wav)
+        assert result['stl_95'] is not None
+        assert abs(result['stl_95'] - result['lufs']) < 1.5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestShortTerm95::test_constant_level_stl_95_close_to_lufs -v
+```
+Expected: FAIL with `KeyError: 'stl_95'`.
+
+- [ ] **Step 3: Implement STL-95 in analyze_track()**
+
+Modify `tools/mastering/analyze_tracks.py`. Replace the short-term loop block (lines ~82–109) and the return dict:
+
+```python
+    # Short-term and momentary loudness dynamics
+    max_short_term = float('-inf')
+    min_short_term = float('inf')
+    max_momentary = float('-inf')
+    st_values: list[float] = []
+
+    # Short-term: 3s window, 1s hop (EBU R128)
+    st_window = int(3.0 * rate)
+    st_hop = int(1.0 * rate)
+    if data.shape[0] > st_window:
+        for start in range(0, data.shape[0] - st_window, st_hop):
+            chunk = data[start:start + st_window]
+            st_lufs = pyln.Meter(rate).integrated_loudness(chunk)
+            if np.isfinite(st_lufs):
+                st_values.append(float(st_lufs))
+                max_short_term = max(max_short_term, st_lufs)
+                min_short_term = min(min_short_term, st_lufs)
+
+    # STL-95: 95th percentile of finite short-term LUFS.
+    # Gated to ≥20 windows (~23s audio) so the percentile has a meaningful
+    # spread; below that it collapses to near-max.
+    stl_95: float | None
+    stl_top_5pct_indices: np.ndarray
+    if len(st_values) >= 20:
+        stl_array = np.asarray(st_values, dtype=np.float64)
+        stl_95 = float(np.percentile(stl_array, 95))
+        top_k = max(1, int(round(0.05 * len(st_values))))
+        # Stable sort on -value: ties resolve to earliest window first.
+        order = np.argsort(-stl_array, kind='stable')
+        stl_top_5pct_indices = order[:top_k]
+    else:
+        stl_95 = None
+        stl_top_5pct_indices = np.array([], dtype=np.int64)
+
+    # Momentary: 400ms window, 100ms hop
+    mom_window = int(0.4 * rate)
+    mom_hop = int(0.1 * rate)
+    if data.shape[0] > mom_window:
+        for start in range(0, data.shape[0] - mom_window, mom_hop):
+            chunk = data[start:start + mom_window]
+            mom_lufs = pyln.Meter(rate).integrated_loudness(chunk)
+            if np.isfinite(mom_lufs):
+                max_momentary = max(max_momentary, mom_lufs)
+
+    short_term_range = (max_short_term - min_short_term
+                        if np.isfinite(max_short_term) and np.isfinite(min_short_term)
+                        else 0.0)
+
+    return {
+        'filename': os.path.basename(filepath),
+        'duration': len(mono) / rate,
+        'sample_rate': rate,
+        'lufs': loudness,
+        'peak_db': peak_db,
+        'rms_db': rms_db,
+        'dynamic_range': dynamic_range,
+        'band_energy': band_energy,
+        'tinniness_ratio': tinniness_ratio,
+        'max_short_term_lufs': max_short_term if np.isfinite(max_short_term) else None,
+        'max_momentary_lufs': max_momentary if np.isfinite(max_momentary) else None,
+        'short_term_range': short_term_range,
+        'stl_95': stl_95,
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestShortTerm95::test_constant_level_stl_95_close_to_lufs -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add test for chorus/verse pattern — STL-95 > integrated LUFS**
+
+Add this fixture and test class method:
+
+```python
+@pytest.fixture
+def chorus_verse_wav(tmp_path):
+    """60 s pattern: 3 s loud chorus, 5 s quiet verse, repeating."""
+    rate = 48000
+    duration = 60.0
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    # Constant sine, then modulate amplitude with a chorus-pattern envelope.
+    base = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    envelope = np.zeros_like(t, dtype=np.float32)
+    period = 8.0  # 3s loud + 5s quiet
+    for i in range(int(duration / period) + 1):
+        loud_start = i * period
+        loud_end = loud_start + 3.0
+        mask = (t >= loud_start) & (t < loud_end)
+        envelope[mask] = 0.6
+        quiet_mask = (t >= loud_end) & (t < loud_start + period)
+        envelope[quiet_mask] = 0.05
+    mono = (base * envelope).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "chorus_verse.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+```
+
+Append inside `class TestShortTerm95:`
+
+```python
+    def test_chorus_verse_stl_95_above_integrated(self, chorus_verse_wav):
+        result = analyze_track(chorus_verse_wav)
+        assert result['stl_95'] is not None
+        assert result['stl_95'] > result['lufs'] + 2.0
+```
+
+- [ ] **Step 6: Run and verify it passes**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestShortTerm95 -v
+```
+Expected: both tests PASS.
+
+- [ ] **Step 7: Add test for short-track gating (< 20 windows → None)**
+
+Add fixture and test:
+
+```python
+@pytest.fixture
+def short_wav(tmp_path):
+    """10 s sine — too short for STL-95 (< 20 ST windows)."""
+    rate = 48000
+    mono = _sine(440, duration=10.0, rate=rate, amplitude=0.3)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "short.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+```
+
+Append in `TestShortTerm95`:
+
+```python
+    def test_short_track_stl_95_is_none(self, short_wav):
+        result = analyze_track(short_wav)
+        assert result['stl_95'] is None
+```
+
+- [ ] **Step 8: Run and verify it passes**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestShortTerm95 -v
+```
+Expected: three tests PASS.
+
+- [ ] **Step 9: Add test for silent track**
+
+```python
+@pytest.fixture
+def silent_60_wav(tmp_path):
+    """60 s of silence."""
+    rate = 48000
+    stereo = np.zeros((int(rate * 60.0), 2), dtype=np.float32)
+    path = tmp_path / "silent_60.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+```
+
+In `TestShortTerm95`:
+
+```python
+    def test_silent_track_stl_95_is_none(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['stl_95'] is None
+```
+
+- [ ] **Step 10: Run and verify**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestShortTerm95 -v
+```
+Expected: four tests PASS.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add tools/mastering/analyze_tracks.py tests/unit/mastering/test_signature_metrics.py
+git commit -m "$(cat <<'EOF'
+feat(mastering): add STL-95 signature metric to analyze_track
+
+Collects short-term LUFS values from the existing 3s/1s loop,
+computes the 95th percentile when at least 20 windows exist, and
+retains the top-5% window indices for downstream low-RMS windowing.
+Returns None for tracks too short or silent to produce a meaningful
+percentile.
+
+Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: low-RMS — bandpass 20–200 Hz, measured within STL-95 windows
+
+**Files:**
+- Modify: `tools/mastering/analyze_tracks.py`
+- Modify: `tests/unit/mastering/test_signature_metrics.py`
+
+- [ ] **Step 1: Write failing test for bass-heavy chorus pattern**
+
+Add fixture + test class:
+
+```python
+@pytest.fixture
+def bass_chorus_verse_wav(tmp_path):
+    """60 s: loud bass chorus (3s, 80 Hz at -6 dBFS) + near-silent verse (5s)."""
+    rate = 48000
+    duration = 60.0
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    bass = np.sin(2 * np.pi * 80 * t).astype(np.float32)
+    envelope = np.zeros_like(t, dtype=np.float32)
+    period = 8.0
+    for i in range(int(duration / period) + 1):
+        loud_start = i * period
+        loud_end = loud_start + 3.0
+        mask = (t >= loud_start) & (t < loud_end)
+        envelope[mask] = 0.5
+        quiet_mask = (t >= loud_end) & (t < loud_start + period)
+        envelope[quiet_mask] = 0.001
+    mono = (bass * envelope).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "bass_chorus_verse.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
+class TestLowRms:
+    def test_bass_chorus_low_rms_reflects_loud_windows(self, bass_chorus_verse_wav):
+        result = analyze_track(bass_chorus_verse_wav)
+        assert result['low_rms'] is not None
+        # Chorus at 0.5 amplitude for 80 Hz → RMS ≈ -9 dB; windowed on loud
+        # choruses should report much louder than if whole-track averaged
+        # with the near-silent verses.
+        assert result['low_rms'] > -20.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestLowRms -v
+```
+Expected: FAIL with `KeyError: 'low_rms'`.
+
+- [ ] **Step 3: Add `_bandpass_sos` helper and low-RMS computation**
+
+In `tools/mastering/analyze_tracks.py`, add the helper above `analyze_track`:
+
+```python
+def _bandpass_sos(data: np.ndarray, rate: int, low_hz: float, high_hz: float,
+                  order: int = 4) -> np.ndarray:
+    """Zero-phase Butterworth bandpass via SOS form (numerically stable)."""
+    nyquist = rate / 2
+    low = max(low_hz, 1.0) / nyquist
+    high = min(high_hz, nyquist - 1.0) / nyquist
+    sos = signal.butter(order, [low, high], btype='bandpass', output='sos')
+    return signal.sosfiltfilt(sos, data)
+
+
+def _rms_db(samples: np.ndarray) -> float:
+    rms = float(np.sqrt(np.mean(samples ** 2)))
+    return 20.0 * np.log10(rms) if rms > 0 else float('-inf')
+```
+
+In `analyze_track`, after the STL-95 block but before the momentary loop, add:
+
+```python
+    # low-RMS: 20-200 Hz band, measured within top-5% STL windows only.
+    # Whole-track measurement false-alarms on arrangements with quiet verses
+    # and wall-of-bass choruses (see #290 spec footnote †).
+    low_rms: float | None
+    if stl_95 is not None and len(stl_top_5pct_indices) > 0:
+        low_filtered = _bandpass_sos(mono, rate, 20.0, 200.0)
+        window_rms_values: list[float] = []
+        for window_idx in stl_top_5pct_indices:
+            start = int(window_idx) * st_hop
+            end = start + st_window
+            chunk = low_filtered[start:end]
+            rms_val = _rms_db(chunk)
+            if np.isfinite(rms_val):
+                window_rms_values.append(rms_val)
+        low_rms = float(np.median(window_rms_values)) if window_rms_values else None
+    else:
+        low_rms = None
+```
+
+Add `low_rms` to the return dict:
+
+```python
+        'stl_95': stl_95,
+        'low_rms': low_rms,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestLowRms -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add test for short-track and silent-track gating**
+
+In `TestLowRms`:
+
+```python
+    def test_short_track_low_rms_is_none(self, short_wav):
+        result = analyze_track(short_wav)
+        assert result['low_rms'] is None
+
+    def test_silent_track_low_rms_is_none(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['low_rms'] is None
+```
+
+- [ ] **Step 6: Run and verify**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestLowRms -v
+```
+Expected: three tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/mastering/analyze_tracks.py tests/unit/mastering/test_signature_metrics.py
+git commit -m "$(cat <<'EOF'
+feat(mastering): add low-RMS signature metric (20-200 Hz, windowed)
+
+Bandpasses the mono mixdown at 20-200 Hz (4th-order Butterworth SOS,
+zero-phase via sosfiltfilt) and takes the median RMS across the
+top-5% STL windows identified by STL-95. Whole-track low-RMS would
+false-alarm on arrangements with sparse verses and wall-of-bass
+choruses; windowing keeps the metric faithful to what listeners
+perceive as the track's low-end signature.
+
+Returns None when STL-95 is None (track too short or silent).
+
+Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: vocal-RMS — explicit stem path (stem branch)
+
+**Files:**
+- Modify: `tools/mastering/analyze_tracks.py`
+- Modify: `tests/unit/mastering/test_signature_metrics.py`
+
+- [ ] **Step 1: Write failing test for explicit stem path**
+
+Add to test file:
+
+```python
+@pytest.fixture
+def full_mix_and_stem(tmp_path):
+    """Full mix at -6 dBFS and a quieter vocal stem at -12 dBFS."""
+    rate = 48000
+    duration = 30.0
+    full_mono = _sine(220, duration=duration, rate=rate, amplitude=0.5)
+    stem_mono = _sine(1000, duration=duration, rate=rate, amplitude=0.25)
+    full_stereo = np.column_stack([full_mono, full_mono])
+    stem_stereo = np.column_stack([stem_mono, stem_mono])
+    full_path = tmp_path / "track.wav"
+    stem_path = tmp_path / "vocals.wav"
+    _write_wav(full_path, full_stereo, rate)
+    _write_wav(stem_path, stem_stereo, rate)
+    return str(full_path), str(stem_path)
+
+
+class TestVocalRmsStem:
+    def test_explicit_stem_path_uses_stem(self, full_mix_and_stem):
+        full, stem = full_mix_and_stem
+        result = analyze_track(full, vocal_stem_path=stem)
+        assert result['vocal_rms'] is not None
+        # Stem at amplitude 0.25 → RMS = 0.25/sqrt(2) ≈ 0.177 → ~ -15 dB
+        assert abs(result['vocal_rms'] - (-15.0)) < 2.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestVocalRmsStem -v
+```
+Expected: FAIL with `TypeError: analyze_track() got an unexpected keyword argument 'vocal_stem_path'`.
+
+- [ ] **Step 3: Add stem reader helper and kwarg**
+
+In `tools/mastering/analyze_tracks.py`, add helper above `analyze_track`:
+
+```python
+def _read_vocal_stem(stem_path: Path | str, target_rate: int) -> np.ndarray | None:
+    """Read a vocal stem, mono-mix, resample to target_rate.
+
+    Returns None if the file cannot be read or resampled.
+    """
+    try:
+        data, rate = sf.read(str(stem_path))
+    except Exception as exc:
+        logger.warning("Could not read vocal stem %s: %s", stem_path, exc)
+        return None
+    if data.ndim > 1:
+        mono = np.mean(data, axis=1)
+    else:
+        mono = data
+    if rate != target_rate:
+        try:
+            # Use rational resampling when possible for stability.
+            from math import gcd
+            g = gcd(int(rate), int(target_rate))
+            up = int(target_rate) // g
+            down = int(rate) // g
+            mono = signal.resample_poly(mono, up, down)
+        except Exception as exc:
+            logger.warning("Could not resample vocal stem %s: %s", stem_path, exc)
+            return None
+    return np.asarray(mono, dtype=np.float64)
+```
+
+Update `analyze_track` signature:
+
+```python
+def analyze_track(filepath: Path | str, *,
+                  vocal_stem_path: Path | str | None = None) -> dict[str, Any]:
+    """Analyze a single track and return metrics."""
+```
+
+Add vocal-RMS computation after the low-RMS block:
+
+```python
+    # vocal-RMS: whole-stem RMS when stem path resolves; 1-4 kHz band of
+    # full mix otherwise. See #290 spec footnote ‡.
+    vocal_rms: float | None = None
+    vocal_rms_source: str = "unavailable"
+
+    resolved_stem = Path(vocal_stem_path) if vocal_stem_path else None
+    if resolved_stem is not None and resolved_stem.is_file():
+        stem_mono = _read_vocal_stem(resolved_stem, rate)
+        if stem_mono is not None:
+            rms_val = _rms_db(stem_mono)
+            if np.isfinite(rms_val):
+                vocal_rms = float(rms_val)
+                vocal_rms_source = "stem"
+```
+
+Append to return dict:
+
+```python
+        'stl_95': stl_95,
+        'low_rms': low_rms,
+        'vocal_rms': vocal_rms,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestVocalRmsStem -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add test for stem at different sample rate (resample path)**
+
+In `TestVocalRmsStem`:
+
+```python
+    def test_stem_different_sample_rate_resamples(self, tmp_path):
+        full_mono = _sine(220, duration=30.0, rate=48000, amplitude=0.5)
+        full_stereo = np.column_stack([full_mono, full_mono])
+        stem_mono = _sine(1000, duration=30.0, rate=44100, amplitude=0.25)
+        stem_stereo = np.column_stack([stem_mono, stem_mono])
+        full_path = tmp_path / "track.wav"
+        stem_path = tmp_path / "vocals.wav"
+        _write_wav(full_path, full_stereo, 48000)
+        _write_wav(stem_path, stem_stereo, 44100)
+        result = analyze_track(str(full_path), vocal_stem_path=str(stem_path))
+        assert result['vocal_rms'] is not None
+        assert abs(result['vocal_rms'] - (-15.0)) < 2.0
+```
+
+- [ ] **Step 6: Add test for unreadable stem falls through (no crash)**
+
+```python
+    def test_unreadable_stem_does_not_crash(self, tmp_path):
+        full_mono = _sine(220, duration=30.0, rate=48000, amplitude=0.5)
+        full_stereo = np.column_stack([full_mono, full_mono])
+        full_path = tmp_path / "track.wav"
+        _write_wav(full_path, full_stereo, 48000)
+        bad_stem = tmp_path / "vocals.wav"
+        bad_stem.write_bytes(b"not a wav file")
+        # Should not raise — must fall through to band fallback (added in Task 4).
+        # For now, vocal_rms should be None and source != "stem".
+        result = analyze_track(str(full_path), vocal_stem_path=str(bad_stem))
+        # Task 3 only implements the stem branch; if unreadable, result is None.
+        assert result['vocal_rms'] is None
+```
+
+- [ ] **Step 7: Run all TestVocalRmsStem tests and verify they pass**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestVocalRmsStem -v
+```
+Expected: three tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/mastering/analyze_tracks.py tests/unit/mastering/test_signature_metrics.py
+git commit -m "$(cat <<'EOF'
+feat(mastering): add vocal-RMS stem branch with explicit stem kwarg
+
+Adds optional vocal_stem_path kwarg to analyze_track(). When the
+stem resolves and reads, measures whole-stem RMS in dB on a mono
+mixdown, resampling to the mix rate when needed. Unreadable stem
+files log a warning and fall through (band fallback lands in Task 4).
+
+Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: vocal-RMS — 1–4 kHz band fallback
+
+**Files:**
+- Modify: `tools/mastering/analyze_tracks.py`
+- Modify: `tests/unit/mastering/test_signature_metrics.py`
+
+- [ ] **Step 1: Write failing test for band fallback**
+
+Add test class:
+
+```python
+class TestVocalRmsFallback:
+    def test_no_stem_falls_back_to_band(self, tmp_path):
+        rate = 48000
+        duration = 30.0
+        # Mid-range-heavy mix: 2 kHz sine dominates 1-4 kHz band.
+        mono = _sine(2000, duration=duration, rate=rate, amplitude=0.5)
+        stereo = np.column_stack([mono, mono])
+        path = tmp_path / "midrange.wav"
+        _write_wav(path, stereo, rate)
+        result = analyze_track(str(path))
+        assert result['vocal_rms'] is not None
+        # 2 kHz at 0.5 amplitude → passes bandpass intact → RMS ≈ -9 dB.
+        assert result['vocal_rms'] > -15.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestVocalRmsFallback -v
+```
+Expected: FAIL — `vocal_rms` is None without stem.
+
+- [ ] **Step 3: Implement band fallback**
+
+In `analyze_track`, extend the vocal-RMS block. Replace the prior block with:
+
+```python
+    # vocal-RMS: whole-stem RMS when stem path resolves; 1-4 kHz band of
+    # full mix otherwise. See #290 spec footnote ‡.
+    vocal_rms: float | None = None
+    vocal_rms_source: str = "unavailable"
+
+    resolved_stem = Path(vocal_stem_path) if vocal_stem_path else None
+    if resolved_stem is not None and resolved_stem.is_file():
+        stem_mono = _read_vocal_stem(resolved_stem, rate)
+        if stem_mono is not None:
+            rms_val = _rms_db(stem_mono)
+            if np.isfinite(rms_val):
+                vocal_rms = float(rms_val)
+                vocal_rms_source = "stem"
+
+    if vocal_rms is None:
+        # Band fallback on full-mix mono: 1-4 kHz.
+        try:
+            band_filtered = _bandpass_sos(mono, rate, 1000.0, 4000.0)
+            rms_val = _rms_db(band_filtered)
+            if np.isfinite(rms_val):
+                vocal_rms = float(rms_val)
+                vocal_rms_source = "band_fallback"
+        except Exception as exc:
+            logger.warning("1-4 kHz band fallback failed: %s", exc)
+```
+
+- [ ] **Step 4: Update prior unreadable-stem test — now expects band_fallback**
+
+In Task 3's `TestVocalRmsStem.test_unreadable_stem_does_not_crash`, change the assertion:
+
+```python
+        result = analyze_track(str(full_path), vocal_stem_path=str(bad_stem))
+        # Unreadable stem → logged warning → band fallback applies.
+        assert result['vocal_rms'] is not None
+```
+
+- [ ] **Step 5: Add silent-track test for band fallback**
+
+In `TestVocalRmsFallback`:
+
+```python
+    def test_silent_track_vocal_rms_is_none(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['vocal_rms'] is None
+```
+
+- [ ] **Step 6: Run all TestVocalRms* tests**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest "tests/unit/mastering/test_signature_metrics.py::TestVocalRmsStem" "tests/unit/mastering/test_signature_metrics.py::TestVocalRmsFallback" -v
+```
+Expected: all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/mastering/analyze_tracks.py tests/unit/mastering/test_signature_metrics.py
+git commit -m "$(cat <<'EOF'
+feat(mastering): add 1-4 kHz band fallback for vocal-RMS
+
+When no vocal stem resolves (or the stem is unreadable), falls back
+to measuring whole-track RMS on the 1-4 kHz bandpassed mono mixdown
+of the full mix. Covers the today-default path (polish does not yet
+preserve per-stem WAVs); stem measurement activates automatically
+once the per-stem artifact lands.
+
+Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: signature_meta provenance dict
+
+**Files:**
+- Modify: `tools/mastering/analyze_tracks.py`
+- Modify: `tests/unit/mastering/test_signature_metrics.py`
+
+- [ ] **Step 1: Write failing test for signature_meta keys**
+
+Add test class:
+
+```python
+class TestSignatureMeta:
+    def test_meta_keys_on_full_length_track(self, long_constant_wav):
+        result = analyze_track(long_constant_wav)
+        assert 'signature_meta' in result
+        meta = result['signature_meta']
+        assert meta['stl_window_count'] >= 20
+        assert meta['stl_top_5pct_count'] == max(1, int(round(0.05 * meta['stl_window_count'])))
+        assert meta['vocal_rms_source'] == 'band_fallback'
+
+    def test_meta_source_stem_when_stem_provided(self, full_mix_and_stem):
+        full, stem = full_mix_and_stem
+        result = analyze_track(full, vocal_stem_path=stem)
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+
+    def test_meta_source_unavailable_on_silence(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['signature_meta']['vocal_rms_source'] == 'unavailable'
+        assert result['signature_meta']['stl_window_count'] >= 20
+        assert result['signature_meta']['stl_top_5pct_count'] == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestSignatureMeta -v
+```
+Expected: FAIL with `KeyError: 'signature_meta'`.
+
+- [ ] **Step 3: Add signature_meta to return dict**
+
+In `analyze_track`, at the start of the return dict construction, replace the silent-case branch with:
+
+```python
+    # signature_meta records provenance for downstream consumers
+    # (anchor selector, coherence check).
+    signature_meta = {
+        'stl_window_count': len(st_values),
+        'stl_top_5pct_count': int(len(stl_top_5pct_indices)),
+        'vocal_rms_source': vocal_rms_source,
+    }
+
+    return {
+        'filename': os.path.basename(filepath),
+        'duration': len(mono) / rate,
+        'sample_rate': rate,
+        'lufs': loudness,
+        'peak_db': peak_db,
+        'rms_db': rms_db,
+        'dynamic_range': dynamic_range,
+        'band_energy': band_energy,
+        'tinniness_ratio': tinniness_ratio,
+        'max_short_term_lufs': max_short_term if np.isfinite(max_short_term) else None,
+        'max_momentary_lufs': max_momentary if np.isfinite(max_momentary) else None,
+        'short_term_range': short_term_range,
+        'stl_95': stl_95,
+        'low_rms': low_rms,
+        'vocal_rms': vocal_rms,
+        'signature_meta': signature_meta,
+    }
+```
+
+Note: when the track is silent, `len(st_values)` may still be ≥20 (windows that returned -inf LUFS are excluded from `st_values` but windows that returned finite silence values are included). Confirm by running the test — if `test_meta_source_unavailable_on_silence` fails on `stl_window_count >= 20`, relax the assertion to `>= 0` since silent audio may not produce finite pyloudnorm output at all.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestSignatureMeta -v
+```
+Expected: three tests PASS. If the silent-track `stl_window_count` assertion fails (because pyloudnorm returns `-inf` for silent windows which get filtered), change the test line to `assert result['signature_meta']['stl_window_count'] >= 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mastering/analyze_tracks.py tests/unit/mastering/test_signature_metrics.py
+git commit -m "$(cat <<'EOF'
+feat(mastering): expose signature_meta provenance dict
+
+Records stl_window_count, stl_top_5pct_count, and vocal_rms_source
+alongside the scalar signature fields. Downstream consumers (anchor
+selector, coherence check) branch on vocal_rms_source to explain
+their decisions ('stem' / 'band_fallback' / 'unavailable') without
+re-parsing paths.
+
+Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Stem auto-resolve
+
+**Files:**
+- Modify: `tools/mastering/analyze_tracks.py`
+- Modify: `tests/unit/mastering/test_signature_metrics.py`
+
+- [ ] **Step 1: Write failing test for album-root auto-resolve**
+
+Add test class:
+
+```python
+class TestAutoResolveStem:
+    def _make_mix(self, path, rate=48000, duration=30.0, amplitude=0.5, freq=220):
+        mono = _sine(freq, duration=duration, rate=rate, amplitude=amplitude)
+        stereo = np.column_stack([mono, mono])
+        _write_wav(path, stereo, rate)
+
+    def _make_stem(self, path, rate=48000, duration=30.0, amplitude=0.25, freq=1000):
+        mono = _sine(freq, duration=duration, rate=rate, amplitude=amplitude)
+        stereo = np.column_stack([mono, mono])
+        _write_wav(path, stereo, rate)
+
+    def test_auto_resolve_album_root_layout(self, tmp_path):
+        # Input at album root: <album>/01-song.wav; stem at <album>/polished/01-song/vocals.wav
+        mix = tmp_path / "01-song.wav"
+        self._make_mix(mix)
+        stem_dir = tmp_path / "polished" / "01-song"
+        stem_dir.mkdir(parents=True)
+        stem = stem_dir / "vocals.wav"
+        self._make_stem(stem)
+        result = analyze_track(str(mix))
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestAutoResolveStem -v
+```
+Expected: FAIL — source is `band_fallback`, not `stem`.
+
+- [ ] **Step 3: Add auto-resolve helper and wire it in**
+
+In `tools/mastering/analyze_tracks.py`, add helper:
+
+```python
+def _auto_resolve_vocal_stem(input_path: Path) -> Path | None:
+    """Find a matching polished vocal stem without explicit kwarg.
+
+    Checks, in order:
+      1. <input_dir>/polished/<input_stem>/vocals.wav  (album-root input)
+      2. <input_dir>/../polished/<input_stem>/vocals.wav  (mastered/ or
+         polished/ subfolder input)
+
+    Returns the first existing path, or None.
+    """
+    stem_name = input_path.stem
+    candidates = [
+        input_path.parent / "polished" / stem_name / "vocals.wav",
+        input_path.parent.parent / "polished" / stem_name / "vocals.wav",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+```
+
+In `analyze_track`, update the stem resolution to use auto-resolve when kwarg is None:
+
+```python
+    resolved_stem: Path | None
+    if vocal_stem_path is not None:
+        resolved_stem = Path(vocal_stem_path)
+    else:
+        resolved_stem = _auto_resolve_vocal_stem(Path(filepath))
+
+    if resolved_stem is not None and resolved_stem.is_file():
+        stem_mono = _read_vocal_stem(resolved_stem, rate)
+        # ... (rest unchanged)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestAutoResolveStem::test_auto_resolve_album_root_layout -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add test for mastered/ subfolder layout**
+
+In `TestAutoResolveStem`:
+
+```python
+    def test_auto_resolve_mastered_subfolder_layout(self, tmp_path):
+        # Input at <album>/mastered/01-song.wav; stem at <album>/polished/01-song/vocals.wav
+        mastered_dir = tmp_path / "mastered"
+        mastered_dir.mkdir()
+        mix = mastered_dir / "01-song.wav"
+        self._make_mix(mix)
+        stem_dir = tmp_path / "polished" / "01-song"
+        stem_dir.mkdir(parents=True)
+        stem = stem_dir / "vocals.wav"
+        self._make_stem(stem)
+        result = analyze_track(str(mix))
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+```
+
+- [ ] **Step 6: Add test for miss → fallback**
+
+```python
+    def test_auto_resolve_miss_falls_back(self, tmp_path):
+        mix = tmp_path / "01-song.wav"
+        self._make_mix(mix)
+        result = analyze_track(str(mix))
+        assert result['signature_meta']['vocal_rms_source'] == 'band_fallback'
+```
+
+- [ ] **Step 7: Add test confirming explicit kwarg still wins over auto-resolve**
+
+```python
+    def test_explicit_kwarg_overrides_auto_resolve(self, tmp_path):
+        mix = tmp_path / "01-song.wav"
+        self._make_mix(mix)
+        # Auto-resolve target (would be found)
+        auto_dir = tmp_path / "polished" / "01-song"
+        auto_dir.mkdir(parents=True)
+        auto_stem = auto_dir / "vocals.wav"
+        self._make_stem(auto_stem, freq=500)
+        # Explicit kwarg: a different file with a different frequency (amplitude)
+        explicit_stem = tmp_path / "explicit.wav"
+        self._make_stem(explicit_stem, amplitude=0.1, freq=1500)  # quieter
+        result = analyze_track(str(mix), vocal_stem_path=str(explicit_stem))
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+        # Explicit is at amplitude 0.1 → RMS ≈ -23 dB; auto would give ≈ -15 dB
+        assert result['vocal_rms'] < -18.0
+```
+
+- [ ] **Step 8: Run all TestAutoResolveStem tests**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/test_signature_metrics.py::TestAutoResolveStem -v
+```
+Expected: four tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add tools/mastering/analyze_tracks.py tests/unit/mastering/test_signature_metrics.py
+git commit -m "$(cat <<'EOF'
+feat(mastering): auto-resolve vocal stem path for analyze_track
+
+When the caller omits vocal_stem_path, analyze_track walks two
+layouts looking for <input_stem>/vocals.wav under a sibling
+polished/ directory — first the input's directory, then one level
+up. Covers album-root, polished/, and mastered/ input callsites
+without touching the wider filesystem.
+
+Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: E2 review item — disk-usage note on delivery_sample_rate
+
+**Files:**
+- Modify: `config/config.example.yaml`
+
+- [ ] **Step 1: Find the current `delivery_sample_rate` comment**
+
+Run:
+```bash
+~/.bitwize-music/venv/bin/python -c "print(open('config/config.example.yaml').read())" | grep -n -A 20 "delivery_sample_rate"
+```
+
+- [ ] **Step 2: Append disk-usage note to the comment block**
+
+Locate the comment block that starts with `# delivery_sample_rate [optional, default: 96000]` and ends just before `# delivery_sample_rate: 96000`. Add this paragraph immediately before the uncommented default:
+
+```yaml
+#   #
+#   # Disk-usage note: at 24-bit / 96 kHz, mastered WAVs are roughly
+#   # ~33 MB per stereo minute (vs. ~10 MB at 44.1 kHz). A 12-track
+#   # album averages ~1.5 GB of mastered/ output before archival; enable
+#   # archival only when you have the headroom for an extra ~3x of that.
+```
+
+- [ ] **Step 3: Verify YAML still parses**
+
+```bash
+~/.bitwize-music/venv/bin/python -c "import yaml; yaml.safe_load(open('config/config.example.yaml'))"
+```
+Expected: no output (clean parse).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/config.example.yaml
+git commit -m "$(cat <<'EOF'
+docs(config): add disk-usage note to delivery_sample_rate comment
+
+Expands the 24/96 default documentation with a concrete disk-usage
+estimate (~33 MB/min at 24/96 vs ~10 MB/min at 44.1; ~1.5 GB per
+12-track album before archival). Surfaces the tradeoff users should
+weigh when enabling archival output.
+
+Carried forward from #304 review item E2. Part of #290 phase 1b.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Full regression suite + final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the full mastering unit test suite**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/unit/mastering/ -v
+```
+Expected: all tests PASS. Existing test count + new signature-metrics tests (around 16 new assertions). No regressions in `test_analyze_tracks.py`, `test_mastering_config.py`, `test_master_audio_config_wiring.py`, `test_master_album_config_wiring.py`, `test_archival_output.py`, or `test_prune_archival.py`.
+
+- [ ] **Step 2: Run the full repo test suite**
+
+```bash
+~/.bitwize-music/venv/bin/python -m pytest tests/ -q
+```
+Expected: PASS. Regression budget: baseline from #304 was 3151 passed + 2 xfailed. New tests should push that to approximately 3167+. Zero unexpected failures.
+
+- [ ] **Step 3: Manual smoke test — analyze a real track**
+
+If a real album exists locally, pick a single mastered WAV and run:
+
+```bash
+~/.bitwize-music/venv/bin/python -c "
+from tools.mastering.analyze_tracks import analyze_track
+from pathlib import Path
+import json
+# Replace with an actual track path on your machine
+track = Path.home() / 'some/test/track.wav'
+if track.is_file():
+    result = analyze_track(str(track))
+    print(json.dumps({
+        'stl_95': result['stl_95'],
+        'low_rms': result['low_rms'],
+        'vocal_rms': result['vocal_rms'],
+        'meta': result['signature_meta'],
+    }, indent=2))
+"
+```
+Expected: non-None STL-95, low-RMS, vocal-RMS for a real-length mastered track; `vocal_rms_source` = `band_fallback` (today's default path).
+
+Skip this step if no suitable local file is available.
+
+- [ ] **Step 4: Confirm no orphaned untracked files**
+
+```bash
+git status
+```
+Expected: clean working tree (only the committed changes).
+
+- [ ] **Step 5: Summary check — verify phase 1b deliverables**
+
+Confirm by inspection that all of these are present:
+- `tools/mastering/analyze_tracks.py` has `_bandpass_sos`, `_rms_db`, `_read_vocal_stem`, `_auto_resolve_vocal_stem` helpers.
+- `analyze_track()` returns `stl_95`, `low_rms`, `vocal_rms`, `signature_meta`.
+- `tests/unit/mastering/test_signature_metrics.py` exists with five test classes (`TestShortTerm95`, `TestLowRms`, `TestVocalRmsStem`, `TestVocalRmsFallback`, `TestSignatureMeta`, `TestAutoResolveStem`).
+- `config/config.example.yaml` has the disk-usage note on `delivery_sample_rate`.
+- No changes to `servers/bitwize-music-server/handlers/processing/audio.py`.
+
+If all present → phase 1b implementation complete. Ready to open PR for review.
+
+---
+
+## Completion checklist
+
+- [ ] Task 1 — STL-95 computation + gating
+- [ ] Task 2 — low-RMS within STL-95 windows
+- [ ] Task 3 — vocal-RMS stem branch (explicit kwarg)
+- [ ] Task 4 — vocal-RMS 1-4 kHz band fallback
+- [ ] Task 5 — signature_meta provenance dict
+- [ ] Task 6 — stem auto-resolve
+- [ ] Task 7 — E2 disk-usage note
+- [ ] Task 8 — full regression run

--- a/docs/superpowers/specs/2026-04-13-phase-1b-multi-metric-signature-design.md
+++ b/docs/superpowers/specs/2026-04-13-phase-1b-multi-metric-signature-design.md
@@ -12,7 +12,9 @@ Extend `analyze_track()` with three new signature metrics — STL-95, low-RMS (S
 ## Architectural context
 
 - Core metric computation lives in `tools/mastering/analyze_tracks.py` (pure Python, no MCP coupling).
-- MCP boundary stays thin in `servers/bitwize-music-server/handlers/processing/audio.py`. The `analyze_audio` handler gains one optional kwarg (`vocal_stem_path`) and passes it through.
+- MCP boundary in `servers/bitwize-music-server/handlers/processing/audio.py` is **unchanged**. The `analyze_audio` handler batches per-album (one call covers many tracks), so a single `vocal_stem_path` kwarg wouldn't fit. Auto-resolve inside `analyze_track()` handles per-file lookup correctly.
+- The new `vocal_stem_path` kwarg exists only on `analyze_track()` itself, for Phase 2 callers (anchor selector, coherence check) that call it programmatically per-track and may already know the stem path.
+- The handler's JSON return blob automatically picks up the new fields through existing serialization — no handler edit required.
 - No consumers in Phase 1b. Phase 2a and 2b read these fields.
 - Fields are **additive**: existing tests and callers only assert on fields they care about, so adding keys cannot regress them.
 
@@ -61,7 +63,7 @@ Whole-track (not windowed) is the spec wording: *"measured directly on the polis
 
 First hit wins; no hit → fall back to band. Walking two levels covers every current layout (raw at album root, polished output, mastered output) without touching the wider filesystem.
 
-The handler `analyze_audio` accepts the same optional kwarg and passes it through. This keeps analyze_audio usable without extra context while letting Phase 2 callers (anchor selector, coherence check) be explicit when they already know the stem path.
+The handler `analyze_audio` does **not** gain the kwarg — it batches per-album and would need per-track values anyway; auto-resolve gives that for free. Phase 2 callers that invoke `analyze_track()` directly per-track can still pass `vocal_stem_path` explicitly when they already know it.
 
 ## Interface
 
@@ -94,16 +96,7 @@ New return keys (all others unchanged):
 
 ### `servers/bitwize-music-server/handlers/processing/audio.py`
 
-```python
-async def analyze_audio(
-    audio_path: str,
-    *,
-    vocal_stem_path: str | None = None,
-) -> str:
-    ...
-```
-
-MCP schema is implicit from the Python signature; existing callers that don't pass `vocal_stem_path` get the auto-resolve behavior.
+No signature change. The handler's existing per-file call to `analyze_track(str(wav))` picks up auto-resolve automatically, and the new return keys flow through JSON serialization unchanged.
 
 ## Error handling
 
@@ -145,12 +138,10 @@ Model after `tests/unit/mastering/test_analyze_tracks.py`. Use existing `_genera
 ## File structure
 
 **Create:**
-- `tests/unit/mastering/test_signature_metrics.py`
-- `tests/unit/mastering/test_analyze_audio_vocal_stem.py`
+- `tests/unit/mastering/test_signature_metrics.py` — unit tests for STL-95, low-RMS, vocal-RMS, auto-resolve.
 
 **Modify:**
-- `tools/mastering/analyze_tracks.py` — extend `analyze_track()` with STL-95, low-RMS, vocal-RMS, `signature_meta`; add `vocal_stem_path` kwarg.
-- `servers/bitwize-music-server/handlers/processing/audio.py` — pass `vocal_stem_path` through `analyze_audio`.
+- `tools/mastering/analyze_tracks.py` — extend `analyze_track()` with STL-95, low-RMS, vocal-RMS, `signature_meta`; add `vocal_stem_path` kwarg and auto-resolve helper.
 - `config/config.example.yaml` — fold in E2 review item: disk-usage note on `delivery_sample_rate` comment.
 
 ## Out of scope / follow-ups

--- a/docs/superpowers/specs/2026-04-13-phase-1b-multi-metric-signature-design.md
+++ b/docs/superpowers/specs/2026-04-13-phase-1b-multi-metric-signature-design.md
@@ -1,0 +1,170 @@
+# Phase 1b — Multi-Metric Signature Foundation (Design)
+
+**Canonical spec**: [Issue #290](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/290)
+**Parent design**: [`2026-04-13-album-mastering-pipeline-design.md`](2026-04-13-album-mastering-pipeline-design.md)
+**Phase**: 1b (follows 1a in #304)
+**Design date**: 2026-04-13
+
+## Summary
+
+Extend `analyze_track()` with three new signature metrics — STL-95, low-RMS (STL-95-windowed, 20–200 Hz), and vocal-RMS (polished vocal stem when present, else 1–4 kHz band of full mix) — and a small `signature_meta` dict recording provenance. Purely additive return schema; no new MCP tool; no pipeline stage changes. These fields are the inputs that Phase 2a (anchor selector) and Phase 2b (album coherence check/correct) consume.
+
+## Architectural context
+
+- Core metric computation lives in `tools/mastering/analyze_tracks.py` (pure Python, no MCP coupling).
+- MCP boundary stays thin in `servers/bitwize-music-server/handlers/processing/audio.py`. The `analyze_audio` handler gains one optional kwarg (`vocal_stem_path`) and passes it through.
+- No consumers in Phase 1b. Phase 2a and 2b read these fields.
+- Fields are **additive**: existing tests and callers only assert on fields they care about, so adding keys cannot regress them.
+
+## Design decisions
+
+### Vocal-RMS source — honor spec path, graceful fallback
+
+Spec (`#290` Multi-metric table footnote ‡) says measure the polished vocal stem at `polished/<track>/vocals.wav` when present, else the 1–4 kHz band of the full mix. Today, `polish_audio` writes only a single mixed stereo WAV at `polished/<track>.wav`; the per-stem subdirectory does not exist. That means the band fallback always fires today.
+
+Phase 1b implements the spec as written. When `polished/<track>/vocals.wav` eventually exists (separate polish upgrade, tracked as a follow-up), stem measurement activates automatically with no further changes to this code path.
+
+Alternatives rejected:
+
+- **Read pre-polish stems** (`stems/<track>/vocals.wav`) — they exist today but are unpolished, so the measurement drifts from what the mastered track contains. Partially defeats the purpose.
+- **Scope-creep polish** to preserve per-stem output — bundles a polish stage change into a metrics-only PR. Clean standalone follow-up instead.
+
+### Return schema — additive flat scalars + `signature_meta`
+
+Three new top-level scalar fields (`stl_95`, `low_rms`, `vocal_rms`) plus a `signature_meta` dict for provenance. Scalars follow existing flat-key convention in `analyze_track()`'s return dict. The meta dict keeps provenance separate so downstream consumers can branch on `vocal_rms_source` without parsing magic numbers.
+
+### Metric algorithms
+
+**STL-95**: reuse existing 3 s window / 1 s hop short-term LUFS loop at `analyze_tracks.py:86–95`. Collect all finite ST-LUFS values into a list. Return `np.percentile(values, 95)` (numpy default linear interpolation). Retain the indices of the top-K windows for reuse by low-RMS, where `K = max(1, round(0.05 * N))` (rounded to nearest, min 1). Sort descending by ST-LUFS; ties broken by window index ascending (earlier window wins) for determinism.
+
+**Gating**: return `None` when fewer than 20 finite ST windows exist. Rationale: at 20 windows (≈23 s of audio) the 95th percentile spans exactly one sample; below that the percentile reports the maximum, which is the wrong statistic. The `stl_window_count` field in `signature_meta` makes the gate visible.
+
+**low-RMS (20–200 Hz)**:
+- Butterworth bandpass, 4th order, zero-phase via `scipy.signal.sosfiltfilt`, `sos` form for numeric stability.
+- For each top-5% window (indices retained from STL-95), compute RMS in dB on the filtered mono mixdown of that window.
+- Return the **median** across those windows. Robust to a single outlier chorus.
+- Return `None` when `stl_95` is `None`.
+
+**vocal-RMS**:
+- **Stem path**: if `vocal_stem_path` resolves and reads successfully → mono mixdown of the stem, whole-stem RMS in dB. `vocal_rms_source = "stem"`.
+- **Band fallback**: 1–4 kHz Butterworth bandpass (4th order, `sosfiltfilt`) on full-mix mono, whole-track RMS in dB. `vocal_rms_source = "band_fallback"`.
+- **Unavailable**: silent / unreadable / unresolvable → `None`, `vocal_rms_source = "unavailable"`.
+
+Whole-track (not windowed) is the spec wording: *"measured directly on the polished vocal stem"* and *"1–4 kHz band of the full mix"* — neither mentions STL-95 windowing. Window alignment can be added later if empirical tuning finds it necessary; the return schema is forward-compatible.
+
+### Stem auto-resolve
+
+`analyze_track()` gains an optional `vocal_stem_path` kwarg. When explicitly passed, it's used directly. When omitted, resolve by convention — check, in order:
+
+1. `<input_dir>/polished/<input_stem>/vocals.wav` — input is at album root.
+2. `<input_dir>/../polished/<input_stem>/vocals.wav` — input is in a `mastered/` or `polished/` subfolder.
+
+First hit wins; no hit → fall back to band. Walking two levels covers every current layout (raw at album root, polished output, mastered output) without touching the wider filesystem.
+
+The handler `analyze_audio` accepts the same optional kwarg and passes it through. This keeps analyze_audio usable without extra context while letting Phase 2 callers (anchor selector, coherence check) be explicit when they already know the stem path.
+
+## Interface
+
+### `tools/mastering/analyze_tracks.py`
+
+```python
+def analyze_track(
+    filepath: Path | str,
+    *,
+    vocal_stem_path: Path | str | None = None,
+) -> dict[str, Any]:
+    ...
+```
+
+New return keys (all others unchanged):
+
+```python
+{
+    # ... existing fields unchanged ...
+    'stl_95': float | None,
+    'low_rms': float | None,
+    'vocal_rms': float | None,
+    'signature_meta': {
+        'stl_window_count': int,
+        'stl_top_5pct_count': int,
+        'vocal_rms_source': 'stem' | 'band_fallback' | 'unavailable',
+    },
+}
+```
+
+### `servers/bitwize-music-server/handlers/processing/audio.py`
+
+```python
+async def analyze_audio(
+    audio_path: str,
+    *,
+    vocal_stem_path: str | None = None,
+) -> str:
+    ...
+```
+
+MCP schema is implicit from the Python signature; existing callers that don't pass `vocal_stem_path` get the auto-resolve behavior.
+
+## Error handling
+
+- **Track < ~23 s (20 ST windows)** → `stl_95 = None`, `low_rms = None`. Visible via `stl_window_count` in `signature_meta`.
+- **Stem file exists but unreadable** → log warning, fall back to band. Do not crash.
+- **Stem at a different sample rate** → resample to mix rate before RMS. If resample fails, fall back.
+- **Stem is mono** → existing mono→stereo duplication in `analyze_track()` handles it when reading; whole-stem mono mixdown for RMS normalizes regardless.
+- **Silent audio** → `rms = 0` → `rms_db` = `-inf` (matches existing behavior). All three new fields return `None` or `"unavailable"`.
+
+## Testing
+
+Model after `tests/unit/mastering/test_analyze_tracks.py`. Use existing `_generate_sine()` and `_write_wav()` helpers.
+
+**New file `tests/unit/mastering/test_signature_metrics.py`:**
+
+- `TestShortTerm95`
+  - Constant-level sine → `stl_95` within 1 LU of integrated LUFS.
+  - Chorus/verse pattern (loud 3 s burst every 8 s) → `stl_95 > lufs + 2`.
+  - Track < 23 s → `stl_95 is None`, `stl_window_count < 20`.
+  - Silent track → `stl_95 is None`.
+
+- `TestLowRms`
+  - Bass-heavy loud windows + quiet verses → median low-RMS reflects bass chorus level, not whole-track.
+  - Full-track silence → `low_rms is None`.
+  - `stl_95 is None` implies `low_rms is None`.
+
+- `TestVocalRms`
+  - Stem at known level adjacent to input → `vocal_rms_source == "stem"`, value within 1 dB of expected.
+  - Explicit `vocal_stem_path` kwarg → honored over auto-resolve.
+  - No stem, 1–4 kHz-rich mix → `vocal_rms_source == "band_fallback"`, finite value.
+  - Stem at 48 kHz, input at 96 kHz → resample path produces finite value.
+  - Stem is an invalid WAV → logged, falls back to band.
+
+**New file `tests/unit/mastering/test_analyze_audio_vocal_stem.py`:**
+
+- Auto-resolve hit: create temp `polished/<name>/vocals.wav` alongside input; confirm `vocal_rms_source == "stem"`.
+- Auto-resolve miss: no stem dir; confirm `vocal_rms_source == "band_fallback"`.
+
+## File structure
+
+**Create:**
+- `tests/unit/mastering/test_signature_metrics.py`
+- `tests/unit/mastering/test_analyze_audio_vocal_stem.py`
+
+**Modify:**
+- `tools/mastering/analyze_tracks.py` — extend `analyze_track()` with STL-95, low-RMS, vocal-RMS, `signature_meta`; add `vocal_stem_path` kwarg.
+- `servers/bitwize-music-server/handlers/processing/audio.py` — pass `vocal_stem_path` through `analyze_audio`.
+- `config/config.example.yaml` — fold in E2 review item: disk-usage note on `delivery_sample_rate` comment.
+
+## Out of scope / follow-ups
+
+- **Polish preserves per-stem output** (new `polished/<track>/vocals.wav` artifact). Required before stem measurement activates in practice. Filed as a new #290 checklist item when this PR lands.
+- **Anchor selector** (Phase 2a) — consumes `stl_95`, `low_rms`, `vocal_rms`.
+- **Album coherence check/correct** (Phase 2b) — consumes signature across a track set.
+- **Genre coherence tolerance fields** (`coherence_stl_95_lu`, `coherence_low_rms_db`, `coherence_vocal_rms_db`) — ship with Phase 2.
+- **Whole-track windowing for vocal-RMS** — deferred; trigger is empirical drift, not currently observed.
+
+## Non-goals
+
+- No changes to polish stage.
+- No new MCP tool.
+- No album-level aggregation (signature persistence is Phase 2c).
+- No genre-specific coherence semantics.
+- No wiring into `master_album` or `master_audio` pipelines.

--- a/tests/unit/mastering/test_analyze_tracks.py
+++ b/tests/unit/mastering/test_analyze_tracks.py
@@ -105,6 +105,7 @@ class TestAnalyzeTrackBasic:
             'peak_db', 'rms_db', 'dynamic_range',
             'band_energy', 'tinniness_ratio',
             'max_short_term_lufs', 'max_momentary_lufs', 'short_term_range',
+            'stl_95', 'low_rms', 'vocal_rms', 'signature_meta',
         }
         assert expected_keys == set(result.keys())
 

--- a/tests/unit/mastering/test_signature_metrics.py
+++ b/tests/unit/mastering/test_signature_metrics.py
@@ -81,6 +81,29 @@ def silent_60_wav(tmp_path):
     return str(path)
 
 
+@pytest.fixture
+def bass_chorus_verse_wav(tmp_path):
+    """60 s: loud bass chorus (3s, 80 Hz at -6 dBFS) + near-silent verse (5s)."""
+    rate = 48000
+    duration = 60.0
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    bass = np.sin(2 * np.pi * 80 * t).astype(np.float32)
+    envelope = np.zeros_like(t, dtype=np.float32)
+    period = 8.0
+    for i in range(int(duration / period) + 1):
+        loud_start = i * period
+        loud_end = loud_start + 3.0
+        mask = (t >= loud_start) & (t < loud_end)
+        envelope[mask] = 0.5
+        quiet_mask = (t >= loud_end) & (t < loud_start + period)
+        envelope[quiet_mask] = 0.001
+    mono = (bass * envelope).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "bass_chorus_verse.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
 class TestShortTerm95:
     def test_constant_level_stl_95_close_to_lufs(self, long_constant_wav):
         result = analyze_track(long_constant_wav)
@@ -99,3 +122,21 @@ class TestShortTerm95:
     def test_silent_track_stl_95_is_none(self, silent_60_wav):
         result = analyze_track(silent_60_wav)
         assert result['stl_95'] is None
+
+
+class TestLowRms:
+    def test_bass_chorus_low_rms_reflects_loud_windows(self, bass_chorus_verse_wav):
+        result = analyze_track(bass_chorus_verse_wav)
+        assert result['low_rms'] is not None
+        # Chorus at 0.5 amplitude for 80 Hz → RMS ≈ -9 dB; windowed on loud
+        # choruses should report much louder than if whole-track averaged
+        # with the near-silent verses.
+        assert result['low_rms'] > -20.0
+
+    def test_short_track_low_rms_is_none(self, short_wav):
+        result = analyze_track(short_wav)
+        assert result['low_rms'] is None
+
+    def test_silent_track_low_rms_is_none(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['low_rms'] is None

--- a/tests/unit/mastering/test_signature_metrics.py
+++ b/tests/unit/mastering/test_signature_metrics.py
@@ -228,3 +228,57 @@ class TestSignatureMeta:
         result = analyze_track(silent_60_wav)
         assert result['signature_meta']['vocal_rms_source'] == 'unavailable'
         assert result['signature_meta']['stl_top_5pct_count'] == 0
+
+
+class TestAutoResolveStem:
+    def _make_mix(self, path, rate=48000, duration=30.0, amplitude=0.5, freq=220):
+        mono = _sine(freq, duration=duration, rate=rate, amplitude=amplitude)
+        stereo = np.column_stack([mono, mono])
+        _write_wav(path, stereo, rate)
+
+    def _make_stem(self, path, rate=48000, duration=30.0, amplitude=0.25, freq=1000):
+        mono = _sine(freq, duration=duration, rate=rate, amplitude=amplitude)
+        stereo = np.column_stack([mono, mono])
+        _write_wav(path, stereo, rate)
+
+    def test_auto_resolve_album_root_layout(self, tmp_path):
+        mix = tmp_path / "01-song.wav"
+        self._make_mix(mix)
+        stem_dir = tmp_path / "polished" / "01-song"
+        stem_dir.mkdir(parents=True)
+        stem = stem_dir / "vocals.wav"
+        self._make_stem(stem)
+        result = analyze_track(str(mix))
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+
+    def test_auto_resolve_mastered_subfolder_layout(self, tmp_path):
+        mastered_dir = tmp_path / "mastered"
+        mastered_dir.mkdir()
+        mix = mastered_dir / "01-song.wav"
+        self._make_mix(mix)
+        stem_dir = tmp_path / "polished" / "01-song"
+        stem_dir.mkdir(parents=True)
+        stem = stem_dir / "vocals.wav"
+        self._make_stem(stem)
+        result = analyze_track(str(mix))
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+
+    def test_auto_resolve_miss_falls_back(self, tmp_path):
+        mix = tmp_path / "01-song.wav"
+        self._make_mix(mix)
+        result = analyze_track(str(mix))
+        assert result['signature_meta']['vocal_rms_source'] == 'band_fallback'
+
+    def test_explicit_kwarg_overrides_auto_resolve(self, tmp_path):
+        mix = tmp_path / "01-song.wav"
+        self._make_mix(mix)
+        auto_dir = tmp_path / "polished" / "01-song"
+        auto_dir.mkdir(parents=True)
+        auto_stem = auto_dir / "vocals.wav"
+        self._make_stem(auto_stem, freq=500, amplitude=0.25)
+        explicit_stem = tmp_path / "explicit.wav"
+        self._make_stem(explicit_stem, amplitude=0.1, freq=1500)
+        result = analyze_track(str(mix), vocal_stem_path=str(explicit_stem))
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+        # Explicit is at amplitude 0.1 → RMS ≈ -23 dB; auto would give ≈ -15 dB.
+        assert result['vocal_rms'] < -18.0

--- a/tests/unit/mastering/test_signature_metrics.py
+++ b/tests/unit/mastering/test_signature_metrics.py
@@ -140,3 +140,52 @@ class TestLowRms:
     def test_silent_track_low_rms_is_none(self, silent_60_wav):
         result = analyze_track(silent_60_wav)
         assert result['low_rms'] is None
+
+
+@pytest.fixture
+def full_mix_and_stem(tmp_path):
+    """Full mix at -6 dBFS and a quieter vocal stem at -12 dBFS."""
+    rate = 48000
+    duration = 30.0
+    full_mono = _sine(220, duration=duration, rate=rate, amplitude=0.5)
+    stem_mono = _sine(1000, duration=duration, rate=rate, amplitude=0.25)
+    full_stereo = np.column_stack([full_mono, full_mono])
+    stem_stereo = np.column_stack([stem_mono, stem_mono])
+    full_path = tmp_path / "track.wav"
+    stem_path = tmp_path / "vocals.wav"
+    _write_wav(full_path, full_stereo, rate)
+    _write_wav(stem_path, stem_stereo, rate)
+    return str(full_path), str(stem_path)
+
+
+class TestVocalRmsStem:
+    def test_explicit_stem_path_uses_stem(self, full_mix_and_stem):
+        full, stem = full_mix_and_stem
+        result = analyze_track(full, vocal_stem_path=stem)
+        assert result['vocal_rms'] is not None
+        # Stem at amplitude 0.25 → RMS = 0.25/sqrt(2) ≈ 0.177 → ~ -15 dB
+        assert abs(result['vocal_rms'] - (-15.0)) < 2.0
+
+    def test_stem_different_sample_rate_resamples(self, tmp_path):
+        full_mono = _sine(220, duration=30.0, rate=48000, amplitude=0.5)
+        full_stereo = np.column_stack([full_mono, full_mono])
+        stem_mono = _sine(1000, duration=30.0, rate=44100, amplitude=0.25)
+        stem_stereo = np.column_stack([stem_mono, stem_mono])
+        full_path = tmp_path / "track.wav"
+        stem_path = tmp_path / "vocals.wav"
+        _write_wav(full_path, full_stereo, 48000)
+        _write_wav(stem_path, stem_stereo, 44100)
+        result = analyze_track(str(full_path), vocal_stem_path=str(stem_path))
+        assert result['vocal_rms'] is not None
+        assert abs(result['vocal_rms'] - (-15.0)) < 2.0
+
+    def test_unreadable_stem_does_not_crash(self, tmp_path):
+        full_mono = _sine(220, duration=30.0, rate=48000, amplitude=0.5)
+        full_stereo = np.column_stack([full_mono, full_mono])
+        full_path = tmp_path / "track.wav"
+        _write_wav(full_path, full_stereo, 48000)
+        bad_stem = tmp_path / "vocals.wav"
+        bad_stem.write_bytes(b"not a wav file")
+        # Task 3 only implements the stem branch; if unreadable, result is None.
+        result = analyze_track(str(full_path), vocal_stem_path=str(bad_stem))
+        assert result['vocal_rms'] is None

--- a/tests/unit/mastering/test_signature_metrics.py
+++ b/tests/unit/mastering/test_signature_metrics.py
@@ -208,3 +208,23 @@ class TestVocalRmsFallback:
     def test_silent_track_vocal_rms_is_none(self, silent_60_wav):
         result = analyze_track(silent_60_wav)
         assert result['vocal_rms'] is None
+
+
+class TestSignatureMeta:
+    def test_meta_keys_on_full_length_track(self, long_constant_wav):
+        result = analyze_track(long_constant_wav)
+        assert 'signature_meta' in result
+        meta = result['signature_meta']
+        assert meta['stl_window_count'] >= 20
+        assert meta['stl_top_5pct_count'] == max(1, int(round(0.05 * meta['stl_window_count'])))
+        assert meta['vocal_rms_source'] == 'band_fallback'
+
+    def test_meta_source_stem_when_stem_provided(self, full_mix_and_stem):
+        full, stem = full_mix_and_stem
+        result = analyze_track(full, vocal_stem_path=stem)
+        assert result['signature_meta']['vocal_rms_source'] == 'stem'
+
+    def test_meta_source_unavailable_on_silence(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['signature_meta']['vocal_rms_source'] == 'unavailable'
+        assert result['signature_meta']['stl_top_5pct_count'] == 0

--- a/tests/unit/mastering/test_signature_metrics.py
+++ b/tests/unit/mastering/test_signature_metrics.py
@@ -179,13 +179,32 @@ class TestVocalRmsStem:
         assert result['vocal_rms'] is not None
         assert abs(result['vocal_rms'] - (-15.0)) < 2.0
 
-    def test_unreadable_stem_does_not_crash(self, tmp_path):
+    def test_unreadable_stem_falls_back(self, tmp_path):
         full_mono = _sine(220, duration=30.0, rate=48000, amplitude=0.5)
         full_stereo = np.column_stack([full_mono, full_mono])
         full_path = tmp_path / "track.wav"
         _write_wav(full_path, full_stereo, 48000)
         bad_stem = tmp_path / "vocals.wav"
         bad_stem.write_bytes(b"not a wav file")
-        # Task 3 only implements the stem branch; if unreadable, result is None.
+        # Unreadable stem → logged warning → band fallback applies.
         result = analyze_track(str(full_path), vocal_stem_path=str(bad_stem))
+        assert result['vocal_rms'] is not None
+
+
+class TestVocalRmsFallback:
+    def test_no_stem_falls_back_to_band(self, tmp_path):
+        rate = 48000
+        duration = 30.0
+        # Mid-range-heavy mix: 2 kHz sine dominates 1-4 kHz band.
+        mono = _sine(2000, duration=duration, rate=rate, amplitude=0.5)
+        stereo = np.column_stack([mono, mono])
+        path = tmp_path / "midrange.wav"
+        _write_wav(path, stereo, rate)
+        result = analyze_track(str(path))
+        assert result['vocal_rms'] is not None
+        # 2 kHz at 0.5 amplitude → passes bandpass intact → RMS ≈ -9 dB.
+        assert result['vocal_rms'] > -15.0
+
+    def test_silent_track_vocal_rms_is_none(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
         assert result['vocal_rms'] is None

--- a/tests/unit/mastering/test_signature_metrics.py
+++ b/tests/unit/mastering/test_signature_metrics.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Unit tests for Phase 1b signature metrics (STL-95, low-RMS, vocal-RMS)."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.analyze_tracks import analyze_track
+
+
+def _write_wav(path, data, rate):
+    sf.write(str(path), data, rate, subtype='PCM_16')
+
+
+def _sine(freq, duration, rate, amplitude):
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    return (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+@pytest.fixture
+def long_constant_wav(tmp_path):
+    """60 s constant-level stereo sine at ~-14 LUFS."""
+    rate = 48000
+    mono = _sine(440, duration=60.0, rate=rate, amplitude=0.3)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "constant.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
+@pytest.fixture
+def chorus_verse_wav(tmp_path):
+    """90 s pattern: 2 s loud chorus, 7 s medium verse — verse stays in EBU
+    relative gate so integrated LUFS trends toward verse level while STL-95
+    peaks on the chorus windows."""
+    rate = 48000
+    duration = 90.0
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    base = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+    envelope = np.zeros_like(t, dtype=np.float32)
+    period = 9.0
+    for i in range(int(duration / period) + 1):
+        loud_start = i * period
+        loud_end = loud_start + 2.0
+        mask = (t >= loud_start) & (t < loud_end)
+        envelope[mask] = 0.7
+        quiet_mask = (t >= loud_end) & (t < loud_start + period)
+        envelope[quiet_mask] = 0.2
+    mono = (base * envelope).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "chorus_verse.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
+@pytest.fixture
+def short_wav(tmp_path):
+    """10 s sine — too short for STL-95 (< 20 ST windows)."""
+    rate = 48000
+    mono = _sine(440, duration=10.0, rate=rate, amplitude=0.3)
+    stereo = np.column_stack([mono, mono])
+    path = tmp_path / "short.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
+@pytest.fixture
+def silent_60_wav(tmp_path):
+    """60 s of silence."""
+    rate = 48000
+    stereo = np.zeros((int(rate * 60.0), 2), dtype=np.float32)
+    path = tmp_path / "silent_60.wav"
+    _write_wav(path, stereo, rate)
+    return str(path)
+
+
+class TestShortTerm95:
+    def test_constant_level_stl_95_close_to_lufs(self, long_constant_wav):
+        result = analyze_track(long_constant_wav)
+        assert result['stl_95'] is not None
+        assert abs(result['stl_95'] - result['lufs']) < 1.5
+
+    def test_chorus_verse_stl_95_above_integrated(self, chorus_verse_wav):
+        result = analyze_track(chorus_verse_wav)
+        assert result['stl_95'] is not None
+        assert result['stl_95'] > result['lufs'] + 2.0
+
+    def test_short_track_stl_95_is_none(self, short_wav):
+        result = analyze_track(short_wav)
+        assert result['stl_95'] is None
+
+    def test_silent_track_stl_95_is_none(self, silent_60_wav):
+        result = analyze_track(silent_60_wav)
+        assert result['stl_95'] is None

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -82,6 +82,7 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
     max_short_term = float('-inf')
     min_short_term = float('inf')
     max_momentary = float('-inf')
+    st_values: list[float] = []
 
     # Short-term: 3s window, 1s hop (EBU R128)
     st_window = int(3.0 * rate)
@@ -91,8 +92,24 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
             chunk = data[start:start + st_window]
             st_lufs = pyln.Meter(rate).integrated_loudness(chunk)
             if np.isfinite(st_lufs):
+                st_values.append(float(st_lufs))
                 max_short_term = max(max_short_term, st_lufs)
                 min_short_term = min(min_short_term, st_lufs)
+
+    # STL-95: 95th percentile of finite short-term LUFS. Gated to ≥20 windows
+    # (~23s audio) so the percentile has a meaningful spread; below that it
+    # collapses to near-max. Top-5% indices retained for downstream low-RMS.
+    stl_95: float | None
+    stl_top_5pct_indices: np.ndarray
+    if len(st_values) >= 20:
+        stl_array = np.asarray(st_values, dtype=np.float64)
+        stl_95 = float(np.percentile(stl_array, 95))
+        top_k = max(1, int(round(0.05 * len(st_values))))
+        order = np.argsort(-stl_array, kind='stable')
+        stl_top_5pct_indices = order[:top_k]
+    else:
+        stl_95 = None
+        stl_top_5pct_indices = np.array([], dtype=np.int64)
 
     # Momentary: 400ms window, 100ms hop
     mom_window = int(0.4 * rate)
@@ -121,6 +138,7 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
         'max_short_term_lufs': max_short_term if np.isfinite(max_short_term) else None,
         'max_momentary_lufs': max_momentary if np.isfinite(max_momentary) else None,
         'short_term_range': short_term_range,
+        'stl_95': stl_95,
     }
 
 def main() -> None:

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -25,6 +25,22 @@ from tools.shared.progress import ProgressBar
 
 logger = logging.getLogger(__name__)
 
+
+def _bandpass_sos(data: np.ndarray, rate: int, low_hz: float, high_hz: float,
+                  order: int = 4) -> np.ndarray:
+    """Zero-phase Butterworth bandpass via SOS form (numerically stable)."""
+    nyquist = rate / 2
+    low = max(low_hz, 1.0) / nyquist
+    high = min(high_hz, nyquist - 1.0) / nyquist
+    sos = signal.butter(order, [low, high], btype='bandpass', output='sos')
+    return signal.sosfiltfilt(sos, data)
+
+
+def _rms_db(samples: np.ndarray) -> float:
+    rms = float(np.sqrt(np.mean(samples ** 2)))
+    return 20.0 * np.log10(rms) if rms > 0 else float('-inf')
+
+
 def analyze_track(filepath: Path | str) -> dict[str, Any]:
     """Analyze a single track and return metrics."""
     data, rate = sf.read(filepath)
@@ -111,6 +127,24 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
         stl_95 = None
         stl_top_5pct_indices = np.array([], dtype=np.int64)
 
+    # low-RMS: 20-200 Hz band, measured within top-5% STL windows only.
+    # Whole-track measurement false-alarms on arrangements with quiet verses
+    # and wall-of-bass choruses (see #290 spec footnote †).
+    low_rms: float | None
+    if stl_95 is not None and len(stl_top_5pct_indices) > 0:
+        low_filtered = _bandpass_sos(mono, rate, 20.0, 200.0)
+        window_rms_values: list[float] = []
+        for window_idx in stl_top_5pct_indices:
+            start = int(window_idx) * st_hop
+            end = start + st_window
+            chunk = low_filtered[start:end]
+            rms_val = _rms_db(chunk)
+            if np.isfinite(rms_val):
+                window_rms_values.append(rms_val)
+        low_rms = float(np.median(window_rms_values)) if window_rms_values else None
+    else:
+        low_rms = None
+
     # Momentary: 400ms window, 100ms hop
     mom_window = int(0.4 * rate)
     mom_hop = int(0.1 * rate)
@@ -139,6 +173,7 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
         'max_momentary_lufs': max_momentary if np.isfinite(max_momentary) else None,
         'short_term_range': short_term_range,
         'stl_95': stl_95,
+        'low_rms': low_rms,
     }
 
 def main() -> None:

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -216,6 +216,14 @@ def analyze_track(filepath: Path | str, *,
                         if np.isfinite(max_short_term) and np.isfinite(min_short_term)
                         else 0.0)
 
+    # signature_meta records provenance for downstream consumers (anchor
+    # selector in phase 2a, coherence check in phase 2b).
+    signature_meta = {
+        'stl_window_count': len(st_values),
+        'stl_top_5pct_count': int(len(stl_top_5pct_indices)),
+        'vocal_rms_source': vocal_rms_source,
+    }
+
     return {
         'filename': os.path.basename(filepath),
         'duration': len(mono) / rate,
@@ -232,6 +240,7 @@ def analyze_track(filepath: Path | str, *,
         'stl_95': stl_95,
         'low_rms': low_rms,
         'vocal_rms': vocal_rms,
+        'signature_meta': signature_meta,
     }
 
 def main() -> None:

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -68,6 +68,27 @@ def _read_vocal_stem(stem_path: Path | str, target_rate: int) -> np.ndarray | No
     return np.asarray(mono, dtype=np.float64)
 
 
+def _auto_resolve_vocal_stem(input_path: Path) -> Path | None:
+    """Find a matching polished vocal stem without explicit kwarg.
+
+    Checks, in order:
+      1. <input_dir>/polished/<input_stem>/vocals.wav  (album-root input)
+      2. <input_dir>/../polished/<input_stem>/vocals.wav  (mastered/ or
+         polished/ subfolder input)
+
+    Returns the first existing path, or None.
+    """
+    stem_name = input_path.stem
+    candidates = [
+        input_path.parent / "polished" / stem_name / "vocals.wav",
+        input_path.parent.parent / "polished" / stem_name / "vocals.wav",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def analyze_track(filepath: Path | str, *,
                   vocal_stem_path: Path | str | None = None) -> dict[str, Any]:
     """Analyze a single track and return metrics.
@@ -183,7 +204,11 @@ def analyze_track(filepath: Path | str, *,
     vocal_rms: float | None = None
     vocal_rms_source: str = "unavailable"
 
-    resolved_stem = Path(vocal_stem_path) if vocal_stem_path else None
+    resolved_stem: Path | None
+    if vocal_stem_path is not None:
+        resolved_stem = Path(vocal_stem_path)
+    else:
+        resolved_stem = _auto_resolve_vocal_stem(Path(filepath))
     if resolved_stem is not None and resolved_stem.is_file():
         stem_mono = _read_vocal_stem(resolved_stem, rate)
         if stem_mono is not None:

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -41,8 +41,41 @@ def _rms_db(samples: np.ndarray) -> float:
     return 20.0 * np.log10(rms) if rms > 0 else float('-inf')
 
 
-def analyze_track(filepath: Path | str) -> dict[str, Any]:
-    """Analyze a single track and return metrics."""
+def _read_vocal_stem(stem_path: Path | str, target_rate: int) -> np.ndarray | None:
+    """Read a vocal stem, mono-mix, resample to target_rate.
+
+    Returns None if the file cannot be read or resampled.
+    """
+    try:
+        data, rate = sf.read(str(stem_path))
+    except Exception as exc:
+        logger.warning("Could not read vocal stem %s: %s", stem_path, exc)
+        return None
+    if data.ndim > 1:
+        mono = np.mean(data, axis=1)
+    else:
+        mono = data
+    if rate != target_rate:
+        try:
+            from math import gcd
+            g = gcd(int(rate), int(target_rate))
+            up = int(target_rate) // g
+            down = int(rate) // g
+            mono = signal.resample_poly(mono, up, down)
+        except Exception as exc:
+            logger.warning("Could not resample vocal stem %s: %s", stem_path, exc)
+            return None
+    return np.asarray(mono, dtype=np.float64)
+
+
+def analyze_track(filepath: Path | str, *,
+                  vocal_stem_path: Path | str | None = None) -> dict[str, Any]:
+    """Analyze a single track and return metrics.
+
+    Optional vocal_stem_path lets Phase 2 callers feed a known stem path
+    directly; omitted calls auto-resolve via the polished/<name>/vocals.wav
+    sibling convention (added in later tasks).
+    """
     data, rate = sf.read(filepath)
 
     # Handle mono
@@ -145,6 +178,20 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
     else:
         low_rms = None
 
+    # vocal-RMS: whole-stem RMS when stem path resolves; 1-4 kHz band of
+    # full mix otherwise. See #290 spec footnote ‡.
+    vocal_rms: float | None = None
+    vocal_rms_source: str = "unavailable"
+
+    resolved_stem = Path(vocal_stem_path) if vocal_stem_path else None
+    if resolved_stem is not None and resolved_stem.is_file():
+        stem_mono = _read_vocal_stem(resolved_stem, rate)
+        if stem_mono is not None:
+            rms_val = _rms_db(stem_mono)
+            if np.isfinite(rms_val):
+                vocal_rms = float(rms_val)
+                vocal_rms_source = "stem"
+
     # Momentary: 400ms window, 100ms hop
     mom_window = int(0.4 * rate)
     mom_hop = int(0.1 * rate)
@@ -174,6 +221,7 @@ def analyze_track(filepath: Path | str) -> dict[str, Any]:
         'short_term_range': short_term_range,
         'stl_95': stl_95,
         'low_rms': low_rms,
+        'vocal_rms': vocal_rms,
     }
 
 def main() -> None:

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -192,6 +192,16 @@ def analyze_track(filepath: Path | str, *,
                 vocal_rms = float(rms_val)
                 vocal_rms_source = "stem"
 
+    if vocal_rms is None:
+        try:
+            band_filtered = _bandpass_sos(mono, rate, 1000.0, 4000.0)
+            rms_val = _rms_db(band_filtered)
+            if np.isfinite(rms_val):
+                vocal_rms = float(rms_val)
+                vocal_rms_source = "band_fallback"
+        except Exception as exc:
+            logger.warning("1-4 kHz band fallback failed: %s", exc)
+
     # Momentary: 400ms window, 100ms hop
     mom_window = int(0.4 * rate)
     mom_hop = int(0.1 * rate)


### PR DESCRIPTION
## Summary

- Extends `analyze_track()` with three new signature fields — `stl_95`, `low_rms`, `vocal_rms` — plus a `signature_meta` dict recording provenance (`stl_window_count`, `stl_top_5pct_count`, `vocal_rms_source`).
- Auto-resolves `polished/<track>/vocals.wav` from album-root or `mastered/` subfolder layouts; 1–4 kHz band fallback when the stem is absent, unreadable, or at a different sample rate.
- New `vocal_stem_path` kwarg on `analyze_track()` lets Phase 2 callers (anchor selector, coherence check) pass the stem explicitly; MCP handler signature is unchanged.
- Additive return schema — purely new keys; existing callers that read field-by-field are unaffected.
- Folds in review item **E2** from #304: disk-usage note on the `delivery_sample_rate` comment in `config.example.yaml`.

## Phase context

This is **Phase 1b** of the 10-phase implementation of #290. Subsequent phases:

- **2a**: Anchor selector (consumes `stl_95`, `low_rms`, `vocal_rms`).
- **2b**: Album coherence check/correct (consumes per-track signatures, computes album median/tolerances).
- **2c**: `ALBUM_SIGNATURE.yaml` persistence + frozen-signature mode for `Released` albums.

Spec: `docs/superpowers/specs/2026-04-13-phase-1b-multi-metric-signature-design.md`
Plan: `docs/superpowers/plans/2026-04-13-phase-1b-multi-metric-signature.md`

## Non-regression notes

- `test_returns_expected_keys` in `test_analyze_tracks.py` uses strict set equality on the return schema; updated to include the four new keys.
- No behavior changes to existing metrics (LUFS, peak, RMS, band energy, tinniness, short-term / momentary dynamics). The existing short-term loop now also captures each finite value into a list for STL-95 percentile — output of pre-existing fields is unchanged.
- Handler `analyze_audio` in `servers/bitwize-music-server/handlers/processing/audio.py` is untouched. New fields flow through the existing JSON serialization automatically.

## Follow-up (filed as new #290 checklist item)

- **Polish preserves per-stem WAVs** — needed to activate stem-first vocal-RMS measurement in practice. Today `polish_audio` writes only a single stereo WAV at `polished/<track>.wav`, so the auto-resolve miss always fires and the 1–4 kHz band fallback applies. Once polish gains per-stem output, stem measurement activates automatically with no further changes to this code path.

## Test plan

- [x] 19 new unit tests in `tests/unit/mastering/test_signature_metrics.py`:
  - `TestShortTerm95` (4): constant-level, chorus/verse pattern, short-track gating, silent track.
  - `TestLowRms` (3): bass-chorus windowed measurement, short-track gating, silent track.
  - `TestVocalRmsStem` (3): explicit stem at known level, stem at different sample rate (resample path), unreadable stem falls back.
  - `TestVocalRmsFallback` (2): 1–4 kHz band fallback without stem, silent track.
  - `TestSignatureMeta` (3): full-length track meta keys, stem-source branch, unavailable on silence.
  - `TestAutoResolveStem` (4): album-root layout hit, `mastered/` subfolder layout hit, miss → fallback, explicit kwarg overrides auto-resolve.
- [x] Full pytest suite: **3184 passed**, 2 xfailed (pre-existing), 0 regressions.
- [x] YAML parse check on modified `config.example.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)