### PR TITLE
fix: qc_audio silence check misclassifies trailing silence as internal gap (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to claude-ai-music-skills.
 
 This project uses [Conventional Commits](https://conventionalcommits.org/) and [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **qc_audio silence check (#321)**: Trailing silence followed by a sub-threshold noise-floor blip no longer gets misclassified as an internal gap. The silence detector now classifies each silent region by position AND by the amount of non-silent content between the region and the file edge — a region ending within 1s of the file end (with <300ms of non-silent content after it) counts as trailing, not internal. Unblocks the `master_album` / `polish_album` pre-QC gate on tracks with natural fade-outs.
+
 ## [0.90.0] - 2026-04-15
 
 ### Added

--- a/tests/unit/mastering/test_qc_tracks.py
+++ b/tests/unit/mastering/test_qc_tracks.py
@@ -377,6 +377,31 @@ class TestCheckSilence:
         assert result["status"] == "FAIL"
         assert "internal gap" in result["detail"]
 
+    def test_trailing_silence_with_boundary_blip_not_internal(self):
+        """Trailing silence followed by a sub-audible noise blip at the
+        file end must be classified as trailing, not an internal gap (#321).
+
+        Regression for the mastering pipeline failing on tracks whose
+        fade-out tail has a noise-floor sample above -60 dBFS within the
+        last few hundred ms — the old detector counted the tail silence
+        as interior because ``trailing`` counted only strictly-silent
+        samples at the very end.
+        """
+        rate = 44100
+        t = np.linspace(0, 1.0, rate, endpoint=False)
+        sig = 0.5 * np.sin(2 * np.pi * 440 * t)
+        silence = np.zeros(int(rate * 0.6), dtype=np.float64)
+        # ~ -46 dBFS: below the -50 dBFS ffmpeg silencedetect threshold
+        # but above the -60 dBFS QC threshold
+        blip = np.full(10, 0.005, dtype=np.float64)
+        mono = np.concatenate([sig, silence, blip])
+        data = np.column_stack([mono, mono])
+
+        result = _check_silence(data, rate)
+
+        assert "internal gap" not in result["detail"]
+        assert result["status"] != "FAIL"
+
 
 class TestCheckSpectral:
     """Tests for the spectral balance check."""

--- a/tools/mastering/qc_tracks.py
+++ b/tools/mastering/qc_tracks.py
@@ -263,66 +263,88 @@ def _check_clicks(
 
 
 def _check_silence(data: Any, rate: int) -> dict[str, str]:
-    """Check for excessive leading, trailing, or internal silence."""
+    """Check for excessive leading, trailing, or internal silence.
+
+    A silent region (samples below -60 dBFS) is classified as leading if
+    it starts within the boundary tolerance AND has essentially no
+    non-silent content before it; trailing by the symmetric rule at the
+    file end. Everything else is internal. The content-side check is what
+    distinguishes a fade-out tail (sub-threshold noise blip above -60 dBFS
+    sitting between the silence and the file end) from a mid-song gap
+    whose region happens to touch the tolerance window (e.g. a sine-wave
+    zero crossing) — without it, legitimate internal gaps get silently
+    demoted to "trailing". Regression for #321.
+    """
     if data.ndim > 1:
         mono = np.mean(data, axis=1)
     else:
         mono = data
 
-    # Threshold: -60 dBFS
     threshold = 10 ** (-60 / 20)
     is_silent = np.abs(mono) < threshold
-
     total_samples = len(mono)
+    if total_samples == 0:
+        return {"status": "PASS", "value": "L:0.0s T:0.0s", "detail": "Empty file"}
+
+    padded = np.concatenate([[False], is_silent, [False]])
+    diffs = np.diff(padded.astype(np.int8))
+    region_starts = np.where(diffs == 1)[0]
+    region_ends = np.where(diffs == -1)[0]  # exclusive
+
+    boundary_tolerance_sec = 1.0
+    tol_samples = int(rate * boundary_tolerance_sec)
+    gap_threshold_samples = int(rate * 0.5)
+    # Permissible non-silent content between a silent region and the
+    # file edge for that region to still count as leading/trailing.
+    min_boundary_content_samples = int(rate * 0.3)
+
+    non_silent_cumsum = np.cumsum((~is_silent).astype(np.int64))
+    total_non_silent = int(non_silent_cumsum[-1])
+
+    def non_silent_before(idx: int) -> int:
+        return int(non_silent_cumsum[idx - 1]) if idx > 0 else 0
+
+    leading_sec = 0.0
+    trailing_sec = 0.0
+    internal_gap_count = 0
+
+    for rs, re in zip(region_starts, region_ends):
+        length_samples = int(re - rs)
+        length_sec = length_samples / rate
+        is_leading = False
+        is_trailing = False
+
+        if rs < tol_samples:
+            if non_silent_before(rs) < min_boundary_content_samples:
+                is_leading = True
+
+        if not is_leading and re > total_samples - tol_samples:
+            ns_after = total_non_silent - non_silent_before(re)
+            if ns_after < min_boundary_content_samples:
+                is_trailing = True
+
+        if is_leading:
+            leading_sec = max(leading_sec, length_sec)
+        elif is_trailing:
+            trailing_sec = max(trailing_sec, length_sec)
+        elif length_samples >= gap_threshold_samples:
+            internal_gap_count += 1
+
     issues = []
     status = "PASS"
 
-    # Leading silence
-    leading = 0
-    for s in is_silent:
-        if s:
-            leading += 1
-        else:
-            break
-    leading_sec = leading / rate
     if leading_sec > 0.5:
         status = "FAIL"
         issues.append(f"Leading silence: {leading_sec:.1f}s")
 
-    # Trailing silence
-    trailing = 0
-    for s in reversed(is_silent):
-        if s:
-            trailing += 1
-        else:
-            break
-    trailing_sec = trailing / rate
-    if trailing_sec > 5.0 or trailing_sec > 3.0:
+    if trailing_sec > 3.0:
         if status != "FAIL":
             status = "WARN"
         issues.append(f"Trailing silence: {trailing_sec:.1f}s")
 
-    # Internal silence gaps (> 0.5s)
-    gap_threshold = int(rate * 0.5)
-    # Skip leading/trailing for internal gap detection
-    content_start = leading
-    content_end = total_samples - trailing
-    if content_end > content_start:
-        interior = is_silent[content_start:content_end]
-        gap_length = 0
-        gap_count = 0
-        for s in interior:
-            if s:
-                gap_length += 1
-            else:
-                if gap_length >= gap_threshold:
-                    gap_count += 1
-                gap_length = 0
-        if gap_length >= gap_threshold:
-            gap_count += 1
-        if gap_count > 0:
-            status = "FAIL"
-            issues.append(f"{gap_count} internal gap(s) > 0.5s")
+    if internal_gap_count > 0:
+        status = "FAIL"
+        issues.append(f"{internal_gap_count} internal gap(s) > 0.5s")
 
     detail = "; ".join(issues) if issues else "No silence issues"
     value = f"L:{leading_sec:.1f}s T:{trailing_sec:.1f}s"


### PR DESCRIPTION
## Summary
- Fixes #321 — `qc_audio` silence check flagged natural fade-out tails as "internal gap > 0.5s" when a sub-threshold noise-floor sample near the file end split the trailing silence into an "internal gap + tiny final silence" pair. Blocked `master_album` / `polish_album` pre-QC on otherwise-fine tracks.
- The detector now finds each contiguous silent region and classifies by position AND surrounding content: a region ending within 1s of the file end with <300ms of non-silent content after it counts as trailing, not internal.
- Content-side check distinguishes a fade tail with a noise-floor blip from a mid-song gap whose region happens to touch the boundary tolerance (e.g. a sine-wave zero crossing in a test fixture).

## Test plan
- [x] `pytest tests/unit/mastering/test_qc_tracks.py` — existing silence tests still pass
- [x] New regression: `test_trailing_silence_with_boundary_blip_not_internal` — reproduces the issue scenario (1s sine + 0.6s silence + tiny above-threshold blip at file end) and asserts no internal-gap classification
- [x] `test_internal_gap_detected` still FAILs on the 1s sine + 1s gap + 1s sine fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)