### PR TITLE
feat: album signature persistence + frozen mode (#290 phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   - Extended loudness metering (short-term, momentary LUFS)
 - **Mix pipeline enhancements** — saturation, sub-bass exciter, transient shaping wired into per-stem processing
 - **Configurable mastering presets** — refactored from tuples to dicts; all parameters exposed via CLI and genre presets
+- **Album signature persistence (#290 phase 4):** `master_album` now writes `ALBUM_SIGNATURE.yaml` alongside `mastered/` after every successful run, capturing the anchor, album medians, delivery targets (LUFS, TP ceiling, LRA), and coherence tolerances. Released albums automatically enter "frozen mode" on re-master — the shipped anchor + targets are reused so subsequent masters don't drift from what's on DSPs.
+- **`freeze_signature` / `new_anchor` params on `master_album`** — force frozen or fresh routing regardless of album status. Mutually exclusive; enforced in pre-flight.
+- **`is_album_released` helper** in `handlers/_shared.py` for cache-backed status checks.
+- **`get_plugin_version` helper** in `handlers/_shared.py` — single source of truth for plugin version reads (DRYed from health.py and master_album's new stage).
+- **`reference/streaming-mastering-specs.md`** — new authoritative reference for delivery targets, the signature contract, and re-mastering behavior.
 
 ### Changed
 - **Default mastered output format** — `master_album` / `master_audio` / `polish_and_master_album` now produce **24-bit WAV at 96 kHz** by default (was 16-bit at source rate, typically 44.1 kHz). Existing user configs without a `mastering:` block pick up the new defaults on the next run. To preserve the legacy 16/44.1 output, set `mastering.delivery_bit_depth: 16` and `mastering.delivery_sample_rate: 44100` in `~/.bitwize-music/config.yaml`. Users with custom `{overrides}/mastering-presets.yaml` per-genre values continue to honor those overrides. Disk usage increases ~3x per track at the new defaults (~33 MB vs. ~10 MB for a 3-minute stereo track).
@@ -51,6 +56,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   Polish results now surface `clicks_removed` per stem and on the full-mix
   result so operators can see whether polish acted (#289).
 - `analyze_mix_issues` in stems mode now analyzes every stem per track and reports per-stem diagnostics under `tracks[].stems[stem_name]`, rather than sampling only the alphabetically first stem. Issues in specific stems (muddy bass, harsh vocals, etc.) are no longer missed, and per-track issue rollups are the union across stems (#272)
+- **Archival stage now mirrors `mastered/` (#290 phase 4, PR #304 review A5):** orphans whose basename is no longer in `mastered/` are pruned before new files are written, so re-masters with fewer or renamed tracks don't retain stale archival entries. Records pruned names under `stages.archival.pruned`.
 
 ## [0.89.0] - 2026-04-10
 

--- a/reference/streaming-mastering-specs.md
+++ b/reference/streaming-mastering-specs.md
@@ -41,7 +41,10 @@ album_slug: "my-album"
 anchor:
   index: 3              # 1-based
   filename: "03-track.wav"
-  method: composite     # composite | override | tie_breaker | frozen_signature
+  method: composite     # composite | override | tie_breaker (persisted file
+                        # always preserves the shipped method; the JSON response
+                        # may temporarily surface "frozen_signature" during a
+                        # frozen-mode run, but that marker is never persisted)
   score: 0.512          # null when method is override or frozen
   signature:            # the anchor's own pre-master signature
     stl_95: -14.8

--- a/reference/streaming-mastering-specs.md
+++ b/reference/streaming-mastering-specs.md
@@ -1,0 +1,108 @@
+# Streaming Mastering Specs
+
+This document is the authoritative reference for how `master_album` delivers audio to streaming services and how its persistent signature works. It's the companion to issue #290.
+
+## Single-master delivery
+
+`master_album` produces one universal master per track and uploads to DistroKid, which fans out to every DSP. No per-platform variants.
+
+| Setting | Default | Where it lives |
+|---|---|---|
+| `delivery_format` | `wav` | `mastering:` block, `config.yaml` |
+| `delivery_bit_depth` | `24` | ↑ |
+| `delivery_sample_rate` | `96000` | ↑ |
+| `target_lufs` | `-14.0` | ↑ |
+| `true_peak_ceiling` | `-1.0` dBTP | ↑ |
+| `archival_enabled` | `false` (opt-in) | ↑ |
+| `adm_aac_encoder` | `aac` (ffmpeg native) | ↑ |
+
+### Why 24/96 specifically
+
+- Apple Music **Hi-Res Lossless** badge: ≥24-bit AND **>48 kHz** (strict `>`). 48 kHz doesn't qualify.
+- Tidal **Max** badge: 24-bit AND >44.1 kHz.
+- Spotify streams at 44.1 kHz regardless; 96 kHz input downsamples cleanly.
+- DistroKid accepts up to 192 kHz; 96 kHz is the sweet spot for badge gating vs. file size.
+
+### Honesty caveat on 96 kHz
+
+Suno source is 44.1 kHz. The 96 kHz output is **upsampled** — it satisfies the Apple/Tidal badge sample-rate gates but adds no audio information above ~22 kHz. The mastering report flags this at runtime whenever `delivery_sample_rate` exceeds the source rate.
+
+## Album signature (`ALBUM_SIGNATURE.yaml`)
+
+After every successful `master_album` run, a YAML snapshot is written to the album's audio directory (alongside `mastered/`, `archival/`). The signature captures what was shipped so future re-masters don't drift.
+
+Layout:
+
+```yaml
+schema_version: 1
+written_at: "2026-04-14T10:00:00Z"
+plugin_version: "0.91.0"
+album_slug: "my-album"
+anchor:
+  index: 3              # 1-based
+  filename: "03-track.wav"
+  method: composite     # composite | override | tie_breaker | frozen_signature
+  score: 0.512          # null when method is override or frozen
+  signature:            # the anchor's own pre-master signature
+    stl_95: -14.8
+    low_rms: -22.1
+    vocal_rms: -17.6
+    short_term_range: 8.4
+    lufs: -14.0
+    peak_db: -3.1
+album_median:           # album-wide medians across tracks
+  lufs: -14.0
+  stl_95: -14.5
+  low_rms: -22.0
+  vocal_rms: -17.8
+  short_term_range: 8.2
+delivery_targets:
+  target_lufs: -14.0
+  tp_ceiling_db: -1.0
+  lra_target_lu: 8.0
+  output_bits: 24
+  output_sample_rate: 96000
+tolerances:
+  coherence_stl_95_lu: 1.0
+  coherence_lra_floor_lu: 6.0
+  coherence_low_rms_db: 2.0
+  coherence_vocal_rms_db: 1.5
+pipeline:
+  polish_subfolder: "polished"
+  source_sample_rate: 44100
+  upsampled_from_source: true
+```
+
+## Re-mastering behavior
+
+| Album state | Signature file present | Default routing | What happens |
+|---|---|---|---|
+| Not `Released` (any sub-state) | may or may not exist | **fresh** | Full pipeline: score a new anchor across the current track set, rewrite signature on success. |
+| `Released` | **must exist** | **frozen** | Skip anchor scoring. Master new/regenerated tracks against the anchor + targets in the signature. |
+| `Released` | missing | — | **Halt + escalate.** Signature was deleted or never written. Cannot safely re-master. |
+
+### Manual overrides
+
+- `freeze_signature=True` — force frozen mode regardless of status. Useful for bonus tracks added during release prep. Errors if no signature file exists.
+- `new_anchor=True` — force fresh anchor selection regardless of status. Useful when intentionally remastering a released album with a new sonic identity.
+- The two flags are mutually exclusive; passing both fails fast in pre-flight.
+
+### Archival stage mirrors `mastered/`
+
+When `archival_enabled: true`, the 32-bit float pre-downconvert master is written to `archival/`. The archival stage now mirrors `mastered/` — entries whose basename is no longer in `mastered/` are pruned. This keeps the archival set in sync across re-masters where tracks are dropped or renamed. The `prune_archival` MCP tool is still available for time-versioned cleanup (keep N newest by mtime) — that's a separate concept.
+
+## AAC encoder selection (future ADM validation step)
+
+Not yet shipped — tracked as a future #290 checklist item. Parity-gap notes for when it lands:
+
+- **macOS**: `afconvert` (Apple's reference encoder) + `afclip` — preferred runtime when available.
+- **Linux / Windows / CI**: `ffmpeg -c:a aac` (native) — spec-equivalent for the zero-clip acid test but not bit-identical to Apple's encoder.
+- **Override**: `mastering.adm_aac_encoder: libfdk_aac` for users with a non-free ffmpeg build.
+
+## References
+
+- iZotope — How to Master an Album: https://www.izotope.com/en/learn/how-to-master-an-album
+- Yamaha Hub — Full Album Mastering: https://hub.yamaha.com/proaudio/recording/the-art-of-mastering-part-5-full-album-mastering/
+- DistroKid Tidal Max badge: https://support.distrokid.com/hc/en-us/articles/360059827614
+- DistroKid Apple audio badges: https://support.distrokid.com/hc/en-us/articles/4408827366675
+- Apple Digital Masters spec (PDF): https://www.apple.com/apple-music/apple-digital-masters/docs/apple-digital-masters.pdf

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -452,6 +452,27 @@ _STREAMING_PLACEHOLDER_MARKERS = [
 _CODE_BLOCK_SECTIONS = frozenset({"Style Box", "Exclude Styles", "Lyrics Box", "Streaming Lyrics", "Original Quote"})
 
 
+def get_plugin_version() -> str:
+    """Return the plugin version string from .claude-plugin/plugin.json.
+
+    Reads ``PLUGIN_ROOT / ".claude-plugin" / "plugin.json"`` and returns the
+    ``version`` field as a string.  Returns ``"unknown"`` on any failure
+    (PLUGIN_ROOT is None, file missing, JSON malformed, field absent).
+
+    This is intentionally a simple helper — use it wherever a plain version
+    string is needed.  For the full stored-vs-current comparison tool, see
+    ``handlers.health.get_plugin_version`` (the async MCP tool).
+    """
+    if PLUGIN_ROOT is None:
+        return "unknown"
+    manifest = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        return str(data.get("version", "unknown"))
+    except (OSError, json.JSONDecodeError):
+        return "unknown"
+
+
 def _find_wav_source_dir(audio_dir: Path) -> Path:
     """Return originals/ if it exists, else album root (legacy fallback)."""
     originals = audio_dir / "originals"

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -473,11 +473,6 @@ def get_plugin_version() -> str:
         return "unknown"
 
 
-def _normalize_album_slug(slug: str) -> str:
-    """Normalize an album slug for cache lookup (lowercase + strip)."""
-    return slug.strip().lower()
-
-
 def is_album_released(album_slug: str) -> bool:
     """Return True when the album's cached status is ``Released``.
 
@@ -486,16 +481,25 @@ def is_album_released(album_slug: str) -> bool:
     from what shipped.
 
     Safe to call before the cache is fully initialized (returns ``False``
-    for any lookup that can't resolve).
+    for any lookup that can't resolve — missing cache, invalid slug,
+    corrupt state, missing album, or any non-"Released" status).
     """
     if cache is None:
         return False
     try:
-        state = cache.get_state() or {}
-    except Exception:  # defensive — cache may raise on corrupt state
+        normalized = _normalize_slug(album_slug)
+    except ValueError:
+        # Invalid slug (path separators, null bytes, traversal) can't
+        # match any album. Safe default.
+        return False
+    try:
+        state = cache.get_state()
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not state:
         return False
     albums = state.get("albums", {})
-    entry = albums.get(album_slug) or albums.get(_normalize_album_slug(album_slug))
+    entry = albums.get(normalized)
     if not isinstance(entry, dict):
         return False
     return entry.get("status") == ALBUM_RELEASED

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -473,6 +473,34 @@ def get_plugin_version() -> str:
         return "unknown"
 
 
+def _normalize_album_slug(slug: str) -> str:
+    """Normalize an album slug for cache lookup (lowercase + strip)."""
+    return slug.strip().lower()
+
+
+def is_album_released(album_slug: str) -> bool:
+    """Return True when the album's cached status is ``Released``.
+
+    Consumed by ``master_album``'s freeze-decision stage — frozen mode
+    is the default for Released albums so re-mastering never drifts
+    from what shipped.
+
+    Safe to call before the cache is fully initialized (returns ``False``
+    for any lookup that can't resolve).
+    """
+    if cache is None:
+        return False
+    try:
+        state = cache.get_state() or {}
+    except Exception:  # defensive — cache may raise on corrupt state
+        return False
+    albums = state.get("albums", {})
+    entry = albums.get(album_slug) or albums.get(_normalize_album_slug(album_slug))
+    if not isinstance(entry, dict):
+        return False
+    return entry.get("status") == ALBUM_RELEASED
+
+
 def _find_wav_source_dir(audio_dir: Path) -> Path:
     """Return originals/ if it exists, else album root (legacy fallback)."""
     originals = audio_dir / "originals"

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from handlers import _shared
-from handlers._shared import _safe_json
+from handlers._shared import _safe_json, get_plugin_version as _read_plugin_version
 
 logger = logging.getLogger(__name__)
 
@@ -175,16 +175,9 @@ async def get_plugin_version() -> str:
     state = _shared.cache.get_state()
     stored = state.get("plugin_version")
 
-    # Read current version from plugin.json
-    assert _shared.PLUGIN_ROOT is not None
-    plugin_json = _shared.PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
-    current = None
-    try:
-        if plugin_json.exists():
-            data = json.loads(plugin_json.read_text(encoding="utf-8"))
-            current = data.get("version")
-    except (json.JSONDecodeError, OSError) as e:
-        logger.warning("Cannot read plugin.json: %s", e)
+    # Read current version via shared helper (handles missing file / bad JSON).
+    current_raw = _read_plugin_version()
+    current = None if current_raw == "unknown" else current_raw
 
     needs_upgrade = False
     if stored is None and current is not None:

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -846,7 +846,7 @@ async def master_album(
         frozen_anchor = frozen_signature.get("anchor") or {}
         frozen_targets = frozen_signature.get("delivery_targets") or {}
 
-        anchor_result = {
+        anchor_result: dict[str, Any] = {
             "selected_index":  frozen_anchor.get("index"),
             "method":          "frozen_signature",
             "override_index":  None,

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -21,8 +21,10 @@ from handlers._shared import (
     _normalize_slug,
     # _resolve_audio_dir accessed via _helpers for patch compatibility
     _safe_json,
+    get_plugin_version as _read_plugin_version,
 )
 from handlers.processing import _helpers
+from tools.mastering.album_signature import build_signature
 from tools.mastering.signature_persistence import (
     SignaturePersistenceError,
     write_signature_file,
@@ -1478,18 +1480,7 @@ async def master_album(
     # the branching below so a frozen-mode run preserves the original
     # anchor block instead of overwriting with ``method=frozen_signature``.
     try:
-        from tools.mastering.album_signature import build_signature
-
-        _plugin_version = "unknown"
-        if _shared.PLUGIN_ROOT is not None:
-            _manifest = _shared.PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
-            try:
-                _plugin_version = str(
-                    json.loads(_manifest.read_text(encoding="utf-8"))
-                    .get("version", "unknown")
-                )
-            except (OSError, json.JSONDecodeError):
-                pass
+        _plugin_version = _read_plugin_version()
 
         sig = build_signature(
             analysis_results,
@@ -1551,7 +1542,14 @@ async def master_album(
         # yaml.safe_dump cannot represent numpy scalars — round-trip through
         # JSON (which already uses float for numpy floats via json default) to
         # produce a plain-Python dict before handing off to signature_persistence.
-        payload = json.loads(json.dumps(payload, default=lambda v: v.item() if hasattr(v, "item") else None))
+        def _coerce_numeric(v: Any) -> Any:
+            if hasattr(v, "item"):
+                return v.item()
+            raise TypeError(
+                f"signature payload contains unserializable {type(v).__name__}: {v!r}"
+            )
+
+        payload = json.loads(json.dumps(payload, default=_coerce_numeric))
 
         sig_path = write_signature_file(
             audio_dir, payload, plugin_version=_plugin_version,
@@ -1560,7 +1558,7 @@ async def master_album(
             "status": "pass",
             "path":   str(sig_path),
         }
-    except (SignaturePersistenceError, OSError) as exc:
+    except (SignaturePersistenceError, OSError, TypeError) as exc:
         # Non-fatal: mastering already succeeded, just couldn't persist.
         warnings.append(f"Signature persist: {exc}")
         stages["signature_persist"] = {

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -569,6 +569,8 @@ async def master_album(
     cut_highmid: float = 0.0,
     cut_highs: float = 0.0,
     source_subfolder: str = "",
+    freeze_signature: bool = False,
+    new_anchor: bool = False,
 ) -> str:
     """End-to-end mastering pipeline: analyze, QC, master, verify, update status.
 
@@ -590,6 +592,14 @@ async def master_album(
         cut_highs: High shelf cut in dB at 8kHz
         source_subfolder: Read WAV files from this subfolder instead of the
             base audio dir (e.g., "polished" to master from mix-engineer output)
+        freeze_signature: Force frozen-signature mode regardless of album
+            status. Skips anchor selection and masters against
+            ``ALBUM_SIGNATURE.yaml``. Useful for bonus tracks during
+            release prep. Mutually exclusive with ``new_anchor``.
+        new_anchor: Force fresh anchor selection regardless of album
+            status. Useful for remastering a Released album with a new
+            anchor (e.g. re-release). Mutually exclusive with
+            ``freeze_signature``.
 
     Returns:
         JSON with per-stage results, settings, warnings, and failure info
@@ -599,6 +609,20 @@ async def master_album(
 
     stages: dict[str, Any] = {}
     warnings: list[Any] = []
+
+    if freeze_signature and new_anchor:
+        return _safe_json({
+            "album_slug": album_slug,
+            "stage_reached": "pre_flight",
+            "stages": {"pre_flight": {
+                "status": "fail",
+                "detail": "freeze_signature and new_anchor are mutually exclusive",
+            }},
+            "failed_stage": "pre_flight",
+            "failure_detail": {
+                "reason": "freeze_signature and new_anchor are mutually exclusive",
+            },
+        })
 
     # --- Stage 1: Pre-flight ---
     dep_err = _helpers._check_mastering_deps()

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -1326,11 +1326,20 @@ async def master_album(
     # of each mastered track to archival/. This is a bit-depth-expanded
     # copy of the delivery master (not a separate render), intended for
     # re-mastering without re-polishing stems.
+    #
+    # The archival dir is a MIRROR of mastered/: orphans (files whose
+    # basename is no longer in mastered/) are removed before the new
+    # float copies go down. Keeps re-mastered albums in sync when tracks
+    # are dropped or renamed (#290 phase 4 — PR #304 review item A5).
     if targets.get("archival_enabled"):
         import soundfile as _sf_archival
+        from tools.mastering.archival import prune_archival_orphans
 
         archival_dir = audio_dir / "archival"
         archival_dir.mkdir(exist_ok=True)
+        mastered_names = {p.name for p in mastered_files}
+        pruned = prune_archival_orphans(archival_dir, mastered_names)
+
         archived = 0
         archive_errors: list[str] = []
         for mastered_path in mastered_files:
@@ -1345,6 +1354,7 @@ async def master_album(
         stages["archival"] = {
             "status": "pass" if not archive_errors else "warn",
             "count": archived,
+            "pruned": pruned or None,
             "output_dir": str(archival_dir),
             "errors": archive_errors or None,
         }

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -26,7 +26,9 @@ from handlers._shared import (
 from handlers.processing import _helpers
 from tools.mastering.album_signature import build_signature
 from tools.mastering.signature_persistence import (
+    SIGNATURE_FILENAME,
     SignaturePersistenceError,
+    read_signature_file,
     write_signature_file,
 )
 
@@ -776,46 +778,149 @@ async def master_album(
         "tinny_tracks": tinny_tracks,
     }
 
-    # --- Stage 2b: Anchor selection (#290 phase 2) ---
-    from tools.mastering.anchor_selector import select_anchor
+    # --- Stage 2a: Freeze decision (#290 phase 4) ---
+    frozen_signature: dict[str, Any] | None = None
+    freeze_reason: str
+    if freeze_signature:
+        freeze_mode = "frozen"
+        freeze_reason = "freeze_signature_override"
+    elif new_anchor:
+        freeze_mode = "fresh"
+        freeze_reason = "new_anchor_override"
+    elif _shared.is_album_released(album_slug):
+        freeze_mode = "frozen"
+        freeze_reason = "album_released"
+    else:
+        freeze_mode = "fresh"
+        freeze_reason = "default"
 
-    # Read anchor_track override from state cache (parse_album_readme
-    # surfaces it as an int or None).
-    anchor_override: int | None = None
-    state_albums = (_shared.cache.get_state() or {}).get("albums", {})
-    album_state = state_albums.get(_normalize_slug(album_slug), {})
-    raw_override = album_state.get("anchor_track")
-    if isinstance(raw_override, int) and not isinstance(raw_override, bool):
-        anchor_override = raw_override
+    if freeze_mode == "frozen":
+        try:
+            frozen_signature = read_signature_file(audio_dir)
+        except SignaturePersistenceError as exc:
+            return _safe_json({
+                "album_slug": album_slug,
+                "stage_reached": "freeze_decision",
+                "stages": {**stages, "freeze_decision": {
+                    "status": "fail",
+                    "mode": freeze_mode,
+                    "reason": f"Corrupt {SIGNATURE_FILENAME}: {exc}",
+                }},
+                "failed_stage": "freeze_decision",
+                "failure_detail": {"reason": str(exc)},
+            })
+        if frozen_signature is None:
+            if freeze_signature:
+                reason_text = (
+                    f"freeze_signature requested but {SIGNATURE_FILENAME} is absent "
+                    f"in {audio_dir}"
+                )
+            else:
+                reason_text = (
+                    f"Album is Released but {SIGNATURE_FILENAME} is absent in "
+                    f"{audio_dir}. Halt + escalate — cannot safely re-master without "
+                    f"a frozen signature."
+                )
+            return _safe_json({
+                "album_slug": album_slug,
+                "stage_reached": "freeze_decision",
+                "stages": {**stages, "freeze_decision": {
+                    "status": "fail",
+                    "mode": freeze_mode,
+                    "reason": reason_text,
+                }},
+                "failed_stage": "freeze_decision",
+                "failure_detail": {"reason": reason_text},
+            })
 
-    # Build anchor preset. load_genre_presets() filters through
-    # _PRESET_DEFAULTS, so nested-dict defaults (spectral_reference_energy)
-    # don't inherit into per-genre presets. select_anchor carries its own
-    # pop-balanced defaults for `genre_ideal_lra_lu` and
-    # `spectral_reference_energy` when the preset omits them.
-    anchor_preset = preset_dict or {}
-
-    anchor_result = select_anchor(
-        analysis_results,
-        anchor_preset,
-        override_index=anchor_override,
-    )
-
-    # Phase 2 records the result but does not yet re-order the mastering
-    # loop — coherence correction lands in a later phase.
-    stages["anchor_selection"] = {
-        "status": "pass" if anchor_result["selected_index"] is not None else "warn",
-        "selected_index": anchor_result["selected_index"],
-        "method": anchor_result["method"],
-        "override_index": anchor_result["override_index"],
-        "override_reason": anchor_result["override_reason"],
-        "scores": anchor_result["scores"],
+    stages["freeze_decision"] = {
+        "status": "pass",
+        "mode":   freeze_mode,
+        "reason": freeze_reason,
     }
-    if anchor_result["selected_index"] is None:
-        warnings.append(
-            "Anchor selector: no eligible tracks (signature metrics missing). "
-            "Mastering proceeds without an anchor; coherence correction disabled."
+
+    # --- Stage 2b: Anchor selection (#290 phase 2 / routed by 2a in phase 4) ---
+    if frozen_signature is not None:
+        # Frozen mode: reuse persisted anchor + targets; no scoring.
+        frozen_anchor = frozen_signature.get("anchor") or {}
+        frozen_targets = frozen_signature.get("delivery_targets") or {}
+
+        anchor_result = {
+            "selected_index":  frozen_anchor.get("index"),
+            "method":          "frozen_signature",
+            "override_index":  None,
+            "override_reason": None,
+            "scores":          [],
+        }
+        stages["anchor_selection"] = {
+            "status":          "pass" if anchor_result["selected_index"] is not None else "warn",
+            "selected_index":  anchor_result["selected_index"],
+            "method":          "frozen_signature",
+            "override_index":  None,
+            "override_reason": None,
+            "scores":          [],
+            "frozen_from":     frozen_anchor.get("filename"),
+        }
+
+        # Override the `targets` dict for downstream mastering so the
+        # run delivers at the same loudness/ceiling as the shipped
+        # signature. Falls back to the current targets when the frozen
+        # file omits a key (forward-compat).
+        for k, sig_key in (
+            ("target_lufs",        "target_lufs"),
+            ("ceiling_db",         "tp_ceiling_db"),
+            ("output_bits",        "output_bits"),
+            ("output_sample_rate", "output_sample_rate"),
+        ):
+            val = frozen_targets.get(sig_key)
+            if val is not None:
+                targets[k] = val
+        # Rebuild `settings` so the JSON response reflects the frozen
+        # targets (settings is already emitted in earlier stages' output).
+        settings["target_lufs"] = targets.get("target_lufs")
+        settings["ceiling_db"]  = targets.get("ceiling_db")
+        settings["output_bits"] = targets.get("output_bits")
+        settings["output_sample_rate"] = targets.get("output_sample_rate")
+    else:
+        from tools.mastering.anchor_selector import select_anchor
+
+        # Read anchor_track override from state cache (parse_album_readme
+        # surfaces it as an int or None).
+        anchor_override: int | None = None
+        state_albums = (_shared.cache.get_state() or {}).get("albums", {})
+        album_state = state_albums.get(_normalize_slug(album_slug), {})
+        raw_override = album_state.get("anchor_track")
+        if isinstance(raw_override, int) and not isinstance(raw_override, bool):
+            anchor_override = raw_override
+
+        # Build anchor preset. load_genre_presets() filters through
+        # _PRESET_DEFAULTS, so nested-dict defaults (spectral_reference_energy)
+        # don't inherit into per-genre presets. select_anchor carries its own
+        # pop-balanced defaults for `genre_ideal_lra_lu` and
+        # `spectral_reference_energy` when the preset omits them.
+        anchor_preset = preset_dict or {}
+
+        anchor_result = select_anchor(
+            analysis_results,
+            anchor_preset,
+            override_index=anchor_override,
         )
+
+        # Phase 2 records the result but does not yet re-order the mastering
+        # loop — coherence correction lands in a later phase.
+        stages["anchor_selection"] = {
+            "status": "pass" if anchor_result["selected_index"] is not None else "warn",
+            "selected_index": anchor_result["selected_index"],
+            "method": anchor_result["method"],
+            "override_index": anchor_result["override_index"],
+            "override_reason": anchor_result["override_reason"],
+            "scores": anchor_result["scores"],
+        }
+        if anchor_result["selected_index"] is None:
+            warnings.append(
+                "Anchor selector: no eligible tracks (signature metrics missing). "
+                "Mastering proceeds without an anchor; coherence correction disabled."
+            )
 
     # --- Stage 3: Pre-QC ---
     # Skip `truepeak` and `clicks` on the raw/polished input:
@@ -1499,10 +1604,10 @@ async def master_album(
     # the signature reflects pre-master state of the shipped tracks
     # (inputs to mastering, not the mastered output).
     #
-    # ``frozen_signature`` is a local reference introduced by task 7
-    # (Stage 2a). For this task's commit it's always None; task 7 amends
-    # the branching below so a frozen-mode run preserves the original
-    # anchor block instead of overwriting with ``method=frozen_signature``.
+    # In frozen mode the original anchor block is preserved verbatim so
+    # re-writes keep method/score from what shipped rather than overwriting
+    # with "frozen_signature". album_median + pipeline still refresh so
+    # added/regenerated tracks get surfaced in the aggregates.
     try:
         _plugin_version = _read_plugin_version()
 
@@ -1538,30 +1643,48 @@ async def master_album(
                           "short_term_range", "lufs", "peak_db")
             }
 
-        payload: dict[str, Any] = {
-            "album_slug":       album_slug,
-            "anchor": {
-                "index":           anchor_idx,
-                "filename":        anchor_filename,
-                "method":          anchor_result.get("method"),
-                "score":           None,  # filled below when composite
-                "signature":       anchor_track_sig,
-            },
-            "album_median":     sig["album"]["median"],
-            "delivery_targets": sig["album"].get("delivery_targets", {}),
-            "tolerances":       sig["album"].get("tolerances", {}),
-            "pipeline": {
-                "polish_subfolder":       source_subfolder or None,
-                "source_sample_rate":     targets.get("source_sample_rate"),
-                "upsampled_from_source":  bool(targets.get("upsampled_from_source")),
-            },
-        }
-        # Carry the composite score when the anchor was chosen by scoring.
-        if anchor_idx is not None:
-            for s in anchor_result.get("scores", []) or []:
-                if s.get("index") == anchor_idx:
-                    payload["anchor"]["score"] = s.get("score")
-                    break
+        if frozen_signature is not None:
+            # Frozen mode: preserve the anchor block from the shipped
+            # signature verbatim. album_median + pipeline still refresh
+            # so added/regenerated tracks get surfaced in the aggregates.
+            frozen_anchor_block = frozen_signature.get("anchor") or {}
+            payload: dict[str, Any] = {
+                "album_slug":       album_slug,
+                "anchor":           dict(frozen_anchor_block),
+                "album_median":     sig["album"]["median"],
+                "delivery_targets": sig["album"].get("delivery_targets", {}),
+                "tolerances":       sig["album"].get("tolerances", {}),
+                "pipeline": {
+                    "polish_subfolder":       source_subfolder or None,
+                    "source_sample_rate":     targets.get("source_sample_rate"),
+                    "upsampled_from_source":  bool(targets.get("upsampled_from_source")),
+                },
+            }
+        else:
+            payload = {
+                "album_slug":       album_slug,
+                "anchor": {
+                    "index":           anchor_idx,
+                    "filename":        anchor_filename,
+                    "method":          anchor_result.get("method"),
+                    "score":           None,  # filled below when composite
+                    "signature":       anchor_track_sig,
+                },
+                "album_median":     sig["album"]["median"],
+                "delivery_targets": sig["album"].get("delivery_targets", {}),
+                "tolerances":       sig["album"].get("tolerances", {}),
+                "pipeline": {
+                    "polish_subfolder":       source_subfolder or None,
+                    "source_sample_rate":     targets.get("source_sample_rate"),
+                    "upsampled_from_source":  bool(targets.get("upsampled_from_source")),
+                },
+            }
+            # Carry the composite score when the anchor was chosen by scoring.
+            if anchor_idx is not None:
+                for s in anchor_result.get("scores", []) or []:
+                    if s.get("index") == anchor_idx:
+                        payload["anchor"]["score"] = s.get("score")
+                        break
 
         # yaml.safe_dump cannot represent numpy scalars — round-trip through
         # JSON (which already uses float for numpy floats via json default) to

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -798,16 +798,17 @@ async def master_album(
         try:
             frozen_signature = read_signature_file(audio_dir)
         except SignaturePersistenceError as exc:
+            reason_text = f"Corrupt {SIGNATURE_FILENAME}: {exc}"
             return _safe_json({
                 "album_slug": album_slug,
                 "stage_reached": "freeze_decision",
                 "stages": {**stages, "freeze_decision": {
                     "status": "fail",
                     "mode": freeze_mode,
-                    "reason": f"Corrupt {SIGNATURE_FILENAME}: {exc}",
+                    "reason": reason_text,
                 }},
                 "failed_stage": "freeze_decision",
-                "failure_detail": {"reason": str(exc)},
+                "failure_detail": {"reason": reason_text},
             })
         if frozen_signature is None:
             if freeze_signature:
@@ -875,12 +876,59 @@ async def master_album(
             val = frozen_targets.get(sig_key)
             if val is not None:
                 targets[k] = val
+
+        # I2: recompute upsampled_from_source after sample-rate mutation.
+        _src_sr = targets.get("source_sample_rate")
+        _out_sr = targets.get("output_sample_rate")
+        if _src_sr is not None and _out_sr is not None:
+            targets["upsampled_from_source"] = _out_sr > _src_sr
+
         # Rebuild `settings` so the JSON response reflects the frozen
         # targets (settings is already emitted in earlier stages' output).
         settings["target_lufs"] = targets.get("target_lufs")
         settings["ceiling_db"]  = targets.get("ceiling_db")
         settings["output_bits"] = targets.get("output_bits")
         settings["output_sample_rate"] = targets.get("output_sample_rate")
+        settings["upsampled_from_source"] = targets.get("upsampled_from_source")
+
+        # C1: Refresh effective_preset in-place with frozen delivery-target
+        # fields so Stage 4's mastering loop and _master_track receive the
+        # frozen values, not the genre defaults cached at Stage 1.
+        _frozen_preset_overrides: dict[str, Any] = {}
+        _lufs_override = frozen_targets.get("target_lufs")
+        if _lufs_override is not None:
+            _frozen_preset_overrides["target_lufs"] = _lufs_override
+        _ceil_override = frozen_targets.get("tp_ceiling_db")
+        if _ceil_override is not None:
+            _frozen_preset_overrides["ceiling_db"] = _ceil_override
+        _bits_override = frozen_targets.get("output_bits")
+        if _bits_override is not None:
+            _frozen_preset_overrides["output_bits"] = _bits_override
+        _sr_override = frozen_targets.get("output_sample_rate")
+        if _sr_override is not None:
+            _frozen_preset_overrides["output_sample_rate"] = _sr_override
+        _lra_override = frozen_targets.get("lra_target_lu")
+        if _lra_override is not None:
+            _frozen_preset_overrides["genre_ideal_lra_lu"] = _lra_override
+        effective_preset.update(_frozen_preset_overrides)
+
+        # I1: Also propagate frozen tolerance fields into effective_preset.
+        for _tol_key in (
+            "coherence_stl_95_lu",
+            "coherence_lra_floor_lu",
+            "coherence_low_rms_db",
+            "coherence_vocal_rms_db",
+        ):
+            _tol_val = frozen_signature.get("tolerances", {}).get(_tol_key)
+            if _tol_val is not None:
+                effective_preset[_tol_key] = _tol_val
+
+        # C1: Reassign cached effective_* locals from updated targets/preset
+        # so all downstream code (Stage 4 mastering loop, Stage 5 verification)
+        # operates on the frozen values.
+        effective_lufs = targets["target_lufs"]
+        effective_ceiling = targets["ceiling_db"]
+        effective_compress = effective_preset.get("compress_ratio", effective_compress)
     else:
         from tools.mastering.anchor_selector import select_anchor
 

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -23,6 +23,10 @@ from handlers._shared import (
     _safe_json,
 )
 from handlers.processing import _helpers
+from tools.mastering.signature_persistence import (
+    SignaturePersistenceError,
+    write_signature_file,
+)
 
 logger = logging.getLogger("bitwize-music-state")
 
@@ -1463,6 +1467,106 @@ async def master_album(
         "album_status": album_status,
         "errors": status_errors if status_errors else None,
     }
+
+    # --- Stage 7.5: Persist ALBUM_SIGNATURE.yaml (#290 phase 4) ---
+    # Build from the same analysis_results used for anchor selection so
+    # the signature reflects pre-master state of the shipped tracks
+    # (inputs to mastering, not the mastered output).
+    #
+    # ``frozen_signature`` is a local reference introduced by task 7
+    # (Stage 2a). For this task's commit it's always None; task 7 amends
+    # the branching below so a frozen-mode run preserves the original
+    # anchor block instead of overwriting with ``method=frozen_signature``.
+    try:
+        from tools.mastering.album_signature import build_signature
+
+        _plugin_version = "unknown"
+        if _shared.PLUGIN_ROOT is not None:
+            _manifest = _shared.PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+            try:
+                _plugin_version = str(
+                    json.loads(_manifest.read_text(encoding="utf-8"))
+                    .get("version", "unknown")
+                )
+            except (OSError, json.JSONDecodeError):
+                pass
+
+        sig = build_signature(
+            analysis_results,
+            delivery_targets={
+                "target_lufs":        targets.get("target_lufs"),
+                "tp_ceiling_db":      targets.get("ceiling_db"),
+                "lra_target_lu":      preset_dict.get("genre_ideal_lra_lu") if preset_dict else None,
+                "output_bits":        targets.get("output_bits"),
+                "output_sample_rate": targets.get("output_sample_rate"),
+            },
+            tolerances={
+                k: preset_dict.get(k)
+                for k in (
+                    "coherence_stl_95_lu",
+                    "coherence_lra_floor_lu",
+                    "coherence_low_rms_db",
+                    "coherence_vocal_rms_db",
+                )
+                if preset_dict is not None and preset_dict.get(k) is not None
+            },
+        )
+        anchor_idx = anchor_result.get("selected_index")
+        anchor_track_sig: dict[str, Any] | None = None
+        anchor_filename: str | None = None
+        if anchor_idx is not None and 1 <= anchor_idx <= len(sig["tracks"]):
+            row = sig["tracks"][anchor_idx - 1]
+            anchor_filename = row.get("filename")
+            anchor_track_sig = {
+                k: row.get(k)
+                for k in ("stl_95", "low_rms", "vocal_rms",
+                          "short_term_range", "lufs", "peak_db")
+            }
+
+        payload: dict[str, Any] = {
+            "album_slug":       album_slug,
+            "anchor": {
+                "index":           anchor_idx,
+                "filename":        anchor_filename,
+                "method":          anchor_result.get("method"),
+                "score":           None,  # filled below when composite
+                "signature":       anchor_track_sig,
+            },
+            "album_median":     sig["album"]["median"],
+            "delivery_targets": sig["album"].get("delivery_targets", {}),
+            "tolerances":       sig["album"].get("tolerances", {}),
+            "pipeline": {
+                "polish_subfolder":       source_subfolder or None,
+                "source_sample_rate":     targets.get("source_sample_rate"),
+                "upsampled_from_source":  bool(targets.get("upsampled_from_source")),
+            },
+        }
+        # Carry the composite score when the anchor was chosen by scoring.
+        if anchor_idx is not None:
+            for s in anchor_result.get("scores", []) or []:
+                if s.get("index") == anchor_idx:
+                    payload["anchor"]["score"] = s.get("score")
+                    break
+
+        # yaml.safe_dump cannot represent numpy scalars — round-trip through
+        # JSON (which already uses float for numpy floats via json default) to
+        # produce a plain-Python dict before handing off to signature_persistence.
+        payload = json.loads(json.dumps(payload, default=lambda v: v.item() if hasattr(v, "item") else None))
+
+        sig_path = write_signature_file(
+            audio_dir, payload, plugin_version=_plugin_version,
+        )
+        stages["signature_persist"] = {
+            "status": "pass",
+            "path":   str(sig_path),
+        }
+    except (SignaturePersistenceError, OSError) as exc:
+        # Non-fatal: mastering already succeeded, just couldn't persist.
+        warnings.append(f"Signature persist: {exc}")
+        stages["signature_persist"] = {
+            "status": "warn",
+            "error":  str(exc),
+        }
 
     # Build runtime notices (caveats worth surfacing to the user).
     notices: list[str] = []

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -1659,16 +1659,40 @@ async def master_album(
     try:
         _plugin_version = _read_plugin_version()
 
-        sig = build_signature(
-            analysis_results,
-            delivery_targets={
-                "target_lufs":        targets.get("target_lufs"),
-                "tp_ceiling_db":      targets.get("ceiling_db"),
-                "lra_target_lu":      preset_dict.get("genre_ideal_lra_lu") if preset_dict else None,
-                "output_bits":        targets.get("output_bits"),
-                "output_sample_rate": targets.get("output_sample_rate"),
-            },
-            tolerances={
+        # In frozen mode, prefer tolerances + lra_target_lu from the
+        # frozen signature to prevent drift (preset_dict holds the
+        # current genre preset, not the shipped values).
+        if frozen_signature is not None:
+            _frozen_targets = frozen_signature.get("delivery_targets") or {}
+            _frozen_tolerances = frozen_signature.get("tolerances") or {}
+            _lra_target_lu = _frozen_targets.get("lra_target_lu")
+            if _lra_target_lu is None:
+                _lra_target_lu = preset_dict.get("genre_ideal_lra_lu") if preset_dict else None
+            _tolerances = {
+                k: _frozen_tolerances.get(k)
+                for k in (
+                    "coherence_stl_95_lu",
+                    "coherence_lra_floor_lu",
+                    "coherence_low_rms_db",
+                    "coherence_vocal_rms_db",
+                )
+                if _frozen_tolerances.get(k) is not None
+            }
+            # If frozen file omits tolerances entirely, fall back to preset_dict.
+            if not _tolerances:
+                _tolerances = {
+                    k: preset_dict.get(k)
+                    for k in (
+                        "coherence_stl_95_lu",
+                        "coherence_lra_floor_lu",
+                        "coherence_low_rms_db",
+                        "coherence_vocal_rms_db",
+                    )
+                    if preset_dict is not None and preset_dict.get(k) is not None
+                }
+        else:
+            _lra_target_lu = preset_dict.get("genre_ideal_lra_lu") if preset_dict else None
+            _tolerances = {
                 k: preset_dict.get(k)
                 for k in (
                     "coherence_stl_95_lu",
@@ -1677,7 +1701,18 @@ async def master_album(
                     "coherence_vocal_rms_db",
                 )
                 if preset_dict is not None and preset_dict.get(k) is not None
+            }
+
+        sig = build_signature(
+            analysis_results,
+            delivery_targets={
+                "target_lufs":        targets.get("target_lufs"),
+                "tp_ceiling_db":      targets.get("ceiling_db"),
+                "lra_target_lu":      _lra_target_lu,
+                "output_bits":        targets.get("output_bits"),
+                "output_sample_rate": targets.get("output_sample_rate"),
             },
+            tolerances=_tolerances,
         )
         anchor_idx = anchor_result.get("selected_index")
         anchor_track_sig: dict[str, Any] | None = None

--- a/tests/unit/handlers/test_shared_helpers.py
+++ b/tests/unit/handlers/test_shared_helpers.py
@@ -32,21 +32,38 @@ def _restore_cache(monkeypatch):
     _shared.cache = original
 
 
-def test_is_album_released_true_when_status_is_released(monkeypatch):
+def test_is_album_released_true_when_status_is_released():
     _shared.cache = _FakeCache({"albums": {"my-album": {"status": "Released"}}})
     assert _shared.is_album_released("my-album") is True
 
 
-def test_is_album_released_false_when_status_is_in_progress(monkeypatch):
+def test_is_album_released_false_when_status_is_in_progress():
     _shared.cache = _FakeCache({"albums": {"my-album": {"status": "In Progress"}}})
     assert _shared.is_album_released("my-album") is False
 
 
-def test_is_album_released_false_when_album_missing(monkeypatch):
+def test_is_album_released_false_when_album_missing():
     _shared.cache = _FakeCache({"albums": {}})
     assert _shared.is_album_released("my-album") is False
 
 
-def test_is_album_released_false_when_cache_not_ready(monkeypatch):
+def test_is_album_released_false_when_cache_not_ready():
     _shared.cache = None
+    assert _shared.is_album_released("my-album") is False
+
+
+def test_is_album_released_false_on_invalid_slug():
+    """_normalize_slug raises ValueError on path separators etc."""
+    _shared.cache = _FakeCache({"albums": {"my-album": {"status": "Released"}}})
+    # Path traversal in slug → normalized lookup raises → False
+    assert _shared.is_album_released("../my-album") is False
+    assert _shared.is_album_released("my/album") is False
+
+
+def test_is_album_released_false_when_cache_raises():
+    """Corrupt state / filesystem error during get_state → False."""
+    class _RaisingCache:
+        def get_state(self):
+            raise OSError("simulated disk failure")
+    _shared.cache = _RaisingCache()
     assert _shared.is_album_released("my-album") is False

--- a/tests/unit/handlers/test_shared_helpers.py
+++ b/tests/unit/handlers/test_shared_helpers.py
@@ -1,0 +1,52 @@
+"""Tests for handlers/_shared.py helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared  # noqa: E402
+
+
+class _FakeCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+    def get_state(self) -> dict:
+        return self._state
+
+
+@pytest.fixture(autouse=True)
+def _restore_cache(monkeypatch):
+    """Keep the module-level ``cache`` attribute isolated between tests."""
+    original = _shared.cache
+    yield
+    _shared.cache = original
+
+
+def test_is_album_released_true_when_status_is_released(monkeypatch):
+    _shared.cache = _FakeCache({"albums": {"my-album": {"status": "Released"}}})
+    assert _shared.is_album_released("my-album") is True
+
+
+def test_is_album_released_false_when_status_is_in_progress(monkeypatch):
+    _shared.cache = _FakeCache({"albums": {"my-album": {"status": "In Progress"}}})
+    assert _shared.is_album_released("my-album") is False
+
+
+def test_is_album_released_false_when_album_missing(monkeypatch):
+    _shared.cache = _FakeCache({"albums": {}})
+    assert _shared.is_album_released("my-album") is False
+
+
+def test_is_album_released_false_when_cache_not_ready(monkeypatch):
+    _shared.cache = None
+    assert _shared.is_album_released("my-album") is False

--- a/tests/unit/mastering/test_album_signature.py
+++ b/tests/unit/mastering/test_album_signature.py
@@ -209,3 +209,48 @@ class TestComputeAnchorDeltas:
             "delta_short_term_range", "delta_low_rms", "delta_vocal_rms",
         }
         assert set(deltas[0].keys()) == expected_keys
+
+
+def test_build_signature_embeds_delivery_targets_when_provided() -> None:
+    from tools.mastering.album_signature import build_signature
+    analysis = [
+        {"filename": "01.wav", "lufs": -14.0, "peak_db": -3.0, "stl_95": -14.2,
+         "short_term_range": 8.0, "low_rms": -22.0, "vocal_rms": -17.5,
+         "band_energy": {"mid": 25.0}, "duration": 120.0, "sample_rate": 96000},
+        {"filename": "02.wav", "lufs": -14.1, "peak_db": -3.1, "stl_95": -14.3,
+         "short_term_range": 8.1, "low_rms": -22.1, "vocal_rms": -17.6,
+         "band_energy": {"mid": 25.1}, "duration": 125.0, "sample_rate": 96000},
+    ]
+    sig = build_signature(
+        analysis,
+        delivery_targets={
+            "target_lufs": -14.0,
+            "tp_ceiling_db": -1.0,
+            "lra_target_lu": 8.0,
+            "output_bits": 24,
+            "output_sample_rate": 96000,
+        },
+        tolerances={
+            "coherence_stl_95_lu": 1.0,
+            "coherence_lra_floor_lu": 6.0,
+            "coherence_low_rms_db": 2.0,
+            "coherence_vocal_rms_db": 1.5,
+        },
+    )
+    assert sig["album"]["delivery_targets"]["target_lufs"] == -14.0
+    assert sig["album"]["delivery_targets"]["tp_ceiling_db"] == -1.0
+    assert sig["album"]["delivery_targets"]["lra_target_lu"] == 8.0
+    assert sig["album"]["tolerances"]["coherence_stl_95_lu"] == 1.0
+
+
+def test_build_signature_omits_delivery_block_when_args_absent() -> None:
+    """Backward compat: existing callers that don't pass targets keep working."""
+    from tools.mastering.album_signature import build_signature
+    analysis = [
+        {"filename": "01.wav", "lufs": -14.0, "peak_db": -3.0, "stl_95": -14.2,
+         "short_term_range": 8.0, "low_rms": -22.0, "vocal_rms": -17.5,
+         "band_energy": {"mid": 25.0}, "duration": 120.0, "sample_rate": 96000},
+    ]
+    sig = build_signature(analysis)
+    assert "delivery_targets" not in sig["album"]
+    assert "tolerances" not in sig["album"]

--- a/tests/unit/mastering/test_archival_prune.py
+++ b/tests/unit/mastering/test_archival_prune.py
@@ -1,0 +1,66 @@
+"""Tests for tools/mastering/archival.py prune helper (#290 phase 4, PR #304 A5)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.archival import prune_archival_orphans  # noqa: E402
+
+
+def test_prune_removes_orphans_keeps_matched(tmp_path: Path) -> None:
+    archival = tmp_path / "archival"
+    archival.mkdir()
+    (archival / "01-keep.wav").write_bytes(b"keep")
+    (archival / "02-keep.wav").write_bytes(b"keep")
+    (archival / "old-orphan.wav").write_bytes(b"orphan")
+
+    pruned = prune_archival_orphans(
+        archival, expected_names={"01-keep.wav", "02-keep.wav"}
+    )
+
+    assert pruned == ["old-orphan.wav"]
+    assert (archival / "01-keep.wav").exists()
+    assert (archival / "02-keep.wav").exists()
+    assert not (archival / "old-orphan.wav").exists()
+
+
+def test_prune_on_empty_archival_dir_is_noop(tmp_path: Path) -> None:
+    archival = tmp_path / "archival"
+    archival.mkdir()
+    assert prune_archival_orphans(archival, expected_names={"01-track.wav"}) == []
+
+
+def test_prune_on_missing_archival_dir_is_noop(tmp_path: Path) -> None:
+    # Called before the stage creates the dir — should not raise.
+    assert prune_archival_orphans(
+        tmp_path / "does-not-exist", expected_names={"01-track.wav"}
+    ) == []
+
+
+def test_prune_skips_subdirectories(tmp_path: Path) -> None:
+    """Nested dirs (e.g. archival/2024-01/) are left alone — the helper
+    only removes files."""
+    archival = tmp_path / "archival"
+    archival.mkdir()
+    (archival / "keep.wav").write_bytes(b"keep")
+    (archival / "subdir").mkdir()
+    (archival / "subdir" / "something.wav").write_bytes(b"nested")
+
+    pruned = prune_archival_orphans(archival, expected_names={"keep.wav"})
+    assert pruned == []  # subdir is not a file → skipped
+    assert (archival / "subdir" / "something.wav").exists()
+
+
+def test_prune_returns_sorted_names(tmp_path: Path) -> None:
+    """Deterministic ordering makes the handler's JSON output stable."""
+    archival = tmp_path / "archival"
+    archival.mkdir()
+    for name in ("z.wav", "a.wav", "m.wav"):
+        (archival / name).write_bytes(b"x")
+    pruned = prune_archival_orphans(archival, expected_names=set())
+    assert pruned == ["a.wav", "m.wav", "z.wav"]

--- a/tests/unit/mastering/test_master_album_freeze_flags.py
+++ b/tests/unit/mastering/test_master_album_freeze_flags.py
@@ -58,3 +58,36 @@ def test_freeze_and_new_anchor_mutually_exclusive(tmp_path, monkeypatch):
     result = json.loads(result_json)
     assert result["failed_stage"] == "pre_flight"
     assert "mutually exclusive" in result["failure_detail"]["reason"].lower()
+
+
+def test_released_album_missing_signature_halts(tmp_path, monkeypatch):
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, "released-no-sig", status="Released")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="released-no-sig"))
+
+    result = json.loads(result_json)
+    assert result["failed_stage"] == "freeze_decision"
+    assert "released" in result["failure_detail"]["reason"].lower()
+    assert "album_signature.yaml" in result["failure_detail"]["reason"].lower()
+
+
+def test_freeze_signature_flag_without_file_errors(tmp_path, monkeypatch):
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, "freeze-no-sig")  # In Progress
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(
+            album_slug="freeze-no-sig", freeze_signature=True,
+        ))
+
+    result = json.loads(result_json)
+    assert result["failed_stage"] == "freeze_decision"
+    assert "requested" in result["failure_detail"]["reason"].lower()

--- a/tests/unit/mastering/test_master_album_freeze_flags.py
+++ b/tests/unit/mastering/test_master_album_freeze_flags.py
@@ -1,0 +1,60 @@
+"""Tests for --freeze-signature / --new-anchor MCP params (#290 phase 4)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers.processing import _helpers as processing_helpers  # noqa: E402
+from handlers.processing import audio as audio_mod  # noqa: E402
+
+
+def _write_sine_wav(path: Path, *, amplitude: float = 0.3) -> Path:
+    import soundfile as sf
+    rate = 44100
+    n = int(2.0 * rate)
+    t = np.arange(n) / rate
+    mono = amplitude * np.sin(2 * np.pi * 220.0 * t).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    sf.write(str(path), stereo, rate, subtype="PCM_24")
+    return path
+
+
+def _install_album(monkeypatch, audio_path: Path, slug: str, status: str = "In Progress"):
+    from handlers import _shared
+    fake = {"albums": {slug: {"path": str(audio_path), "status": status, "tracks": {}}}}
+    class _FC:
+        def get_state(self): return fake
+        def get_state_ref(self): return fake
+    monkeypatch.setattr(_shared, "cache", _FC())
+
+
+def test_freeze_and_new_anchor_mutually_exclusive(tmp_path, monkeypatch):
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, "dual-album")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(
+            album_slug="dual-album",
+            freeze_signature=True,
+            new_anchor=True,
+        ))
+
+    result = json.loads(result_json)
+    assert result["failed_stage"] == "pre_flight"
+    assert "mutually exclusive" in result["failure_detail"]["reason"].lower()

--- a/tests/unit/mastering/test_master_album_signature_flow.py
+++ b/tests/unit/mastering/test_master_album_signature_flow.py
@@ -132,3 +132,141 @@ def test_master_album_signature_write_failure_is_nonfatal(tmp_path: Path, monkey
     assert result.get("failed_stage") is None
     assert result["stages"]["signature_persist"]["status"] == "warn"
     assert "simulated failure" in result["stages"]["signature_persist"]["error"]
+
+
+def test_released_album_with_signature_enters_frozen_mode(tmp_path: Path, monkeypatch) -> None:
+    from tools.mastering.signature_persistence import write_signature_file
+
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _write_sine_wav(tmp_path / "02-track.wav", amplitude=0.3, freq=330.0)
+    _install_album(monkeypatch, tmp_path, "rel-album", status="Released")
+
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
+
+    # Pre-seed the signature as if a prior master run wrote it.
+    payload = {
+        "album_slug": "rel-album",
+        "anchor": {
+            "index": 1,
+            "filename": "01-track.wav",
+            "method": "composite",
+            "score": 0.5,
+            "signature": {"lufs": -14.0, "peak_db": -3.0, "stl_95": -14.1,
+                          "short_term_range": 8.0, "low_rms": -22.0, "vocal_rms": -17.5},
+        },
+        "album_median": {"lufs": -14.0, "stl_95": -14.1, "low_rms": -22.0,
+                         "vocal_rms": -17.5, "short_term_range": 8.0},
+        "delivery_targets": {"target_lufs": -14.0, "tp_ceiling_db": -1.0,
+                             "lra_target_lu": 8.0, "output_bits": 24,
+                             "output_sample_rate": 96000},
+        "tolerances": {},
+        "pipeline": {},
+    }
+    write_signature_file(tmp_path, payload, plugin_version="0.91.0")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="rel-album"))
+
+    result = json.loads(result_json)
+    assert result.get("failed_stage") is None, result.get("failure_detail")
+    assert result["stages"]["freeze_decision"]["mode"] == "frozen"
+    # Anchor selection is skipped in frozen mode.
+    assert result["stages"]["anchor_selection"]["method"] == "frozen_signature"
+    assert result["stages"]["anchor_selection"]["selected_index"] == 1
+
+
+def test_in_progress_album_uses_fresh_mode(tmp_path: Path, monkeypatch) -> None:
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _write_sine_wav(tmp_path / "02-track.wav", amplitude=0.32, freq=330.0)
+    _install_album(monkeypatch, tmp_path, "wip-album", status="In Progress")
+
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="wip-album"))
+
+    result = json.loads(result_json)
+    assert result["stages"]["freeze_decision"]["mode"] == "fresh"
+    assert result["stages"]["anchor_selection"]["method"] in ("composite", "tie_breaker")
+
+
+def test_new_anchor_forces_fresh_on_released(tmp_path: Path, monkeypatch) -> None:
+    from tools.mastering.signature_persistence import write_signature_file
+
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _install_album(monkeypatch, tmp_path, "relock-album", status="Released")
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
+    # Signature present, but --new-anchor overrides the default frozen routing.
+    write_signature_file(tmp_path, {
+        "album_slug": "relock-album",
+        "anchor": {"index": 1, "filename": "01-track.wav", "method": "composite",
+                   "score": 0.5, "signature": {}},
+        "album_median": {}, "delivery_targets": {}, "tolerances": {}, "pipeline": {},
+    }, plugin_version="0.91.0")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(
+            album_slug="relock-album", new_anchor=True,
+        ))
+
+    result = json.loads(result_json)
+    assert result["stages"]["freeze_decision"]["mode"] == "fresh"
+    assert result["stages"]["freeze_decision"]["reason"] == "new_anchor_override"
+
+
+def test_frozen_mode_preserves_original_anchor_block(tmp_path: Path, monkeypatch) -> None:
+    """Re-mastering a Released album keeps anchor.method from the shipped
+    signature (e.g. "composite"), not "frozen_signature"."""
+    import pytest
+    from tools.mastering.signature_persistence import (
+        read_signature_file, write_signature_file,
+    )
+
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _write_sine_wav(tmp_path / "02-track.wav", amplitude=0.3, freq=330.0)
+    _install_album(monkeypatch, tmp_path, "pres-album", status="Released")
+
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
+
+    original_anchor = {
+        "index": 2,
+        "filename": "02-track.wav",
+        "method": "composite",
+        "score": 0.612,
+        "signature": {"lufs": -14.0, "peak_db": -3.0, "stl_95": -14.1,
+                      "short_term_range": 8.0, "low_rms": -22.0, "vocal_rms": -17.5},
+    }
+    write_signature_file(tmp_path, {
+        "album_slug": "pres-album",
+        "anchor": original_anchor,
+        "album_median": {}, "delivery_targets": {
+            "target_lufs": -14.0, "tp_ceiling_db": -1.0,
+            "lra_target_lu": 8.0, "output_bits": 24, "output_sample_rate": 96000,
+        },
+        "tolerances": {}, "pipeline": {},
+    }, plugin_version="0.91.0")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        asyncio.run(audio_mod.master_album(album_slug="pres-album"))
+
+    after = read_signature_file(tmp_path)
+    assert after is not None
+    assert after["anchor"]["method"] == "composite"
+    assert after["anchor"]["score"] == pytest.approx(0.612)
+    assert after["anchor"]["filename"] == "02-track.wav"

--- a/tests/unit/mastering/test_master_album_signature_flow.py
+++ b/tests/unit/mastering/test_master_album_signature_flow.py
@@ -55,6 +55,11 @@ def test_master_album_writes_signature_on_success(tmp_path: Path, monkeypatch) -
     _write_sine_wav(tmp_path / "02-track.wav", amplitude=0.32, freq=330.0)
     _install_album(monkeypatch, tmp_path, album_slug="sig-album")
 
+    # Force PLUGIN_ROOT=None so plugin_version falls back deterministically
+    # (other tests may leave PLUGIN_ROOT populated).
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
+
     def _fake_resolve(slug, *_, **__):
         return None, tmp_path
 
@@ -106,6 +111,11 @@ def test_master_album_signature_write_failure_is_nonfatal(tmp_path: Path, monkey
     """Stage 7.5 warnings when signature write fails — master_album still succeeds."""
     _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
     _install_album(monkeypatch, tmp_path, album_slug="warn-album")
+
+    # Force PLUGIN_ROOT=None so plugin_version falls back deterministically
+    # (other tests may leave PLUGIN_ROOT populated).
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
 
     def _fake_resolve(slug, *_, **__):
         return None, tmp_path

--- a/tests/unit/mastering/test_master_album_signature_flow.py
+++ b/tests/unit/mastering/test_master_album_signature_flow.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
-import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 if str(PROJECT_ROOT) not in sys.path:
@@ -75,6 +74,18 @@ def test_master_album_writes_signature_on_success(tmp_path: Path, monkeypatch) -
     assert sig["delivery_targets"]["tp_ceiling_db"] == -1.0
     assert sig["delivery_targets"]["target_lufs"] == -14.0
 
+    # Verify numpy coercion produced native Python floats.
+    anchor_sig = sig["anchor"]["signature"]
+    assert anchor_sig is not None
+    assert isinstance(anchor_sig["peak_db"], float)
+    assert isinstance(anchor_sig["lufs"], float)
+
+    # Verify method, pipeline, album_median, and plugin version fallback.
+    assert sig["anchor"]["method"] in ("composite", "tie_breaker", "override")
+    assert sig["pipeline"]["source_sample_rate"] == 44100
+    assert sig["album_median"]["lufs"] is not None
+    assert sig["plugin_version"] == "unknown"  # PLUGIN_ROOT=None in tests
+
 
 def test_master_album_does_not_write_signature_on_stage_failure(tmp_path: Path, monkeypatch) -> None:
     # No WAV files → pre_flight fails.
@@ -89,3 +100,25 @@ def test_master_album_does_not_write_signature_on_stage_failure(tmp_path: Path, 
     result = json.loads(result_json)
     assert result["failed_stage"] == "pre_flight"
     assert not (tmp_path / SIGNATURE_FILENAME).exists()
+
+
+def test_master_album_signature_write_failure_is_nonfatal(tmp_path: Path, monkeypatch) -> None:
+    """Stage 7.5 warnings when signature write fails — master_album still succeeds."""
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _install_album(monkeypatch, tmp_path, album_slug="warn-album")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    def _raising_write(*_args, **_kw):
+        from tools.mastering.signature_persistence import SignaturePersistenceError
+        raise SignaturePersistenceError("simulated failure")
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve), \
+         patch.object(audio_mod, "write_signature_file", _raising_write):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="warn-album"))
+
+    result = json.loads(result_json)
+    assert result.get("failed_stage") is None
+    assert result["stages"]["signature_persist"]["status"] == "warn"
+    assert "simulated failure" in result["stages"]["signature_persist"]["error"]

--- a/tests/unit/mastering/test_master_album_signature_flow.py
+++ b/tests/unit/mastering/test_master_album_signature_flow.py
@@ -254,9 +254,16 @@ def test_frozen_mode_preserves_original_anchor_block(tmp_path: Path, monkeypatch
         "anchor": original_anchor,
         "album_median": {}, "delivery_targets": {
             "target_lufs": -14.0, "tp_ceiling_db": -1.0,
-            "lra_target_lu": 8.0, "output_bits": 24, "output_sample_rate": 96000,
+            "lra_target_lu": 7.3,  # non-default value to detect drift
+            "output_bits": 24, "output_sample_rate": 96000,
         },
-        "tolerances": {}, "pipeline": {},
+        "tolerances": {
+            "coherence_stl_95_lu": 0.75,   # non-default: default is 1.0
+            "coherence_lra_floor_lu": 5.0, # non-default: default is 6.0
+            "coherence_low_rms_db": 1.8,   # non-default: default is 2.0
+            "coherence_vocal_rms_db": 1.2, # non-default: default is 1.5
+        },
+        "pipeline": {},
     }, plugin_version="0.91.0")
 
     def _fake_resolve(slug, *_, **__):
@@ -270,6 +277,13 @@ def test_frozen_mode_preserves_original_anchor_block(tmp_path: Path, monkeypatch
     assert after["anchor"]["method"] == "composite"
     assert after["anchor"]["score"] == pytest.approx(0.612)
     assert after["anchor"]["filename"] == "02-track.wav"
+
+    # Frozen mode must preserve tolerances and LRA target across re-masters.
+    assert after["delivery_targets"]["lra_target_lu"] == pytest.approx(7.3)
+    assert after["tolerances"]["coherence_stl_95_lu"] == pytest.approx(0.75)
+    assert after["tolerances"]["coherence_lra_floor_lu"] == pytest.approx(5.0)
+    assert after["tolerances"]["coherence_low_rms_db"] == pytest.approx(1.8)
+    assert after["tolerances"]["coherence_vocal_rms_db"] == pytest.approx(1.2)
 
 
 def test_frozen_mode_delivery_matches_frozen_target(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/mastering/test_master_album_signature_flow.py
+++ b/tests/unit/mastering/test_master_album_signature_flow.py
@@ -270,3 +270,70 @@ def test_frozen_mode_preserves_original_anchor_block(tmp_path: Path, monkeypatch
     assert after["anchor"]["method"] == "composite"
     assert after["anchor"]["score"] == pytest.approx(0.612)
     assert after["anchor"]["filename"] == "02-track.wav"
+
+
+def test_frozen_mode_delivery_matches_frozen_target(tmp_path: Path, monkeypatch) -> None:
+    """Phase-4 core guarantee: frozen re-master delivers at the frozen target,
+    not at the genre default.
+
+    Regression for the bug where Stage 2b mutated targets but the effective_*
+    locals cached at Stage 1 were never refreshed, so Stage 4's mastering loop
+    silently used the genre default (-14 LUFS) instead of the frozen target.
+    """
+    import soundfile as sf
+    import pyloudnorm as pyln
+
+    from tools.mastering.signature_persistence import write_signature_file
+
+    # Wav amplitude chosen so genre-default mastering would drive it to ~-14 LUFS;
+    # frozen target at -11 LUFS lets us detect the delta clearly.
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _install_album(monkeypatch, tmp_path, "drift-album", status="Released")
+
+    from handlers import _shared
+    monkeypatch.setattr(_shared, "PLUGIN_ROOT", None)
+
+    frozen_target_lufs = -11.0
+    write_signature_file(tmp_path, {
+        "album_slug": "drift-album",
+        "anchor": {
+            "index": 1, "filename": "01-track.wav",
+            "method": "composite", "score": 0.5,
+            "signature": {"lufs": frozen_target_lufs, "peak_db": -3.0,
+                          "stl_95": -11.1, "short_term_range": 8.0,
+                          "low_rms": -22.0, "vocal_rms": -17.5},
+        },
+        "album_median": {},
+        "delivery_targets": {
+            "target_lufs": frozen_target_lufs,
+            "tp_ceiling_db": -1.0,
+            "lra_target_lu": 8.0,
+            "output_bits": 24,
+            "output_sample_rate": 96000,
+        },
+        "tolerances": {}, "pipeline": {},
+    }, plugin_version="0.91.0")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="drift-album"))
+
+    result = json.loads(result_json)
+    assert result.get("failed_stage") is None, result.get("failure_detail")
+    assert result["stages"]["freeze_decision"]["mode"] == "frozen"
+
+    # Read the delivered WAV and compute integrated LUFS.
+    mastered_path = tmp_path / "mastered" / "01-track.wav"
+    assert mastered_path.exists(), "mastered file missing"
+    data, sr = sf.read(str(mastered_path))
+    meter = pyln.Meter(sr)
+    delivered_lufs = meter.integrated_loudness(data)
+
+    # Frozen mode must deliver within 0.5 LU of the frozen target.
+    assert abs(delivered_lufs - frozen_target_lufs) < 0.5, (
+        f"Frozen re-master drifted: delivered {delivered_lufs:.2f} LUFS vs "
+        f"frozen target {frozen_target_lufs} LUFS "
+        f"(delta {delivered_lufs - frozen_target_lufs:+.2f})"
+    )

--- a/tests/unit/mastering/test_master_album_signature_flow.py
+++ b/tests/unit/mastering/test_master_album_signature_flow.py
@@ -1,0 +1,91 @@
+"""Integration tests for signature persistence inside master_album (#290 phase 4)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers.processing import _helpers as processing_helpers  # noqa: E402
+from handlers.processing import audio as audio_mod  # noqa: E402
+from tools.mastering.signature_persistence import (  # noqa: E402
+    SIGNATURE_FILENAME,
+    read_signature_file,
+)
+
+
+def _write_sine_wav(path: Path, *, duration: float = 30.0, sample_rate: int = 44100,
+                    freq: float = 220.0, amplitude: float = 0.3) -> Path:
+    import soundfile as sf
+    n = int(duration * sample_rate)
+    t = np.arange(n) / sample_rate
+    mono = amplitude * np.sin(2 * np.pi * freq * t).astype(np.float32)
+    stereo = np.column_stack([mono, mono])
+    sf.write(str(path), stereo, sample_rate, subtype="PCM_24")
+    return path
+
+
+def _install_album(monkeypatch, audio_path: Path, album_slug: str,
+                   status: str = "In Progress") -> None:
+    from handlers import _shared
+    fake_state = {"albums": {album_slug: {
+        "path": str(audio_path),
+        "status": status,
+        "tracks": {},
+    }}}
+    class _FakeCache:
+        def get_state(self): return fake_state
+        def get_state_ref(self): return fake_state
+    monkeypatch.setattr(_shared, "cache", _FakeCache())
+
+
+def test_master_album_writes_signature_on_success(tmp_path: Path, monkeypatch) -> None:
+    _write_sine_wav(tmp_path / "01-track.wav", amplitude=0.3)
+    _write_sine_wav(tmp_path / "02-track.wav", amplitude=0.32, freq=330.0)
+    _install_album(monkeypatch, tmp_path, album_slug="sig-album")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="sig-album"))
+
+    result = json.loads(result_json)
+    assert result.get("failed_stage") is None, f"master_album failed: {result.get('failure_detail')}"
+    assert "signature_persist" in result["stages"]
+    assert result["stages"]["signature_persist"]["status"] == "pass"
+
+    # File exists and round-trips.
+    sig = read_signature_file(tmp_path)
+    assert sig is not None
+    assert sig["album_slug"] == "sig-album"
+    assert sig["anchor"]["index"] in (1, 2)
+    assert sig["delivery_targets"]["tp_ceiling_db"] == -1.0
+    assert sig["delivery_targets"]["target_lufs"] == -14.0
+
+
+def test_master_album_does_not_write_signature_on_stage_failure(tmp_path: Path, monkeypatch) -> None:
+    # No WAV files → pre_flight fails.
+    _install_album(monkeypatch, tmp_path, album_slug="empty-album")
+
+    def _fake_resolve(slug, *_, **__):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(audio_mod.master_album(album_slug="empty-album"))
+
+    result = json.loads(result_json)
+    assert result["failed_stage"] == "pre_flight"
+    assert not (tmp_path / SIGNATURE_FILENAME).exists()

--- a/tests/unit/mastering/test_signature_persistence.py
+++ b/tests/unit/mastering/test_signature_persistence.py
@@ -122,3 +122,10 @@ def test_write_is_atomic(tmp_path: Path) -> None:
     write_signature_file(tmp_path, payload, plugin_version="0.91.0")
     read = read_signature_file(tmp_path)
     assert read["anchor"]["index"] == 3
+
+
+def test_read_raises_on_non_mapping_yaml(tmp_path: Path) -> None:
+    """Top-level YAML that parses to a list / scalar / null is rejected."""
+    (tmp_path / SIGNATURE_FILENAME).write_text("- not\n- a\n- mapping\n")
+    with pytest.raises(SignaturePersistenceError, match="expected YAML mapping"):
+        read_signature_file(tmp_path)

--- a/tests/unit/mastering/test_signature_persistence.py
+++ b/tests/unit/mastering/test_signature_persistence.py
@@ -1,0 +1,124 @@
+"""Tests for tools/mastering/signature_persistence.py (#290 phase 4)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.signature_persistence import (  # noqa: E402
+    SIGNATURE_FILENAME,
+    SIGNATURE_SCHEMA_VERSION,
+    SignaturePersistenceError,
+    read_signature_file,
+    write_signature_file,
+)
+
+
+def _sample_payload() -> dict:
+    return {
+        "album_slug": "test-album",
+        "anchor": {
+            "index": 2,
+            "filename": "02-track.wav",
+            "method": "composite",
+            "score": 0.512,
+            "signature": {
+                "stl_95": -14.8,
+                "low_rms": -22.1,
+                "vocal_rms": -17.6,
+                "short_term_range": 8.4,
+                "lufs": -14.0,
+                "peak_db": -3.1,
+            },
+        },
+        "album_median": {
+            "lufs": -14.0,
+            "stl_95": -14.5,
+            "low_rms": -22.0,
+            "vocal_rms": -17.8,
+            "short_term_range": 8.2,
+        },
+        "delivery_targets": {
+            "target_lufs": -14.0,
+            "tp_ceiling_db": -1.0,
+            "lra_target_lu": 8.0,
+            "output_bits": 24,
+            "output_sample_rate": 96000,
+        },
+        "tolerances": {
+            "coherence_stl_95_lu": 1.0,
+            "coherence_lra_floor_lu": 6.0,
+            "coherence_low_rms_db": 2.0,
+            "coherence_vocal_rms_db": 1.5,
+        },
+        "pipeline": {
+            "polish_subfolder": "polished",
+            "source_sample_rate": 44100,
+            "upsampled_from_source": True,
+        },
+    }
+
+
+def test_write_then_read_roundtrip(tmp_path: Path) -> None:
+    payload = _sample_payload()
+    path = write_signature_file(tmp_path, payload, plugin_version="0.91.0")
+    assert path == tmp_path / SIGNATURE_FILENAME
+    assert path.exists()
+
+    read = read_signature_file(tmp_path)
+    assert read["album_slug"] == "test-album"
+    assert read["anchor"]["index"] == 2
+    assert read["delivery_targets"]["target_lufs"] == -14.0
+    assert read["schema_version"] == SIGNATURE_SCHEMA_VERSION
+    assert read["plugin_version"] == "0.91.0"
+    assert "written_at" in read  # ISO-8601 timestamp was inserted
+
+
+def test_read_returns_none_when_missing(tmp_path: Path) -> None:
+    assert read_signature_file(tmp_path) is None
+
+
+def test_read_raises_on_unknown_schema_version(tmp_path: Path) -> None:
+    bogus = {
+        "schema_version": 999,
+        "written_at": "2026-04-14T10:00:00Z",
+        "album_slug": "x",
+    }
+    (tmp_path / SIGNATURE_FILENAME).write_text(yaml.safe_dump(bogus))
+    with pytest.raises(SignaturePersistenceError, match="unsupported schema_version"):
+        read_signature_file(tmp_path)
+
+
+def test_read_raises_on_missing_required_key(tmp_path: Path) -> None:
+    # Missing "anchor" block.
+    (tmp_path / SIGNATURE_FILENAME).write_text(
+        yaml.safe_dump({"schema_version": SIGNATURE_SCHEMA_VERSION, "album_slug": "x",
+                        "written_at": "2026-04-14T10:00:00Z"})
+    )
+    with pytest.raises(SignaturePersistenceError, match="missing required key"):
+        read_signature_file(tmp_path)
+
+
+def test_read_raises_on_malformed_yaml(tmp_path: Path) -> None:
+    (tmp_path / SIGNATURE_FILENAME).write_text(":::\nnot: valid: yaml:[")
+    with pytest.raises(SignaturePersistenceError, match="parse error"):
+        read_signature_file(tmp_path)
+
+
+def test_write_is_atomic(tmp_path: Path) -> None:
+    """Overwriting an existing signature must not leave the file empty at any
+    observable point (relies on atomic_write_text's rename semantics)."""
+    payload = _sample_payload()
+    write_signature_file(tmp_path, payload, plugin_version="0.91.0")
+    # Second write with slightly different payload.
+    payload["anchor"]["index"] = 3
+    write_signature_file(tmp_path, payload, plugin_version="0.91.0")
+    read = read_signature_file(tmp_path)
+    assert read["anchor"]["index"] == 3

--- a/tools/mastering/album_signature.py
+++ b/tools/mastering/album_signature.py
@@ -68,17 +68,30 @@ def _aggregate(values: list[float]) -> dict[str, float | None]:
     }
 
 
-def build_signature(analysis_results: list[dict[str, Any]]) -> dict[str, Any]:
+def build_signature(
+    analysis_results: list[dict[str, Any]],
+    *,
+    delivery_targets: dict[str, Any] | None = None,
+    tolerances: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build per-track + album-level signature summary.
 
     Args:
         analysis_results: List of ``analyze_track()`` result dicts, in
             track-number order (index 0 == track #1). Dicts may have
             ``None`` values for ``stl_95`` / ``low_rms`` / ``vocal_rms``.
+        delivery_targets: Optional dict of mastering delivery targets
+            (``target_lufs``, ``tp_ceiling_db``, ``lra_target_lu``,
+            ``output_bits``, ``output_sample_rate``). When provided, gets
+            embedded under ``album.delivery_targets`` for downstream
+            persistence. Only the keys present in the input dict are
+            forwarded — unknown keys pass through.
+        tolerances: Optional dict of coherence tolerances (e.g.
+            ``coherence_stl_95_lu``). Embedded under ``album.tolerances``.
 
     Returns:
         Dict with ``tracks`` (per-track signature list) and ``album``
-        (aggregates). See the phase-3a plan doc for the full shape.
+        (aggregates, plus optional ``delivery_targets`` / ``tolerances``).
     """
     tracks: list[dict[str, Any]] = []
     for i, t in enumerate(analysis_results):
@@ -119,6 +132,11 @@ def build_signature(analysis_results: list[dict[str, Any]]) -> dict[str, Any]:
             album["range"][key] = agg["max"] - agg["min"]
     for key in ELIGIBILITY_KEYS:
         album["eligible_count"][key] = len(_finite_values(analysis_results, key))
+
+    if delivery_targets is not None:
+        album["delivery_targets"] = dict(delivery_targets)
+    if tolerances is not None:
+        album["tolerances"] = dict(tolerances)
 
     return {"tracks": tracks, "album": album}
 

--- a/tools/mastering/archival.py
+++ b/tools/mastering/archival.py
@@ -1,0 +1,47 @@
+"""Archival-dir helpers for the mastering pipeline (#290 phase 4).
+
+Pure-Python, no MCP coupling. The archival stage of ``master_album``
+consumes ``prune_archival_orphans`` before writing new 32-bit float
+copies, so the archival dir stays a mirror of ``mastered/`` — re-masters
+that drop or rename tracks don't leave stale entries behind.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def prune_archival_orphans(
+    archival_dir: Path,
+    expected_names: set[str],
+) -> list[str]:
+    """Remove files in ``archival_dir`` whose basename is not in ``expected_names``.
+
+    Args:
+        archival_dir: The archival directory path. Missing directory is
+            a silent no-op (the caller hasn't created it yet).
+        expected_names: The set of basenames that SHOULD remain — typically
+            the filenames in ``mastered/``.
+
+    Returns:
+        Sorted list of pruned basenames. Empty when nothing was removed.
+        Does not raise on individual unlink failures — callers that want
+        to surface errors should check ``expected_names`` against the
+        directory contents afterwards.
+    """
+    if not archival_dir.is_dir():
+        return []
+    pruned: list[str] = []
+    for entry in archival_dir.iterdir():
+        if not entry.is_file():
+            continue
+        if entry.name in expected_names:
+            continue
+        try:
+            entry.unlink()
+            pruned.append(entry.name)
+        except OSError:
+            # Caller-level verification catches leftovers; keep the helper
+            # pure.
+            continue
+    return sorted(pruned)

--- a/tools/mastering/signature_persistence.py
+++ b/tools/mastering/signature_persistence.py
@@ -1,0 +1,158 @@
+"""Persist and load ``ALBUM_SIGNATURE.yaml`` (#290 phase 4).
+
+Pure-Python schema layer — no MCP coupling, no handler imports. Callers
+supply a ready-made payload dict; this module wraps it with the schema
+envelope (``schema_version`` + ``written_at`` + ``plugin_version``) and
+handles atomic on-disk writes / strict on-disk reads.
+
+Schema v1 layout (top-level keys required at read time):
+
+.. code-block:: yaml
+
+    schema_version: 1
+    written_at: "2026-04-14T10:00:00Z"
+    plugin_version: "0.91.0"
+    album_slug: "my-album"
+    anchor:
+      index: 3
+      filename: "03-track.wav"
+      method: "composite"           # composite | override | tie_breaker
+      score: 0.512                  # composite score (null for override)
+      signature:                    # anchor's own pre-master signature
+        stl_95: -14.8
+        low_rms: -22.1
+        vocal_rms: -17.6
+        short_term_range: 8.4
+        lufs: -14.0
+        peak_db: -3.1
+    album_median:                   # album-wide median across tracks
+      lufs: -14.0
+      stl_95: -14.5
+      low_rms: -22.0
+      vocal_rms: -17.8
+      short_term_range: 8.2
+    delivery_targets:               # what the album was actually shipped at
+      target_lufs: -14.0
+      tp_ceiling_db: -1.0
+      lra_target_lu: 8.0
+      output_bits: 24
+      output_sample_rate: 96000
+    tolerances:                     # coherence-correction tolerances in force
+      coherence_stl_95_lu: 1.0
+      coherence_lra_floor_lu: 6.0
+      coherence_low_rms_db: 2.0
+      coherence_vocal_rms_db: 1.5
+    pipeline:                       # provenance, informational
+      polish_subfolder: "polished"
+      source_sample_rate: 44100
+      upsampled_from_source: true
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Allow ``handlers._atomic`` import when run as a pure-Python module
+# (mastering tests don't boot the MCP server).
+_SERVER_DIR = Path(__file__).resolve().parent.parent.parent / "servers" / "bitwize-music-server"
+if str(_SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(_SERVER_DIR))
+
+from handlers._atomic import atomic_write_text  # noqa: E402
+
+SIGNATURE_FILENAME = "ALBUM_SIGNATURE.yaml"
+SIGNATURE_SCHEMA_VERSION = 1
+
+# Top-level keys that must be present when reading an existing file.
+_REQUIRED_TOP_LEVEL_KEYS = (
+    "schema_version",
+    "written_at",
+    "album_slug",
+    "anchor",
+    "album_median",
+    "delivery_targets",
+)
+
+
+class SignaturePersistenceError(Exception):
+    """Raised when ALBUM_SIGNATURE.yaml is corrupt, malformed, or on an
+    unsupported schema version. Callers should treat this as "halt +
+    escalate" for Released albums; for in-progress albums they may choose
+    to overwrite (frozen-mode is not engaged)."""
+
+
+def write_signature_file(
+    audio_dir: Path,
+    payload: dict[str, Any],
+    *,
+    plugin_version: str,
+) -> Path:
+    """Write ``ALBUM_SIGNATURE.yaml`` atomically to ``audio_dir``.
+
+    Args:
+        audio_dir: Directory that contains ``mastered/``, ``archival/``,
+            etc. for this album. Signature lives alongside those.
+        payload: Caller-built payload dict. Must contain ``album_slug``,
+            ``anchor``, ``album_median``, ``delivery_targets``. May
+            contain ``tolerances``, ``pipeline``, or other keys —
+            everything passes through verbatim.
+        plugin_version: Plugin semver string (e.g. ``"0.91.0"``) for
+            forward-compat debugging.
+
+    Returns:
+        Path to the written file.
+    """
+    envelope = {
+        "schema_version": SIGNATURE_SCHEMA_VERSION,
+        "written_at":     _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "plugin_version": plugin_version,
+    }
+    # payload keys override envelope ordering but envelope keys are
+    # emitted first — YAML preserves insertion order when sort_keys=False.
+    combined: dict[str, Any] = {**envelope, **payload}
+
+    path = audio_dir / SIGNATURE_FILENAME
+    text = yaml.safe_dump(
+        combined,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+    atomic_write_text(path, text)
+    return path
+
+
+def read_signature_file(audio_dir: Path) -> dict[str, Any] | None:
+    """Load and validate ``ALBUM_SIGNATURE.yaml`` from ``audio_dir``.
+
+    Returns:
+        The parsed dict, or ``None`` if the file is absent.
+
+    Raises:
+        SignaturePersistenceError: file is malformed, on an unsupported
+            schema version, or missing a required top-level key.
+    """
+    path = audio_dir / SIGNATURE_FILENAME
+    if not path.is_file():
+        return None
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise SignaturePersistenceError(f"{path}: parse error — {exc}") from exc
+    if not isinstance(raw, dict):
+        raise SignaturePersistenceError(f"{path}: expected YAML mapping, got {type(raw).__name__}")
+    version = raw.get("schema_version")
+    if version != SIGNATURE_SCHEMA_VERSION:
+        raise SignaturePersistenceError(
+            f"{path}: unsupported schema_version {version!r} "
+            f"(this build expects {SIGNATURE_SCHEMA_VERSION})"
+        )
+    for key in _REQUIRED_TOP_LEVEL_KEYS:
+        if key not in raw:
+            raise SignaturePersistenceError(f"{path}: missing required key {key!r}")
+    return raw

--- a/tools/mastering/signature_persistence.py
+++ b/tools/mastering/signature_persistence.py
@@ -99,8 +99,11 @@ def write_signature_file(
             etc. for this album. Signature lives alongside those.
         payload: Caller-built payload dict. Must contain ``album_slug``,
             ``anchor``, ``album_median``, ``delivery_targets``. May
-            contain ``tolerances``, ``pipeline``, or other keys —
-            everything passes through verbatim.
+            contain ``tolerances``, ``pipeline``, or other keys — those
+            pass through verbatim. If the payload happens to contain
+            any envelope-owned key (``schema_version``, ``written_at``,
+            ``plugin_version``), the envelope value wins to preserve the
+            schema contract.
         plugin_version: Plugin semver string (e.g. ``"0.91.0"``) for
             forward-compat debugging.
 
@@ -112,9 +115,12 @@ def write_signature_file(
         "written_at":     _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "plugin_version": plugin_version,
     }
-    # payload keys override envelope ordering but envelope keys are
-    # emitted first — YAML preserves insertion order when sort_keys=False.
-    combined: dict[str, Any] = {**envelope, **payload}
+    # Envelope keys (schema_version, written_at, plugin_version) are
+    # authoritative — if a caller's payload contains any of them, the
+    # envelope values win. This prevents accidental shadowing of the
+    # schema contract. YAML preserves insertion order when
+    # sort_keys=False, so envelope keys also emit first.
+    combined: dict[str, Any] = {**payload, **envelope}
 
     path = audio_dir / SIGNATURE_FILENAME
     text = yaml.safe_dump(


### PR DESCRIPTION
## Summary

Phase 4 of #290 ships **album signature persistence** and **frozen-signature mode**:

- `master_album` writes `ALBUM_SIGNATURE.yaml` to the album audio directory after every successful run — captures anchor (method/score/signature), album medians, delivery targets (LUFS, TP ceiling, LRA), and coherence tolerances.
- Released albums automatically enter **frozen mode** on re-master: the shipped anchor + targets are reused so re-masters don't drift from what's on DSPs.
- New `freeze_signature` / `new_anchor` MCP params force frozen/fresh routing regardless of status (mutex-validated in pre-flight).
- Archival stage now **mirrors** `mastered/` — orphans (files whose basename is no longer in `mastered/`) are pruned before new 32-bit float copies are written. Closes PR #304 review item A5.
- New `reference/streaming-mastering-specs.md` doc covers the 24/96 single-master delivery spec, `ALBUM_SIGNATURE.yaml` schema + contract, re-mastering behavior (fresh/frozen/halt), archival mirror behavior, and future ADM encoder notes.

## #290 checklist items closed by this PR

- [x] Add `ALBUM_SIGNATURE.yaml` persistence + frozen-signature mode
- [x] Add `--freeze-signature` / `--new-anchor` CLI flags (shipped as MCP params — equivalent)
- [x] Archival stage mirrors `mastered/` — remove orphans (A5)
- [x] Document in `reference/streaming-mastering-specs.md`
- [x] Document re-mastering behavior (frozen vs. fresh anchor, `ALBUM_SIGNATURE.yaml` contract)

Remaining #290 items (layout generator, ceiling guard, ADM validator, metadata embed, opus_safe, polish_audio per-stem, test fixtures) continue in later phases.

## Architecture

- New pure-Python module `tools/mastering/signature_persistence.py` — atomic YAML read/write with schema envelope (`schema_version: 1`, `written_at`, `plugin_version`), strict validation on read, `SignaturePersistenceError` on malformed/unsupported files.
- New pure-Python module `tools/mastering/archival.py` — `prune_archival_orphans(archival_dir, expected_names) -> list[str]` helper consumed by the archival stage.
- Extended `tools/mastering/album_signature.py::build_signature()` with optional keyword-only `delivery_targets` + `tolerances` args.
- New `handlers/_shared.py` helpers: `is_album_released(album_slug)` (cache-backed, uses existing `_normalize_slug`) and `get_plugin_version()` (DRY'd from `health.py` and `master_album` Stage 7.5).
- `master_album` gains **Stage 2a** (freeze decision) and **Stage 7.5** (signature persist). Stage 2b (anchor selection) branches on frozen mode. In frozen mode, `effective_preset` + cached `effective_lufs`/`effective_ceiling`/`effective_compress` are refreshed from the frozen signature so the limiter/loudness normalizer/bit-depth actually deliver at the frozen targets (caught during review — see notes).

## Notable review-driven fixes

- **Envelope-key override defense** in `signature_persistence` — reversed merge order so callers can't silently shadow `schema_version` / `written_at` / `plugin_version`.
- **Frozen mode `effective_*` refresh** — initial Task 7 implementation mutated `targets`/`settings` but didn't refresh the cached `effective_*` locals read by the mastering loop, silently delivering at genre defaults instead of frozen targets. Caught by whole-branch review; regression test `test_frozen_mode_delivery_matches_frozen_target` now probes delivered LUFS with `pyloudnorm`.
- **Frozen tolerance preservation** — Stage 7.5 was re-reading tolerances + LRA from the current genre preset, causing persisted signatures to drift to genre defaults on every re-master. Now sources those fields from the frozen signature itself.
- **`_normalize_slug` consistency** — initial Task 5 introduced a new `_normalize_album_slug` helper; consolidated to use the project's existing `_normalize_slug` with a `try/except ValueError` so behavior matches every other handler.
- **`get_plugin_version` DRY** — extracted from inline duplication in `health.py` + `master_album` to a single helper in `_shared.py`.

## Test Plan

- [x] `python3 -m pytest tests/unit/` — **3040 passed, 3 skipped, 0 failures** (up from 3033 baseline, +7 new)
- [x] `python3 -m pytest tests/unit/mastering/` — 461 passed (14 new across 4 test files)
- [x] `python3 -m pytest tests/unit/handlers/` — 6 new tests for `is_album_released` (including invalid-slug + raising-cache paths)
- [x] Regression for the headline bug: `test_frozen_mode_delivery_matches_frozen_target` reads the delivered WAV with `pyloudnorm` and asserts LUFS within ±0.5 LU of the frozen target (would have caught the original Task 7 drift bug pre-merge)
- [x] Happy-path + warn-path + failure-path coverage for Stage 7.5 (signature write success, write failure non-fatal, halt on Released-without-signature, halt on freeze_signature-flag-without-file)
- [ ] Manual: re-master an in-progress album, confirm `ALBUM_SIGNATURE.yaml` appears alongside `mastered/`
- [ ] Manual: promote album to Released, re-master a single regenerated track, confirm frozen mode engages and delivers at the shipped LUFS/ceiling
- [ ] Manual: delete the signature file from a Released album, confirm halt+escalate fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)