### PR TITLE
fix: post_qc drops genre + slope-aware ADM ceiling + terminal notice

### DIFF
--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -1478,9 +1478,20 @@ async def _stage_post_qc(ctx: MasterAlbumCtx) -> str | None:
     """
     from tools.mastering.qc_tracks import qc_track
 
+    # Post-QC must pass the genre through just like pre-QC does. Without
+    # it, `_resolve_click_thresholds(None)` returns the generic default
+    # (peak_ratio=6.0, fail_count=3), which causes every electronic /
+    # EDM / IDM / metal kick and snare transient to read as a "click"
+    # and fails 10/10 tracks on a legitimate master. The electronic
+    # preset's intentional peak_ratio=10.0, fail_count=30 only applies
+    # when the genre reaches the click detector.
+    qc_genre = ctx.genre or None
+
     post_qc_results = []
     for wav in ctx.mastered_files:
-        result = await ctx.loop.run_in_executor(None, qc_track, str(wav), None)
+        result = await ctx.loop.run_in_executor(
+            None, qc_track, str(wav), None, qc_genre,
+        )
         post_qc_results.append(result)
 
     post_passed = sum(1 for r in post_qc_results if r["verdict"] == "PASS")

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -655,10 +655,15 @@ async def master_album(
     # Most albums don't need the ADM loop; reserve it for Apple Hi-Res
     # Lossless / ADM submission prep.
     adm_enabled = bool(ctx.targets.get("adm_validation_enabled", False))
-    _ADM_MAX_CYCLES = 3 if adm_enabled else 1
-    _ADM_MIN_CEILING_DB = -6.0       # never tighten below this
-    _ADM_SAFETY_DB = 0.3             # extra headroom below observed peak
-    _ADM_MIN_TIGHTEN_DB = 0.5        # preserves legacy step as the floor
+    # Bumped 3 → 5: dense-transient electronic content needs more cycles
+    # because AAC ripple shrinks only ~0.6 dB per 1 dB of ceiling tighten,
+    # not 1:1. Combined with slope-aware tightening below, 5 cycles
+    # converges any album that isn't structurally divergent.
+    _ADM_MAX_CYCLES = 5 if adm_enabled else 1
+    _ADM_MIN_CEILING_DB = -6.0              # never tighten below this
+    _ADM_SAFETY_DB = 0.3                    # extra headroom below observed peak
+    _ADM_MIN_TIGHTEN_DB = 0.5               # preserves legacy step as floor
+    _ADM_MIN_EFFECTIVE_RATIO = 0.4          # floor on slope efficacy
     adm_loop_stages: list[_StageFn] = [
         _album_stages._stage_mastering,
         _album_stages._stage_verification,
@@ -680,17 +685,31 @@ async def master_album(
             "(adds ~10-12 min per cycle on a 10-track album)."
         )
 
+    # Per-cycle (ceiling, worst_peak) observations. Used to estimate the
+    # actual AAC-ripple-to-ceiling slope and pick a convergent tighten,
+    # and to detect divergence (slope ≤ 0) where tightening the limiter
+    # drives it harder and actually grows inter-sample ripple.
+    adm_history: list[dict[str, float]] = []
+
     def _adm_adaptive_ceiling(
         failure_detail: dict[str, Any], current: float,
-    ) -> tuple[float, bool]:
-        """Compute next ceiling from observed worst decoded peak.
+    ) -> tuple[float, bool, bool]:
+        """Compute next ceiling from observed worst decoded peak + history.
 
-        Returns ``(new_ceiling, hit_floor)``. The WAV ceiling is placed
-        ``_ADM_SAFETY_DB`` below the worst decoded peak so the re-master
-        starts with enough headroom for AAC ripple. Clamped to
-        ``_ADM_MIN_CEILING_DB``; when clamped, ``hit_floor=True`` so the
-        loop can fall through to warn-fallback instead of looping forever
-        at the same ceiling.
+        Returns ``(new_ceiling, hit_floor, diverging)``.
+
+        - With no history yet: assumes 1:1 ripple-to-ceiling scaling
+          (legacy formula).
+        - With ≥2 history points: fits a slope from the last two cycles
+          and scales the tighten by ``1/effective_ratio``, so material
+          with a 0.6:1 ripple scaling gets a ~1.67× larger tighten than
+          the legacy formula would apply.
+        - When slope ≤ 0 (ripple growing as we tighten): flags
+          ``diverging=True`` so the caller falls through to warn-fallback
+          instead of looping forever with worsening decoded peaks.
+
+        Clamped to ``_ADM_MIN_CEILING_DB``; ``hit_floor=True`` when the
+        proposed ceiling would go below the floor.
         """
         tracks = failure_detail.get("tracks_with_clips") or []
         peaks = [
@@ -699,16 +718,46 @@ async def master_album(
         ]
         if not peaks:
             proposed = current - _ADM_MIN_TIGHTEN_DB
+            floored = proposed < _ADM_MIN_CEILING_DB
+            return (max(proposed, _ADM_MIN_CEILING_DB), floored, False)
+
+        worst_peak = max(peaks)
+        overshoot = worst_peak - current
+        adm_history.append({"ceiling": current, "worst_peak": worst_peak})
+
+        if len(adm_history) >= 2:
+            prev, curr = adm_history[-2], adm_history[-1]
+            # d_ceiling > 0 when we tightened between cycles; d_peak > 0
+            # when the decoded peak dropped as a result.
+            d_ceiling = prev["ceiling"] - curr["ceiling"]
+            d_peak = prev["worst_peak"] - curr["worst_peak"]
+            if d_ceiling > 1e-3:
+                slope = d_peak / d_ceiling
+                if slope <= 0:
+                    # Ripple grew (or held) despite tightening — the
+                    # limiter is contributing more inter-sample content
+                    # than we're gaining headroom. Not convergent.
+                    return (current, True, True)
+                effective_ratio = max(slope, _ADM_MIN_EFFECTIVE_RATIO)
+                tighten = (overshoot + _ADM_SAFETY_DB) / effective_ratio
+                tighten = max(tighten, _ADM_MIN_TIGHTEN_DB)
+            else:
+                tighten = max(
+                    overshoot + _ADM_SAFETY_DB, _ADM_MIN_TIGHTEN_DB,
+                )
         else:
-            worst_peak = max(peaks)
-            overshoot = worst_peak - current
-            tighten = max(overshoot + _ADM_SAFETY_DB, _ADM_MIN_TIGHTEN_DB)
-            proposed = current - tighten
+            # First retry — no slope yet, assume 1:1 scaling.
+            tighten = max(
+                overshoot + _ADM_SAFETY_DB, _ADM_MIN_TIGHTEN_DB,
+            )
+
+        proposed = current - tighten
         floored = proposed < _ADM_MIN_CEILING_DB
-        return (max(proposed, _ADM_MIN_CEILING_DB), floored)
+        return (max(proposed, _ADM_MIN_CEILING_DB), floored, False)
 
     adm_clip_failure_persisted = False
     adm_last_failure_detail: dict[str, Any] = {}
+    adm_diverging = False
 
     for adm_cycle in range(_ADM_MAX_CYCLES):
         ctx.adm_cycle = adm_cycle
@@ -727,9 +776,26 @@ async def master_album(
                 if is_adm_clip_failure:
                     adm_last_failure_detail = _d.get("failure_detail") or {}
                     if adm_cycle < _ADM_MAX_CYCLES - 1:
-                        new_ceiling, hit_floor = _adm_adaptive_ceiling(
-                            adm_last_failure_detail, ctx.effective_ceiling,
+                        new_ceiling, hit_floor, diverging = (
+                            _adm_adaptive_ceiling(
+                                adm_last_failure_detail,
+                                ctx.effective_ceiling,
+                            )
                         )
+                        if diverging:
+                            # Ripple grew with tightening — any further
+                            # tightening makes it worse. Bail to warn.
+                            adm_diverging = True
+                            adm_clip_failure_persisted = True
+                            ctx.notices.append(
+                                f"ADM cycle {adm_cycle + 1}: decoded peak "
+                                f"grew despite ceiling tightening (slope "
+                                f"≤ 0 between last two cycles). Material "
+                                f"not convergent at current limiter "
+                                f"settings — falling through to "
+                                f"warn-fallback."
+                            )
+                            break
                         # If the adaptive pass can't move the ceiling any
                         # further (already at floor from a previous cycle)
                         # then another retry would just repeat the same
@@ -770,15 +836,21 @@ async def master_album(
     # the manual call on whether to republish.
     if adm_clip_failure_persisted:
         stage = ctx.stages.get("adm_validation")
+        reason_suffix = (
+            "; ripple growing with tightening (divergent)"
+            if adm_diverging else ""
+        )
         if isinstance(stage, dict):
             stage["status"] = "warn"
             stage["reason"] = (
                 f"inter-sample clips persist at ceiling "
                 f"{ctx.effective_ceiling:.2f} dBTP after "
                 f"{_ADM_MAX_CYCLES} cycle(s); floor is "
-                f"{_ADM_MIN_CEILING_DB:.1f} dBTP"
+                f"{_ADM_MIN_CEILING_DB:.1f} dBTP{reason_suffix}"
             )
             stage["clip_failure_persisted"] = True
+            stage["diverging"] = adm_diverging
+            stage["adm_history"] = list(adm_history)
         tracks_with_clips = adm_last_failure_detail.get("tracks_with_clips") or []
         clip_count = len(tracks_with_clips)
         ctx.warnings.append(
@@ -787,6 +859,18 @@ async def master_album(
             f"{ctx.effective_ceiling:.2f} dBTP, floor "
             f"{_ADM_MIN_CEILING_DB:.1f} dBTP). Album delivered with flag — "
             f"see ADM_VALIDATION.md for per-track detail."
+        )
+        # Terminal notice so operators reading the notice stream see the
+        # final state immediately, without having to scan warnings. The
+        # existing per-cycle tightening notices only cover cycles that
+        # triggered a retry — this one names the exit condition.
+        ctx.notices.append(
+            f"ADM loop terminated without convergence after "
+            f"{_ADM_MAX_CYCLES} cycle(s). Final ceiling: "
+            f"{ctx.effective_ceiling:.2f} dBTP. Delivered with "
+            f"{clip_count} track(s) flagged for inter-sample clips — "
+            "inspect ADM_VALIDATION.md before republishing if AAC "
+            "delivery matters."
         )
 
     # ── Phase 3: post-loop stages (run once) ─────────────────────────────

--- a/tests/unit/mastering/test_master_album_adm_retry.py
+++ b/tests/unit/mastering/test_master_album_adm_retry.py
@@ -761,3 +761,182 @@ def test_adm_failure_detail_suggests_dynamic_ceiling(
         f"Suggestion must name the computed ceiling {suggested_ceiling:.2f}, got: "
         f"{suggestion}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Slope-aware adaptive tightening — 0.6:1 ripple scaling converges
+# ---------------------------------------------------------------------------
+
+def test_adm_slope_aware_scales_tighten_on_sub_linear_ripple(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """When AAC ripple shrinks at ~0.6 dB per 1 dB of ceiling tighten,
+    the slope-aware formula must scale the tighten proportionally so
+    convergence happens within the cycle budget.
+
+    Reporter's real data: cycles 0→1→2 with ceiling going -1.5 →
+    -2.33 → -3.49 and decoded peaks -0.97 → -1.47 → -2.80. The 1:1
+    legacy formula proposed too-small tightens and never converged in
+    3 cycles. The slope-aware formula observes d_peak / d_ceiling ≈
+    0.6 after cycle 1 and multiplies subsequent tightens by ~1.67×.
+    """
+    album_slug = "adm-slope-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    # Model: decoded_peak(ceiling) = ceiling + base_overshoot - 0.6 *
+    # tighten_from_start. Converges when overshoot ≤ 0.
+    start_ceiling = -1.0
+    base_overshoot = 1.0
+
+    def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        tighten_from_start = start_ceiling - ceiling_db
+        remaining_overshoot = base_overshoot - 0.6 * tighten_from_start
+        clips_here = remaining_overshoot > 0
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 1 if clips_here else 0,
+            "peak_db_decoded": ceiling_db + remaining_overshoot,
+            "ceiling_db": ceiling_db,
+            "clips_found": clips_here,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    mastered_ceilings: list[float] = []
+    import tools.mastering.master_tracks as _mt_mod
+    _real_master_track = _mt_mod.master_track
+
+    def _capture(src, dst, *, ceiling_db=-1.0, **kwargs):
+        mastered_ceilings.append(float(ceiling_db))
+        return _real_master_track(src, dst, ceiling_db=ceiling_db, **kwargs)
+
+    monkeypatch.setattr(_mt_mod, "master_track", _capture)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug, adm_enabled=True)
+
+    assert result.get("failed_stage") is None, (
+        f"Expected pipeline completion, got: {result.get('failure_detail')}"
+    )
+    # On 0.6:1 material, slope-aware convergence fits inside the 5-
+    # cycle budget. Pre-fix behavior (fixed 0.5 dB steps) would NOT
+    # converge with base_overshoot=1.0. Upper bound: ≤4 re-masters.
+    assert len(mastered_ceilings) <= 4, (
+        f"Expected convergence in ≤4 re-masters with slope-aware formula, "
+        f"got {len(mastered_ceilings)}: {mastered_ceilings}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Divergence detection: ripple grows with tightening → warn-fallback
+# ---------------------------------------------------------------------------
+
+def test_adm_divergence_triggers_warn_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Material where tightening increases decoded ripple must
+    terminate the loop early with a divergence notice, not burn all
+    5 cycles. Mimics limiter pumping harder on tighter ceilings.
+    """
+    album_slug = "adm-divergent-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    # Pathological limiter: tightening the ceiling makes the decoded
+    # peak GROW, not shrink. On cycle 0 at ceiling -1.0 the peak is
+    # -0.5 dBTP; on cycle 1 at a tighter ceiling the peak rises to
+    # -0.3 dBTP (higher = closer to 0 = worse). slope = Δpeak/Δceiling
+    # = (-0.5 - (-0.3)) / (-1.0 - tightened) is negative — divergent.
+    def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        if ceiling_db >= -1.25:  # cycle 0 only
+            peak = -0.5
+        else:  # cycle 1 and beyond — peak actually worsened
+            peak = -0.3
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 5,
+            "peak_db_decoded": peak,
+            "ceiling_db": ceiling_db,
+            "clips_found": True,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    mastered_ceilings: list[float] = []
+    import tools.mastering.master_tracks as _mt_mod
+    _real_master_track = _mt_mod.master_track
+
+    def _capture(src, dst, *, ceiling_db=-1.0, **kwargs):
+        mastered_ceilings.append(float(ceiling_db))
+        return _real_master_track(src, dst, ceiling_db=ceiling_db, **kwargs)
+
+    monkeypatch.setattr(_mt_mod, "master_track", _capture)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug, adm_enabled=True)
+
+    assert result.get("failed_stage") is None, (
+        f"Expected warn-fallback completion on divergent material, "
+        f"got: {result.get('failure_detail')}"
+    )
+    stage = result.get("stages", {}).get("adm_validation", {})
+    assert stage.get("status") == "warn", (
+        f"Expected warn status on divergent material, got: {stage}"
+    )
+    assert stage.get("diverging") is True, (
+        f"Expected diverging=True on slope-≤-0 material, got: {stage}"
+    )
+    # Divergence detection must bail well before the 5-cycle budget —
+    # cycle 0 + cycle 1 produce enough observations, cycle 2 detects.
+    assert len(mastered_ceilings) <= 2, (
+        f"Expected divergence bail after ≤2 re-masters, got "
+        f"{len(mastered_ceilings)}: {mastered_ceilings}"
+    )
+    notices = result.get("notices", [])
+    assert any(
+        "divergent" in n.lower() or "slope" in n.lower() for n in notices
+    ), f"Expected divergence notice, got notices: {notices}"
+
+
+# ---------------------------------------------------------------------------
+# Warn-fallback terminal notice appears in notices
+# ---------------------------------------------------------------------------
+
+def test_adm_warn_fallback_emits_terminal_notice(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Operators reading the notice stream must see an explicit
+    'ADM loop terminated without convergence' notice so they know the
+    exit condition without scanning warnings. Previously only
+    per-cycle tightening notices were emitted; no terminal notice
+    named the warn-fallback exit.
+    """
+    album_slug = "adm-terminal-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    def _always_clips(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 5,
+            "peak_db_decoded": ceiling_db + 0.3,
+            "ceiling_db": ceiling_db,
+            "clips_found": True,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _always_clips)
+    monkeypatch.setattr(album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None)
+
+    result = _run_master_album(tmp_path, album_slug=album_slug, adm_enabled=True)
+    notices = result.get("notices", [])
+    assert any(
+        "terminated" in n.lower() and "convergence" in n.lower()
+        for n in notices
+    ), f"Expected terminal warn-fallback notice, got notices: {notices}"

--- a/tests/unit/mastering/test_master_album_lra_floor.py
+++ b/tests/unit/mastering/test_master_album_lra_floor.py
@@ -47,7 +47,7 @@ def test_lra_floor_fail_halts_pipeline(
     wav = tmp_path / "01-track.wav"
     wav.touch()
 
-    def _fake_qc(path, _preset):
+    def _fake_qc(path, _preset=None, _genre=None):
         return _make_qc_pass(Path(path).name)
 
     with patch("tools.mastering.qc_tracks.qc_track", _fake_qc):
@@ -84,7 +84,7 @@ def test_lra_floor_pass_does_not_halt(
     wav = tmp_path / "01-track.wav"
     wav.touch()
 
-    def _fake_qc(path, _preset):
+    def _fake_qc(path, _preset=None, _genre=None):
         return _make_qc_pass(Path(path).name)
 
     with patch("tools.mastering.qc_tracks.qc_track", _fake_qc):
@@ -113,7 +113,7 @@ def test_lra_floor_skipped_when_no_preset(
     wav = tmp_path / "01-track.wav"
     wav.touch()
 
-    def _fake_qc(path, _preset):
+    def _fake_qc(path, _preset=None, _genre=None):
         return _make_qc_pass(Path(path).name)
 
     with patch("tools.mastering.qc_tracks.qc_track", _fake_qc):

--- a/tests/unit/mastering/test_post_qc_genre.py
+++ b/tests/unit/mastering/test_post_qc_genre.py
@@ -1,0 +1,87 @@
+"""Post-QC must pass the album genre through to qc_track.
+
+Reporter case (if-anyone-makes-it-everyone-dances, electronic, 10
+tracks): post_qc failed 10/10 on the "clicks" check because the stage
+called `qc_track(path, None)` without `genre`, falling back to the
+generic peak_ratio=6.0 / fail_count=3 threshold. Every legitimate
+kick/snare transient registered as a click.
+
+The electronic preset in `genre-presets.yaml` specifies
+`click_peak_ratio: 10.0, click_fail_count: 30` precisely to let dense
+transient content pass — but the threshold only applies if the genre
+reaches the detector.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers.processing import _album_stages as album_stages_mod  # noqa: E402
+
+
+def _make_ctx(genre: str, wav: Path) -> "album_stages_mod.MasterAlbumCtx":
+    ctx = album_stages_mod.MasterAlbumCtx(
+        album_slug="genre-test", genre=genre, target_lufs=-14.0,
+        ceiling_db=-1.0, cut_highmid=0.0, cut_highs=0.0,
+        source_subfolder="", freeze_signature=False, new_anchor=False,
+        loop=asyncio.get_event_loop(),
+    )
+    ctx.mastered_files = [wav]
+    ctx.preset_dict = None
+    ctx.verify_results = [{
+        "filename": wav.name, "lufs": -14.0, "peak_db": -1.5,
+        "short_term_range": 9.0,
+    }]
+    return ctx
+
+
+@pytest.mark.parametrize("album_genre", ["electronic", "idm", "metal", ""])
+def test_post_qc_passes_genre_to_qc_track(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, album_genre: str,
+) -> None:
+    """Pin the contract: _stage_post_qc forwards ctx.genre to qc_track.
+
+    Without this the click detector falls back to generic thresholds
+    (peak_ratio=6.0, fail_count=3) and rejects legitimate dense-
+    transient masters — the root cause of the 10/10 fail on the
+    reporter's electronic album.
+    """
+    wav = tmp_path / "01-track.wav"
+    wav.touch()
+
+    captured_calls: list[dict] = []
+
+    def _spy_qc_track(path, checks=None, genre=None):
+        captured_calls.append({"path": path, "checks": checks, "genre": genre})
+        return {"filename": Path(path).name, "verdict": "PASS", "checks": {}}
+
+    monkeypatch.setattr("tools.mastering.qc_tracks.qc_track", _spy_qc_track)
+
+    async def _run():
+        ctx = _make_ctx(album_genre, wav)
+        await album_stages_mod._stage_post_qc(ctx)
+        return ctx
+
+    asyncio.run(_run())
+
+    assert len(captured_calls) == 1, (
+        f"Expected exactly 1 qc_track call, got {len(captured_calls)}"
+    )
+    call = captured_calls[0]
+    expected_genre = album_genre or None
+    assert call["genre"] == expected_genre, (
+        f"post_qc must forward ctx.genre={album_genre!r} → qc_track(genre=...), "
+        f"got genre={call['genre']!r}. This causes the click detector to "
+        f"fall back to generic thresholds and reject legitimate masters."
+    )


### PR DESCRIPTION
## Summary

Three bugs from the 24-min end-to-end run report on `if-anyone-makes-it-everyone-dances`.

**Bug 1 (CRITICAL) — post_qc drops `genre`.** `_stage_post_qc` called `qc_track(path, None)` without threading the album's genre, so `_resolve_click_thresholds(None)` returned generic defaults (peak_ratio=6.0, fail_count=3). Every legitimate electronic kick/snare registered as a click → 10/10 tracks failed on a valid master. Fix: thread `ctx.genre or None` like `_stage_pre_qc` already does.

**Bug 2a + 2b — Adaptive ceiling didn't account for AAC ripple scaling.** Observed 0.6:1 ripple-to-ceiling scaling (1 dB tighten yielded only ~0.6 dB decoded headroom). 3-cycle budget exhausted with clips still present. Fix: `_ADM_MAX_CYCLES` bumped 3 → 5, and `_adm_adaptive_ceiling` now records `(ceiling, worst_peak)` history and scales tightens by `1/slope` once ≥2 observations exist. Divergence (slope ≤ 0) bails to warn-fallback with a clear notice — guaranteed termination on any album.

**Bug 2c — Missing terminal warn-fallback notice.** Added a closing notice naming the final ceiling and flag count.

## Already fixed / out of scope

- **Bug 3** (hardcoded -1.5 suggestion) — already fixed in PR #331.
- **Bug 4** (MCP server timeout on 24-min runs) — architectural, needs product discussion.
- **Unrelated 1/2** (polish click counts, coherence_correct timing) — by-design per-genre tuning and cycle re-analysis.

## Tests

- `test_post_qc_genre.py` (4 parametrized) — asserts `qc_track` receives the correct genre for electronic/idm/metal/"".
- `test_adm_slope_aware_scales_tighten_on_sub_linear_ripple` — 0.6:1 material converges in ≤4 re-masters.
- `test_adm_divergence_triggers_warn_fallback` — divergent material bails in ≤2 re-masters, `diverging=True` on stage dict.
- `test_adm_warn_fallback_emits_terminal_notice` — "terminated without convergence" notice present.

Existing fake `qc_track` mocks in `test_master_album_lra_floor.py` updated to accept the new 3rd argument.

`make check` green: 3579 passed, 84.92% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)