### PR TITLE
fix: adaptive ADM ceiling + hard floor + warn-fallback (any album completes)

### DIFF
--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -641,8 +641,17 @@ async def master_album(
         if result := await stage_fn(ctx):
             return _inject_notices_and_return(result)
 
-    # ── Phase 2: ADM loop (max 2 outer cycles) ───────────────────────────
-    _ADM_MAX_CYCLES = 2
+    # ── Phase 2: ADM loop (adaptive ceiling, max 3 cycles) ────────────────
+    # Convergence: fixed 0.5 dB steps failed on dense-transient content
+    # because AAC ripple only drops ~0.47 dB per 0.5 dB of ceiling — the
+    # loop would exhaust its budget with overshoot still present. Adaptive
+    # tightening uses the observed worst decoded peak to pick the next
+    # ceiling in one shot, then backs that with a hard floor and a
+    # warn-fallback so any album can complete without halting.
+    _ADM_MAX_CYCLES = 3
+    _ADM_MIN_CEILING_DB = -6.0       # never tighten below this
+    _ADM_SAFETY_DB = 0.3             # extra headroom below observed peak
+    _ADM_MIN_TIGHTEN_DB = 0.5        # preserves legacy step as the floor
     adm_loop_stages: list[_StageFn] = [
         _album_stages._stage_mastering,
         _album_stages._stage_verification,
@@ -652,47 +661,114 @@ async def master_album(
         _album_stages._stage_adm_validation,
     ]
 
+    def _adm_adaptive_ceiling(
+        failure_detail: dict[str, Any], current: float,
+    ) -> tuple[float, bool]:
+        """Compute next ceiling from observed worst decoded peak.
+
+        Returns ``(new_ceiling, hit_floor)``. The WAV ceiling is placed
+        ``_ADM_SAFETY_DB`` below the worst decoded peak so the re-master
+        starts with enough headroom for AAC ripple. Clamped to
+        ``_ADM_MIN_CEILING_DB``; when clamped, ``hit_floor=True`` so the
+        loop can fall through to warn-fallback instead of looping forever
+        at the same ceiling.
+        """
+        tracks = failure_detail.get("tracks_with_clips") or []
+        peaks = [
+            float(t["peak_db_decoded"])
+            for t in tracks if t.get("peak_db_decoded") is not None
+        ]
+        if not peaks:
+            proposed = current - _ADM_MIN_TIGHTEN_DB
+        else:
+            worst_peak = max(peaks)
+            overshoot = worst_peak - current
+            tighten = max(overshoot + _ADM_SAFETY_DB, _ADM_MIN_TIGHTEN_DB)
+            proposed = current - tighten
+        floored = proposed < _ADM_MIN_CEILING_DB
+        return (max(proposed, _ADM_MIN_CEILING_DB), floored)
+
+    adm_clip_failure_persisted = False
+    adm_last_failure_detail: dict[str, Any] = {}
+
     for adm_cycle in range(_ADM_MAX_CYCLES):
         ctx.adm_cycle = adm_cycle
         adm_retry = False
 
         for stage_fn in adm_loop_stages:
             if result := await stage_fn(ctx):
-                # Check if this is a retryable ADM clip failure
                 try:
                     _d = json.loads(result)
                 except json.JSONDecodeError:
                     _d = {}
-                is_adm_clip = (
+                is_adm_clip_failure = (
                     _d.get("failed_stage") == "adm_validation"
                     and _d.get("failure_detail", {}).get("clips_retry_eligible")
-                    and adm_cycle < _ADM_MAX_CYCLES - 1
                 )
-                if is_adm_clip:
-                    ctx.effective_ceiling -= 0.5
-                    # Propagate the tightened ceiling everywhere the ADM stage
-                    # and downstream consumers (sidecar, halt JSON, signature
-                    # persist) read it. Without this, cycle-2 masters to the
-                    # new ceiling but ADM still compares against the original.
-                    ctx.targets["ceiling_db"] = ctx.effective_ceiling
-                    if isinstance(ctx.effective_preset, dict):
-                        ctx.effective_preset["true_peak_ceiling"] = (
-                            ctx.effective_ceiling
+                if is_adm_clip_failure:
+                    adm_last_failure_detail = _d.get("failure_detail") or {}
+                    if adm_cycle < _ADM_MAX_CYCLES - 1:
+                        new_ceiling, hit_floor = _adm_adaptive_ceiling(
+                            adm_last_failure_detail, ctx.effective_ceiling,
                         )
-                    ctx.notices.append(
-                        f"ADM cycle {adm_cycle + 1}: inter-sample clips detected, "
-                        f"tightening ceiling to {ctx.effective_ceiling:.1f} dBTP "
-                        f"and re-mastering."
-                    )
-                    adm_retry = True
+                        # If the adaptive pass can't move the ceiling any
+                        # further (already at floor from a previous cycle)
+                        # then another retry would just repeat the same
+                        # re-master. Fall through to warn-fallback.
+                        if new_ceiling >= ctx.effective_ceiling:
+                            adm_clip_failure_persisted = True
+                            break
+                        ctx.effective_ceiling = new_ceiling
+                        # Propagate the tightened ceiling everywhere the
+                        # ADM stage and downstream consumers read it.
+                        ctx.targets["ceiling_db"] = ctx.effective_ceiling
+                        if isinstance(ctx.effective_preset, dict):
+                            ctx.effective_preset["true_peak_ceiling"] = (
+                                ctx.effective_ceiling
+                            )
+                        floor_note = " (floor reached)" if hit_floor else ""
+                        ctx.notices.append(
+                            f"ADM cycle {adm_cycle + 1}: inter-sample clips "
+                            f"detected, tightening ceiling to "
+                            f"{ctx.effective_ceiling:.2f} dBTP{floor_note} "
+                            f"and re-mastering."
+                        )
+                        adm_retry = True
+                        break
+                    # Last cycle with clips → warn-fallback, don't halt.
+                    adm_clip_failure_persisted = True
                     break
-
-                # Non-retryable halt
+                # Non-ADM / non-retryable halt
                 return _inject_notices_and_return(result)
 
         if adm_retry:
             continue
-        break  # ADM passed
+        break  # ADM passed, or warn-fallback break
+
+    # Warn-fallback: ADM clips persist after all retries or at floor. The
+    # album still finishes — operators get a flagged deliverable and the
+    # ADM_VALIDATION.md sidecar with per-track peak data so they can make
+    # the manual call on whether to republish.
+    if adm_clip_failure_persisted:
+        stage = ctx.stages.get("adm_validation")
+        if isinstance(stage, dict):
+            stage["status"] = "warn"
+            stage["reason"] = (
+                f"inter-sample clips persist at ceiling "
+                f"{ctx.effective_ceiling:.2f} dBTP after "
+                f"{_ADM_MAX_CYCLES} cycle(s); floor is "
+                f"{_ADM_MIN_CEILING_DB:.1f} dBTP"
+            )
+            stage["clip_failure_persisted"] = True
+        tracks_with_clips = adm_last_failure_detail.get("tracks_with_clips") or []
+        clip_count = len(tracks_with_clips)
+        ctx.warnings.append(
+            f"ADM validation: {clip_count} track(s) retain inter-sample "
+            f"clips after {_ADM_MAX_CYCLES} retry cycles (final ceiling "
+            f"{ctx.effective_ceiling:.2f} dBTP, floor "
+            f"{_ADM_MIN_CEILING_DB:.1f} dBTP). Album delivered with flag — "
+            f"see ADM_VALIDATION.md for per-track detail."
+        )
 
     # ── Phase 3: post-loop stages (run once) ─────────────────────────────
     post_loop_stages: list[_StageFn] = [

--- a/tests/unit/mastering/test_master_album_adm_retry.py
+++ b/tests/unit/mastering/test_master_album_adm_retry.py
@@ -161,45 +161,184 @@ def test_adm_retry_tightens_ceiling_on_clips(
 
 
 # ---------------------------------------------------------------------------
-# Test 2: Retry halts after max ADM cycles (2) when clips always present
+# Test 2: Retry warn-falls-back after max cycles (was: halts) — #323 follow-up
 # ---------------------------------------------------------------------------
 
-def test_adm_retry_halts_after_max_cycles(
+def test_adm_retry_warn_fallback_after_max_cycles(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """_adm_check_fn always returns clips → pipeline halts after 2 ADM cycles.
+    """_adm_check_fn always returns clips → pipeline completes with WARN,
+    does not halt.
 
-    Verifies:
-    - failed_stage == "adm_validation"
-    - failure_detail contains adm_cycles == 2
-    - clips_retry_eligible is True in failure_detail
+    Per #323 follow-up: any album must complete rather than halting on
+    pathological dense-transient content. The final ADM state is preserved
+    as a warn on the stage plus a human-readable warning; the
+    ADM_VALIDATION.md sidecar has per-track detail so operators can
+    republish manually if the flag matters for distribution.
     """
     album_slug = "adm-retry-album"
     _write_sine_wav(tmp_path / "01-track.wav")
     _install_album(monkeypatch, tmp_path, album_slug)
 
     def _always_clips(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        # Peak tracks the current ceiling so adaptive tightening advances
+        # but never converges.
         return {
             "filename": Path(path).name,
             "encoder_used": encoder,
             "clip_count": 5,
-            "peak_db_decoded": -0.3,
+            "peak_db_decoded": ceiling_db + 0.3,
             "ceiling_db": ceiling_db,
             "clips_found": True,
         }
 
     monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _always_clips)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
 
     result = _run_master_album(tmp_path, album_slug=album_slug)
 
-    assert result["failed_stage"] == "adm_validation", (
-        f"Expected failed_stage=adm_validation, got: {result.get('failed_stage')}"
+    # Warn-fallback: pipeline completes rather than halting.
+    assert result.get("failed_stage") is None, (
+        f"Expected pipeline to complete (warn-fallback), got failure: "
+        f"{result.get('failure_detail')}"
     )
-    fd = result.get("failure_detail", {})
-    assert fd.get("adm_cycles") == 2, (
-        f"Expected adm_cycles=2 in failure_detail, got: {fd.get('adm_cycles')}"
+    adm_stage = result.get("stages", {}).get("adm_validation", {})
+    assert adm_stage.get("status") == "warn", (
+        f"Expected adm_validation stage status=warn, got: {adm_stage.get('status')}"
     )
-    assert fd.get("clips_retry_eligible") is True, (
-        f"Expected clips_retry_eligible=True in failure_detail, got: {fd.get('clips_retry_eligible')}"
+    assert adm_stage.get("clip_failure_persisted") is True, (
+        f"Expected clip_failure_persisted=True on warn-fallback, got: {adm_stage}"
+    )
+    warnings = result.get("warnings", [])
+    assert any("ADM validation" in w and "retain inter-sample" in w for w in warnings), (
+        f"Expected ADM warn-fallback warning, got warnings: {warnings}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Adaptive tightening derives new ceiling from worst decoded peak
+# ---------------------------------------------------------------------------
+
+def test_adm_retry_adaptive_ceiling_from_worst_peak(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cycle 1 ceiling must be set based on cycle 0's worst observed peak.
+
+    With a peak of -0.71 dBTP at ceiling -1.0 dBTP (overshoot 0.29 dB),
+    the adaptive formula picks ceiling - max(overshoot + 0.3 safety,
+    0.5 min-step) = -1.0 - 0.59 = -1.59 dBTP.
+    """
+    album_slug = "adm-retry-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    call_count = {"n": 0}
+
+    def _fake_check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Cycle 0 first (only) file → worst peak -0.71
+            return {
+                "filename": Path(path).name,
+                "encoder_used": encoder,
+                "clip_count": 3,
+                "peak_db_decoded": -0.71,
+                "ceiling_db": ceiling_db,
+                "clips_found": True,
+            }
+        # Subsequent cycles pass.
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 0,
+            "peak_db_decoded": ceiling_db - 0.5,
+            "ceiling_db": ceiling_db,
+            "clips_found": False,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _fake_check)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    mastered_ceilings: list[float] = []
+    import tools.mastering.master_tracks as _mt_mod
+    _real_master_track = _mt_mod.master_track
+
+    def _capture_master_track(src, dst, *, ceiling_db=-1.0, **kwargs):
+        mastered_ceilings.append(float(ceiling_db))
+        return _real_master_track(src, dst, ceiling_db=ceiling_db, **kwargs)
+
+    monkeypatch.setattr(_mt_mod, "master_track", _capture_master_track)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug)
+
+    assert result.get("failed_stage") is None, (
+        f"Expected pipeline to succeed, got: {result.get('failure_detail')}"
+    )
+    # Cycle 1 (post-adaptive) ceilings: any call below -1.0 is cycle 1+.
+    cycle1_ceilings = [c for c in mastered_ceilings if c < -1.0]
+    assert cycle1_ceilings, (
+        f"Expected cycle 1 ceiling < -1.0, got ceilings: {mastered_ceilings}"
+    )
+    # Target ~-1.59; accept [-1.65, -1.55] to cover float rounding.
+    for c in cycle1_ceilings:
+        assert -1.65 <= c <= -1.55, (
+            f"Expected adaptive cycle-1 ceiling near -1.59, got {c:.3f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Hard floor at -6 dBTP never exceeded
+# ---------------------------------------------------------------------------
+
+def test_adm_retry_respects_hard_floor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Catastrophic peaks must not drive the ceiling below -6 dBTP.
+
+    If every cycle reports a ridiculously high peak (e.g. +5 dBFS —
+    impossible but worst-case robust) the adaptive formula would compute
+    a ceiling far below -6 dBTP. The floor must clamp it, and the loop
+    must warn-fallback rather than loop forever at the floor.
+    """
+    album_slug = "adm-retry-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    def _catastrophic_peak(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 500,
+            "peak_db_decoded": 5.0,
+            "ceiling_db": ceiling_db,
+            "clips_found": True,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _catastrophic_peak)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    mastered_ceilings: list[float] = []
+    import tools.mastering.master_tracks as _mt_mod
+    _real_master_track = _mt_mod.master_track
+
+    def _capture_master_track(src, dst, *, ceiling_db=-1.0, **kwargs):
+        mastered_ceilings.append(float(ceiling_db))
+        return _real_master_track(src, dst, ceiling_db=ceiling_db, **kwargs)
+
+    monkeypatch.setattr(_mt_mod, "master_track", _capture_master_track)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug)
+
+    assert result.get("failed_stage") is None, (
+        f"Expected warn-fallback completion, got: {result.get('failure_detail')}"
+    )
+    assert all(c >= -6.0 for c in mastered_ceilings), (
+        f"Ceiling breached floor at -6 dBTP, got ceilings: {mastered_ceilings}"
+    )
+    adm_stage = result.get("stages", {}).get("adm_validation", {})
+    assert adm_stage.get("status") == "warn", (
+        f"Expected warn status after floor exhaustion, got: {adm_stage}"
     )


### PR DESCRIPTION
## Summary

Fixes the ADM retry loop so mastering completes for **any** album, including pathological dense-transient content where the previous fixed-step loop halted.

**Before:** Fixed 0.5 dB ceiling tighten per cycle, `_ADM_MAX_CYCLES = 2`. On dense electronic content, each 0.5 dB tighten reduced AAC decoded overshoot by only ~0.16–0.47 dB, so the loop exhausted its budget with clips still present and halted at `adm_validation`. Symptom on `if-anyone-makes-it-everyone-dances`: mastering never finished, operator saw `[Tool result missing due to internal error]`.

**After:** Three coupled changes:

1. **Adaptive tightening.** Replace the fixed 0.5 dB step with `new_ceiling = current - max(worst_overshoot + 0.3, 0.5)` where `worst_overshoot = max(peak_db_decoded) - current_ceiling` across clipping tracks. The retry jumps directly to a ceiling that accounts for observed AAC ripple — usually converges in one shot on cycle 1. The 0.5 dB min-step preserves legacy behavior as a floor on tightening.

2. **Hard floor (-6 dBTP) + cycle bump to 3.** Adaptive formula clamped at -6 dBTP so degenerate input can't drive ceiling into noise. `_ADM_MAX_CYCLES` raised from 2 to 3 for extra headroom on content needing two adaptive jumps.

3. **Warn-fallback.** When retries exhaust or the ceiling hits the floor with clips still present, the pipeline no longer halts. `adm_validation` status flips fail → warn, `clip_failure_persisted=True` on the stage, a warning names the track count + final ceiling, and control continues through post-loop stages (metadata, layout, signature, status). Operators get a finished album plus `ADM_VALIDATION.md` per-track detail for manual judgment.

## Expected behavior for the reported case

On `if-anyone-makes-it-everyone-dances` (worst track: carbon-and-silicon, peak -0.65 at ceiling -1.5):
- Cycle 0: ceiling -1.5, observed worst peak -0.65 → overshoot 0.85 → tighten 1.15 dB
- Cycle 1: ceiling -2.65, observed worst peak drops to ~-2.5-ish (well below ceiling) → PASS

The previous loop needed 3+ cycles at 0.5 dB step (-1.5 → -2.0 → -2.5 → -3.0) and halted at cycle 2.

## Test plan

- [x] `pytest tests/unit/mastering/test_master_album_adm_retry.py` — 4 tests, all pass:
  - `test_adm_retry_tightens_ceiling_on_clips` (existing) — adaptive ceiling drops below -1.5 on cycle 2
  - `test_adm_retry_warn_fallback_after_max_cycles` (renamed from halt test) — pipeline completes with warn, not halt
  - `test_adm_retry_adaptive_ceiling_from_worst_peak` (new) — adaptive math: peak -0.71 at ceiling -1.0 → cycle 1 ceiling ≈ -1.59
  - `test_adm_retry_respects_hard_floor` (new) — catastrophic +5 dBFS peaks never drive ceiling below -6 dBTP
- [x] `make check` green: 3422 passed, ruff + bandit + mypy + pytest + 84.93% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)