### PR TITLE
feat: opt-in ADM validation via config + dynamic ceiling suggestion

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -847,6 +847,24 @@ sheet_music:
 #   #                 (--enable-libfdk_aac).
 #   #
 #   # adm_aac_encoder: aac
+#
+#   # ---------------------------
+#   # adm_validation_enabled [optional, default: false]
+#   # ---------------------------
+#   # When true, master_album runs the ADM (Apple Digital Masters)
+#   # validation stage — encodes each mastered track to AAC, decodes,
+#   # and scans for inter-sample peaks above the true-peak ceiling.
+#   # If clips are found, the adaptive retry loop tightens the ceiling
+#   # up to 2 additional times.
+#   #
+#   # Cost: each cycle re-masters every track, so on a 10-track album
+#   # this adds ~10-12 minutes per cycle (up to ~30-36 min in the worst
+#   # case). Default OFF — opt in per album when preparing for Apple
+#   # Hi-Res Lossless / ADM submission, or when you need provable
+#   # zero-clip delivery. Normal streaming-target mastering doesn't
+#   # need it.
+#   #
+#   # adm_validation_enabled: false
 
 
 # =============================================================================

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2004,6 +2004,21 @@ async def _stage_adm_validation(ctx: MasterAlbumCtx) -> str | None:
             "tracks_with_clips": len(clips_found),
             "encoder_used": encoder_used,
         }
+        # Compute a dynamic suggestion: the next ceiling the adaptive
+        # loop would try. Previously this string was hardcoded to
+        # "-1.5 dBTP" regardless of the current ceiling, which was
+        # misleading when the loop had already tightened past that.
+        worst_decoded = max(
+            (float(r.get("peak_db_decoded", 0.0)) for r in clips_found),
+            default=ceiling_db,
+        )
+        suggested_ceiling = min(
+            ceiling_db - 0.5,
+            worst_decoded - 0.3,
+        )
+        # Clamp suggestion to the -6 dBTP adaptive floor for consistency
+        # with the actual retry formula.
+        suggested_ceiling = max(suggested_ceiling, -6.0)
         return _safe_json({
             "album_slug": ctx.album_slug,
             "stage_reached": "adm_validation",
@@ -2022,9 +2037,13 @@ async def _stage_adm_validation(ctx: MasterAlbumCtx) -> str | None:
                      "peak_db_decoded": r["peak_db_decoded"]}
                     for r in clips_found
                 ],
