### PR TITLE
fix: pipeline gate follow-ups from #323 comment (drum clicks, electronic intros, truepeak pre-master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Changed
+- **Dense-transient genre click QC thresholds bumped** to match `idm`'s calibration (`click_peak_ratio: 10.0`, `click_fail_count: 30`, was 8.0/15). Applies to `electronic`, `edm`, `techno`, `drum-and-bass`, `jungle`, `dubstep`, `hardstyle`, `breakbeat`, `metal`, `industrial`, `trap`, `drill`, `phonk`, `grime`, `shoegaze`, `dream-pop`. Prior values were flagging post-polish electronic drum transients as clicks (20+ clicks on a 3-min track → FAIL) even though the hits are musical, not digital pops. (#323 comment)
+- **`polish_album` verify stage** now runs a pre-master check subset (`format, mono, phase, clipping, silence, spectral`) and defers `truepeak` / `clicks` to post-mastering QC. Polished audio is un-limited and dense-transient (the limiter is what enforces the ceiling), so failing those checks on pre-master files is a false gate. The stage surfaces `checks_run` and `checks_deferred_to_post_master` for transparency. (#323 comment)
+- **`master_album` pre-QC stage** now forwards `genre` to `qc_track` (so genre-preset silence / click thresholds apply) and surfaces `checks_run` / `checks_deferred_to_post_master` in its status output. (#323 comment)
+
+### Added
+- **Genre-aware silence QC thresholds**: new `silence_leading_max_s` / `silence_trailing_max_s` preset fields (`tools/mastering/genre-presets.yaml`). Defaults 0.5 / 3.0 s. `electronic` and `edm` override `silence_leading_max_s: 1.5` so filter-sweep / build intros don't FAIL the silence gate. (#323 comment)
+
 ### Fixed
 - **qc_audio silence check (#321)**: Trailing silence followed by a sub-threshold noise-floor blip no longer gets misclassified as an internal gap. The silence detector now classifies each silent region by position AND by the amount of non-silent content between the region and the file edge — a region ending within 1s of the file end (with <300ms of non-silent content after it) counts as trailing, not internal. Unblocks the `master_album` / `polish_album` pre-QC gate on tracks with natural fade-outs.
 - **analyze_mix_issues click detection (#323)**: Replaced the sample-wise `|diff| > 6·σ(diff)` detector with a windowed peak-to-RMS check (matches `qc_tracks._check_clicks`) at `peak_ratio=15` over 10 ms windows. The old detector flagged tens of thousands of "clicks" on every clean vocal, bass, and synth stem (vocal consonants and synth attacks have high instantaneous derivatives but spread their energy across a window), emitting `click_removal: true` recommendations that the polish pipeline silently ignored. The analyzer now only recommends click removal when genuine single-sample discontinuities exist.

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -569,11 +569,13 @@ async def _stage_pre_qc(ctx: MasterAlbumCtx) -> str | None:
     from tools.mastering.qc_tracks import qc_track
 
     PRE_QC_CHECKS = ["format", "mono", "phase", "clipping", "silence", "spectral"]
+    PRE_QC_DEFERRED = ["truepeak", "clicks"]
 
     pre_qc_results = []
+    qc_genre = ctx.genre or None
     for wav in ctx.wav_files:
         result = await ctx.loop.run_in_executor(
-            None, qc_track, str(wav), PRE_QC_CHECKS
+            None, qc_track, str(wav), PRE_QC_CHECKS, qc_genre
         )
         pre_qc_results.append(result)
 
@@ -605,6 +607,8 @@ async def _stage_pre_qc(ctx: MasterAlbumCtx) -> str | None:
             "passed": pre_passed,
             "warned": pre_warned,
             "failed": pre_failed,
+            "checks_run": PRE_QC_CHECKS,
+            "checks_deferred_to_post_master": PRE_QC_DEFERRED,
             "verdict": "FAILURES FOUND",
         }
         return _safe_json({
@@ -625,6 +629,8 @@ async def _stage_pre_qc(ctx: MasterAlbumCtx) -> str | None:
         "passed": pre_passed,
         "warned": pre_warned,
         "failed": 0,
+        "checks_run": PRE_QC_CHECKS,
+        "checks_deferred_to_post_master": PRE_QC_DEFERRED,
         "verdict": "ALL PASS" if pre_warned == 0 else "WARNINGS",
     }
     return None

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -482,8 +482,17 @@ async def polish_album(
     qc_genre = genre or None
     verify_results = []
 
+    # Pre-master verify skips `truepeak` and `clicks`. Polished audio is
+    # un-limited so peaks legitimately sit above the streaming ceiling
+    # until mastering applies its limiter; genre-dense-transient stems
+    # (kicks, snares) legitimately trip the click detector until the
+    # full mix is mastered. Those checks are gates at post-master QC,
+    # not pre-master. (Matches `_stage_pre_qc` in `_album_stages.py`.)
+    VERIFY_CHECKS = ["format", "mono", "phase", "clipping", "silence", "spectral"]
     for wav in polished_files:
-        result = await loop.run_in_executor(None, qc_track, str(wav), None, qc_genre)
+        result = await loop.run_in_executor(
+            None, qc_track, str(wav), VERIFY_CHECKS, qc_genre
+        )
         verify_results.append(result)
 
     failed = [r["filename"] for r in verify_results if r["verdict"] == "FAIL"]
@@ -507,6 +516,8 @@ async def polish_album(
     stages["verify"] = {
         "status": verify_status,
         "tracks_verified": len(verify_results),
+        "checks_run": VERIFY_CHECKS,
+        "checks_deferred_to_post_master": ["truepeak", "clicks"],
         "failed_tracks": failed,
         "warned_tracks": warned,
         "qc_issues": qc_warnings,

--- a/tests/unit/mastering/test_qc_tracks.py
+++ b/tests/unit/mastering/test_qc_tracks.py
@@ -377,6 +377,28 @@ class TestCheckSilence:
         assert result["status"] == "FAIL"
         assert "internal gap" in result["detail"]
 
+    def test_leading_silence_electronic_allows_build_intro(self, tmp_path):
+        """An electronic track opening with a 1.0 s filter-sweep build
+        must not FAIL the silence gate — `electronic` preset raises the
+        leading-silence limit to 1.5 s (#323 comment point 4).
+        """
+        rate = 44100
+        silence = np.zeros(int(rate * 1.0), dtype=np.float64)
+        t = np.linspace(0, 2.0, rate * 2, endpoint=False)
+        sig = 0.5 * np.sin(2 * np.pi * 440 * t)
+        mono = np.concatenate([silence, sig])
+        data = np.column_stack([mono, mono])
+        wav_path = tmp_path / "electronic_intro.wav"
+        sf.write(str(wav_path), data, rate)
+
+        # Default (no genre) — 1.0 s leading silence FAILs at 0.5 s cap.
+        default_result = qc_track(str(wav_path), checks=["silence"])
+        assert default_result["checks"]["silence"]["status"] == "FAIL"
+
+        # Electronic preset — 1.5 s cap, so 1.0 s passes.
+        electronic_result = qc_track(str(wav_path), checks=["silence"], genre="electronic")
+        assert electronic_result["checks"]["silence"]["status"] != "FAIL"
+
     def test_trailing_silence_with_boundary_blip_not_internal(self):
         """Trailing silence followed by a sub-audible noise blip at the
         file end must be classified as trailing, not an internal gap (#321).

--- a/tests/unit/state/test_server_qc.py
+++ b/tests/unit/state/test_server_qc.py
@@ -666,7 +666,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)):
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)):
             result = json.loads(_run(server.master_album("test-album")))
 
         assert master_called[0], "Mastering should have run before verification"
@@ -704,7 +704,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)):
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)):
             result = json.loads(_run(server.master_album("test-album")))
 
         assert result["failed_stage"] == "verification"
@@ -875,7 +875,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"), \
              patch.object(server, "parse_track_file", return_value={"status": "Final"}):
             result = json.loads(_run(server.master_album("test-album")))
@@ -933,7 +933,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"), \
              patch.object(server, "parse_track_file", return_value={"status": "Final"}):
             result = json.loads(_run(server.master_album("test-album")))
@@ -966,7 +966,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album", genre="rock")))
 
@@ -1042,7 +1042,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album")))
 
@@ -1080,7 +1080,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)):
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)):
             result = json.loads(_run(server.master_album("test-album")))
 
         assert result["failed_stage"] == "verification"
@@ -1102,7 +1102,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)):
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)):
             result = json.loads(_run(server.master_album("test-album")))
 
         assert result["failed_stage"] == "mastering"
@@ -1141,7 +1141,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album")))
 
@@ -1178,7 +1178,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-13.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album", genre="country")))
 
@@ -1247,7 +1247,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch("tools.mastering.fix_dynamic_track.fix_dynamic", side_effect=mock_fix_dynamic), \
              patch("soundfile.read", return_value=(fake_audio, 44100)), \
              patch("soundfile.write"):
@@ -1290,7 +1290,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch("tools.mastering.fix_dynamic_track.fix_dynamic", side_effect=mock_fix_dynamic):
             result = json.loads(_run(server.master_album("test-album")))
 
@@ -1333,7 +1333,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch("tools.mastering.fix_dynamic_track.fix_dynamic", side_effect=mock_fix_dynamic), \
              patch("soundfile.read", return_value=(fake_audio, 44100)), \
              patch("soundfile.write"):
@@ -1386,7 +1386,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch("tools.mastering.fix_dynamic_track.fix_dynamic", side_effect=mock_fix_dynamic), \
              patch("soundfile.read", return_value=(fake_audio, 44100)), \
              patch("soundfile.write"):
@@ -1433,7 +1433,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             json.loads(_run(server.master_album("test-album")))
 
@@ -1486,7 +1486,7 @@ class TestMasterAlbumPipeline:
              patch("tools.mastering.master_tracks.master_track", side_effect=mock_master), \
              patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch("tools.mastering.fix_dynamic_track.fix_dynamic", side_effect=mock_fix_dynamic), \
              patch("soundfile.read", return_value=(fake_audio, 44100)), \
              patch("soundfile.write"):
@@ -1769,7 +1769,7 @@ class TestMasterAlbumStaging:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)):
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)):
             with pytest.raises(RuntimeError, match="simulated mastering crash"):
                 _run(server.master_album("test-album"))
 
@@ -1804,7 +1804,7 @@ class TestMasterAlbumStaging:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album")))
 
@@ -1847,7 +1847,7 @@ class TestMasterAlbumStaging:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name, lufs=-14.0)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album")))
 
@@ -1873,7 +1873,7 @@ class TestMasterAlbumStaging:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc_result(Path(f).name)):
+                   side_effect=lambda f, c=None, g=None: self._mock_qc_result(Path(f).name)):
             result = json.loads(_run(server.master_album("test-album")))
 
         assert result["failed_stage"] == "mastering"
@@ -1958,7 +1958,7 @@ class TestMasterAlbumMasteringSamplesStage:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album")))
 
@@ -1994,7 +1994,7 @@ class TestMasterAlbumMasteringSamplesStage:
              patch("tools.mastering.analyze_tracks.analyze_track",
                    side_effect=lambda f: self._mock_analyze(Path(f).name)), \
              patch("tools.mastering.qc_tracks.qc_track",
-                   side_effect=lambda f, c=None: self._mock_qc(Path(f).name)), \
+                   side_effect=lambda f, c=None, g=None: self._mock_qc(Path(f).name)), \
              patch.object(server, "write_state"):
             result = json.loads(_run(server.master_album("test-album")))
 

--- a/tools/mastering/genre-presets.yaml
+++ b/tools/mastering/genre-presets.yaml
@@ -52,6 +52,11 @@
 #                            sharp transients (e.g., 8.0–10.0 for electronic/IDM/metal).
 #   click_fail_count       - QC click detector: absolute click count above which clicks FAIL
 #                            (default 3). Raise alongside peak_ratio for dense-transient genres.
+#   silence_leading_max_s  - QC silence check: leading silence longer than this duration (s)
+#                            FAILs. Default 0.5. Raise (e.g. 1.5) for genres whose intros
+#                            open with filter sweeps / builds (electronic, EDM, progressive).
+#   silence_trailing_max_s - QC silence check: trailing silence longer than this duration (s)
+#                            WARNs. Default 3.0.
 #   codec_preview_enabled  - Render a 128 kbps AAC .aac.m4a next to each master in
 #                            mastering_samples/ for operator Bluetooth audition (issue #296).
 #                            1 = on (default), 0 = off.
@@ -201,8 +206,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   dream-pop:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -247,8 +252,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   jangle-pop:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -300,20 +305,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   drill:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   phonk:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   grime:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -358,8 +363,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   mumble-rap:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -536,8 +541,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   britpop:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -609,26 +614,26 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   crust-punk:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   d-beat:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   powerviolence:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   screamo:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -672,20 +677,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   thrash-metal:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   black-metal:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   doom-metal:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -694,14 +699,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   metalcore:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   nu-metal:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -722,20 +727,20 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   grindcore:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   groove-metal:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   sludge-metal:
     target_lufs: -14.0
     cut_highmid: -2.5
@@ -748,21 +753,21 @@ genres:
     target_lufs: -14.0
     cut_highmid: -3.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   djent:
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   industrial:
     opus_safe: true
     target_lufs: -14.0
     cut_highmid: -2.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   hair-metal:
     target_lufs: -14.0
     cut_highmid: -2.0
@@ -805,15 +810,19 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
+    # Electronic intros often open with filter sweeps / builds that
+    # read as near-silence for the first 1-2 s.
+    silence_leading_max_s: 1.5
   edm:
     opus_safe: true
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
+    silence_leading_max_s: 1.5
   eurodance:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -842,8 +851,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   trance:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -853,14 +862,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   jungle:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   uk-garage:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -870,8 +879,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   synthwave:
     target_lufs: -14.0
     cut_highmid: -1.5
@@ -888,8 +897,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   electro:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -899,8 +908,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -2.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   electroswing:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -941,8 +950,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   speedcore:
     target_lufs: -12.0
     cut_highmid: -2.0
@@ -953,8 +962,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   wave:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -971,8 +980,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   vocal-trance:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -989,8 +998,8 @@ genres:
     target_lufs: -12.0
     cut_highmid: -2.0
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   dub-techno:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -1005,14 +1014,14 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   glitch-pop:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   moombahton:
     target_lufs: -14.0
     cut_highmid: -1.0
@@ -1021,8 +1030,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -1.5
     cut_highs: 0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   witch-house:
     target_lufs: -16.0
     cut_highmid: -1.0
@@ -1031,8 +1040,8 @@ genres:
     target_lufs: -14.0
     cut_highmid: -2.0
     cut_highs: -1.0
-    click_peak_ratio: 8.0
-    click_fail_count: 15
+    click_peak_ratio: 10.0
+    click_fail_count: 30
   ebm:
     target_lufs: -14.0
     cut_highmid: -1.5

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -126,6 +126,8 @@ _PRESET_DEFAULTS: dict[str, float] = {
     # QC thresholds (consumed by tools/mastering/qc_tracks.py)
     'click_peak_ratio': 6.0,
     'click_fail_count': 3,
+    'silence_leading_max_s': 0.5,
+    'silence_trailing_max_s': 3.0,
     # Mastering-samples QC artifacts (issue #296, consumed by handlers/processing/audio.py)
     'codec_preview_enabled': 1,
     'codec_preview_bitrate_kbps': 128,

--- a/tools/mastering/qc_tracks.py
+++ b/tools/mastering/qc_tracks.py
@@ -262,7 +262,12 @@ def _check_clicks(
     }
 
 
-def _check_silence(data: Any, rate: int) -> dict[str, str]:
+def _check_silence(
+    data: Any,
+    rate: int,
+    leading_max_s: float = 0.5,
+    trailing_max_s: float = 3.0,
+) -> dict[str, str]:
     """Check for excessive leading, trailing, or internal silence.
 
     A silent region (samples below -60 dBFS) is classified as leading if
@@ -274,6 +279,12 @@ def _check_silence(data: Any, rate: int) -> dict[str, str]:
     whose region happens to touch the tolerance window (e.g. a sine-wave
     zero crossing) — without it, legitimate internal gaps get silently
     demoted to "trailing". Regression for #321.
+
+    Args:
+        leading_max_s: Leading silence > this duration FAILs. Raise for
+            genres with intentional intro builds/filter sweeps (e.g.
+            electronic ~1.5 s).
+        trailing_max_s: Trailing silence > this duration WARNs.
     """
     if data.ndim > 1:
         mono = np.mean(data, axis=1)
@@ -333,11 +344,11 @@ def _check_silence(data: Any, rate: int) -> dict[str, str]:
     issues = []
     status = "PASS"
 
-    if leading_sec > 0.5:
+    if leading_sec > leading_max_s:
         status = "FAIL"
         issues.append(f"Leading silence: {leading_sec:.1f}s")
 
-    if trailing_sec > 3.0:
+    if trailing_sec > trailing_max_s:
         if status != "FAIL":
             status = "WARN"
         issues.append(f"Trailing silence: {trailing_sec:.1f}s")
@@ -436,6 +447,32 @@ def _resolve_click_thresholds(genre: str | None) -> tuple[float, int]:
     return float(preset.get('click_peak_ratio', 6.0)), int(preset.get('click_fail_count', 3))
 
 
+def _resolve_silence_thresholds(genre: str | None) -> tuple[float, float]:
+    """Look up silence_leading_max_s and silence_trailing_max_s for a genre preset.
+
+    Falls back to (0.5, 3.0) if no genre is given. Raises ValueError
+    for an unknown genre name. Electronic/EDM and similar builds-with-
+    intros genres override `silence_leading_max_s` upward so natural
+    filter sweeps / builds don't FAIL QC.
+    """
+    if genre is None:
+        return 0.5, 3.0
+
+    from tools.mastering.master_tracks import GENRE_PRESETS
+
+    key = genre.lower()
+    if key not in GENRE_PRESETS:
+        raise ValueError(
+            f"Unknown genre: {genre}. "
+            f"Available: {', '.join(sorted(GENRE_PRESETS.keys()))}"
+        )
+    preset = GENRE_PRESETS[key]
+    return (
+        float(preset.get('silence_leading_max_s', 0.5)),
+        float(preset.get('silence_trailing_max_s', 3.0)),
+    )
+
+
 def qc_track(
     filepath: Path | str,
     checks: list[str] | None = None,
@@ -460,6 +497,7 @@ def qc_track(
     active_checks = checks or ALL_CHECKS
 
     click_peak_ratio, click_fail_count = _resolve_click_thresholds(genre)
+    silence_leading_max_s, silence_trailing_max_s = _resolve_silence_thresholds(genre)
 
     info = sf.info(filepath)
     data, rate = sf.read(filepath)
@@ -493,7 +531,11 @@ def qc_track(
         )
 
     if "silence" in active_checks:
-        results["silence"] = _check_silence(data, rate)
+        results["silence"] = _check_silence(
+            data, rate,
+            leading_max_s=silence_leading_max_s,
+            trailing_max_s=silence_trailing_max_s,
+        )
 
     if "spectral" in active_checks:
         results["spectral"] = _check_spectral(data, rate)


### PR DESCRIPTION
## Summary
Fixes the four pipeline-gate bugs called out in the comment on #323, hit while mastering an electronic album through the #290 pipeline.

1. **Drum click over-trigger** (comment #2) — dense-transient genre presets bumped from `click_peak_ratio: 8.0 / click_fail_count: 15` → `10.0 / 30` to match `idm`'s calibration. Applies to `electronic`, `edm`, `techno`, `drum-and-bass`, `jungle`, `dubstep`, `hardstyle`, `breakbeat`, `metal`, `industrial`, `trap`, `drill`, `phonk`, `grime`, `shoegaze`, `dream-pop`. 20 electronic drum transients crossing 8× peak/RMS in a 3-min track was a false FAIL.
2. **Truepeak on pre-master** (comment #3) — `polish_album` verify stage now runs the pre-master subset (`format, mono, phase, clipping, silence, spectral`) and defers `truepeak` / `clicks` to post-master QC. Polished audio is un-limited and dense-transient; the limiter enforces the ceiling.
3. **Silence too strict for electronic intros** (comment #4) — new `silence_leading_max_s` / `silence_trailing_max_s` genre-preset fields plumbed through `qc_track → _check_silence`. `electronic` and `edm` override `silence_leading_max_s: 1.5` so filter-sweep / build intros don't FAIL.
4. **Pre-QC aggregation transparency** (comment #1) — `_stage_pre_qc` (master_album) and `polish_album` verify now forward `genre` to `qc_track` and surface `checks_run` / `checks_deferred_to_post_master` so the summary makes deferred checks explicit.

Comment point 5 ("no highs" on track 09) is an album-specific observation, not a code bug — left out of this PR.

## Test plan
- [x] New regression `test_leading_silence_electronic_allows_build_intro` — 1.0 s leading silence FAILs default but PASSes with `genre="electronic"`
- [x] 22 existing `test_server_qc.py` lambda mocks updated to accept new `genre` positional arg
- [x] 69 tests pass across `tests/unit/mastering/test_qc_tracks.py`, `test_integration_realistic_audio.py`, `tests/unit/state/test_handlers_mixing.py`, `test_server_qc.py`
- [ ] Verify on real electronic album (`if-anyone-makes-it-everyone-dances`) that pipeline no longer halts at pre_qc on silence / click / truepeak

🤖 Generated with [Claude Code](https://claude.com/claude-code)