### PR TITLE
fix: analyze_mix_issues click detector false-positives on non-drum stems (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ### Fixed
 - **qc_audio silence check (#321)**: Trailing silence followed by a sub-threshold noise-floor blip no longer gets misclassified as an internal gap. The silence detector now classifies each silent region by position AND by the amount of non-silent content between the region and the file edge — a region ending within 1s of the file end (with <300ms of non-silent content after it) counts as trailing, not internal. Unblocks the `master_album` / `polish_album` pre-QC gate on tracks with natural fade-outs.
+- **analyze_mix_issues click detection (#323)**: Replaced the sample-wise `|diff| > 6·σ(diff)` detector with a windowed peak-to-RMS check (matches `qc_tracks._check_clicks`) at `peak_ratio=15` over 10 ms windows. The old detector flagged tens of thousands of "clicks" on every clean vocal, bass, and synth stem (vocal consonants and synth attacks have high instantaneous derivatives but spread their energy across a window), emitting `click_removal: true` recommendations that the polish pipeline silently ignored. The analyzer now only recommends click removal when genuine single-sample discontinuities exist.
 
 ## [0.90.0] - 2026-04-15
 

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -284,11 +284,29 @@ async def analyze_mix_issues(
                 result["issues"].append("harsh_highmids")
                 result["recommendations"]["high_tame_db"] = -2.0
 
-        # Click detection (sudden amplitude spikes)
-        diff = np.diff(data[:, 0])
-        diff_std = float(np.std(diff))
-        if diff_std > 0:
-            click_count = int(np.sum(np.abs(diff) > 6 * diff_std))
+        # Click detection (sudden amplitude spikes).
+        #
+        # Count 10 ms windows whose peak-to-RMS ratio exceeds `peak_ratio`
+        # — genuine digital clicks are single-sample discontinuities that
+        # spike a short window's crest factor well above 10×, while
+        # musical transients (vocal consonants, synth attacks, kick
+        # drums) distribute energy across the window and stay below.
+        # The previous sample-wise `|diff| > 6·σ(diff)` detector flagged
+        # tens of thousands of musical samples per stem on vocals/synth/
+        # bass and emitted false `click_removal` recommendations that
+        # the polish pipeline silently ignored (#323).
+        mono_col = data[:, 0]
+        window = max(int(rate * 0.01), 1)
+        n_windows = len(mono_col) // window
+        if n_windows > 0:
+            windows = mono_col[: n_windows * window].reshape(n_windows, window)
+            win_rms = np.sqrt(np.mean(windows ** 2, axis=1))
+            win_peak = np.max(np.abs(windows), axis=1)
+            active = win_rms > 1e-8
+            ratios = np.zeros(n_windows, dtype=np.float64)
+            np.divide(win_peak, win_rms, out=ratios, where=active)
+            peak_ratio = 15.0
+            click_count = int(np.sum(ratios > peak_ratio))
             result["click_count"] = click_count
             if click_count > 10:
                 result["issues"].append("clicks_detected")

--- a/tests/unit/state/test_handlers_mixing.py
+++ b/tests/unit/state/test_handlers_mixing.py
@@ -298,6 +298,58 @@ class TestAnalyzeMixIssues:
             assert "issues" in stem_analysis
         assert "issues" in track
 
+    def test_vocal_stem_does_not_false_positive_clicks(self, tmp_path):
+        """Formant-shaped vocal with sibilant bursts must not emit a
+        `click_removal` recommendation — vocal consonants have high
+        instantaneous derivatives but their energy is spread across the
+        10 ms detector window. Regression for #323 where the old
+        sample-wise 6·σ(diff) detector flagged tens of thousands of
+        "clicks" on every clean vocal stem.
+        """
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        data, rate = make_vocal(duration=3.0)
+        write_wav(str(audio_dir / "vocal.wav"), data, rate)
+
+        with patch.object(_helpers_mod, "_check_mixing_deps", return_value=None), \
+             patch.object(_helpers_mod, "_resolve_audio_dir", return_value=(None, audio_dir)):
+            raw = _run(_mixing_mod.analyze_mix_issues("test"))
+        result = json.loads(raw)
+        track = result["tracks"][0]
+        assert track["click_count"] < 10, (
+            f"vocal stem produced {track['click_count']} false-positive clicks"
+        )
+        assert "clicks_detected" not in track["issues"]
+        assert "click_removal" not in track["recommendations"]
+
+    def test_actual_clicks_still_detected(self, tmp_path):
+        """Single-sample discontinuities inserted into an otherwise clean
+        tone must still trigger the `click_removal` recommendation — the
+        detector recalibration for #323 must not regress genuine click
+        detection.
+        """
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        rate = 44100
+        duration = 3.0
+        t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+        mono = 0.02 * np.sin(2 * np.pi * 440 * t)
+        # 30 single-sample spikes spaced ~100 ms apart — each lifts one
+        # 10 ms window's peak-to-RMS ratio well above 15.
+        for i in range(30):
+            idx = 2000 + i * 4410
+            mono[idx] = 0.9
+        data = np.column_stack([mono, mono]).astype(np.float64)
+        write_wav(str(audio_dir / "clicky.wav"), data, rate)
+
+        with patch.object(_helpers_mod, "_check_mixing_deps", return_value=None), \
+             patch.object(_helpers_mod, "_resolve_audio_dir", return_value=(None, audio_dir)):
+            raw = _run(_mixing_mod.analyze_mix_issues("test"))
+        result = json.loads(raw)
+        track = result["tracks"][0]
+        assert "clicks_detected" in track["issues"]
+        assert track["recommendations"].get("click_removal") is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: polish_album (3-stage pipeline)


### PR DESCRIPTION
## Summary
- Fixes #323 — `analyze_mix_issues` flagged tens of thousands of "clicks" on every clean vocal / bass / synth stem and emitted `click_removal: true` recommendations that the polish pipeline silently ignored (click removal is only wired into drums / percussion per-stem chains).
- Root cause: the sample-wise `|diff| > 6·σ(diff)` detector fires on musical transients (vocal consonants, synth attacks) because those have high instantaneous derivatives, even though their energy is spread across many samples.
- Fix: switch to a 10 ms windowed peak-to-RMS check at `peak_ratio=15` — matches `qc_tracks._check_clicks` methodology. Genuine single-sample discontinuities spike a short window's crest factor well above 15; musical transients stay below.

## Test plan
- [x] New regression `test_vocal_stem_does_not_false_positive_clicks` — formant-shaped vocal with sibilant bursts produces <10 clicks and no `click_removal` recommendation
- [x] New positive test `test_actual_clicks_still_detected` — 30 single-sample spikes on a quiet sine still trigger `clicks_detected` + `click_removal: true`
- [x] All 23 `tests/unit/state/test_handlers_mixing.py` tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)