### PR TITLE
fix: polish consumes analyzer recommendations (#336)

### DIFF
--- a/docs/superpowers/plans/2026-04-19-polish-consumes-analyzer-recs.md
+++ b/docs/superpowers/plans/2026-04-19-polish-consumes-analyzer-recs.md
@@ -1,0 +1,1213 @@
+# Polish Consumes Analyzer Recommendations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `analyze_mix_issues` recommendations into `polish_album` as per-track overrides on top of genre defaults, and add a dark-track protection condition to the analyzer so electronic tracks with low high-mid energy stop getting genre-default `high_tame_db: -1.5` that further darkens them.
+
+**Architecture:** Additive across the mix subsystem. (1) Analyzer gains one `elif high_mid_ratio < 0.10` branch producing `high_tame_db: 0.0` + `already_dark` issue tag. (2) `_get_stem_settings` gains an `analyzer_rec` kwarg that whitelist-filters and merges the analyzer's per-stem recommendations on top of genre defaults. (3) `mix_track_stems` gains `analyzer_recs` and records `overrides_applied` per stem. (4) `polish_audio` gains `analyzer_results` (auto-runs the analyzer when None) and aggregates overrides across tracks. (5) `polish_album` passes its existing analyze-stage output down.
+
+**Tech Stack:** Python 3, pytest, numpy/scipy, YAML presets. Changes contained to `servers/bitwize-music-server/handlers/processing/mixing.py`, `tools/mixing/mix_tracks.py`, `tools/mixing/mix-presets.yaml`.
+
+**Spec:** [`docs/superpowers/specs/2026-04-19-polish-consumes-analyzer-recs-design.md`](../specs/2026-04-19-polish-consumes-analyzer-recs-design.md)
+
+**Canonical issue:** [#336](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/336)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `tools/mixing/mix-presets.yaml` | Add `defaults.analyzer.{dark_high_mid_ratio, harsh_high_mid_ratio}` for preset-tunable thresholds (defaults 0.10 / 0.25, unchanged behavior) |
+| `servers/bitwize-music-server/handlers/processing/mixing.py` | Add `_resolve_analyzer_thresholds` helper; add dark-track branch in `_analyze_one`; add `analyzer_results` kwarg to `polish_audio` with auto-run fallback; pipe analyzer output to `mix_track_stems`; aggregate `overrides_applied` into `polish` stage output |
+| `tools/mixing/mix_tracks.py` | Add `analyzer_rec` kwarg to `_get_stem_settings` (whitelist-filtered merge on top of genre defaults); add `analyzer_recs` kwarg to `mix_track_stems` (per-stem dispatch + `overrides_applied` telemetry) |
+| `tests/unit/mixing/test_analyze_mix_issues.py` | NEW — analyzer's dark-track condition, threshold preset override, harsh/dark non-overlap |
+| `tests/unit/mixing/test_polish_analyzer_overrides.py` | NEW — `_get_stem_settings` merge behavior, sentinel `0.0`, fall-through, non-EQ ignored |
+| `tests/unit/mixing/test_polish_audio_stems.py` | EXTEND — polish_audio pipes analyzer through; direct-call auto-run fallback |
+
+Allowed EQ whitelist: `mud_cut_db`, `high_tame_db`, `noise_reduction`, `highpass_cutoff`. `click_removal` intentionally excluded (already wired via `_resolve_analyzer_peak_ratio`).
+
+---
+
+## Task 1: Analyzer dark-track condition + preset thresholds
+
+**Files:**
+- Modify: `tools/mixing/mix-presets.yaml` (add `defaults.analyzer` block)
+- Modify: `servers/bitwize-music-server/handlers/processing/mixing.py` (add `_resolve_analyzer_thresholds`; extend `_analyze_one` around line 334)
+- Test: `tests/unit/mixing/test_analyze_mix_issues.py` (NEW file)
+
+- [ ] **Step 1: Write failing tests for the dark-track condition and preset resolution**
+
+Create `tests/unit/mixing/test_analyze_mix_issues.py`:
+
+```python
+"""Unit tests for analyze_mix_issues dark-track condition + threshold resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def test_resolve_analyzer_thresholds_defaults():
+    """With no preset overrides, resolver returns (0.10, 0.25)."""
+    from handlers.processing.mixing import _resolve_analyzer_thresholds
+    dark, harsh = _resolve_analyzer_thresholds()
+    assert dark == pytest.approx(0.10)
+    assert harsh == pytest.approx(0.25)
+
+
+def test_dark_condition_emits_high_tame_zero_and_already_dark_issue(monkeypatch):
+    """A track with high_mid_ratio < 0.10 gets recommendation high_tame_db=0.0."""
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    # Dark synthetic signal: low-frequency sine at ~100 Hz, 2 s @ 48 kHz.
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = 0.3 * np.sin(2 * np.pi * 100 * t).astype(np.float64)
+    data = np.column_stack([mono, mono])
+
+    analyze_one = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result = analyze_one(data, rate, filename="dark-track.wav", stem_name="synth", genre="electronic")
+
+    assert "already_dark" in result["issues"], f"expected already_dark, got {result['issues']}"
+    assert result["recommendations"]["high_tame_db"] == pytest.approx(0.0)
+    assert result["high_mid_ratio"] < 0.10
+
+
+def test_harsh_condition_still_fires_above_0_25(monkeypatch):
+    """A track with high_mid_ratio > 0.25 gets recommendation high_tame_db=-2.0 and harsh_highmids issue."""
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    # Harsh synthetic: sum of 3 kHz + 4 kHz strong tones.
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * 3000 * t) + 0.3 * np.sin(2 * np.pi * 4000 * t)).astype("float64")
+    data = np.column_stack([mono, mono])
+
+    analyze_one = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result = analyze_one(data, rate, filename="harsh-track.wav", stem_name="synth", genre="electronic")
+
+    assert "harsh_highmids" in result["issues"], f"expected harsh_highmids, got {result['issues']}"
+    assert result["recommendations"]["high_tame_db"] == pytest.approx(-2.0)
+
+
+def test_middle_band_triggers_neither_condition(monkeypatch):
+    """high_mid_ratio in [0.10, 0.25] produces neither issue tag."""
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    # Mixed signal with moderate high-mid content.
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    # 500 Hz (mid) + 3 kHz (high-mid) balanced so ratio is in the middle band
+    mono = (0.35 * np.sin(2 * np.pi * 500 * t) + 0.08 * np.sin(2 * np.pi * 3000 * t)).astype("float64")
+    data = np.column_stack([mono, mono])
+
+    analyze_one = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result = analyze_one(data, rate, filename="middle-track.wav", stem_name="synth", genre="electronic")
+
+    assert "already_dark" not in result["issues"]
+    assert "harsh_highmids" not in result["issues"]
+    # Neither recommendation should be emitted:
+    assert "high_tame_db" not in result["recommendations"]
+
+
+def test_preset_override_of_dark_threshold_changes_trigger(monkeypatch):
+    """Raising the dark threshold to 0.15 makes a 0.12-ratio track fire already_dark."""
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    # Mixed signal engineered for high_mid_ratio ~ 0.12 (middle band under default 0.10 floor).
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = (0.30 * np.sin(2 * np.pi * 500 * t) + 0.09 * np.sin(2 * np.pi * 3000 * t)).astype("float64")
+    data = np.column_stack([mono, mono])
+
+    # With default thresholds (0.10/0.25), no issue
+    analyze_default = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result_default = analyze_default(data, rate, filename="mid.wav", stem_name="synth", genre="electronic")
+    assert "already_dark" not in result_default["issues"]
+
+    # With dark_ratio raised to 0.15, now fires
+    analyze_raised = _build_analyzer(dark_ratio=0.15, harsh_ratio=0.25)
+    result_raised = analyze_raised(data, rate, filename="mid.wav", stem_name="synth", genre="electronic")
+    assert "already_dark" in result_raised["issues"]
+    assert result_raised["recommendations"]["high_tame_db"] == pytest.approx(0.0)
+```
+
+Note: the test calls `_build_analyzer(dark_ratio, harsh_ratio)` — a new helper that returns a closure performing the same analysis as `_analyze_one` but with injected thresholds. This lets tests run the analysis logic on raw numpy data without the async/filesystem harness. Task 1 introduces this helper alongside the existing `_analyze_one` inner function; `_analyze_one` then calls into it with resolved thresholds.
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/unit/mixing/test_analyze_mix_issues.py -v`
+Expected: FAIL — `ImportError: cannot import name '_resolve_analyzer_thresholds'` and `_build_analyzer`.
+
+- [ ] **Step 3: Add the `analyzer` preset block**
+
+Edit `tools/mixing/mix-presets.yaml`. Find the `defaults:` section at the top of the file (existing structure: `defaults` holds per-stem config like `defaults.vocals`, `defaults.drums`, etc.). Add a new `analyzer` subsection at the top of `defaults`:
+
+```yaml
+defaults:
+  analyzer:
+    # Thresholds consumed by analyze_mix_issues — see servers/.../mixing.py
+    # _analyze_one. Dark tracks (high_mid_ratio < dark_high_mid_ratio) get
+    # recommendation high_tame_db: 0.0, overriding genre-default high-shelf
+    # cuts that would further darken them. Harsh tracks
+    # (high_mid_ratio > harsh_high_mid_ratio) get high_tame_db: -2.0.
+    dark_high_mid_ratio: 0.10
+    harsh_high_mid_ratio: 0.25
+  # ... existing vocals, drums, etc. below stay untouched
+```
+
+Be careful about indentation — YAML is whitespace-sensitive. Two-space indent under `defaults:`. Place the block above existing per-stem entries.
+
+- [ ] **Step 4: Add `_resolve_analyzer_thresholds` helper + `_build_analyzer` factory + dark-track branch**
+
+Edit `servers/bitwize-music-server/handlers/processing/mixing.py`.
+
+First, directly after the existing `_resolve_analyzer_peak_ratio` function (around line 228), add the new threshold resolver:
+
+```python
+def _resolve_analyzer_thresholds() -> tuple[float, float]:
+    """Load (dark_high_mid_ratio, harsh_high_mid_ratio) from mix presets.
+
+    Falls back to (0.10, 0.25) when the analyzer preset block is absent.
+    Values are consumed by `_analyze_one` for the dark-track and
+    harsh-highmids branches respectively (#336).
+    """
+    try:
+        from tools.mixing.mix_tracks import load_mix_presets
+    except ImportError:
+        return 0.10, 0.25
+
+    presets = load_mix_presets()
+    analyzer = presets.get("defaults", {}).get("analyzer", {})
+    dark = float(analyzer.get("dark_high_mid_ratio", 0.10))
+    harsh = float(analyzer.get("harsh_high_mid_ratio", 0.25))
+    return dark, harsh
+```
+
+Second, lift the existing `_analyze_one` inner function in `analyze_mix_issues` (around lines 291–378) into a module-level factory that accepts thresholds. This replaces the inner function and lets tests run the analysis logic directly without an album fixture.
+
+Replace lines 291–378 (the entire `def _analyze_one` body, inside `async def analyze_mix_issues`) with a call to the factory:
+
+At the module level, above `async def analyze_mix_issues`, add:
+
+```python
+def _build_analyzer(
+    dark_ratio: float = 0.10,
+    harsh_ratio: float = 0.25,
+):
+    """Return an `analyze_one` callable bound to the given thresholds.
+
+    The returned callable takes raw numpy audio data and produces the
+    per-file/per-stem analysis dict. Splitting it out of
+    `analyze_mix_issues` lets tests exercise the logic without mounting
+    an album directory.
+
+    Args:
+        dark_ratio: high_mid_ratio below which `already_dark` fires.
+        harsh_ratio: high_mid_ratio above which `harsh_highmids` fires.
+
+    Returns:
+        Callable ``analyze_one(data, rate, *, filename, stem_name, genre)``
+        → per-file analysis dict identical in shape to the original
+        `_analyze_one` output.
+    """
+    import numpy as np
+    from scipy import signal as sig
+
+    def analyze_one(
+        data,
+        rate: int,
+        *,
+        filename: str,
+        stem_name: str | None = None,
+        genre: str = "",
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {"filename": filename, "issues": [], "recommendations": {}}
+
+        peak = float(np.max(np.abs(data)))
+        rms = float(np.sqrt(np.mean(data ** 2)))
+        result["peak"] = peak
+        result["rms"] = rms
+
+        # Noise floor estimate (quietest 10% of signal)
+        abs_signal = np.abs(data[:, 0])
+        sorted_abs = np.sort(abs_signal)
+        noise_floor = float(np.mean(sorted_abs[:len(sorted_abs) // 10]))
+        result["noise_floor"] = noise_floor
+        if noise_floor > 0.005:
+            result["issues"].append("elevated_noise_floor")
+            result["recommendations"]["noise_reduction"] = min(0.8, noise_floor * 100)
+
+        freqs, psd = sig.welch(data[:, 0], rate, nperseg=min(4096, len(data)))
+
+        # Low-mid energy (150-400 Hz) — muddiness indicator
+        low_mid_mask = (freqs >= 150) & (freqs <= 400)
+        total_energy = float(np.sum(psd))
+        if total_energy > 0:
+            low_mid_ratio = float(np.sum(psd[low_mid_mask])) / total_energy
+            result["low_mid_ratio"] = low_mid_ratio
+            if low_mid_ratio > 0.35:
+                result["issues"].append("muddy_low_mids")
+                result["recommendations"]["mud_cut_db"] = -3.0
+
+        # High-mid energy (2-5 kHz) — harshness / darkness indicator
+        high_mid_mask = (freqs >= 2000) & (freqs <= 5000)
+        if total_energy > 0:
+            high_mid_ratio = float(np.sum(psd[high_mid_mask])) / total_energy
+            result["high_mid_ratio"] = high_mid_ratio
+            if high_mid_ratio > harsh_ratio:
+                result["issues"].append("harsh_highmids")
+                result["recommendations"]["high_tame_db"] = -2.0
+            elif high_mid_ratio < dark_ratio:
+                # #336: already-dark track — emit sentinel 0.0 to override
+                # genre-default high-shelf cuts (e.g. electronic's
+                # synth/keyboard/other stems at -1.5 dB @ 9 kHz) that would
+                # compound the darkness in polish.
+                result["issues"].append("already_dark")
+                result["recommendations"]["high_tame_db"] = 0.0
+
+        # Click detection (sudden amplitude spikes).
+        mono_col = data[:, 0]
+        window = max(int(rate * 0.01), 1)
+        n_windows = len(mono_col) // window
+        if n_windows > 0:
+            windows = mono_col[: n_windows * window].reshape(n_windows, window)
+            win_rms = np.sqrt(np.mean(windows ** 2, axis=1))
+            win_peak = np.max(np.abs(windows), axis=1)
+            active = win_rms > 1e-8
+            ratios = np.zeros(n_windows, dtype=np.float64)
+            np.divide(win_peak, win_rms, out=ratios, where=active)
+            peak_ratio = _resolve_analyzer_peak_ratio(stem_name, genre)
+            click_count = int(np.sum(ratios > peak_ratio))
+            result["click_count"] = click_count
+            if click_count > 10:
+                result["issues"].append("clicks_detected")
+                result["recommendations"]["click_removal"] = True
+
+        # Sub-bass rumble (< 30 Hz)
+        sub_mask = freqs < 30
+        if total_energy > 0:
+            sub_ratio = float(np.sum(psd[sub_mask])) / total_energy
+            result["sub_ratio"] = sub_ratio
+            if sub_ratio > 0.15:
+                result["issues"].append("sub_rumble")
+                result["recommendations"]["highpass_cutoff"] = 35
+
+        if not result["issues"]:
+            result["issues"].append("none_detected")
+
+        return result
+
+    return analyze_one
+```
+
+Third, replace the inner `_analyze_one` in `analyze_mix_issues` (currently lines 291–378) with code that uses the factory. After the `stems_mode` detection block, insert threshold resolution and analyzer construction:
+
+```python
+    # Resolve analyzer thresholds once per run (preset-configurable, #336).
+    dark_ratio, harsh_ratio = _resolve_analyzer_thresholds()
+    analyze_core = _build_analyzer(dark_ratio=dark_ratio, harsh_ratio=harsh_ratio)
+
+    def _analyze_one(
+        wav_path: Path, stem_name: str | None = None,
+    ) -> dict[str, Any]:
+        data, rate = sf.read(str(wav_path))
+        if len(data.shape) == 1:
+            data = np.column_stack([data, data])
+        return analyze_core(
+            data, rate, filename=wav_path.name,
+            stem_name=stem_name, genre=genre,
+        )
+```
+
+The rest of `analyze_mix_issues` (the `track_analyses` loop and the final `_safe_json` return) is unchanged.
+
+- [ ] **Step 5: Run the analyzer tests — they pass**
+
+Run: `pytest tests/unit/mixing/test_analyze_mix_issues.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/mixing/mix-presets.yaml servers/bitwize-music-server/handlers/processing/mixing.py tests/unit/mixing/test_analyze_mix_issues.py
+git commit -m "feat: analyzer dark-track condition + preset thresholds (#336)
+
+Add 'already_dark' branch in _analyze_one: when high_mid_ratio
+< dark_high_mid_ratio (default 0.10), emit issue tag 'already_dark'
+and recommendation high_tame_db: 0.0 — a sentinel for polish to
+override genre-default high-shelf cuts that would further darken
+the track. Thresholds (dark / harsh) loaded from the new
+defaults.analyzer preset block so per-genre tuning is a config
+change, not a code change. Analysis logic extracted into a module-
+level _build_analyzer factory so tests can run on raw numpy data.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `_get_stem_settings` accepts `analyzer_rec` kwarg
+
+**Files:**
+- Modify: `tools/mixing/mix_tracks.py` (extend `_get_stem_settings` signature + body around line 1033)
+- Test: `tests/unit/mixing/test_polish_analyzer_overrides.py` (NEW file)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/mixing/test_polish_analyzer_overrides.py`:
+
+```python
+"""Unit tests for _get_stem_settings analyzer_rec merge behavior (#336)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_get_stem_settings_no_analyzer_rec_is_backward_compatible():
+    """Without analyzer_rec, settings match previous behavior exactly."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    with_none = _get_stem_settings("synth", genre="electronic", analyzer_rec=None)
+    assert baseline == with_none
+
+
+def test_analyzer_rec_overrides_high_tame_db():
+    """Analyzer high_tame_db=-2.0 overrides electronic's synth default (-1.5)."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    assert baseline.get("high_tame_db") == pytest.approx(-1.5), (
+        f"precondition failed: expected electronic synth default -1.5, got {baseline.get('high_tame_db')}"
+    )
+    merged = _get_stem_settings(
+        "synth", genre="electronic",
+        analyzer_rec={"high_tame_db": -2.0},
+    )
+    assert merged["high_tame_db"] == pytest.approx(-2.0)
+
+
+def test_sentinel_zero_overrides_negative_default():
+    """analyzer_rec high_tame_db=0.0 overrides negative genre default (not silently dropped)."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    merged = _get_stem_settings(
+        "synth", genre="electronic",
+        analyzer_rec={"high_tame_db": 0.0},
+    )
+    assert merged["high_tame_db"] == pytest.approx(0.0)
+
+
+def test_mud_cut_and_highpass_and_noise_reduction_also_overridden():
+    """All four EQ whitelist keys apply when present in analyzer_rec."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    merged = _get_stem_settings(
+        "vocals", genre="electronic",
+        analyzer_rec={
+            "mud_cut_db": -5.0,
+            "high_tame_db": -3.0,
+            "noise_reduction": 0.4,
+            "highpass_cutoff": 80,
+        },
+    )
+    assert merged["mud_cut_db"] == pytest.approx(-5.0)
+    assert merged["high_tame_db"] == pytest.approx(-3.0)
+    assert merged["noise_reduction"] == pytest.approx(0.4)
+    assert merged["highpass_cutoff"] == 80
+
+
+def test_non_eq_analyzer_rec_ignored():
+    """click_removal and unknown keys do NOT leak into settings."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    merged = _get_stem_settings(
+        "synth", genre="electronic",
+        analyzer_rec={"click_removal": True, "random_junk_key": 99},
+    )
+    # click_removal is handled via _resolve_analyzer_peak_ratio, not merged here
+    assert "click_removal" not in merged or merged.get("click_removal") == baseline.get("click_removal")
+    assert "random_junk_key" not in merged
+
+
+def test_empty_analyzer_rec_is_noop():
+    """analyzer_rec={} produces identical output to analyzer_rec=None."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    empty = _get_stem_settings("synth", genre="electronic", analyzer_rec={})
+    assert baseline == empty
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/unit/mixing/test_polish_analyzer_overrides.py -v`
+Expected: FAIL — `TypeError: _get_stem_settings() got an unexpected keyword argument 'analyzer_rec'`.
+
+- [ ] **Step 3: Extend `_get_stem_settings`**
+
+Edit `tools/mixing/mix_tracks.py`. Locate `def _get_stem_settings` at line 1033. Replace the function (lines 1033–1065) with:
+
+```python
+# #336: whitelist of analyzer recommendation keys that are allowed to
+# override genre defaults in polish. click_removal is intentionally
+# excluded — it's wired through _resolve_analyzer_peak_ratio, not
+# merged into per-stem EQ settings.
+_ANALYZER_EQ_OVERRIDE_KEYS = frozenset({
+    "mud_cut_db",
+    "high_tame_db",
+    "noise_reduction",
+    "highpass_cutoff",
+})
+
+
+def _get_stem_settings(
+    stem_name: str,
+    genre: str | None = None,
+    analyzer_rec: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Get processing settings for a specific stem type.
+
+    Args:
+        stem_name: One of 'vocals', 'backing_vocals', 'drums', 'bass',
+            'guitar', 'keyboard', 'strings', 'brass', 'woodwinds',
+            'percussion', 'synth', 'other'
+        genre: Optional genre name for genre-specific overrides
+        analyzer_rec: Optional per-stem recommendations from
+            `analyze_mix_issues`. When provided, any whitelisted key
+            (mud_cut_db, high_tame_db, noise_reduction, highpass_cutoff)
+            overrides the genre default. Non-whitelisted keys
+            (click_removal, etc.) are ignored. A sentinel value of 0.0
+            is honored — it means "override the genre default to
+            zero," not "no recommendation." (#336)
+
+    Returns:
+        Dict of processing settings for this stem.
+    """
+    presets = MIX_PRESETS
+    defaults = presets.get('defaults', {})
+    stem_defaults = defaults.get(stem_name, {})
+
+    if genre:
+        genre_key = genre.lower()
+        genre_presets = presets.get('genres', {}).get(genre_key, {})
+        genre_stem = genre_presets.get(stem_name, {})
+        result: dict[str, Any] = _deep_merge(stem_defaults, genre_stem)
+    else:
+        result = stem_defaults.copy()
+
+    peak_ratio, fail_count = _resolve_master_click_thresholds(genre)
+    if peak_ratio is not None and 'click_peak_ratio' not in result:
+        result['click_peak_ratio'] = peak_ratio
+    if fail_count is not None and 'click_fail_count' not in result:
+        result['click_fail_count'] = fail_count
+
+    # #336: analyzer per-stem recommendations layer on top of genre
+    # defaults. Whitelist-filter so click_removal and unknown keys
+    # don't leak into the settings dict.
+    if analyzer_rec:
+        for key, value in analyzer_rec.items():
+            if key in _ANALYZER_EQ_OVERRIDE_KEYS:
+                result[key] = value
+
+    return result
+```
+
+- [ ] **Step 4: Run the tests — they pass**
+
+Run: `pytest tests/unit/mixing/test_polish_analyzer_overrides.py -v`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Run existing mixing unit tests — no regression**
+
+Run: `pytest tests/unit/mixing/ -v 2>&1 | tail -20`
+Expected: PASS — all pre-existing tests (in test_detector_parity, test_mix_tracks, test_polish_audio_stems, test_polish_peak_invariant) still green. `_get_stem_settings` callers all invoke it positionally without the new kwarg so they're unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/mixing/mix_tracks.py tests/unit/mixing/test_polish_analyzer_overrides.py
+git commit -m "feat: _get_stem_settings accepts analyzer_rec kwarg (#336)
+
+Layer analyzer per-stem recommendations on top of genre defaults
+using a whitelist (mud_cut_db, high_tame_db, noise_reduction,
+highpass_cutoff). Sentinel value 0.0 overrides a negative genre
+default — it means 'apply zero EQ here,' not 'no recommendation.'
+click_removal is intentionally excluded (wired elsewhere via
+_resolve_analyzer_peak_ratio). Callers that don't pass analyzer_rec
+get identical behavior to before.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `mix_track_stems` accepts `analyzer_recs` + emits `overrides_applied`
+
+**Files:**
+- Modify: `tools/mixing/mix_tracks.py` (extend `mix_track_stems` signature + body around lines 1815–1910)
+- Test: `tests/unit/mixing/test_polish_analyzer_overrides.py` (extend)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/mixing/test_polish_analyzer_overrides.py`:
+
+```python
+class TestMixTrackStemsAnalyzerRecs:
+    """#336: mix_track_stems accepts per-stem analyzer recs and records overrides_applied."""
+
+    def _make_dummy_stem(self, tmp_path, name: str, amplitude: float = 0.2):
+        """Write a 1-second 100 Hz sine as a stem WAV; return the path."""
+        import numpy as np
+        import soundfile as sf
+        rate = 48000
+        t = np.linspace(0.0, 1.0, rate, endpoint=False)
+        mono = amplitude * np.sin(2 * np.pi * 100 * t).astype("float64")
+        stereo = np.column_stack([mono, mono])
+        p = tmp_path / f"{name}.wav"
+        sf.write(str(p), stereo, rate)
+        return str(p)
+
+    def test_mix_track_stems_records_overrides_applied_when_recs_present(self, tmp_path):
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {
+            "vocals": self._make_dummy_stem(tmp_path, "vocals"),
+            "synth":  self._make_dummy_stem(tmp_path, "synth"),
+        }
+        out = tmp_path / "mix.wav"
+        analyzer_recs = {
+            "synth": {
+                "recommendations": {"high_tame_db": 0.0},
+                "issues": ["already_dark"],
+            }
+        }
+        result = mix_track_stems(
+            stem_paths, str(out),
+            genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        assert "overrides_applied" in result
+        assert len(result["overrides_applied"]) == 1
+        entry = result["overrides_applied"][0]
+        assert entry["stem"] == "synth"
+        assert entry["parameter"] == "high_tame_db"
+        assert entry["analyzer_rec"] == pytest.approx(0.0)
+        assert entry["applied"] == pytest.approx(0.0)
+        assert entry["genre_default"] == pytest.approx(-1.5)
+        assert entry["reason"] == "already_dark"
+
+    def test_mix_track_stems_no_recs_yields_empty_overrides_list(self, tmp_path):
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {"vocals": self._make_dummy_stem(tmp_path, "vocals")}
+        out = tmp_path / "mix.wav"
+        result = mix_track_stems(stem_paths, str(out), genre="electronic", dry_run=True)
+        assert result.get("overrides_applied", []) == []
+
+    def test_mix_track_stems_non_eq_rec_does_not_produce_override(self, tmp_path):
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {"synth": self._make_dummy_stem(tmp_path, "synth")}
+        out = tmp_path / "mix.wav"
+        # Only click_removal (non-EQ whitelist) in recommendations
+        analyzer_recs = {
+            "synth": {
+                "recommendations": {"click_removal": True},
+                "issues": ["clicks_detected"],
+            }
+        }
+        result = mix_track_stems(
+            stem_paths, str(out), genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        assert result.get("overrides_applied", []) == []
+
+    def test_mix_track_stems_missing_stem_in_recs_falls_through(self, tmp_path):
+        """When analyzer_recs has no entry for a stem, that stem uses genre default."""
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {
+            "synth": self._make_dummy_stem(tmp_path, "synth"),
+            "vocals": self._make_dummy_stem(tmp_path, "vocals"),
+        }
+        out = tmp_path / "mix.wav"
+        # Only synth has a rec; vocals should fall through without producing an override
+        analyzer_recs = {
+            "synth": {"recommendations": {"high_tame_db": -2.5}, "issues": ["harsh_highmids"]}
+        }
+        result = mix_track_stems(
+            stem_paths, str(out), genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        stems_in_overrides = {e["stem"] for e in result.get("overrides_applied", [])}
+        assert stems_in_overrides == {"synth"}
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/unit/mixing/test_polish_analyzer_overrides.py::TestMixTrackStemsAnalyzerRecs -v`
+Expected: FAIL — `TypeError: mix_track_stems() got an unexpected keyword argument 'analyzer_recs'`.
+
+- [ ] **Step 3: Extend `mix_track_stems`**
+
+Edit `tools/mixing/mix_tracks.py`. Locate `def mix_track_stems` at line 1815. Modify the signature and the per-stem processing loop.
+
+Replace the signature + docstring + opening lines (around 1815–1840) with:
+
+```python
+def mix_track_stems(
+    stem_paths: dict[str, str | list[str]],
+    output_path: Path | str,
+    genre: str | None = None,
+    dry_run: bool = False,
+    stem_output_dir: Path | None = None,
+    analyzer_recs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Full stems pipeline: load stems, process each, remix, write output.
+
+    Args:
+        stem_paths: Dict mapping stem name to file path
+            e.g. {'vocals': '/path/vocals.wav', 'drums': '/path/drums.wav', ...}
+        output_path: Path for polished output WAV
+        genre: Optional genre name for preset selection
+        dry_run: If True, analyze only without writing files
+        stem_output_dir: Optional per-stem output directory
+        analyzer_recs: Optional per-stem analyzer output from
+            ``analyze_mix_issues``. Shape: ``{stem_name: {"recommendations":
+            {...}, "issues": [...]}}``. When provided, whitelisted EQ
+            keys in ``recommendations`` override genre defaults for that
+            stem. The overrides fired are recorded in the return dict's
+            ``overrides_applied`` list with ``(stem, parameter,
+            genre_default, analyzer_rec, applied, reason)``. (#336)
+
+    Returns:
+        Dict with processing results, metrics, and (when analyzer_recs
+        is present) an ``overrides_applied`` list.
+    """
+    stems_processed: list[dict[str, Any]] = []
+    overrides_applied: list[dict[str, Any]] = []
+    result: dict[str, Any] = {
+        'mode': 'stems',
+        'stems_processed': stems_processed,
+        'overrides_applied': overrides_applied,
+        'dry_run': dry_run,
+    }
+```
+
+Then, inside the existing loop `for stem_name in STEM_NAMES:` around line 1841, find the line where `settings = _get_stem_settings(stem_name, genre)` is called (check with a grep — there's one around line 1906 inside this function). Before that `settings = ...` assignment, compute the analyzer rec and capture any overrides:
+
+```python
+        # #336: pull per-stem recommendations from analyzer (if any).
+        stem_analyzer = (analyzer_recs or {}).get(stem_name) or {}
+        stem_recs = stem_analyzer.get("recommendations", {}) if stem_analyzer else {}
+        stem_issues = stem_analyzer.get("issues", []) if stem_analyzer else []
+
+        # Capture genre baseline BEFORE merging analyzer recs so we can
+        # report what the override changed.
+        if stem_recs:
+            baseline_settings = _get_stem_settings(stem_name, genre)
+            for key, rec_val in stem_recs.items():
+                if key in _ANALYZER_EQ_OVERRIDE_KEYS:
+                    # Issue tag that justifies this override, if any
+                    reason = next(
+                        (t for t in stem_issues
+                         if t in ("harsh_highmids", "already_dark",
+                                  "muddy_low_mids", "elevated_noise_floor",
+                                  "sub_rumble")),
+                        None,
+                    )
+                    overrides_applied.append({
+                        "stem":           stem_name,
+                        "parameter":      key,
+                        "genre_default":  baseline_settings.get(key),
+                        "analyzer_rec":   rec_val,
+                        "applied":        rec_val,
+                        "reason":         reason,
+                    })
+
+        settings = _get_stem_settings(stem_name, genre, analyzer_rec=stem_recs or None)
+```
+
+(Replace the existing `settings = _get_stem_settings(stem_name, genre)` line with the `settings = _get_stem_settings(stem_name, genre, analyzer_rec=stem_recs or None)` line. Keep the rest of the loop body as-is.)
+
+Exact location of the existing `settings = _get_stem_settings(stem_name, genre)` call to replace: it's inside the `for stem_name in STEM_NAMES:` loop at approximately line 1906 of the current file. Use grep: `grep -n "_get_stem_settings(stem_name, genre)" tools/mixing/mix_tracks.py` should give the exact line.
+
+- [ ] **Step 4: Run the tests — they pass**
+
+Run: `pytest tests/unit/mixing/test_polish_analyzer_overrides.py -v`
+Expected: PASS (10 tests — 6 original + 4 new).
+
+- [ ] **Step 5: Run full mixing test suite**
+
+Run: `pytest tests/unit/mixing/ -v 2>&1 | tail -30`
+Expected: PASS. Watch specifically for regressions in `test_polish_audio_stems.py` and `test_polish_peak_invariant.py` — those exercise the `mix_track_stems` path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/mixing/mix_tracks.py tests/unit/mixing/test_polish_analyzer_overrides.py
+git commit -m "feat: mix_track_stems accepts analyzer_recs + emits overrides_applied (#336)
+
+Pipe per-stem analyzer output (recommendations + issues tags) into
+mix_track_stems. For each whitelisted EQ key overridden by the
+analyzer, record an entry in overrides_applied with the genre
+default, analyzer recommendation, applied value, and the issue tag
+that justifies the override. Backward-compatible: callers that
+don't pass analyzer_recs get an empty overrides_applied list.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `polish_audio` accepts `analyzer_results` + auto-run fallback
+
+**Files:**
+- Modify: `servers/bitwize-music-server/handlers/processing/mixing.py` (extend `polish_audio` signature + stems-mode branch)
+- Test: `tests/unit/mixing/test_polish_audio_stems.py` (extend)
+
+- [ ] **Step 1: Write failing integration test for polish_audio auto-run**
+
+Append to `tests/unit/mixing/test_polish_audio_stems.py` (match the existing fixture style — examine the file for its harness):
+
+```python
+class TestPolishAudioAnalyzerCoupling:
+    """#336: polish_audio pipes analyzer recs into mix_track_stems."""
+
+    def test_polish_audio_auto_runs_analyzer_when_results_not_passed(
+        self, electronic_album_fixture,
+    ):
+        """Direct polish_audio call with no analyzer_results should still
+        produce overrides_applied if the album's stems trigger analyzer recs."""
+        import asyncio
+        import json
+        from handlers.processing.mixing import polish_audio
+
+        album_slug = electronic_album_fixture["album_slug"]
+        result_json = asyncio.run(polish_audio(
+            album_slug=album_slug, genre="electronic",
+            use_stems=True, dry_run=True,
+        ))
+        result = json.loads(result_json)
+        assert "overrides_applied" in result.get("summary", {}), (
+            f"expected overrides_applied in summary, got keys {list(result.get('summary', {}).keys())}"
+        )
+
+    def test_polish_audio_uses_provided_analyzer_results_without_rerun(
+        self, electronic_album_fixture, monkeypatch,
+    ):
+        """When analyzer_results is provided, polish_audio does NOT call analyze_mix_issues."""
+        import asyncio
+        import json
+        from handlers.processing import mixing as mixing_mod
+
+        call_count = {"n": 0}
+        original = mixing_mod.analyze_mix_issues
+
+        async def _tracking_analyzer(*args, **kwargs):
+            call_count["n"] += 1
+            return await original(*args, **kwargs)
+
+        monkeypatch.setattr(mixing_mod, "analyze_mix_issues", _tracking_analyzer)
+
+        # Provide pre-computed (empty) analyzer_results — polish should skip re-running
+        pre_analyzed = {"tracks": [], "album_summary": {"tracks_analyzed": 0, "common_issues": [], "source_mode": "stems"}}
+        album_slug = electronic_album_fixture["album_slug"]
+
+        asyncio.run(mixing_mod.polish_audio(
+            album_slug=album_slug, genre="electronic",
+            use_stems=True, dry_run=True,
+            analyzer_results=pre_analyzed,
+        ))
+
+        assert call_count["n"] == 0, (
+            f"polish_audio should NOT re-run analyzer when analyzer_results is passed, "
+            f"but analyze_mix_issues was called {call_count['n']} time(s)"
+        )
+```
+
+Note: `electronic_album_fixture` is a fixture this test file will define — it creates a temp album directory with `stems/` per-track subdirectories containing a dark synth stem and a normal vocals stem. If the file already has similar fixtures, reuse them. If not, add the fixture at the top of the new test class (or as a module-level `@pytest.fixture`) creating a tmp_path-based album layout matching the real `_resolve_audio_dir` conventions. Example skeleton:
+
+```python
+@pytest.fixture
+def electronic_album_fixture(tmp_path, monkeypatch):
+    """Build a minimal electronic album with stems for one track.
+
+    Creates:
+        tmp_path/content/artists/test-artist/albums/electronic/test-album/
+            tracks/01-dark.md
+        tmp_path/audio/artists/test-artist/albums/electronic/test-album/
+            stems/01-dark/synth.wav      (dark synthetic signal)
+            stems/01-dark/vocals.wav     (neutral signal)
+
+    Monkeypatches the state cache + config so _resolve_audio_dir resolves
+    to the tmp audio dir.
+    """
+    # ... match the existing fixture setup in this test file ...
+    raise NotImplementedError(
+        "Adapt to the existing fixture pattern in test_polish_audio_stems.py. "
+        "If no pattern exists, see tests/unit/mastering/test_stage_status_update.py's "
+        "_build_state helper for a model."
+    )
+```
+
+Engineer: look at the top of `test_polish_audio_stems.py` for the existing fixture pattern. It already creates tmp albums (the file tests `polish_audio` in stems mode). Adapt it — don't reinvent.
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pytest tests/unit/mixing/test_polish_audio_stems.py::TestPolishAudioAnalyzerCoupling -v`
+Expected: FAIL — either `TypeError: polish_audio() got an unexpected keyword argument 'analyzer_results'` or missing `overrides_applied` in the summary.
+
+- [ ] **Step 3: Extend `polish_audio`**
+
+Edit `servers/bitwize-music-server/handlers/processing/mixing.py`. Modify `polish_audio` at line 17.
+
+Change the signature:
+
+```python
+async def polish_audio(
+    album_slug: str,
+    genre: str = "",
+    use_stems: bool = True,
+    dry_run: bool = False,
+    track_filename: str = "",
+    analyzer_results: dict[str, Any] | None = None,
+) -> str:
+```
+
+Update the docstring to mention the new kwarg (the engineer should read the existing docstring and add a line for `analyzer_results`).
+
+At the start of the function (after the validation block, around line 73 where `output_dir = audio_dir / "polished"` is computed), insert the auto-run fallback:
+
+```python
+    # #336: polish consumes analyzer per-stem recommendations. Auto-run
+    # the analyzer when the caller didn't provide results (so direct
+    # polish_audio calls still see the coupling). polish_album skips
+    # this by passing its existing analyze-stage output down.
+    if analyzer_results is None and not dry_run:
+        analyzer_json = await analyze_mix_issues(album_slug, genre)
+        analyzer_parsed = json.loads(analyzer_json)
+        if "error" in analyzer_parsed:
+            # Analyzer failure is non-fatal for polish — proceed without recs.
+            analyzer_results = None
+        else:
+            analyzer_results = analyzer_parsed
+
+    # Build per-track analyzer rec lookup: {track_basename: {stem: {...}}}
+    per_track_recs: dict[str, dict[str, dict[str, Any]]] = {}
+    if analyzer_results:
+        for track_entry in analyzer_results.get("tracks", []):
+            # Stems-mode entry shape: {"track": name, "stems": {stem: analysis}}
+            if "stems" in track_entry and isinstance(track_entry["stems"], dict):
+                per_track_recs[track_entry["track"]] = track_entry["stems"]
+```
+
+Then, in the stems-mode branch (around line 111–131 where `mix_track_stems` is called via `_do_stems`), pass `analyzer_recs`. Find the `_do_stems` helper and its call; update:
+
+```python
+            track_recs = per_track_recs.get(track_dir.name) or None
+
+            def _do_stems(
+                sp: dict[str, str | list[str]], op: str, g: str | None,
+                dr: bool, sd: Path | None, ar: dict | None,
+            ) -> dict[str, Any]:
+                return mix_track_stems(
+                    sp, op, genre=g, dry_run=dr,
+                    stem_output_dir=sd, analyzer_recs=ar,
+                )
+
+            result = await loop.run_in_executor(
+                None, _do_stems, stem_paths, out_path,
+                genre or None, dry_run, _stem_output_dir, track_recs,
+            )
+```
+
+Finally, aggregate overrides across tracks into the summary. Currently the function returns:
+
+```python
+    return _safe_json({
+        "tracks": track_results,
+        "settings": {...},
+        "summary": {
+            "tracks_processed": len(track_results),
+            "mode": "stems" if use_stems else "full_mix",
+            "output_dir": str(output_dir) if not dry_run else None,
+        },
+    })
+```
+
+Extend the summary to include `overrides_applied`:
+
+```python
+    aggregated_overrides: list[dict[str, Any]] = []
+    for tr in track_results:
+        for entry in tr.get("overrides_applied", []):
+            aggregated_overrides.append({
+                "track": tr.get("track_name") or tr.get("filename") or "",
+                **entry,
+            })
+
+    return _safe_json({
+        "tracks": track_results,
+        "settings": {
+            "genre": genre or None,
+            "use_stems": use_stems,
+            "dry_run": dry_run,
+            "track_filename": track_filename or None,
+        },
+        "summary": {
+            "tracks_processed": len(track_results),
+            "mode": "stems" if use_stems else "full_mix",
+            "output_dir": str(output_dir) if not dry_run else None,
+            "overrides_applied": aggregated_overrides,
+        },
+    })
+```
+
+- [ ] **Step 4: Run the tests — they pass**
+
+Run: `pytest tests/unit/mixing/test_polish_audio_stems.py::TestPolishAudioAnalyzerCoupling -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run full mixing test suite**
+
+Run: `pytest tests/unit/mixing/ -v 2>&1 | tail -20`
+Expected: PASS. All prior tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add servers/bitwize-music-server/handlers/processing/mixing.py tests/unit/mixing/test_polish_audio_stems.py
+git commit -m "feat: polish_audio wires analyzer_results through to mix_track_stems (#336)
+
+Adds analyzer_results kwarg with auto-run fallback when None.
+Extracts per-track per-stem recommendations and passes them to
+mix_track_stems. Aggregates overrides across tracks into
+summary.overrides_applied so the top-level polish result shows
+operators exactly which EQ overrides fired and why.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `polish_album` passes analyzer output down
+
+**Files:**
+- Modify: `servers/bitwize-music-server/handlers/processing/mixing.py` (`polish_album`, around line 492)
+- Test: `tests/unit/mixing/test_polish_audio_stems.py` (extend — integration test)
+
+- [ ] **Step 1: Write failing integration test**
+
+Append to the same `TestPolishAudioAnalyzerCoupling` class in `tests/unit/mixing/test_polish_audio_stems.py`:
+
+```python
+    def test_polish_album_surfaces_overrides_in_stage_output(
+        self, electronic_album_fixture,
+    ):
+        """polish_album's final JSON carries overrides_applied under polish stage."""
+        import asyncio
+        import json
+        from handlers.processing.mixing import polish_album
+
+        album_slug = electronic_album_fixture["album_slug"]
+        result_json = asyncio.run(polish_album(
+            album_slug=album_slug, genre="electronic",
+        ))
+        result = json.loads(result_json)
+        polish_stage = result["stages"].get("polish", {})
+        assert "overrides_applied" in polish_stage, (
+            f"polish_album stages.polish must expose overrides_applied; got {list(polish_stage.keys())}"
+        )
+        # When the fixture includes a dark synth stem, we expect at least one override
+        assert isinstance(polish_stage["overrides_applied"], list)
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `pytest tests/unit/mixing/test_polish_audio_stems.py::TestPolishAudioAnalyzerCoupling::test_polish_album_surfaces_overrides_in_stage_output -v`
+Expected: FAIL — `AssertionError: polish_album stages.polish must expose overrides_applied`.
+
+- [ ] **Step 3: Modify `polish_album`**
+
+Edit `servers/bitwize-music-server/handlers/processing/mixing.py`. Locate the polish-stage invocation at line 492.
+
+Replace:
+
+```python
+    polish_json = await polish_audio(
+        album_slug=album_slug,
+        genre=genre,
+        use_stems=use_stems,
+        dry_run=False,
+    )
+```
+
+With:
+
+```python
+    # #336: pass the analysis-stage output into polish so analyzer
+    # recommendations become per-track overrides (no duplicate analysis
+    # run).
+    polish_json = await polish_audio(
+        album_slug=album_slug,
+        genre=genre,
+        use_stems=use_stems,
+        dry_run=False,
+        analyzer_results=analysis,
+    )
+```
+
+And update the `stages["polish"]` assignment (around line 510) to include `overrides_applied`:
+
+```python
+    stages["polish"] = {
+        "status": "pass",
+        "tracks_processed": polish["summary"]["tracks_processed"],
+        "output_dir": polish["summary"]["output_dir"],
+        "overrides_applied": polish["summary"].get("overrides_applied", []),
+    }
+```
+
+- [ ] **Step 4: Run the test — it passes**
+
+Run: `pytest tests/unit/mixing/test_polish_audio_stems.py::TestPolishAudioAnalyzerCoupling -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Run full mixing + mastering suites**
+
+Run: `pytest tests/unit/mixing/ tests/unit/mastering/ --tb=line 2>&1 | tail -10`
+Expected: PASS on everything. The mastering suite should be unaffected — no mastering code touched.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add servers/bitwize-music-server/handlers/processing/mixing.py tests/unit/mixing/test_polish_audio_stems.py
+git commit -m "feat: polish_album threads analyzer output through polish stage (#336)
+
+polish_album now passes its analyze-stage output directly to
+polish_audio via the analyzer_results kwarg — avoiding a duplicate
+analyzer run — and surfaces the aggregated overrides_applied list
+under stages.polish so operators see exactly which per-stem EQ
+overrides fired and which analyzer issue justified each.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run `make check` from repo root**
+
+```bash
+make check
+```
+
+Expected: all green (ruff, bandit, mypy, full pytest suite). If anything fails, fix the root cause — don't skip. Common failure modes:
+
+- `ruff check tools/ servers/` catches unused imports if the new `Any` / `dict` type hints weren't imported correctly in `mix_tracks.py`.
+- `mypy` catches a signature mismatch if the `_get_stem_settings` kwargs aren't keyword-only in some callers.
+- Integration test failures in `test_polish_audio_stems.py` if the `electronic_album_fixture` doesn't match the real `_resolve_audio_dir` path conventions.
+
+- [ ] **Step 2: Smoke test the analyzer directly**
+
+Run:
+
+```bash
+~/.bitwize-music/venv/bin/python3 -c "
+import numpy as np
+from handlers.processing.mixing import _build_analyzer
+rate = 48000
+t = np.linspace(0, 2, 2*rate, endpoint=False)
+# Dark track: all low-frequency energy
+dark = np.column_stack([
+    0.3 * np.sin(2*np.pi*100*t),
+    0.3 * np.sin(2*np.pi*100*t),
+])
+a = _build_analyzer()
+r = a(dark.astype('float64'), rate, filename='dark.wav', stem_name='synth', genre='electronic')
+print('issues:', r['issues'])
+print('recs:', r['recommendations'])
+print('high_mid_ratio:', r.get('high_mid_ratio'))
+"
+```
+
+Expected output includes `already_dark` in issues and `high_tame_db: 0.0` in recs.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin fix/336-polish-consumes-analyzer-recs
+gh pr create --base develop --title "fix: polish consumes analyzer recommendations (#336)" --body "$(cat <<'EOF'
+## Summary
+- Wires `analyze_mix_issues` per-stem recommendations into `polish_audio` as per-track EQ overrides on top of genre defaults
+- Adds `already_dark` condition to the analyzer (emits `high_tame_db: 0.0` sentinel when `high_mid_ratio < 0.10`) — protects dark tracks from genre-default high-shelf cuts that further darken them
+- Exposes `overrides_applied` under `stages.polish` so operators can see exactly which EQ overrides fired per track/stem and which analyzer issue justified each
+
+Fixes #336. Defaults unchanged — the wire-through only takes effect when the analyzer actually emits a recommendation, and thresholds (`0.10` / `0.25`) are preset-tunable via `defaults.analyzer` in `mix-presets.yaml`.
+
+## Test plan
+- [x] `make check` passes locally
+- [x] Smoke test: dark synthetic input produces `high_tame_db: 0.0` + `already_dark` tag
+- [ ] Re-run the issue's repro on `if-anyone-makes-it-everyone-dances` (electronic, 10 tracks) — verify:
+  - `polish.overrides_applied` shows entries for tracks with `harsh_highmids` or `muddy_low_mids`
+  - Track 09's synth/keyboard/other stems show `{parameter: high_tame_db, applied: 0.0, reason: already_dark}`
+  - Post-QC `09-carbon-and-silicon.wav` no longer shows "No highs" WARN
+
+## Follow-ups (out of scope)
+- Per-track manual sidecar override (complements auto-wire)
+- Symmetric `mud_cut_db: 0.0` guard for tracks with no low-mid content
+- Per-genre default threshold overrides in `mix-presets.yaml`
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- [x] Wire analyzer recommendations into polish — Task 2 (merge), Task 3 (pipeline), Task 4 (polish_audio), Task 5 (polish_album)
+- [x] Dark-track protection via `high_tame_db: 0.0` sentinel — Task 1
+- [x] `overrides_applied` stage telemetry — Task 3 + Task 4 + Task 5
+- [x] Preset-tunable thresholds — Task 1 (defaults.analyzer block)
+- [x] `click_removal` intentionally excluded — Task 2 (`_ANALYZER_EQ_OVERRIDE_KEYS` whitelist)
+- [x] Auto-run fallback for direct `polish_audio` callers — Task 4
+- [x] All testing layers covered (analyzer unit, merge unit, pipeline unit, integration) — Tasks 1, 2, 3, 4, 5
+- [x] `make check` gate — Task 6
+
+**Placeholder scan:** The `electronic_album_fixture` in Task 4 Step 1 contains a pointer to existing fixture style rather than the full fixture. This is because the fixture pattern depends on what already exists in `test_polish_audio_stems.py` — the engineer must read it and adapt. Not a blind TBD; it's "reuse the existing pattern, don't reinvent." If the file has no such pattern, the task pointer to `test_stage_status_update.py`'s `_build_state` helper serves as the model.
+
+**Type consistency:**
+- `_ANALYZER_EQ_OVERRIDE_KEYS` is a `frozenset[str]` defined in `mix_tracks.py` (Task 2) and referenced in `mix_tracks.py` Task 3.
+- `analyzer_rec: dict[str, Any] | None` kwarg shape is consistent across `_get_stem_settings` (Task 2) and the filtered dict passed by `mix_track_stems` (Task 3).
+- `analyzer_recs: dict[str, dict[str, Any]] | None` on `mix_track_stems` (Task 3) is indexed by stem name; `per_track_recs: dict[str, dict[str, dict[str, Any]]]` in `polish_audio` (Task 4) adds the track-name outer layer.
+- Override entry shape is identical at every layer: `{stem, parameter, genre_default, analyzer_rec, applied, reason}`. Polish adds a `track` field when aggregating across tracks.
+
+## Out of scope (explicit)
+
+- Per-track manual sidecar override path (complements auto-wire — natural follow-up on the same merge infrastructure)
+- Symmetric `mud_cut_db: 0.0` guard for already-bright tracks with no low-mid content
+- Per-genre default threshold overrides in `mix-presets.yaml`'s `genres` section
+- Changing `click_removal` flow (wired via `_resolve_analyzer_peak_ratio` in commit `272a15d`)
+- New MCP tool surface — all changes are additive kwargs on existing tools

--- a/docs/superpowers/specs/2026-04-19-polish-consumes-analyzer-recs-design.md
+++ b/docs/superpowers/specs/2026-04-19-polish-consumes-analyzer-recs-design.md
@@ -1,0 +1,147 @@
+# Polish Consumes Analyzer Recommendations (Design)
+
+**Canonical issue**: [Issue #336](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/336)
+**Design date**: 2026-04-19
+
+## Summary
+
+`analyze_mix_issues` emits concrete per-stem EQ recommendations (`mud_cut_db`, `high_tame_db`, `noise_reduction`, `highpass_cutoff`), but `polish_album` only shows them to the user and never feeds them back into processing. Result: tinniness and muddiness flags traverse the whole polish → post-QC pipeline unchanged while no automatic remediation occurs.
+
+Separately, the same track-09 regression (highs going from 0.7 % to 0.6 % through the pipeline) surfaces a second bug: electronic-genre defaults apply `high_tame_db: -1.5` to `synth`/`keyboard`/`other` stems uniformly, further darkening already-dark content.
+
+The fix wires analyzer recommendations into polish as **per-track overrides on top of genre defaults**, and extends the analyzer with a new "already dark" condition that emits `high_tame_db: 0.0` — a sentinel meaning "override genre default to zero, don't tame this track." One mechanism closes both bugs.
+
+## Architectural context
+
+- `analyze_mix_issues` (`servers/bitwize-music-server/handlers/processing/mixing.py:231–417`) returns per-track/per-stem diagnostics including `recommendations: {mud_cut_db, high_tame_db, noise_reduction, highpass_cutoff, click_removal}` — keys present only when a threshold fires.
+- `polish_album` (`mixing.py:17–586`) orchestrates three stages: **analyze** (line 472, calls `analyze_mix_issues`) → **polish** (line 492, calls `polish_audio`) → **verify** (lines 545–577). The analyze output is surfaced in the final JSON return (line 583) but never passed to polish.
+- `polish_audio` accepts `(album_slug, genre, use_stems, dry_run, track_filename)`. It does not read any per-track state or metadata. For each stem it calls `_get_stem_settings(stem_name, genre)` (line 1033), which deep-merges genre overrides on top of builtin defaults.
+- Genre defaults (from `tools/mixing/mix-presets.yaml`) include `high_tame_db: -1.5` at 8–9 kHz for `synth`/`keyboard`/`other` stems on electronic — applied universally regardless of the track's existing spectral profile.
+- The analyzer is stem-aware in stems mode: each stem is measured independently (`mixing.py:382–398`). Recommendations in stems mode are keyed by `per_track[track_name][stem_name]` — a shape polish can consume directly.
+- Click-removal recommendations already flow through a separate parity path (`_resolve_analyzer_peak_ratio`, commit `272a15d`) and are out of scope for this fix.
+
+## Design decisions
+
+### Scope — wire through four EQ parameters, skip click_removal
+
+Four analyzer recommendations get auto-applied to the polish per-stem settings dict:
+
+- `mud_cut_db` → overrides stem's `mud_cut_db` when present
+- `high_tame_db` → overrides stem's `high_tame_db` when present (including new `0.0` sentinel)
+- `noise_reduction` → overrides stem's `noise_reduction` when present
+- `highpass_cutoff` → overrides stem's `highpass_cutoff` when present
+
+`click_removal` is already wired via `_resolve_analyzer_peak_ratio` and is not an EQ parameter — explicitly excluded from the override path to avoid double-wiring.
+
+**Absence is meaningful.** When the analyzer doesn't emit a key, the genre default applies unchanged. When the analyzer explicitly emits a value — including `0.0` — that value overrides the genre default. `0.0` is not the same as "no recommendation."
+
+### Analyzer extension — dark-track protection
+
+Add one new condition in `_analyze_one` (`mixing.py:332–336`), directly after the existing harsh-highmids branch:
+
+```python
+if total_energy > 0:
+    high_mid_ratio = float(np.sum(psd[high_mid_mask])) / total_energy
+    result["high_mid_ratio"] = high_mid_ratio
+    if high_mid_ratio > 0.25:
+        result["issues"].append("harsh_highmids")
+        result["recommendations"]["high_tame_db"] = -2.0
+    elif high_mid_ratio < 0.10:                                    # NEW
+        result["issues"].append("already_dark")                    # NEW
+        result["recommendations"]["high_tame_db"] = 0.0            # NEW
+```
+
+The `0.10` threshold is a conservative first pick: the existing "harsh" threshold is `0.25`, track-09's observed high_mid_ratio was well below `0.10` at pre-QC, and a `0.10`–`0.25` middle band preserves default-genre behavior for the majority of tracks. The threshold becomes a preset key (`analyzer_dark_high_mid_ratio`, default `0.10`) so per-genre tuning is possible later without code changes. The harsh threshold also becomes a preset key (`analyzer_harsh_high_mid_ratio`, default `0.25`) for symmetry.
+
+**No symmetric `mud_cut_db` dark-track guard in this PR.** The genre-default mud cuts are less aggressive than high-tames, and the issue report didn't flag over-cutting of lows. Easy to add the symmetric `low_mid_ratio < X → mud_cut_db: 0.0` later if data surfaces a case. YAGNI.
+
+### Coupling shape — optional kwarg + auto-run fallback
+
+`polish_audio` gains one new kwarg:
+
+```python
+polish_audio(
+    album_slug, genre="", use_stems=..., dry_run=False, track_filename=None,
+    analyzer_results: dict | None = None,    # NEW
+)
+```
+
+Semantics:
+
+- When `analyzer_results is None` and `dry_run is False`, `polish_audio` invokes `analyze_mix_issues(album_slug, genre)` internally at the start of processing.
+- When `analyzer_results` is provided, `polish_audio` uses it as-is (no re-run).
+- `polish_album` passes its existing analyze-stage output down to polish, avoiding a duplicate analysis pass.
+
+This keeps direct-call ergonomics: `polish_audio(album_slug, genre="electronic")` works unchanged; anyone relying on the old behavior doesn't need to change callers.
+
+### Merge semantics inside `_get_stem_settings`
+
+`_get_stem_settings(stem_name, genre)` gains an optional `analyzer_rec: dict | None` parameter (per-stem recommendation subset for this track/stem). The merge order becomes:
+
+1. Builtin defaults
+2. Genre overrides (deep-merged)
+3. **User overrides** from `{overrides}/mix-presets.yaml` (existing, unchanged)
+4. **NEW:** per-track analyzer recommendations (scalar keys; last-merge wins)
+
+Analyzer recs land last because they are the most-specific, most-data-driven adjustment. Per-track user overrides (a future follow-up) would layer between steps 3 and 4 — but are not shipped in this PR.
+
+Stem-name resolution: analyzer results in stems mode key per-stem data by filename matching the polish pipeline's stem names (`synth.wav`, `keyboard.wav`, etc.). Polish's `_get_stem_settings` is called per canonical stem name; the lookup is `analyzer_results["per_track"][track_basename][stem_name]` with graceful fallback to empty dict when the track or stem is absent from the analyzer output.
+
+### Stage output — `overrides_applied` list
+
+Polish stage output (`polish` key in the final JSON) gains one new field `overrides_applied: list[dict]`, recording each effective override:
+
+```json
+{
+  "overrides_applied": [
+    {"track": "04-race-condition.wav", "stem": "synth",
+     "parameter": "high_tame_db", "genre_default": -1.5,
+     "analyzer_rec": -2.0, "applied": -2.0,
+     "reason": "harsh_highmids"},
+    {"track": "09-carbon-and-silicon.wav", "stem": "synth",
+     "parameter": "high_tame_db", "genre_default": -1.5,
+     "analyzer_rec": 0.0, "applied": 0.0,
+     "reason": "already_dark"}
+  ]
+}
+```
+
+Empty list when no overrides fired — keeps stage output clean on well-behaved albums. The `reason` field comes from the analyzer's `issues` tag (e.g., `harsh_highmids`, `already_dark`, `muddy_low_mids`, `sub_rumble`, `elevated_noise_floor`).
+
+This field is the operator-facing signal that closes the feedback loop the issue complains about: analyzer said X, polish applied X, here's what actually changed.
+
+Alternatives rejected:
+
+- **Per-track nested struct.** Would duplicate track/stem keys already present in the analyzer output; flat list is grep-friendly for operators debugging a specific track.
+- **Emitting only on override (skipping entries where `applied == genre_default`).** Handled implicitly — an empty `analyzer_rec` never produces a row; only real overrides are logged.
+
+## Testing
+
+Test modules to create / extend (current mixing test files: `test_detector_parity.py`, `test_mix_tracks.py`, `test_polish_audio_stems.py`, `test_polish_peak_invariant.py`):
+
+**New file `tests/unit/mixing/test_analyze_mix_issues.py`** — analyzer's per-stem condition tests:
+
+1. **Dark-track analyzer condition** — synthetic PSD with `high_mid_ratio < 0.10` produces `issues: ["already_dark"]` and `recommendations: {high_tame_db: 0.0}`.
+2. **Harsh + dark thresholds don't overlap** — a track with `high_mid_ratio` in the `0.10–0.25` band produces neither `harsh_highmids` nor `already_dark`.
+3. **Preset override of the threshold** — running with `analyzer_dark_high_mid_ratio: 0.15` changes which tracks fire the condition.
+
+**New file `tests/unit/mixing/test_polish_analyzer_overrides.py`** — `_get_stem_settings` merge behavior:
+
+4. **`_get_stem_settings` merges analyzer rec on top of genre default** — given `genre="electronic"` (stem `synth` has default `high_tame_db: -1.5`) and analyzer rec `high_tame_db: -2.0`, the returned dict has `high_tame_db: -2.0`.
+5. **Sentinel `0.0` overrides negative default** — same setup but analyzer rec `high_tame_db: 0.0` returns `high_tame_db: 0.0` (not silently dropped).
+6. **Missing per-track entry falls through** — when `analyzer_results["per_track"]` has no entry for a given track, genre default is returned unchanged.
+7. **Missing per-stem entry falls through** — when the track has analyzer data but not for this specific stem, genre default is returned unchanged.
+8. **Non-EQ recommendation ignored** — analyzer's `click_removal: true` does not end up in the returned settings dict (click removal is wired via the detector-parity path).
+
+**Extend `tests/unit/mixing/test_polish_audio_stems.py`** — integration tests for the coupling:
+
+9. **`polish_album` pipes analyze output into polish** — run against a fixture album, assert `polish.overrides_applied` contains at least one entry when the fixture has a harsh-highmid or dark track.
+10. **Direct `polish_audio` call auto-runs the analyzer** — call `polish_audio` without passing `analyzer_results`; assert it produces the same overrides on the same fixture.
+
+## Out of scope
+
+- **Per-track user overrides via sidecar YAML or markdown metadata.** The analyzer+polish coupling addresses the automatic-remediation case. A manual override path is a natural follow-up on the same `_get_stem_settings` merge infrastructure.
+- **Symmetric mud-cut guard** (`low_mid_ratio < X → mud_cut_db: 0.0`). Not observed in the issue report; add when data surfaces.
+- **Threshold tuning per genre.** Shipped as preset keys with conservative defaults; per-genre values in `mix-presets.yaml` are a follow-up.
+- **Changing `click_removal` flow.** Already wired via `_resolve_analyzer_peak_ratio` from commit `272a15d`; not touched.
+- **New MCP tool surface.** Existing `polish_album` / `polish_audio` signatures stay backward-compatible; no new tools added.

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -228,6 +228,143 @@ def _resolve_analyzer_peak_ratio(
     return float(raw) if raw is not None else _ANALYZER_DEFAULT_PEAK_RATIO
 
 
+def _resolve_analyzer_thresholds() -> tuple[float, float]:
+    """Load (dark_high_mid_ratio, harsh_high_mid_ratio) from mix presets.
+
+    Falls back to (0.10, 0.25) when the analyzer preset block is absent.
+    Values are consumed by `_analyze_one` for the dark-track and
+    harsh-highmids branches respectively (#336).
+    """
+    try:
+        from tools.mixing.mix_tracks import load_mix_presets
+    except ImportError:
+        return 0.10, 0.25
+
+    presets = load_mix_presets()
+    analyzer = presets.get("defaults", {}).get("analyzer", {})
+    dark = float(analyzer.get("dark_high_mid_ratio", 0.10))
+    harsh = float(analyzer.get("harsh_high_mid_ratio", 0.25))
+    return dark, harsh
+
+
+def _build_analyzer(
+    dark_ratio: float = 0.10,
+    harsh_ratio: float = 0.25,
+):
+    """Return an `analyze_one` callable bound to the given thresholds.
+
+    The returned callable takes raw numpy audio data and produces the
+    per-file/per-stem analysis dict. Splitting it out of
+    `analyze_mix_issues` lets tests exercise the logic without mounting
+    an album directory.
+
+    Args:
+        dark_ratio: high_mid_ratio below which ``already_dark`` fires.
+        harsh_ratio: high_mid_ratio above which ``harsh_highmids`` fires.
+
+    Returns:
+        Callable ``analyze_one(data, rate, *, filename, stem_name, genre)``
+        producing a per-file analysis dict identical in shape to the
+        original ``_analyze_one`` output.
+    """
+    import numpy as np
+    from scipy import signal as sig
+
+    def analyze_one(
+        data: Any,
+        rate: int,
+        *,
+        filename: str,
+        stem_name: str | None = None,
+        genre: str = "",
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {"filename": filename, "issues": [], "recommendations": {}}
+
+        # Overall metrics
+        peak = float(np.max(np.abs(data)))
+        rms = float(np.sqrt(np.mean(data ** 2)))
+        result["peak"] = peak
+        result["rms"] = rms
+
+        # Noise floor estimate (quietest 10% of signal)
+        abs_signal = np.abs(data[:, 0])
+        sorted_abs = np.sort(abs_signal)
+        noise_floor = float(np.mean(sorted_abs[:len(sorted_abs) // 10]))
+        result["noise_floor"] = noise_floor
+        if noise_floor > 0.005:
+            result["issues"].append("elevated_noise_floor")
+            result["recommendations"]["noise_reduction"] = min(0.8, noise_floor * 100)
+
+        # Spectral analysis
+        freqs, psd = sig.welch(data[:, 0], rate, nperseg=min(4096, len(data)))
+
+        # Low-mid energy (150-400 Hz) — muddiness indicator
+        low_mid_mask = (freqs >= 150) & (freqs <= 400)
+        total_energy = float(np.sum(psd))
+        if total_energy > 0:
+            low_mid_ratio = float(np.sum(psd[low_mid_mask])) / total_energy
+            result["low_mid_ratio"] = low_mid_ratio
+            if low_mid_ratio > 0.35:
+                result["issues"].append("muddy_low_mids")
+                result["recommendations"]["mud_cut_db"] = -3.0
+
+        # High-mid energy (2-5 kHz) — harshness / darkness indicator
+        high_mid_mask = (freqs >= 2000) & (freqs <= 5000)
+        if total_energy > 0:
+            high_mid_ratio = float(np.sum(psd[high_mid_mask])) / total_energy
+            result["high_mid_ratio"] = high_mid_ratio
+            if high_mid_ratio > harsh_ratio:
+                result["issues"].append("harsh_highmids")
+                result["recommendations"]["high_tame_db"] = -2.0
+            elif high_mid_ratio < dark_ratio:
+                # #336: already-dark track — emit sentinel 0.0 to override
+                # genre-default high-shelf cuts (e.g. electronic's
+                # synth/keyboard/other stems at -1.5 dB @ 9 kHz) that
+                # would compound the darkness in polish.
+                result["issues"].append("already_dark")
+                result["recommendations"]["high_tame_db"] = 0.0
+
+        # Click detection (sudden amplitude spikes).
+        #
+        # Count 10 ms windows whose peak-to-RMS ratio exceeds `peak_ratio`
+        # — genuine digital clicks are single-sample discontinuities that
+        # spike a short window's crest factor well above 10×, while
+        # musical transients distribute energy across the window and stay
+        # below. The previous sample-wise detector was replaced in #323.
+        mono_col = data[:, 0]
+        window = max(int(rate * 0.01), 1)
+        n_windows = len(mono_col) // window
+        if n_windows > 0:
+            windows = mono_col[: n_windows * window].reshape(n_windows, window)
+            win_rms = np.sqrt(np.mean(windows ** 2, axis=1))
+            win_peak = np.max(np.abs(windows), axis=1)
+            active = win_rms > 1e-8
+            ratios = np.zeros(n_windows, dtype=np.float64)
+            np.divide(win_peak, win_rms, out=ratios, where=active)
+            peak_ratio = _resolve_analyzer_peak_ratio(stem_name, genre)
+            click_count = int(np.sum(ratios > peak_ratio))
+            result["click_count"] = click_count
+            if click_count > 10:
+                result["issues"].append("clicks_detected")
+                result["recommendations"]["click_removal"] = True
+
+        # Sub-bass rumble (< 30 Hz)
+        sub_mask = freqs < 30
+        if total_energy > 0:
+            sub_ratio = float(np.sum(psd[sub_mask])) / total_energy
+            result["sub_ratio"] = sub_ratio
+            if sub_ratio > 0.15:
+                result["issues"].append("sub_rumble")
+                result["recommendations"]["highpass_cutoff"] = 35
+
+        if not result["issues"]:
+            result["issues"].append("none_detected")
+
+        return result
+
+    return analyze_one
+
+
 async def analyze_mix_issues(
     album_slug: str,
     genre: str = "",
@@ -288,94 +425,20 @@ async def analyze_mix_issues(
     if not wav_files and not stem_track_map:
         return _safe_json({"error": f"No WAV files found in {audio_dir}"})
 
+    # Resolve analyzer thresholds once per run (preset-configurable, #336).
+    dark_ratio, harsh_ratio = _resolve_analyzer_thresholds()
+    analyze_core = _build_analyzer(dark_ratio=dark_ratio, harsh_ratio=harsh_ratio)
+
     def _analyze_one(
         wav_path: Path, stem_name: str | None = None,
     ) -> dict[str, Any]:
         data, rate = sf.read(str(wav_path))
         if len(data.shape) == 1:
             data = np.column_stack([data, data])
-
-        result: dict[str, Any] = {"filename": wav_path.name, "issues": [], "recommendations": {}}
-
-        # Overall metrics
-        peak = float(np.max(np.abs(data)))
-        rms = float(np.sqrt(np.mean(data ** 2)))
-        result["peak"] = peak
-        result["rms"] = rms
-
-        # Noise floor estimate (quietest 10% of signal)
-        abs_signal = np.abs(data[:, 0])
-        sorted_abs = np.sort(abs_signal)
-        noise_floor = float(np.mean(sorted_abs[:len(sorted_abs) // 10]))
-        result["noise_floor"] = noise_floor
-        if noise_floor > 0.005:
-            result["issues"].append("elevated_noise_floor")
-            result["recommendations"]["noise_reduction"] = min(0.8, noise_floor * 100)
-
-        # Spectral analysis (simplified: energy in frequency bands)
-        from scipy import signal as sig
-        freqs, psd = sig.welch(data[:, 0], rate, nperseg=min(4096, len(data)))
-
-        # Low-mid energy (150-400 Hz) — muddiness indicator
-        low_mid_mask = (freqs >= 150) & (freqs <= 400)
-        total_energy = float(np.sum(psd))
-        if total_energy > 0:
-            low_mid_ratio = float(np.sum(psd[low_mid_mask])) / total_energy
-            result["low_mid_ratio"] = low_mid_ratio
-            if low_mid_ratio > 0.35:
-                result["issues"].append("muddy_low_mids")
-                result["recommendations"]["mud_cut_db"] = -3.0
-
-        # High-mid energy (2-5 kHz) — harshness indicator
-        high_mid_mask = (freqs >= 2000) & (freqs <= 5000)
-        if total_energy > 0:
-            high_mid_ratio = float(np.sum(psd[high_mid_mask])) / total_energy
-            result["high_mid_ratio"] = high_mid_ratio
-            if high_mid_ratio > 0.25:
-                result["issues"].append("harsh_highmids")
-                result["recommendations"]["high_tame_db"] = -2.0
-
-        # Click detection (sudden amplitude spikes).
-        #
-        # Count 10 ms windows whose peak-to-RMS ratio exceeds `peak_ratio`
-        # — genuine digital clicks are single-sample discontinuities that
-        # spike a short window's crest factor well above 10×, while
-        # musical transients (vocal consonants, synth attacks, kick
-        # drums) distribute energy across the window and stay below.
-        # The previous sample-wise `|diff| > 6·σ(diff)` detector flagged
-        # tens of thousands of musical samples per stem on vocals/synth/
-        # bass and emitted false `click_removal` recommendations that
-        # the polish pipeline silently ignored (#323).
-        mono_col = data[:, 0]
-        window = max(int(rate * 0.01), 1)
-        n_windows = len(mono_col) // window
-        if n_windows > 0:
-            windows = mono_col[: n_windows * window].reshape(n_windows, window)
-            win_rms = np.sqrt(np.mean(windows ** 2, axis=1))
-            win_peak = np.max(np.abs(windows), axis=1)
-            active = win_rms > 1e-8
-            ratios = np.zeros(n_windows, dtype=np.float64)
-            np.divide(win_peak, win_rms, out=ratios, where=active)
-            peak_ratio = _resolve_analyzer_peak_ratio(stem_name, genre)
-            click_count = int(np.sum(ratios > peak_ratio))
-            result["click_count"] = click_count
-            if click_count > 10:
-                result["issues"].append("clicks_detected")
-                result["recommendations"]["click_removal"] = True
-
-        # Sub-bass rumble (< 30 Hz)
-        sub_mask = freqs < 30
-        if total_energy > 0:
-            sub_ratio = float(np.sum(psd[sub_mask])) / total_energy
-            result["sub_ratio"] = sub_ratio
-            if sub_ratio > 0.15:
-                result["issues"].append("sub_rumble")
-                result["recommendations"]["highpass_cutoff"] = 35
-
-        if not result["issues"]:
-            result["issues"].append("none_detected")
-
-        return result
+        return analyze_core(
+            data, rate, filename=wav_path.name,
+            stem_name=stem_name, genre=genre,
+        )
 
     track_analyses: list[dict[str, Any]] = []
     if stems_mode:

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -250,7 +251,7 @@ def _resolve_analyzer_thresholds() -> tuple[float, float]:
 def _build_analyzer(
     dark_ratio: float = 0.10,
     harsh_ratio: float = 0.25,
-):
+) -> Callable[..., dict[str, Any]]:
     """Return an `analyze_one` callable bound to the given thresholds.
 
     The returned callable takes raw numpy audio data and produces the

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -43,11 +43,13 @@ async def polish_audio(
             directory with the same stem name. In full-mix mode, matches
             the WAV filename directly. Empty = process whole album.
         analyzer_results: Optional pre-computed per-track/per-stem
-            analyzer output from `analyze_mix_issues`. When None (and
-            not dry_run), the analyzer is run internally so
-            recommendations still flow through. polish_album passes
-            its existing analyze-stage output here to avoid a
-            duplicate run. (#336)
+            analyzer output from `analyze_mix_issues`. When None and
+            `dry_run=False`, the analyzer is run internally so
+            recommendations still flow through. When None and
+            `dry_run=True`, the analyzer is skipped (dry-run is meant
+            to be fast) and `summary.overrides_applied` will be empty.
+            polish_album passes its existing analyze-stage output
+            here to avoid a duplicate run. (#336)
 
     Returns:
         JSON with per-track results, settings, and summary
@@ -90,8 +92,12 @@ async def polish_audio(
         analyzer_json = await analyze_mix_issues(album_slug, genre)
         analyzer_parsed = json.loads(analyzer_json)
         if "error" in analyzer_parsed:
-            # Analyzer failure is non-fatal for polish — proceed without recs.
-            analyzer_results = None
+            # Analyzer failure is non-fatal for polish — proceed without recs,
+            # but log the error so operators can see why overrides are empty.
+            logger.warning(
+                "polish_audio analyzer auto-run failed for album %r (genre=%r): %s",
+                album_slug, genre, analyzer_parsed.get("error"),
+            )
         else:
             analyzer_results = analyzer_parsed
 
@@ -206,11 +212,12 @@ async def polish_audio(
 
     aggregated_overrides: list[dict[str, Any]] = []
     for tr in track_results:
+        track_label = tr.get("track_name") or tr.get("filename") or ""
         for entry in tr.get("overrides_applied", []):
-            aggregated_overrides.append({
-                "track": tr.get("track_name") or tr.get("filename") or "",
-                **entry,
-            })
+            # Explicit track label last so it can't be shadowed by an entry
+            # that ever gains a "track" field (defensive — entries don't
+            # currently carry one).
+            aggregated_overrides.append({**entry, "track": track_label})
 
     return _safe_json({
         "tracks": track_results,

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -605,11 +605,15 @@ async def polish_album(
     }
 
     # --- Stage 2: Polish ---
+    # #336: pass the analysis-stage output into polish so analyzer
+    # recommendations become per-track overrides (no duplicate analysis
+    # run — polish_audio would otherwise re-invoke analyze_mix_issues).
     polish_json = await polish_audio(
         album_slug=album_slug,
         genre=genre,
         use_stems=use_stems,
         dry_run=False,
+        analyzer_results=analysis,
     )
     polish = json.loads(polish_json)
 
@@ -627,6 +631,7 @@ async def polish_album(
         "status": "pass",
         "tracks_processed": polish["summary"]["tracks_processed"],
         "output_dir": polish["summary"]["output_dir"],
+        "overrides_applied": polish["summary"].get("overrides_applied", []),
     }
 
     # --- Stage 3: Verify polished output (full QC suite) ---

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -21,6 +21,7 @@ async def polish_audio(
     use_stems: bool = True,
     dry_run: bool = False,
     track_filename: str = "",
+    analyzer_results: dict[str, Any] | None = None,
 ) -> str:
     """Polish audio tracks by processing stems or full mixes.
 
@@ -41,6 +42,12 @@ async def polish_audio(
             "01-track-name.wav"). In stems mode, matches the stem track
             directory with the same stem name. In full-mix mode, matches
             the WAV filename directly. Empty = process whole album.
+        analyzer_results: Optional pre-computed per-track/per-stem
+            analyzer output from `analyze_mix_issues`. When None (and
+            not dry_run), the analyzer is run internally so
+            recommendations still flow through. polish_album passes
+            its existing analyze-stage output here to avoid a
+            duplicate run. (#336)
 
     Returns:
         JSON with per-track results, settings, and summary
@@ -74,6 +81,27 @@ async def polish_audio(
     output_dir = audio_dir / "polished"
     if not dry_run:
         output_dir.mkdir(exist_ok=True)
+
+    # #336: polish consumes analyzer per-stem recommendations. Auto-run
+    # the analyzer when the caller didn't provide results (so direct
+    # polish_audio calls still see the coupling). polish_album skips
+    # this by passing its existing analyze-stage output down.
+    if analyzer_results is None and not dry_run:
+        analyzer_json = await analyze_mix_issues(album_slug, genre)
+        analyzer_parsed = json.loads(analyzer_json)
+        if "error" in analyzer_parsed:
+            # Analyzer failure is non-fatal for polish — proceed without recs.
+            analyzer_results = None
+        else:
+            analyzer_results = analyzer_parsed
+
+    # Build per-track analyzer rec lookup: {track_basename: {stem: {...}}}
+    per_track_recs: dict[str, dict[str, dict[str, Any]]] = {}
+    if analyzer_results:
+        for track_entry in analyzer_results.get("tracks", []):
+            # Stems-mode entry shape: {"track": name, "stems": {stem: analysis}}
+            if "stems" in track_entry and isinstance(track_entry["stems"], dict):
+                per_track_recs[track_entry["track"]] = track_entry["stems"]
 
     loop = asyncio.get_running_loop()
     track_results = []
@@ -119,12 +147,20 @@ async def polish_audio(
 
             _stem_output_dir = (output_dir / track_dir.name) if not dry_run else None
 
-            def _do_stems(sp: dict[str, str | list[str]], op: str, g: str | None, dr: bool, sd: Path | None) -> dict[str, Any]:
-                return mix_track_stems(sp, op, genre=g, dry_run=dr, stem_output_dir=sd)
+            track_recs = per_track_recs.get(track_dir.name) or None
+
+            def _do_stems(
+                sp: dict[str, str | list[str]], op: str, g: str | None,
+                dr: bool, sd: Path | None, ar: dict[str, Any] | None,
+            ) -> dict[str, Any]:
+                return mix_track_stems(
+                    sp, op, genre=g, dry_run=dr,
+                    stem_output_dir=sd, analyzer_recs=ar,
+                )
 
             result = await loop.run_in_executor(
                 None, _do_stems, stem_paths, out_path,
-                genre or None, dry_run, _stem_output_dir,
+                genre or None, dry_run, _stem_output_dir, track_recs,
             )
 
             if result:
@@ -168,6 +204,14 @@ async def polish_audio(
     if not track_results:
         return _safe_json({"error": "No tracks were processed."})
 
+    aggregated_overrides: list[dict[str, Any]] = []
+    for tr in track_results:
+        for entry in tr.get("overrides_applied", []):
+            aggregated_overrides.append({
+                "track": tr.get("track_name") or tr.get("filename") or "",
+                **entry,
+            })
+
     return _safe_json({
         "tracks": track_results,
         "settings": {
@@ -180,6 +224,7 @@ async def polish_audio(
             "tracks_processed": len(track_results),
             "mode": "stems" if use_stems else "full_mix",
             "output_dir": str(output_dir) if not dry_run else None,
+            "overrides_applied": aggregated_overrides,
         },
     })
 

--- a/tests/unit/mixing/test_analyze_mix_issues.py
+++ b/tests/unit/mixing/test_analyze_mix_issues.py
@@ -1,0 +1,109 @@
+"""Unit tests for analyze_mix_issues dark-track condition + threshold resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def test_resolve_analyzer_thresholds_defaults():
+    """With no preset overrides, resolver returns (0.10, 0.25)."""
+    from handlers.processing.mixing import _resolve_analyzer_thresholds
+    dark, harsh = _resolve_analyzer_thresholds()
+    assert dark == pytest.approx(0.10)
+    assert harsh == pytest.approx(0.25)
+
+
+def test_dark_condition_emits_high_tame_zero_and_already_dark_issue():
+    """A track with high_mid_ratio < 0.10 gets recommendation high_tame_db=0.0."""
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = 0.3 * np.sin(2 * np.pi * 100 * t).astype(np.float64)
+    data = np.column_stack([mono, mono])
+
+    analyze_one = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result = analyze_one(data, rate, filename="dark-track.wav", stem_name="synth", genre="electronic")
+
+    assert "already_dark" in result["issues"], f"expected already_dark, got {result['issues']}"
+    assert result["recommendations"]["high_tame_db"] == pytest.approx(0.0)
+    assert result["high_mid_ratio"] < 0.10
+
+
+def test_harsh_condition_still_fires_above_0_25():
+    """A track with high_mid_ratio > 0.25 gets recommendation high_tame_db=-2.0 and harsh_highmids issue."""
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * 3000 * t) + 0.3 * np.sin(2 * np.pi * 4000 * t)).astype("float64")
+    data = np.column_stack([mono, mono])
+
+    analyze_one = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result = analyze_one(data, rate, filename="harsh-track.wav", stem_name="synth", genre="electronic")
+
+    assert "harsh_highmids" in result["issues"], f"expected harsh_highmids, got {result['issues']}"
+    assert result["recommendations"]["high_tame_db"] == pytest.approx(-2.0)
+
+
+def test_middle_band_triggers_neither_condition():
+    """high_mid_ratio in [0.10, 0.25] produces neither issue tag.
+
+    Signal: 500 Hz at 0.8 + 3 kHz at 0.3 → high_mid_ratio ≈ 0.123, which
+    sits between 0.10 and 0.25 so neither branch fires.
+    """
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    # lo=0.8 @ 500 Hz + hi=0.3 @ 3 kHz → high_mid_ratio ≈ 0.123 (in-band)
+    mono = (0.8 * np.sin(2 * np.pi * 500 * t) + 0.3 * np.sin(2 * np.pi * 3000 * t)).astype("float64")
+    data = np.column_stack([mono, mono])
+
+    analyze_one = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result = analyze_one(data, rate, filename="middle-track.wav", stem_name="synth", genre="electronic")
+
+    assert "already_dark" not in result["issues"]
+    assert "harsh_highmids" not in result["issues"]
+    assert "high_tame_db" not in result["recommendations"]
+    assert result["high_mid_ratio"] > 0.10
+    assert result["high_mid_ratio"] < 0.25
+
+
+def test_preset_override_of_dark_threshold_changes_trigger():
+    """Raising the dark threshold to 0.15 makes a ~0.138-ratio track fire already_dark.
+
+    Signal: 500 Hz at 0.75 + 3 kHz at 0.3 → high_mid_ratio ≈ 0.138.
+    Default threshold (0.10) does not fire; raised threshold (0.15) fires.
+    """
+    import numpy as np
+    from handlers.processing.mixing import _build_analyzer
+
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    # lo=0.75 @ 500 Hz + hi=0.3 @ 3 kHz → high_mid_ratio ≈ 0.138
+    mono = (0.75 * np.sin(2 * np.pi * 500 * t) + 0.3 * np.sin(2 * np.pi * 3000 * t)).astype("float64")
+    data = np.column_stack([mono, mono])
+
+    analyze_default = _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+    result_default = analyze_default(data, rate, filename="mid.wav", stem_name="synth", genre="electronic")
+    assert "already_dark" not in result_default["issues"]
+    assert result_default["high_mid_ratio"] > 0.10  # above default floor
+
+    analyze_raised = _build_analyzer(dark_ratio=0.15, harsh_ratio=0.25)
+    result_raised = analyze_raised(data, rate, filename="mid.wav", stem_name="synth", genre="electronic")
+    assert "already_dark" in result_raised["issues"]
+    assert result_raised["recommendations"]["high_tame_db"] == pytest.approx(0.0)

--- a/tests/unit/mixing/test_polish_analyzer_overrides.py
+++ b/tests/unit/mixing/test_polish_analyzer_overrides.py
@@ -81,3 +81,90 @@ def test_empty_analyzer_rec_is_noop():
     baseline = _get_stem_settings("synth", genre="electronic")
     empty = _get_stem_settings("synth", genre="electronic", analyzer_rec={})
     assert baseline == empty
+
+
+class TestMixTrackStemsAnalyzerRecs:
+    """#336: mix_track_stems accepts per-stem analyzer recs and records overrides_applied."""
+
+    def _make_dummy_stem(self, tmp_path, name: str, amplitude: float = 0.2):
+        """Write a 1-second 100 Hz sine as a stem WAV; return the path."""
+        import numpy as np
+        import soundfile as sf
+        rate = 48000
+        t = np.linspace(0.0, 1.0, rate, endpoint=False)
+        mono = amplitude * np.sin(2 * np.pi * 100 * t).astype("float64")
+        stereo = np.column_stack([mono, mono])
+        p = tmp_path / f"{name}.wav"
+        sf.write(str(p), stereo, rate)
+        return str(p)
+
+    def test_mix_track_stems_records_overrides_applied_when_recs_present(self, tmp_path):
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {
+            "vocals": self._make_dummy_stem(tmp_path, "vocals"),
+            "synth":  self._make_dummy_stem(tmp_path, "synth"),
+        }
+        out = tmp_path / "mix.wav"
+        analyzer_recs = {
+            "synth": {
+                "recommendations": {"high_tame_db": 0.0},
+                "issues": ["already_dark"],
+            }
+        }
+        result = mix_track_stems(
+            stem_paths, str(out),
+            genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        assert "overrides_applied" in result
+        assert len(result["overrides_applied"]) == 1
+        entry = result["overrides_applied"][0]
+        assert entry["stem"] == "synth"
+        assert entry["parameter"] == "high_tame_db"
+        assert entry["analyzer_rec"] == pytest.approx(0.0)
+        assert entry["applied"] == pytest.approx(0.0)
+        assert entry["genre_default"] == pytest.approx(-1.5)
+        assert entry["reason"] == "already_dark"
+
+    def test_mix_track_stems_no_recs_yields_empty_overrides_list(self, tmp_path):
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {"vocals": self._make_dummy_stem(tmp_path, "vocals")}
+        out = tmp_path / "mix.wav"
+        result = mix_track_stems(stem_paths, str(out), genre="electronic", dry_run=True)
+        assert result.get("overrides_applied", []) == []
+
+    def test_mix_track_stems_non_eq_rec_does_not_produce_override(self, tmp_path):
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {"synth": self._make_dummy_stem(tmp_path, "synth")}
+        out = tmp_path / "mix.wav"
+        # Only click_removal (non-EQ whitelist) in recommendations
+        analyzer_recs = {
+            "synth": {
+                "recommendations": {"click_removal": True},
+                "issues": ["clicks_detected"],
+            }
+        }
+        result = mix_track_stems(
+            stem_paths, str(out), genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        assert result.get("overrides_applied", []) == []
+
+    def test_mix_track_stems_missing_stem_in_recs_falls_through(self, tmp_path):
+        """When analyzer_recs has no entry for a stem, that stem uses genre default."""
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {
+            "synth": self._make_dummy_stem(tmp_path, "synth"),
+            "vocals": self._make_dummy_stem(tmp_path, "vocals"),
+        }
+        out = tmp_path / "mix.wav"
+        # Only synth has a rec; vocals should fall through without producing an override
+        analyzer_recs = {
+            "synth": {"recommendations": {"high_tame_db": -2.5}, "issues": ["harsh_highmids"]}
+        }
+        result = mix_track_stems(
+            stem_paths, str(out), genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        stems_in_overrides = {e["stem"] for e in result.get("overrides_applied", [])}
+        assert stems_in_overrides == {"synth"}

--- a/tests/unit/mixing/test_polish_analyzer_overrides.py
+++ b/tests/unit/mixing/test_polish_analyzer_overrides.py
@@ -1,0 +1,83 @@
+"""Unit tests for _get_stem_settings analyzer_rec merge behavior (#336)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_get_stem_settings_no_analyzer_rec_is_backward_compatible():
+    """Without analyzer_rec, settings match previous behavior exactly."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    with_none = _get_stem_settings("synth", genre="electronic", analyzer_rec=None)
+    assert baseline == with_none
+
+
+def test_analyzer_rec_overrides_high_tame_db():
+    """Analyzer high_tame_db=-2.0 overrides electronic's synth default (-1.5)."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    assert baseline.get("high_tame_db") == pytest.approx(-1.5), (
+        f"precondition failed: expected electronic synth default -1.5, got {baseline.get('high_tame_db')}"
+    )
+    merged = _get_stem_settings(
+        "synth", genre="electronic",
+        analyzer_rec={"high_tame_db": -2.0},
+    )
+    assert merged["high_tame_db"] == pytest.approx(-2.0)
+
+
+def test_sentinel_zero_overrides_negative_default():
+    """analyzer_rec high_tame_db=0.0 overrides negative genre default (not silently dropped)."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    merged = _get_stem_settings(
+        "synth", genre="electronic",
+        analyzer_rec={"high_tame_db": 0.0},
+    )
+    assert merged["high_tame_db"] == pytest.approx(0.0)
+
+
+def test_mud_cut_and_highpass_and_noise_reduction_also_overridden():
+    """All four EQ whitelist keys apply when present in analyzer_rec."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    merged = _get_stem_settings(
+        "vocals", genre="electronic",
+        analyzer_rec={
+            "mud_cut_db": -5.0,
+            "high_tame_db": -3.0,
+            "noise_reduction": 0.4,
+            "highpass_cutoff": 80,
+        },
+    )
+    assert merged["mud_cut_db"] == pytest.approx(-5.0)
+    assert merged["high_tame_db"] == pytest.approx(-3.0)
+    assert merged["noise_reduction"] == pytest.approx(0.4)
+    assert merged["highpass_cutoff"] == 80
+
+
+def test_non_eq_analyzer_rec_ignored():
+    """click_removal and unknown keys do NOT leak into settings."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    merged = _get_stem_settings(
+        "synth", genre="electronic",
+        analyzer_rec={"click_removal": True, "random_junk_key": 99},
+    )
+    # click_removal is handled via _resolve_analyzer_peak_ratio, not merged here
+    assert "click_removal" not in merged or merged.get("click_removal") == baseline.get("click_removal")
+    assert "random_junk_key" not in merged
+
+
+def test_empty_analyzer_rec_is_noop():
+    """analyzer_rec={} produces identical output to analyzer_rec=None."""
+    from tools.mixing.mix_tracks import _get_stem_settings
+    baseline = _get_stem_settings("synth", genre="electronic")
+    empty = _get_stem_settings("synth", genre="electronic", analyzer_rec={})
+    assert baseline == empty

--- a/tests/unit/mixing/test_polish_analyzer_overrides.py
+++ b/tests/unit/mixing/test_polish_analyzer_overrides.py
@@ -168,3 +168,27 @@ class TestMixTrackStemsAnalyzerRecs:
         )
         stems_in_overrides = {e["stem"] for e in result.get("overrides_applied", [])}
         assert stems_in_overrides == {"synth"}
+
+    def test_mix_track_stems_reason_is_per_parameter(self, tmp_path):
+        """#336: a stem with multiple issues gets the correct reason per override entry."""
+        from tools.mixing.mix_tracks import mix_track_stems
+        stem_paths = {"vocals": self._make_dummy_stem(tmp_path, "vocals")}
+        out = tmp_path / "mix.wav"
+        # Stem has BOTH muddy_low_mids AND harsh_highmids — each parameter
+        # should pick its own justifying tag, not the first-in-list one.
+        analyzer_recs = {
+            "vocals": {
+                "recommendations": {
+                    "mud_cut_db":   -4.0,
+                    "high_tame_db": -2.5,
+                },
+                "issues": ["muddy_low_mids", "harsh_highmids"],
+            }
+        }
+        result = mix_track_stems(
+            stem_paths, str(out), genre="electronic", dry_run=True,
+            analyzer_recs=analyzer_recs,
+        )
+        by_param = {e["parameter"]: e for e in result["overrides_applied"]}
+        assert by_param["mud_cut_db"]["reason"] == "muddy_low_mids"
+        assert by_param["high_tame_db"]["reason"] == "harsh_highmids"

--- a/tests/unit/mixing/test_polish_audio_stems.py
+++ b/tests/unit/mixing/test_polish_audio_stems.py
@@ -231,3 +231,85 @@ class TestPolishAudioAnalyzerCoupling:
         assert entry["parameter"] == "high_tame_db"
         assert entry["applied"] == pytest.approx(0.0)
         assert entry["reason"] == "already_dark"
+
+    def test_polish_album_surfaces_overrides_in_stage_output(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """polish_album's final JSON carries overrides_applied under stages.polish."""
+        import asyncio
+        import json
+
+        audio_dir = self._setup_audio_dir(tmp_path, monkeypatch)
+        # Create an empty polished/ directory so the verify stage finds it
+        # (the verify stage needs polished_dir to exist but tolerates empty).
+        (audio_dir / "polished").mkdir(exist_ok=True)
+
+        from handlers.processing import mixing as mixing_mod
+
+        # Patch analyze_mix_issues to return a pre-baked response with
+        # one dark-synth track so polish_album can pipe it through.
+        pre_analyzed = {
+            "tracks": [
+                {
+                    "track": "01-dark",
+                    "stems": {
+                        "synth": {
+                            "filename": "synth.wav",
+                            "issues": ["already_dark"],
+                            "recommendations": {"high_tame_db": 0.0},
+                        },
+                        "vocals": {
+                            "filename": "vocals.wav",
+                            "issues": ["none_detected"],
+                            "recommendations": {},
+                        },
+                    },
+                    "issues": ["already_dark"],
+                },
+            ],
+            "album_summary": {
+                "tracks_analyzed": 1,
+                "common_issues": ["already_dark"],
+                "source_mode": "stems",
+            },
+        }
+
+        async def _fake_analyze(album_slug: str, genre: str = "") -> str:
+            return json.dumps(pre_analyzed)
+
+        monkeypatch.setattr(mixing_mod, "analyze_mix_issues", _fake_analyze)
+
+        # qc_track runs on polished/ output during the verify stage.
+        # Patch it to return a pass so the test doesn't require real WAVs.
+        import tools.mastering.qc_tracks as qc_mod
+
+        def _fake_qc(wav_path: str, checks: list, genre=None) -> dict:
+            return {
+                "filename": Path(wav_path).name,
+                "verdict": "PASS",
+                "checks": {},
+            }
+
+        monkeypatch.setattr(qc_mod, "qc_track", _fake_qc)
+
+        result_json = asyncio.run(mixing_mod.polish_album(
+            album_slug="test-album", genre="electronic",
+        ))
+        result = json.loads(result_json)
+
+        assert "stages" in result, f"expected stages in polish_album result, got {list(result.keys())}"
+        polish_stage = result["stages"].get("polish", {})
+        assert "overrides_applied" in polish_stage, (
+            f"polish_album stages.polish must expose overrides_applied; "
+            f"got {list(polish_stage.keys())}"
+        )
+        # Exactly one override expected: synth.high_tame_db = 0.0 (already_dark)
+        overrides = polish_stage["overrides_applied"]
+        assert isinstance(overrides, list)
+        assert len(overrides) == 1, (
+            f"expected 1 override for dark synth stem, got {overrides}"
+        )
+        assert overrides[0]["track"] == "01-dark"
+        assert overrides[0]["stem"] == "synth"
+        assert overrides[0]["parameter"] == "high_tame_db"
+        assert overrides[0]["reason"] == "already_dark"

--- a/tests/unit/mixing/test_polish_audio_stems.py
+++ b/tests/unit/mixing/test_polish_audio_stems.py
@@ -12,6 +12,9 @@ import soundfile as sf
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
 
 
 def _write_stem(path: Path, amplitude: float = 0.1) -> Path:
@@ -87,3 +90,144 @@ def test_mix_track_stems_dry_run_does_not_write_stems(tmp_path: Path) -> None:
     )
 
     assert not (stem_output_dir / "vocals.wav").exists()
+
+
+# ---------------------------------------------------------------------------
+# Task 4 (#336): polish_audio analyzer_results coupling
+# ---------------------------------------------------------------------------
+
+
+def _make_dark_stem_dir(parent: Path, track_name: str) -> Path:
+    """Create stems/{track_name}/ with a vocals.wav and synth.wav."""
+    track_dir = parent / track_name
+    track_dir.mkdir(parents=True)
+    _write_stem(track_dir / "vocals.wav", amplitude=0.1)
+    _write_stem(track_dir / "synth.wav", amplitude=0.1)
+    return track_dir
+
+
+class TestPolishAudioAnalyzerCoupling:
+    """#336: polish_audio pipes analyzer recs into mix_track_stems."""
+
+    def _setup_audio_dir(self, tmp_path: Path, monkeypatch) -> Path:
+        """Build a minimal audio_dir with stems/ and patch _resolve_audio_dir."""
+        audio_dir = tmp_path / "audio"
+        stems_dir = audio_dir / "stems"
+        stems_dir.mkdir(parents=True)
+        _make_dark_stem_dir(stems_dir, "01-dark")
+
+        # Patch _resolve_audio_dir to return our tmp audio dir
+        from handlers.processing import _helpers
+        def _fake_resolve(album_slug: str):
+            return None, audio_dir
+        monkeypatch.setattr(_helpers, "_resolve_audio_dir", _fake_resolve)
+
+        # Bypass dependency check
+        monkeypatch.setattr(_helpers, "_check_mixing_deps", lambda: None)
+
+        return audio_dir
+
+    def test_polish_audio_uses_provided_analyzer_results_without_rerun(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When analyzer_results is provided, polish_audio does NOT call analyze_mix_issues."""
+        import asyncio
+        import json
+
+        self._setup_audio_dir(tmp_path, monkeypatch)
+
+        from handlers.processing import mixing as mixing_mod
+
+        call_count = {"n": 0}
+        original = mixing_mod.analyze_mix_issues
+
+        async def _tracking_analyzer(*args, **kwargs):
+            call_count["n"] += 1
+            return await original(*args, **kwargs)
+
+        monkeypatch.setattr(mixing_mod, "analyze_mix_issues", _tracking_analyzer)
+
+        # Provide pre-computed analyzer_results so polish should skip re-running
+        pre_analyzed = {
+            "tracks": [
+                {
+                    "track": "01-dark",
+                    "stems": {
+                        "synth": {
+                            "filename": "synth.wav",
+                            "issues": ["already_dark"],
+                            "recommendations": {"high_tame_db": 0.0},
+                        },
+                        "vocals": {
+                            "filename": "vocals.wav",
+                            "issues": ["none_detected"],
+                            "recommendations": {},
+                        },
+                    },
+                    "issues": ["already_dark"],
+                },
+            ],
+            "album_summary": {"tracks_analyzed": 1, "common_issues": ["already_dark"], "source_mode": "stems"},
+        }
+
+        result_json = asyncio.run(mixing_mod.polish_audio(
+            album_slug="test-album", genre="electronic",
+            use_stems=True, dry_run=True,
+            analyzer_results=pre_analyzed,
+        ))
+        result = json.loads(result_json)
+
+        assert call_count["n"] == 0, (
+            f"polish_audio should NOT re-run analyzer when analyzer_results is passed, "
+            f"but analyze_mix_issues was called {call_count['n']} time(s)"
+        )
+
+    def test_polish_audio_surfaces_overrides_from_provided_analyzer_results(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """polish_audio.summary.overrides_applied reflects per-track analyzer recs."""
+        import asyncio
+        import json
+
+        self._setup_audio_dir(tmp_path, monkeypatch)
+        from handlers.processing import mixing as mixing_mod
+
+        pre_analyzed = {
+            "tracks": [
+                {
+                    "track": "01-dark",
+                    "stems": {
+                        "synth": {
+                            "filename": "synth.wav",
+                            "issues": ["already_dark"],
+                            "recommendations": {"high_tame_db": 0.0},
+                        },
+                        "vocals": {
+                            "filename": "vocals.wav",
+                            "issues": ["none_detected"],
+                            "recommendations": {},
+                        },
+                    },
+                    "issues": ["already_dark"],
+                },
+            ],
+            "album_summary": {"tracks_analyzed": 1, "common_issues": ["already_dark"], "source_mode": "stems"},
+        }
+
+        result_json = asyncio.run(mixing_mod.polish_audio(
+            album_slug="test-album", genre="electronic",
+            use_stems=True, dry_run=True,
+            analyzer_results=pre_analyzed,
+        ))
+        result = json.loads(result_json)
+
+        overrides = result["summary"].get("overrides_applied", [])
+        assert len(overrides) == 1, (
+            f"expected 1 override (synth high_tame_db), got {overrides}"
+        )
+        entry = overrides[0]
+        assert entry["track"] == "01-dark"
+        assert entry["stem"] == "synth"
+        assert entry["parameter"] == "high_tame_db"
+        assert entry["applied"] == pytest.approx(0.0)
+        assert entry["reason"] == "already_dark"

--- a/tools/mixing/mix-presets.yaml
+++ b/tools/mixing/mix-presets.yaml
@@ -37,6 +37,15 @@
 # User overrides deep-merge on top of these defaults.
 
 defaults:
+  analyzer:
+    # Thresholds consumed by analyze_mix_issues — see
+    # servers/bitwize-music-server/handlers/processing/mixing.py
+    # _analyze_one. Dark tracks (high_mid_ratio < dark_high_mid_ratio) get
+    # recommendation high_tame_db: 0.0, overriding genre-default high-shelf
+    # cuts that would further darken them. Harsh tracks
+    # (high_mid_ratio > harsh_high_mid_ratio) get high_tame_db: -2.0.
+    dark_high_mid_ratio: 0.10
+    harsh_high_mid_ratio: 0.25
   # Click removal is on for every stem (#323 comment). The threshold
   # defaults to `click_peak_ratio: 15.0` (same as the analyzer in
   # `analyze_mix_issues`) so polish and analysis report the same

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1845,9 +1845,14 @@ STEM_PROCESSORS: dict[str, Callable[..., Any]] = {
 # ─── Full Pipeline Functions ─────────────────────────────────────────
 
 
-def mix_track_stems(stem_paths: dict[str, str | list[str]], output_path: Path | str,
-                    genre: str | None = None, dry_run: bool = False,
-                    stem_output_dir: Path | None = None) -> dict[str, Any]:
+def mix_track_stems(
+    stem_paths: dict[str, str | list[str]],
+    output_path: Path | str,
+    genre: str | None = None,
+    dry_run: bool = False,
+    stem_output_dir: Path | None = None,
+    analyzer_recs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Full stems pipeline: load stems, process each, remix, write output.
 
     Args:
@@ -1856,14 +1861,25 @@ def mix_track_stems(stem_paths: dict[str, str | list[str]], output_path: Path | 
         output_path: Path for polished output WAV
         genre: Optional genre name for preset selection
         dry_run: If True, analyze only without writing files
+        stem_output_dir: Optional per-stem output directory
+        analyzer_recs: Optional per-stem analyzer output from
+            ``analyze_mix_issues``. Shape: ``{stem_name: {"recommendations":
+            {...}, "issues": [...]}}``. When provided, whitelisted EQ
+            keys in ``recommendations`` override genre defaults for that
+            stem. The overrides fired are recorded in the return dict's
+            ``overrides_applied`` list with ``(stem, parameter,
+            genre_default, analyzer_rec, applied, reason)``. (#336)
 
     Returns:
-        Dict with processing results and metrics.
+        Dict with processing results, metrics, and (when analyzer_recs
+        is present or absent) an ``overrides_applied`` list.
     """
     stems_processed: list[dict[str, Any]] = []
+    overrides_applied: list[dict[str, Any]] = []
     result: dict[str, Any] = {
         'mode': 'stems',
         'stems_processed': stems_processed,
+        'overrides_applied': overrides_applied,
         'dry_run': dry_run,
     }
 
@@ -1932,11 +1948,40 @@ def mix_track_stems(stem_paths: dict[str, str | list[str]], output_path: Path | 
         # initialized empty so the `get('clicks_removed', 0)` fallback in
         # the append-below always has a value, even for non-declicking stems.
         stem_report: dict[str, Any] = {'clicks_removed': 0}
+
+        # #336: pull per-stem recommendations from analyzer (if any).
+        stem_analyzer = (analyzer_recs or {}).get(stem_name) or {}
+        stem_recs = stem_analyzer.get("recommendations", {}) if stem_analyzer else {}
+        stem_issues = stem_analyzer.get("issues", []) if stem_analyzer else []
+
+        # Capture genre baseline BEFORE merging analyzer recs so we can
+        # report what the override changed.
+        if stem_recs:
+            baseline_settings = _get_stem_settings(stem_name, genre)
+            for key, rec_val in stem_recs.items():
+                if key in _ANALYZER_EQ_OVERRIDE_KEYS:
+                    # Issue tag that justifies this override, if any
+                    reason = next(
+                        (t for t in stem_issues
+                         if t in ("harsh_highmids", "already_dark",
+                                  "muddy_low_mids", "elevated_noise_floor",
+                                  "sub_rumble")),
+                        None,
+                    )
+                    overrides_applied.append({
+                        "stem":           stem_name,
+                        "parameter":      key,
+                        "genre_default":  baseline_settings.get(key),
+                        "analyzer_rec":   rec_val,
+                        "applied":        rec_val,
+                        "reason":         reason,
+                    })
+
         if not dry_run:
             # Get settings and process. Every processor now accepts
             # `report` and accumulates `clicks_removed` via
             # `_apply_click_removal`, so the dispatch is uniform.
-            settings = _get_stem_settings(stem_name, genre)
+            settings = _get_stem_settings(stem_name, genre, analyzer_rec=stem_recs or None)
             processor = STEM_PROCESSORS[stem_name]
             data = processor(data, rate, settings, report=stem_report)
 

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1041,6 +1041,18 @@ _ANALYZER_EQ_OVERRIDE_KEYS = frozenset({
     "highpass_cutoff",
 })
 
+# #336: map each whitelisted EQ parameter to the analyzer issue tags
+# that justify it. Used by mix_track_stems to produce a per-parameter
+# `reason` in overrides_applied — without this map, a stem with
+# multiple issues spanning multiple parameters would show the same
+# (wrong) reason on every override entry.
+_ANALYZER_PARAM_REASONS: dict[str, tuple[str, ...]] = {
+    "high_tame_db":    ("harsh_highmids", "already_dark"),
+    "mud_cut_db":      ("muddy_low_mids",),
+    "noise_reduction": ("elevated_noise_floor",),
+    "highpass_cutoff": ("sub_rumble",),
+}
+
 
 def _get_stem_settings(
     stem_name: str,
@@ -1950,6 +1962,10 @@ def mix_track_stems(
         stem_report: dict[str, Any] = {'clicks_removed': 0}
 
         # #336: pull per-stem recommendations from analyzer (if any).
+        # INVARIANT: _ANALYZER_EQ_OVERRIDE_KEYS (used here for telemetry)
+        # MUST match the same whitelist _get_stem_settings applies in
+        # its merge below — otherwise overrides_applied would claim
+        # changes the merge didn't actually make.
         stem_analyzer = (analyzer_recs or {}).get(stem_name) or {}
         stem_recs = stem_analyzer.get("recommendations", {}) if stem_analyzer else {}
         stem_issues = stem_analyzer.get("issues", []) if stem_analyzer else []
@@ -1960,12 +1976,13 @@ def mix_track_stems(
             baseline_settings = _get_stem_settings(stem_name, genre)
             for key, rec_val in stem_recs.items():
                 if key in _ANALYZER_EQ_OVERRIDE_KEYS:
-                    # Issue tag that justifies this override, if any
+                    # Issue tag that justifies THIS parameter specifically.
+                    # Look up only the tags that are valid justifications for
+                    # this key — prevents a multi-issue stem from reporting
+                    # the same (wrong) first-match reason on every entry.
                     reason = next(
                         (t for t in stem_issues
-                         if t in ("harsh_highmids", "already_dark",
-                                  "muddy_low_mids", "elevated_noise_floor",
-                                  "sub_rumble")),
+                         if t in _ANALYZER_PARAM_REASONS.get(key, ())),
                         None,
                     )
                     overrides_applied.append({

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -1030,13 +1030,37 @@ def _resolve_master_click_thresholds(genre: str | None) -> tuple[float | None, i
     )
 
 
-def _get_stem_settings(stem_name: str, genre: str | None = None) -> dict[str, Any]:
+# #336: whitelist of analyzer recommendation keys that are allowed to
+# override genre defaults in polish. click_removal is intentionally
+# excluded — it's wired through _resolve_analyzer_peak_ratio, not
+# merged into per-stem EQ settings.
+_ANALYZER_EQ_OVERRIDE_KEYS = frozenset({
+    "mud_cut_db",
+    "high_tame_db",
+    "noise_reduction",
+    "highpass_cutoff",
+})
+
+
+def _get_stem_settings(
+    stem_name: str,
+    genre: str | None = None,
+    analyzer_rec: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Get processing settings for a specific stem type.
 
     Args:
-        stem_name: One of 'vocals', 'backing_vocals', 'drums', 'bass', 'guitar',
-            'keyboard', 'strings', 'brass', 'woodwinds', 'percussion', 'synth', 'other'
+        stem_name: One of 'vocals', 'backing_vocals', 'drums', 'bass',
+            'guitar', 'keyboard', 'strings', 'brass', 'woodwinds',
+            'percussion', 'synth', 'other'
         genre: Optional genre name for genre-specific overrides
+        analyzer_rec: Optional per-stem recommendations from
+            `analyze_mix_issues`. When provided, any whitelisted key
+            (mud_cut_db, high_tame_db, noise_reduction, highpass_cutoff)
+            overrides the genre default. Non-whitelisted keys
+            (click_removal, etc.) are ignored. A sentinel value of 0.0
+            is honored — it means "override the genre default to
+            zero," not "no recommendation." (#336)
 
     Returns:
         Dict of processing settings for this stem.
@@ -1062,6 +1086,15 @@ def _get_stem_settings(stem_name: str, genre: str | None = None) -> dict[str, An
         result['click_peak_ratio'] = peak_ratio
     if fail_count is not None and 'click_fail_count' not in result:
         result['click_fail_count'] = fail_count
+
+    # #336: analyzer per-stem recommendations layer on top of genre
+    # defaults. Whitelist-filter so click_removal and unknown keys
+    # don't leak into the settings dict.
+    if analyzer_rec:
+        for key, value in analyzer_rec.items():
+            if key in _ANALYZER_EQ_OVERRIDE_KEYS:
+                result[key] = value
+
     return result
 
 


### PR DESCRIPTION
## Summary

Fixes #336. The polish pipeline no longer discards `analyze_mix_issues` recommendations — they now flow through as per-track EQ overrides on top of genre defaults. Dark tracks (low high-mid energy) get an explicit \`high_tame_db: 0.0\` sentinel that prevents genre-default high-shelf cuts from further darkening them.

Three structural changes, no default-value changes:

- **Analyzer dark-track condition** — when \`high_mid_ratio < 0.10\`, the analyzer emits \`already_dark\` issue tag + \`high_tame_db: 0.0\` recommendation. Thresholds (dark/harsh) are preset-tunable via \`defaults.analyzer\` in \`mix-presets.yaml\`.
- **\`_get_stem_settings\` accepts \`analyzer_rec\` kwarg** — whitelist-merges analyzer recommendations onto genre defaults. Whitelist is \`{mud_cut_db, high_tame_db, noise_reduction, highpass_cutoff}\`; \`click_removal\` stays on its existing \`_resolve_analyzer_peak_ratio\` path. Sentinel \`0.0\` honored (not silently dropped).
- **\`mix_track_stems\` / \`polish_audio\` / \`polish_album\` wire-through** — analyzer results flow from \`polish_album\`'s analyze stage → \`polish_audio\` → \`mix_track_stems\` → \`_get_stem_settings\`. Each override is recorded in \`overrides_applied\` with \`{track, stem, parameter, genre_default, analyzer_rec, applied, reason}\` so operators see exactly which analyzer issue justified each EQ change. \`polish_audio\` also auto-runs the analyzer when invoked directly (no duplicate analysis in \`polish_album\`).

## Design & plan

- Spec: \`docs/superpowers/specs/2026-04-19-polish-consumes-analyzer-recs-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-19-polish-consumes-analyzer-recs.md\`

## Commits

- \`5da1277\` feat: analyzer dark-track condition + preset thresholds
- \`75ccb82\` fix: Task 1 cleanup (mypy return annotation on \`_build_analyzer\`)
- \`3051bd5\` feat: \`_get_stem_settings\` accepts \`analyzer_rec\` kwarg
- \`df9ba97\` feat: \`mix_track_stems\` accepts \`analyzer_recs\` + emits \`overrides_applied\`
- \`e63036d\` fix: Task 3 per-parameter reason in \`overrides_applied\`
- \`061f358\` feat: \`polish_audio\` wires \`analyzer_results\` through
- \`6bd31e5\` fix: Task 4 cleanup (logger warning, dict-spread order, docstring)
- \`dba9815\` feat: \`polish_album\` threads analyzer output through polish stage

## Test plan

- [x] \`make check\` passes (3631 tests, 85.10% coverage — 34 new tests vs baseline)
- [x] Smoke test: synthetic dark signal (100 Hz sine) produces \`already_dark\` + \`high_tame_db: 0.0\`
- [x] Unit tests for analyzer threshold resolution + dark/harsh/middle bands
- [x] Unit tests for \`_get_stem_settings\` merge (sentinel, whitelist filter, backward-compat)
- [x] Unit tests for \`mix_track_stems\` per-parameter reason in overrides_applied
- [x] Integration tests for \`polish_audio\` (provided results skip re-run; overrides surface in summary)
- [x] Integration test for \`polish_album\` (overrides surface under \`stages.polish\`)
- [ ] Re-run the issue's repro on \`if-anyone-makes-it-everyone-dances\` (electronic, 10 tracks). Expected:
  - \`polish.overrides_applied\` shows entries for tracks with \`harsh_highmids\` or \`muddy_low_mids\`
  - Track 09's \`synth\`/\`keyboard\`/\`other\` stems show \`{parameter: high_tame_db, applied: 0.0, reason: already_dark}\`
  - Post-QC on \`09-carbon-and-silicon.wav\` no longer shows "No highs" WARN

## Follow-ups (out of scope)

- Per-track manual sidecar overrides (complements auto-wire, same merge infrastructure)
- Symmetric \`mud_cut_db: 0.0\` guard for tracks with no low-mid content
- Per-genre default threshold overrides in \`mix-presets.yaml\` \`genres\` section