### PR TITLE
fix: cap ADM ceiling step at 1.0 dB per cycle

### DIFF
--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -759,6 +759,10 @@ async def master_album(
     _ADM_MIN_CEILING_DB = -6.0              # never tighten below this
     _ADM_SAFETY_DB = 0.3                    # extra headroom below observed peak
     _ADM_MIN_TIGHTEN_DB = 0.5               # preserves legacy step as floor
+    _ADM_MAX_TIGHTEN_DB = 1.0               # cap per-cycle step; shallow AAC
+    #                                         ripple (slope ≪ 1) would otherwise
+    #                                         propose 3–4 dB one-shot tightens,
+    #                                         starving the limiter of headroom.
     _ADM_MIN_EFFECTIVE_RATIO = 0.4          # floor on slope efficacy
     adm_loop_stages: list[_StageFn] = [
         _album_stages._stage_mastering,
@@ -847,6 +851,7 @@ async def master_album(
                 overshoot + _ADM_SAFETY_DB, _ADM_MIN_TIGHTEN_DB,
             )
 
+        tighten = min(tighten, _ADM_MAX_TIGHTEN_DB)
         proposed = current - tighten
         floored = proposed < _ADM_MIN_CEILING_DB
         return (max(proposed, _ADM_MIN_CEILING_DB), floored, False)

--- a/tests/unit/mastering/test_master_album_adm_retry.py
+++ b/tests/unit/mastering/test_master_album_adm_retry.py
@@ -940,3 +940,75 @@ def test_adm_warn_fallback_emits_terminal_notice(
         "terminated" in n.lower() and "convergence" in n.lower()
         for n in notices
     ), f"Expected terminal warn-fallback notice, got notices: {notices}"
+
+
+# ---------------------------------------------------------------------------
+# Step-cap test: cycle-to-cycle tighten must not exceed _ADM_MAX_TIGHTEN_DB
+# ---------------------------------------------------------------------------
+
+def test_adm_retry_caps_tighten_per_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A single retry must not drop the ceiling by more than 1.0 dB.
+
+    Regression: when AAC ripple scales poorly with ceiling (peak drops
+    only ~0.1 dB for every 1 dB of tightening), the slope-aware formula
+    `(overshoot + 0.3) / max(slope, 0.4)` proposes ~4 dB one-shot
+    tightens. The resulting ceiling is so low downstream limiting can't
+    reach target LUFS and verification fails with -20-to-24 LUFS
+    outputs. Cap each step at _ADM_MAX_TIGHTEN_DB.
+    """
+    album_slug = "adm-retry-album"
+    _write_sine_wav(tmp_path / "01-track.wav")
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    def _shallow_slope(
+        path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256,
+    ):
+        # Cycle 0 (ceiling -1.0): peak -0.4 → tighten 0.9 → ceiling -1.9
+        # Cycle 1 (ceiling -1.9): peak -0.5 → slope 0.11, clamped to
+        #   0.4 → uncapped tighten 4.25 dB (floored at -6.0). With cap:
+        #   tighten 1.0 → ceiling -2.9.
+        # Cycle 2+ (clean): exits the loop.
+        if ceiling_db > -1.5:
+            peak, clips = -0.4, True
+        elif ceiling_db > -2.5:
+            peak, clips = -0.5, True
+        else:
+            peak, clips = ceiling_db - 0.5, False
+        return {
+            "filename": Path(path).name,
+            "encoder_used": encoder,
+            "clip_count": 100 if clips else 0,
+            "peak_db_decoded": peak,
+            "ceiling_db": ceiling_db,
+            "clips_found": clips,
+        }
+
+    monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _shallow_slope)
+    monkeypatch.setattr(
+        album_stages_mod, "_embed_wav_metadata_fn", lambda *a, **kw: None,
+    )
+
+    mastered_ceilings: list[float] = []
+    import tools.mastering.master_tracks as _mt_mod
+    _real = _mt_mod.master_track
+
+    def _capture(src, dst, *, ceiling_db=-1.0, **kwargs):
+        mastered_ceilings.append(float(ceiling_db))
+        return _real(src, dst, ceiling_db=ceiling_db, **kwargs)
+
+    monkeypatch.setattr(_mt_mod, "master_track", _capture)
+
+    _run_master_album(tmp_path, album_slug=album_slug)
+
+    assert len(mastered_ceilings) >= 2, (
+        f"Expected at least 2 cycles, got: {mastered_ceilings}"
+    )
+    for prev, curr in zip(mastered_ceilings, mastered_ceilings[1:]):
+        step = prev - curr
+        assert step <= 1.0 + 1e-3, (
+            f"Cycle-to-cycle ceiling step {step:.3f} dB exceeds 1.0 dB "
+            f"cap. Full ceiling history: {mastered_ceilings}"
+        )


### PR DESCRIPTION
## Summary
- Adds `_ADM_MAX_TIGHTEN_DB = 1.0` cap applied inside `_adm_adaptive_ceiling` before the floor clamp.
- Prevents the slope-aware tighten formula from proposing 3–4 dB one-shot ceiling drops when AAC ripple scales poorly (slope clamped to the 0.4 floor).
- Adds `test_adm_retry_caps_tighten_per_cycle` — shallow-slope fixture that, without the cap, lands the ceiling at -6.0 dBTP in a single cycle 1→2 step. RED verified before implementing, GREEN after.

## Why
Observed run sequence: ceiling -1.5 → -2.59 → -5.82 dBTP over 3 cycles. The `(overshoot + 0.3) / max(slope, 0.4)` formula is unbounded above, so one shallow-slope cycle collapses the ceiling to the floor. The downstream limiter then can't reach -14 LUFS and verification halts the pipeline with tracks at -20 to -24 LUFS — leaving `mastered/` in a broken state.

A 1.0 dB cap turns that sequence into a steady 1.0 dB/cycle walk. Worst case (floor at -6.0 dBTP, start at -1.0) converges in 5 cycles, matching `_ADM_MAX_CYCLES`.

## Test plan
- [x] New test fails on current code (4.1 dB step observed) — RED verified
- [x] New test passes after the cap
- [x] All 15 tests in `test_master_album_adm_retry.py` pass (existing `test_adm_retry_respects_hard_floor` and `test_adm_retry_breaks_when_ceiling_cannot_decrease` still green — catastrophic-peak scenarios now exit via divergence/no-decrease rather than one-shot floor hit, which is the intended behavior)
- [x] `make check` green — 3666 passed, 85.14% coverage