+                "suggested_ceiling_db": suggested_ceiling,
                 "suggestion": (
-                    "Tighten true-peak ceiling by 0.5 dB and re-master, "
-                    "or set mastering.true_peak_ceiling: -1.5 in config.yaml."
+                    f"Worst decoded peak was {worst_decoded:.2f} dBTP; "
+                    f"tighten true-peak ceiling to {suggested_ceiling:.2f} dBTP "
+                    f"and re-master, or set "
+                    f"`mastering.true_peak_ceiling: {suggested_ceiling:.2f}` "
+                    f"in config.yaml."
                 ),
             },
         })

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -648,7 +648,14 @@ async def master_album(
     # tightening uses the observed worst decoded peak to pick the next
     # ceiling in one shot, then backs that with a hard floor and a
     # warn-fallback so any album can complete without halting.
-    _ADM_MAX_CYCLES = 3
+    #
+    # ADM validation is OPT-IN via `mastering.adm_validation_enabled: true`
+    # (default false) because each cycle re-masters every track and the
+    # AAC encode/decode adds ~10-12 min per cycle on a 10-track album.
+    # Most albums don't need the ADM loop; reserve it for Apple Hi-Res
+    # Lossless / ADM submission prep.
+    adm_enabled = bool(ctx.targets.get("adm_validation_enabled", False))
+    _ADM_MAX_CYCLES = 3 if adm_enabled else 1
     _ADM_MIN_CEILING_DB = -6.0       # never tighten below this
     _ADM_SAFETY_DB = 0.3             # extra headroom below observed peak
     _ADM_MIN_TIGHTEN_DB = 0.5        # preserves legacy step as the floor
@@ -658,8 +665,20 @@ async def master_album(
         _album_stages._stage_coherence_check,
         _album_stages._stage_coherence_correct,
         _ceiling_guard,
-        _album_stages._stage_adm_validation,
     ]
+    if adm_enabled:
+        adm_loop_stages.append(_album_stages._stage_adm_validation)
+    else:
+        ctx.stages["adm_validation"] = {
+            "status": "skipped",
+            "reason": "disabled_by_config",
+        }
+        ctx.notices.append(
+            "ADM validation skipped — enable with "
+            "`mastering.adm_validation_enabled: true` in config.yaml "
+            "when preparing for Apple Hi-Res Lossless / ADM submission "
+            "(adds ~10-12 min per cycle on a 10-track album)."
+        )
 
     def _adm_adaptive_ceiling(
         failure_detail: dict[str, Any], current: float,

--- a/tests/unit/mastering/test_master_album_adm_retry.py
+++ b/tests/unit/mastering/test_master_album_adm_retry.py
@@ -71,11 +71,31 @@ def _install_album(
     monkeypatch.setattr(_shared, "cache", _FakeCache())
 
 
-def _run_master_album(tmp_path: Path, album_slug: str = "adm-retry-album") -> dict:
+def _run_master_album(
+    tmp_path: Path,
+    album_slug: str = "adm-retry-album",
+    adm_enabled: bool = True,
+) -> dict:
+    """Invoke master_album with ADM toggled on/off via config patching.
+
+    ADM is opt-in (default false) as of the adm_validation_enabled
+    config gate. These ADM-retry tests all test ADM-specific logic, so
+    default to True and let new tests override when exercising the
+    skip path.
+    """
     def _fake_resolve(slug, subfolder=""):
         return None, tmp_path
 
-    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+    from tools.mastering import config as _master_config
+    real_load = _master_config.load_mastering_config
+
+    def _load_with_adm() -> dict:
+        cfg = real_load()
+        cfg["adm_validation_enabled"] = adm_enabled
+        return cfg
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve), \
+         patch.object(_master_config, "load_mastering_config", _load_with_adm):
         return json.loads(asyncio.run(audio_mod.master_album(album_slug=album_slug)))
 
 
@@ -552,3 +572,192 @@ def test_adm_warn_fallback_runs_post_loop_stages(
             f"Expected post-loop stage {stage_name!r} to run after "
             f"warn-fallback, got stages: {sorted(stages.keys())}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Gate tests: ADM validation is opt-in via mastering.adm_validation_enabled
+# ---------------------------------------------------------------------------
+
+def test_adm_skipped_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing `mastering.adm_validation_enabled` config key → ADM off.
+
+    Each ADM cycle re-masters every track and AAC encode/decode adds
+    ~10-12 min per cycle on a 10-track album. Default off keeps normal
+    mastering runs fast; users opt in for ADM submission prep.
+    """
+    album_slug = "adm-gate-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    adm_called = {"n": 0}
+
+    def _should_not_be_called(*args, **kwargs):
+        adm_called["n"] += 1
+        raise AssertionError(
+            "_adm_check_fn should not be called when adm_validation_enabled=False"
+        )
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _should_not_be_called)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug, adm_enabled=False)
+
+    assert result.get("failed_stage") is None, (
+        f"Expected pipeline to complete, got failure: {result.get('failure_detail')}"
+    )
+    assert adm_called["n"] == 0, (
+        f"Expected 0 ADM calls when disabled, got {adm_called['n']}"
+    )
+    adm_stage = result.get("stages", {}).get("adm_validation", {})
+    assert adm_stage.get("status") == "skipped", (
+        f"Expected adm_validation.status=skipped, got: {adm_stage}"
+    )
+    assert adm_stage.get("reason") == "disabled_by_config", (
+        f"Expected reason=disabled_by_config, got: {adm_stage}"
+    )
+    notices = result.get("notices", [])
+    assert any(
+        "ADM validation skipped" in n and "adm_validation_enabled" in n
+        for n in notices
+    ), f"Expected ADM-skipped notice, got notices: {notices}"
+
+
+def test_adm_enabled_runs_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Explicit `adm_validation_enabled: true` → ADM stage runs.
+
+    Companion to the default-skip test. Pins the gate bidirectionally.
+    """
+    album_slug = "adm-gate-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    adm_called = {"n": 0}
+
+    def _clean(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        adm_called["n"] += 1
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 0,
+            "peak_db_decoded": ceiling_db - 0.5,
+            "ceiling_db": ceiling_db,
+            "clips_found": False,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _clean)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug, adm_enabled=True)
+
+    assert result.get("failed_stage") is None
+    assert adm_called["n"] >= 1, (
+        f"Expected >= 1 ADM call when enabled, got {adm_called['n']}"
+    )
+    adm_stage = result.get("stages", {}).get("adm_validation", {})
+    assert adm_stage.get("status") == "pass", (
+        f"Expected adm_validation.status=pass with clean checks, got: {adm_stage}"
+    )
+
+
+def test_adm_failure_detail_suggests_dynamic_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """failure_detail.suggestion must reflect the current ceiling, not a
+    hardcoded -1.5.
+
+    Bug reported: "the suggestion field says 'set mastering.
+    true_peak_ceiling: -1.5 in config.yaml' — but the ceiling is
+    already at -1.5". Pin the dynamic computation.
+
+    Approach: set the starting ceiling to -2.5 via a genre override is
+    involved, so we instead test by letting the retry loop tighten then
+    inspecting the final halt suggestion. Since warn-fallback is the
+    normal terminal state now, halt JSON isn't returned on clip failure
+    — we test the suggestion string via the stage-level failure return
+    by forcing clips on the last cycle only (cycle 3 with 2 prior
+    tightenings). That last cycle's ceiling is well below -1.5, so the
+    suggestion must reflect that.
+
+    Simpler: we force a persistent clip on the first cycle and capture
+    the notices pushed during tightening — the retry notice already
+    shows the dynamic next ceiling (implemented in audio.py). What we
+    pin here is the stage-level failure_detail.suggestion contents at
+    the moment it's first generated.
+    """
+    album_slug = "adm-gate-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    # Force a single ADM failure on cycle 0, clean thereafter (so retry
+    # is attempted once and the pipeline completes successfully).
+    # We capture the failure_detail that would have been returned to
+    # the retry driver before it moved on.
+    captured_suggestions: list[str] = []
+    captured_suggested_ceilings: list[float] = []
+    original_stage = album_stages_mod._stage_adm_validation
+
+    async def _wrap_stage(ctx):
+        result = await original_stage(ctx)
+        if result:
+            payload = json.loads(result)
+            fd = payload.get("failure_detail", {})
+            if "suggestion" in fd:
+                captured_suggestions.append(str(fd["suggestion"]))
+            if "suggested_ceiling_db" in fd:
+                captured_suggested_ceilings.append(float(fd["suggested_ceiling_db"]))
+        return result
+
+    monkeypatch.setattr(album_stages_mod, "_stage_adm_validation", _wrap_stage)
+
+    call_count = {"n": 0}
+
+    def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        call_count["n"] += 1
+        clips = call_count["n"] == 1
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 5 if clips else 0,
+            # Peak at -0.4 dBTP when ceiling -1.0 → overshoot 0.6
+            "peak_db_decoded": -0.4 if clips else ceiling_db - 0.5,
+            "ceiling_db": ceiling_db,
+            "clips_found": clips,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    _run_master_album(tmp_path, album_slug=album_slug, adm_enabled=True)
+
+    assert captured_suggestions, (
+        f"Expected at least one suggestion to be generated on clip failure"
+    )
+    suggestion = captured_suggestions[0]
+    suggested_ceiling = captured_suggested_ceilings[0]
+    # Dynamic suggestion: worst_peak -0.4 at ceiling -1.0 → min(
+    # ceiling - 0.5, peak - 0.3) = min(-1.5, -0.7) = -1.5. Acceptable
+    # in a band around -1.5 given float precision.
+    assert -1.55 <= suggested_ceiling <= -1.45, (
+        f"Expected suggested_ceiling near -1.5 (computed from "
+        f"peak=-0.4, ceiling=-1.0), got: {suggested_ceiling}"
+    )
+    # The string must name the actual computed value, not a hardcoded
+    # one. For this fixture the computed value IS -1.5, but the string
+    # must NOT use the literal hardcoded phrasing from the pre-fix
+    # code: "set mastering.true_peak_ceiling: -1.5 in config.yaml"
+    # without the "Worst decoded peak was ..." prefix.
+    assert "Worst decoded peak" in suggestion, (
+        f"Suggestion must reference observed worst peak (dynamic), got: "
+        f"{suggestion}"
+    )
+    assert f"{suggested_ceiling:.2f}" in suggestion, (
+        f"Suggestion must name the computed ceiling {suggested_ceiling:.2f}, got: "
+        f"{suggestion}"
+    )

--- a/tests/unit/state/test_server_qc.py
+++ b/tests/unit/state/test_server_qc.py
@@ -825,7 +825,17 @@ class TestMasterAlbumPipeline:
         assert "status_update" in result["stages"]
 
         for stage_name, stage_data in result["stages"].items():
-            assert stage_data["status"] == "pass", f"Stage '{stage_name}' did not pass"
+            # adm_validation is opt-in via `mastering.adm_validation_enabled`
+            # (default false) — "skipped" is the expected healthy state when
+            # the config key is missing. Every other stage must PASS.
+            if stage_name == "adm_validation":
+                assert stage_data["status"] in ("pass", "skipped"), (
+                    f"adm_validation must be pass or skipped, got: {stage_data}"
+                )
+            else:
+                assert stage_data["status"] == "pass", (
+                    f"Stage '{stage_name}' did not pass"
+                )
 
     def test_full_pipeline_updates_track_status(self, tmp_path):
         """Successful pipeline should write 'Final' to track files."""

--- a/tools/mastering/config.py
+++ b/tools/mastering/config.py
@@ -28,6 +28,14 @@ DEFAULT_MASTERING_CONFIG: dict[str, Any] = {
     "true_peak_ceiling": -1.0,
     "archival_enabled": False,
     "adm_aac_encoder": "aac",
+    # ADM (Apple Digital Masters) validation runs AAC encode + decode
+    # per track to scan for inter-sample peaks above the ceiling, plus
+    # up to two adaptive retry cycles when clips are found. Each cycle
+    # re-masters every track, so on a 10-track album this adds ~10-12
+    # minutes per cycle. Default OFF — opt in per album via
+    # `mastering.adm_validation_enabled: true` when preparing for an
+    # Apple Hi-Res Lossless / ADM submission.
+    "adm_validation_enabled": False,
 }
 
 # Per-key type coercion. Values from YAML may come through as strings when
@@ -41,6 +49,7 @@ _KEY_TYPES: dict[str, type] = {
     "true_peak_ceiling": float,
     "archival_enabled": bool,
     "adm_aac_encoder": str,
+    "adm_validation_enabled": bool,
 }
 
 
@@ -150,6 +159,9 @@ def resolve_mastering_targets(
         "output_sample_rate": output_sample_rate,
         "archival_enabled": bool(config.get("archival_enabled", False)),
         "adm_aac_encoder": str(config.get("adm_aac_encoder", "aac")),
+        "adm_validation_enabled": bool(
+            config.get("adm_validation_enabled", False)
+        ),
     }
 
     if source_sample_rate is not None:
@@ -255,6 +267,7 @@ def build_effective_preset(
         "upsampled_from_source": targets["upsampled_from_source"],
         "archival_enabled": targets["archival_enabled"],
         "adm_aac_encoder": targets["adm_aac_encoder"],
+        "adm_validation_enabled": targets["adm_validation_enabled"],
         "cut_highmid": effective_highmid,
         "cut_highs": effective_highs,
     }


### PR DESCRIPTION
## Summary

Two changes, both driven by issues found during last session's end-to-end run:

**1. ADM validation is now opt-in** via `mastering.adm_validation_enabled: true` (default false). The stage re-masters every track and runs AAC encode/decode per track — ~10-12 min per cycle on a 10-track album, up to 30-36 min in the worst case with adaptive retries. Most albums never need ADM; it's only useful when preparing for Apple Hi-Res Lossless / ADM submission. Running it by default burned time and surfaced warn-fallback warnings that were noise for the 99% case.

When disabled, the pipeline runs cycle 0 once (mastering → verification → coherence → ceiling_guard), skips `_stage_adm_validation`, adds a notice explaining how to opt in, and continues to post-loop stages. When enabled, the existing adaptive retry + warn-fallback behavior is unchanged.

**2. Dynamic ceiling suggestion in failure_detail.** Previously the `suggestion` field hardcoded `"set mastering.true_peak_ceiling: -1.5 in config.yaml"` regardless of the current ceiling — misleading once the retry loop had tightened past that. Now `suggested_ceiling_db` is computed from the observed worst decoded peak (peak - 0.3 safety margin, clamped to the -6.0 dBTP floor) and templated into the suggestion string.

## Tests

- **3 new gate tests** (all pass):
  - `test_adm_skipped_by_default` — missing config key → ADM not run, stage status `"skipped"`, `_adm_check_fn` never invoked, notice explains opt-in
  - `test_adm_enabled_runs_validation` — explicit `true` → ADM stage runs and passes on clean checks
  - `test_adm_failure_detail_suggests_dynamic_ceiling` — pins "Worst decoded peak" phrasing and dynamic `suggested_ceiling_db` value against regression to hardcoded strings
- **8 existing ADM retry tests** updated to use `adm_enabled=True` via `load_mastering_config` patch in the shared `_run_master_album` helper
- **`test_full_pipeline_success`** updated to accept `adm_validation` in `("pass", "skipped")`
- **`make check`** green: 3572 passed, ruff + bandit + mypy + pytest + 84.93% coverage

## Config

`config/config.example.yaml` documents the new key, the cost tradeoff, and when to opt in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)