### PR TITLE
fix: accurate ADM warn-fallback reporting on all-dark short-circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- ADM warn-fallback reporting was inaccurate when the loop
+  short-circuited on the all-dark first check:
+  - Warning text hardcoded `_ADM_MAX_CYCLES` (the configured max)
+    instead of the actual executed count. Now reports
+    `adm_cycles_executed` + `adm_tightening_cycles` separately and
+    uses different wording when no tightening ran.
+  - `ADM_VALIDATION.md` advice contradicted the pipeline verdict —
+    recommended "Tighten true-peak ceiling by 0.5 dB and re-master"
+    even when every failure was a dark-content casualty. The
+    renderer now takes a `dark_casualty_filenames` kwarg and tailors
+    the advice: all-dark failures get harmonic-excitation guidance,
+    partial failures split advice by track class.
+  - `per_track_decisions` dict on `adm_validation` stage output —
+    records classification (`dark_casualty` / `tightenable`),
+    outcome (`not_tightened` / `diverged` / `floor_reached` /
+    `tightened`), reason, cycle, and final ceiling per clipping
+    track. Survives the all-dark short-circuit path where
+    `adm_history` and `track_ceilings` are both empty.
+
 ### Added
 - Post-QC spectral regression guard — WARN when mastering pushed a
   track's `tinniness_ratio` (high_mid/mid) above 0.6 AND the ratio

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2333,9 +2333,20 @@ async def _stage_adm_validation(ctx: MasterAlbumCtx) -> str | None:
         ctx.notices.append("ADM validation skipped — no results to write")
     else:
         try:
+            # Tracks that are both in ctx.dark_tracks AND clipping WILL be
+            # routed to dark_adm_casualties by the orchestrator — predict
+            # that here so the markdown's advice doesn't contradict the
+            # pipeline's verdict (regression for observability bug: prior
+            # markdown unconditionally recommended tightening even when
+            # the orchestrator had already decided tightening won't help).
+            dark_casualty_fnames = {
+                r["filename"] for r in results
+                if r.get("clips_found") and r["filename"] in ctx.dark_tracks
+            }
             md = render_adm_validation_markdown(
                 ctx.album_slug, results,
                 encoder_used=encoder_used, ceiling_db=ceiling_db,
+                dark_casualty_filenames=dark_casualty_fnames,
             )
             atomic_write_text(ctx.audio_dir / "ADM_VALIDATION.md", md)
         except Exception as exc:

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -864,12 +864,26 @@ async def master_album(
     # time each dark track clips). Empty if no dark tracks clipped.
     dark_adm_casualties: dict[str, dict[str, Any]] = {}
 
+    # Per-track decision trace for the warn-fallback sidecar. Survives
+    # the all-dark short-circuit (where no tightening runs) so operators
+    # can still see why each clipping track was left alone vs. tightened.
+    per_track_decisions: dict[str, dict[str, Any]] = {}
+
     adm_clip_failure_persisted = False
     adm_last_failure_detail: dict[str, Any] = {}
     adm_diverging = False
 
+    # Separate counters: adm_cycles_executed is the number of full ADM
+    # passes the loop ran (stages: mastering → verification → coherence →
+    # ceiling_guard → adm_validation). adm_tightening_cycles is the
+    # number of times the loop actually retightened and re-mastered.
+    # They diverge on the all-dark short-circuit (executed=1, tightening=0).
+    adm_cycles_executed = 0
+    adm_tightening_cycles = 0
+
     for adm_cycle in range(_ADM_MAX_CYCLES):
         ctx.adm_cycle = adm_cycle
+        adm_cycles_executed = adm_cycle + 1
         adm_retry = False
 
         for stage_fn in adm_loop_stages:
@@ -903,6 +917,28 @@ async def master_album(
                             )
                             if entry is not None:
                                 dark_adm_casualties[fname] = dict(entry)
+                        # Decision trace: every dark clipper is classified
+                        # here regardless of cycle number. Survives the
+                        # all-dark short-circuit when no tightening runs.
+                        if fname not in per_track_decisions:
+                            entry = next(
+                                (e for e in clip_entries
+                                 if e.get("filename") == fname),
+                                None,
+                            )
+                            per_track_decisions[fname] = {
+                                "classification":   "dark_casualty",
+                                "outcome":          "not_tightened",
+                                "reason": (
+                                    "high_mid band energy < 10 % — "
+                                    "tightening would not improve ADM"
+                                ),
+                                "cycle_detected":   adm_cycle,
+                                "peak_db_decoded":  (
+                                    float(entry.get("peak_db_decoded", 0.0))
+                                    if entry else None
+                                ),
+                            }
 
                     if adm_cycle >= _ADM_MAX_CYCLES - 1:
                         # Last cycle: whatever's left goes to warn-fallback.
@@ -948,12 +984,50 @@ async def master_album(
                         if diverging:
                             any_diverged = True
                             dark_adm_casualties[fname] = dict(entry)
+                            per_track_decisions[fname] = {
+                                "classification":   "tightenable",
+                                "outcome":          "diverged",
+                                "reason": (
+                                    "limiter ripple grew despite "
+                                    "tightening — further tightening "
+                                    "would worsen ADM compliance"
+                                ),
+                                "cycle_detected":   adm_cycle,
+                                "final_ceiling":    current,
+                                "peak_db_decoded":  float(
+                                    entry.get("peak_db_decoded", 0.0),
+                                ),
+                            }
                             continue
                         if new_ceiling >= current:
                             any_floored = True
+                            per_track_decisions[fname] = {
+                                "classification":   "tightenable",
+                                "outcome":          "floor_reached",
+                                "reason": (
+                                    "per-track ceiling at adaptive floor"
+                                ),
+                                "cycle_detected":   adm_cycle,
+                                "final_ceiling":    current,
+                                "peak_db_decoded":  float(
+                                    entry.get("peak_db_decoded", 0.0),
+                                ),
+                            }
                             continue
                         ctx.track_ceilings[fname] = new_ceiling
                         next_remaster.add(fname)
+                        # Overwrite each cycle so the latest-state outcome
+                        # for this track is reflected (e.g. track may
+                        # tighten on cycle 0 then hit floor on cycle 1).
+                        per_track_decisions[fname] = {
+                            "classification":   "tightenable",
+                            "outcome":          "tightened",
+                            "cycle_applied":    adm_cycle,
+                            "final_ceiling":    new_ceiling,
+                            "peak_db_decoded":  float(
+                                entry.get("peak_db_decoded", 0.0),
+                            ),
+                        }
                         adm_history.append({
                             "ceiling": new_ceiling,
                             "worst_peak": float(entry.get("peak_db_decoded", 0.0)),
@@ -984,6 +1058,7 @@ async def master_album(
                 return _inject_notices_and_return(result)
 
         if adm_retry:
+            adm_tightening_cycles += 1
             continue
         break  # ADM passed, or warn-fallback break
 
@@ -996,45 +1071,77 @@ async def master_album(
         tightened_fnames = sorted(ctx.track_ceilings.keys())
         dark_casualty_count = len(dark_adm_casualties)
         tightened_count = len(tightened_fnames)
+        total_flagged = dark_casualty_count + tightened_count
 
-        reason_suffix = (
-            "; ripple growing with tightening (divergent)"
-            if adm_diverging else ""
-        )
-        if dark_casualty_count:
-            reason_suffix += (
-                f"; {dark_casualty_count} dark track(s) not tightened"
+        # Cycle-count-aware wording (observability bug: prior text
+        # hardcoded _ADM_MAX_CYCLES regardless of what actually ran).
+        if adm_tightening_cycles == 0:
+            # All-dark short-circuit: clips hit on first ADM check and
+            # every clipping track was classified dark-casualty. No
+            # tightening was attempted.
+            reason_text = (
+                f"all {dark_casualty_count} clipping track(s) classified "
+                f"as dark-casualty on first ADM check; no tightening "
+                f"attempted"
+            )
+            warn_text = (
+                f"ADM validation: {total_flagged} track(s) flagged on "
+                f"the first ADM check, all {dark_casualty_count} "
+                f"classified as dark-casualty. No tightening was "
+                f"attempted — tightening dark-content tracks would not "
+                f"improve ADM compliance. See ADM_VALIDATION.md."
+            )
+            notice_text = (
+                f"ADM loop terminated: {dark_casualty_count} dark "
+                f"casualty (no tightening attempted). Delivered with "
+                f"flagged tracks; inspect ADM_VALIDATION.md before "
+                f"republish."
+            )
+        else:
+            reason_text = (
+                f"inter-sample clips persist at per-track ceilings after "
+                f"{adm_tightening_cycles} tightening cycle(s) "
+                f"({adm_cycles_executed} ADM pass(es) total); floor is "
+                f"{_ADM_MIN_CEILING_DB:.1f} dBTP"
+            )
+            if adm_diverging:
+                reason_text += "; ripple growing with tightening (divergent)"
+            if dark_casualty_count:
+                reason_text += (
+                    f"; {dark_casualty_count} dark track(s) not tightened"
+                )
+            warn_text = (
+                f"ADM validation: clips persist on {total_flagged} "
+                f"track(s) after {adm_tightening_cycles} tightening "
+                f"cycle(s). {dark_casualty_count} dark (not tightened), "
+                f"{tightened_count} tightened to floor or diverged. "
+                f"See ADM_VALIDATION.md for per-track detail."
+            )
+            notice_text = (
+                f"ADM loop terminated after {adm_tightening_cycles} "
+                f"tightening cycle(s): {dark_casualty_count} dark "
+                f"casualty, {tightened_count} tightened casualty. "
+                f"Delivered with flagged tracks; inspect ADM_VALIDATION.md "
+                f"before republish."
             )
 
         if isinstance(stage, dict):
             stage["status"] = "warn"
-            stage["reason"] = (
-                f"inter-sample clips persist at per-track ceilings after "
-                f"{_ADM_MAX_CYCLES} cycle(s); floor is "
-                f"{_ADM_MIN_CEILING_DB:.1f} dBTP{reason_suffix}"
-            )
+            stage["reason"] = reason_text
             stage["clip_failure_persisted"] = True
             stage["diverging"] = adm_diverging
             stage["dark_casualties"] = sorted(dark_adm_casualties.keys())
             stage["tightened_tracks"] = tightened_fnames
             stage["track_ceilings"] = dict(ctx.track_ceilings)
             stage["adm_history"] = list(adm_history)
+            stage["per_track_decisions"] = dict(per_track_decisions)
+            stage["adm_cycles_executed"] = adm_cycles_executed
+            stage["adm_tightening_cycles"] = adm_tightening_cycles
 
-        total_flagged = dark_casualty_count + tightened_count
-        ctx.warnings.append(
-            f"ADM validation: clips persist on {total_flagged} track(s) "
-            f"after {_ADM_MAX_CYCLES} retry cycle(s). "
-            f"{dark_casualty_count} dark (not tightened), "
-            f"{tightened_count} tightened to floor or diverged. "
-            "See ADM_VALIDATION.md for per-track detail."
-        )
+        ctx.warnings.append(warn_text)
         # Terminal notice so operators reading the notice stream see the
         # final state immediately, without having to scan warnings.
-        ctx.notices.append(
-            f"ADM loop terminated: {dark_casualty_count} dark casualty, "
-            f"{tightened_count} tightened casualty. Delivered with "
-            "flagged tracks; inspect ADM_VALIDATION.md before republish."
-        )
+        ctx.notices.append(notice_text)
 
     # ── Phase 3: post-loop stages (run once) ─────────────────────────────
     post_loop_stages: list[_StageFn] = [

--- a/tests/unit/mastering/test_adm_validation.py
+++ b/tests/unit/mastering/test_adm_validation.py
@@ -121,3 +121,54 @@ def test_render_adm_validation_markdown_clip_fail() -> None:
     md = render_adm_validation_markdown("my-album", results, encoder_used="aac", ceiling_db=-1.0)
     assert "FAIL" in md
     assert "5" in md
+    # No dark casualties → standard "tighten and re-master" advice.
+    assert "Tighten true-peak ceiling" in md
+
+
+def test_render_adm_validation_markdown_all_dark_casualties() -> None:
+    """When every failing track is a dark casualty, the advice must NOT
+    recommend tightening (which won't help for dark-content tracks).
+    Regression guard for observability bug #3."""
+    from tools.mastering.adm_validation import render_adm_validation_markdown
+    results = [
+        {"filename": "01-dark.wav", "peak_db_decoded": -0.3, "clip_count": 4,
+         "clips_found": True, "ceiling_db": -1.0, "encoder_used": "aac"},
+        {"filename": "02-dark.wav", "peak_db_decoded": -0.5, "clip_count": 2,
+         "clips_found": True, "ceiling_db": -1.0, "encoder_used": "aac"},
+    ]
+    md = render_adm_validation_markdown(
+        "my-album", results,
+        encoder_used="aac", ceiling_db=-1.0,
+        dark_casualty_filenames={"01-dark.wav", "02-dark.wav"},
+    )
+    assert "FAIL" in md
+    # Dark-casualty rows carry a distinguishing marker.
+    assert "dark casualty" in md.lower()
+    # Generic "Tighten and re-master" advice MUST NOT appear when every
+    # failure is dark — tightening would not help.
+    assert "Tighten true-peak ceiling by 0.5 dB and re-master" not in md
+    # Dark-specific advice should appear.
+    assert "harmonic excitation" in md.lower() or "cannot" in md.lower()
+
+
+def test_render_adm_validation_markdown_mixed_casualties() -> None:
+    """Mixed failures (some dark, some tightenable) → advice mentions
+    both: tighten the non-dark, skip the dark."""
+    from tools.mastering.adm_validation import render_adm_validation_markdown
+    results = [
+        {"filename": "01-dark.wav", "peak_db_decoded": -0.3, "clip_count": 4,
+         "clips_found": True, "ceiling_db": -1.0, "encoder_used": "aac"},
+        {"filename": "02-bright.wav", "peak_db_decoded": -0.4, "clip_count": 1,
+         "clips_found": True, "ceiling_db": -1.0, "encoder_used": "aac"},
+    ]
+    md = render_adm_validation_markdown(
+        "my-album", results,
+        encoder_used="aac", ceiling_db=-1.0,
+        dark_casualty_filenames={"01-dark.wav"},
+    )
+    # Both track types flagged with distinguishing labels.
+    assert "FAIL (dark casualty)" in md
+    # Advice should mention tightening for non-dark AND skipping for dark.
+    lower = md.lower()
+    assert "tightening" in lower
+    assert "dark" in lower

--- a/tests/unit/mastering/test_master_album_dark_track_adm.py
+++ b/tests/unit/mastering/test_master_album_dark_track_adm.py
@@ -214,3 +214,64 @@ def test_all_dark_clipping_breaks_to_warn_fallback(
         f"Expected exactly 1 mastering cycle (no re-master for dark tracks), "
         f"got {mastering_call_count['n']} calls"
     )
+
+    # ── Observability guards (bugs #1, #2) ────────────────────────────────
+    # Bug #1: cycle counts must reflect what actually happened, not the
+    # configured _ADM_MAX_CYCLES. On an all-dark short-circuit, exactly
+    # 1 full ADM pass ran and 0 tightening cycles were attempted.
+    assert adm_stage.get("adm_cycles_executed") == 1, (
+        f"Expected adm_cycles_executed=1, got: "
+        f"{adm_stage.get('adm_cycles_executed')}"
+    )
+    assert adm_stage.get("adm_tightening_cycles") == 0, (
+        f"Expected adm_tightening_cycles=0 (all-dark short-circuit), "
+        f"got: {adm_stage.get('adm_tightening_cycles')}"
+    )
+
+    # Warning text must NOT report the configured max (_ADM_MAX_CYCLES=5)
+    # as if it were the executed count.
+    warnings_blob = " ".join(result.get("warnings", []))
+    assert "5 retry cycle" not in warnings_blob, (
+        f"Warning text hardcodes _ADM_MAX_CYCLES; should reflect actual "
+        f"cycles executed. Got: {warnings_blob!r}"
+    )
+    assert "5 tightening cycle" not in warnings_blob
+    # Warning should mention the all-dark short-circuit in some form.
+    assert "dark" in warnings_blob.lower() and (
+        "no tightening" in warnings_blob.lower()
+        or "first adm check" in warnings_blob.lower()
+    ), (
+        f"Warning should describe the all-dark short-circuit. "
+        f"Got: {warnings_blob!r}"
+    )
+
+    # Bug #2: per-track decisions must be populated even when no
+    # tightening happened. The orchestrator classified 01-dark.wav as a
+    # dark casualty — that decision must be visible in the stage output.
+    per_track = adm_stage.get("per_track_decisions", {})
+    assert "01-dark.wav" in per_track, (
+        f"Expected per_track_decisions to include '01-dark.wav', "
+        f"got: {per_track}"
+    )
+    dark_decision = per_track["01-dark.wav"]
+    assert dark_decision.get("classification") == "dark_casualty", (
+        f"Expected classification='dark_casualty', got: {dark_decision}"
+    )
+    assert dark_decision.get("outcome") == "not_tightened", (
+        f"Expected outcome='not_tightened', got: {dark_decision}"
+    )
+
+    # Bug #3: ADM_VALIDATION.md must not recommend the generic "tighten
+    # and re-master" action when all failing tracks are dark casualties.
+    adm_sidecar = tmp_path / "ADM_VALIDATION.md"
+    assert adm_sidecar.exists(), "ADM_VALIDATION.md not written"
+    sidecar_body = adm_sidecar.read_text()
+    assert "Tighten true-peak ceiling by 0.5 dB and re-master" not in sidecar_body, (
+        "ADM_VALIDATION.md gave contradictory advice: pipeline classified "
+        "these clips as dark casualties (tightening won't help), but the "
+        "markdown still recommended tightening."
+    )
+    assert "dark casualty" in sidecar_body.lower(), (
+        "ADM_VALIDATION.md should label dark-casualty rows as such; "
+        f"body was: {sidecar_body!r}"
+    )

--- a/tools/mastering/adm_validation.py
+++ b/tools/mastering/adm_validation.py
@@ -216,8 +216,18 @@ def render_adm_validation_markdown(
     *,
     encoder_used: str,
     ceiling_db: float,
+    dark_casualty_filenames: set[str] | None = None,
 ) -> str:
-    """Render ADM_VALIDATION.md content for the mastered album."""
+    """Render ADM_VALIDATION.md content for the mastered album.
+
+    Args:
+        dark_casualty_filenames: Tracks classified as dark-casualty by
+            the orchestrator (high_mid band_energy < 10 %). Their rows
+            are labelled 'FAIL (dark casualty)' and the recommendation
+            section tailors the advice — further limiter tightening
+            cannot improve ADM compliance on dark-content material.
+    """
+    dark_set = dark_casualty_filenames or set()
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     clips_total = sum(r.get("clip_count", 0) for r in results)
     overall = "PASS" if clips_total == 0 else "FAIL"
@@ -234,17 +244,53 @@ def render_adm_validation_markdown(
         "|-------|---------------|-------|--------|",
     ]
     for r in results:
-        verdict = "FAIL ❌" if r.get("clips_found") else "PASS ✅"
+        fname = r["filename"]
+        if r.get("clips_found"):
+            verdict = "FAIL (dark casualty) ❌" if fname in dark_set else "FAIL ❌"
+        else:
+            verdict = "PASS ✅"
         peak = f"{r['peak_db_decoded']:.2f} dBTP"
         lines.append(
-            f"| {r['filename']} | {peak} | {r['clip_count']} | {verdict} |"
+            f"| {fname} | {peak} | {r['clip_count']} | {verdict} |"
         )
 
     if clips_total > 0:
+        failing = [r for r in results if r.get("clips_found")]
+        fail_count = len(failing)
+        dark_fail_count = sum(1 for r in failing if r["filename"] in dark_set)
+        tightenable_fail_count = fail_count - dark_fail_count
+
         lines += [
             "",
             f"> ⚠️ **{clips_total} inter-sample peak(s) detected** across "
-            f"{sum(1 for r in results if r.get('clips_found'))} track(s). "
-            f"Tighten true-peak ceiling by 0.5 dB and re-master.",
+            f"{fail_count} track(s).",
         ]
+        if dark_fail_count == fail_count:
+            # All flagged tracks are dark — tightening would not help.
+            lines.append(
+                "> All flagged tracks are dark-content (high_mid band "
+                "energy < 10 %). Further limiter tightening cannot "
+                "improve ADM compliance on dark-content material — the "
+                "missing high-frequency energy is the root cause. "
+                "Consider harmonic excitation during polish, or accept "
+                "the flag and ship."
+            )
+        elif dark_fail_count > 0:
+            # Partial — some tightenable, some dark.
+            lines.append(
+                f"> {tightenable_fail_count} track(s) can be improved "
+                "by tightening the true-peak ceiling by 0.5 dB and "
+                "re-mastering."
+            )
+            lines.append(
+                f"> {dark_fail_count} track(s) are dark-content "
+                "casualties (labelled above). Tightening will not help; "
+                "consider harmonic excitation in polish or accept the "
+                "flag."
+            )
+        else:
+            # No dark casualties — standard recommendation.
+            lines.append(
+                "> Tighten true-peak ceiling by 0.5 dB and re-master."
+            )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary

Three observability bugs in the ADM warn-fallback surface, spotted when running the Plan A/B/C-fixed pipeline on a real album. All three fire on the same code path: every clipping track is dark-content on the first ADM check, so the loop short-circuits to warn-fallback without ever tightening or retrying.

### Bugs fixed

1. **Warning text vs reality mismatch.** Text said "clips persist on N track(s) after 5 retry cycle(s)" — but "5" was `_ADM_MAX_CYCLES`, not the actual executed count. On the all-dark short-circuit, zero retries ran. Now separates \`adm_cycles_executed\` (full ADM passes through the loop body) from \`adm_tightening_cycles\` (retries that fired), reports both, and uses different wording when no tightening was attempted: "all N tracks classified as dark-casualty on first ADM check; no tightening attempted".

2. **No per-track decision trace in the short-circuit path.** \`adm_history\` and \`track_ceilings\` were both empty in the warn-fallback stage output — operators couldn't see why each clipping track was left alone. Adds \`per_track_decisions\` dict with classification (\`dark_casualty\` / \`tightenable\`), outcome (\`not_tightened\` / \`diverged\` / \`floor_reached\` / \`tightened\`), reason, detection cycle, and final ceiling per clipping track.

3. **ADM_VALIDATION.md gave contradictory advice.** Rendered at \`_stage_adm_validation\` time with "Tighten true-peak ceiling by 0.5 dB and re-master" even when the orchestrator had already classified every failure as a dark casualty (tightening won't help). The renderer now takes a \`dark_casualty_filenames\` kwarg; \`_stage_adm_validation\` predicts the classification from \`ctx.dark_tracks ∩ clipping_filenames\` (deterministic — no re-render needed). Advice branches three ways: all-dark → harmonic-excitation guidance, partial → split by class, no-dark → existing recommendation.

## Backward compat

Non-short-circuit paths (clean albums, or mixed albums where tightening partially succeeds before falling back) keep the existing wording style with the additional accuracy — e.g., "after 2 tightening cycle(s) (3 ADM passes total)" instead of "after 5 cycle(s)". Existing regression tests updated their exact string matches to loose \`in\` substring matches during Plan B, so they continue to pass unchanged.

## Test plan

- [x] Extended \`tests/unit/mastering/test_master_album_dark_track_adm.py::test_all_dark_clipping_breaks_to_warn_fallback\` to cover cycle counts, per-track decisions, warning text, and sidecar content on the all-dark short-circuit.
- [x] New: \`tests/unit/mastering/test_adm_validation.py::test_render_adm_validation_markdown_all_dark_casualties\` and \`::test_render_adm_validation_markdown_mixed_casualties\` — unit coverage of the three advice branches.
- [x] \`make check\` green: ruff + bandit + mypy + 3725 pytest @ 85.32% coverage.

## Not in this PR

- Bug #4 from the halt report (1h 23min stall at \`coherence_correct\` on the 2026-04-21 02:30 run) — no repro data; deserves a tracking issue with the log.
- Bug #5 (ModuleNotFoundError from metadata stage on 2026-04-19) — already safe; \`tools/mastering/metadata.py\` does all mutagen imports lazily inside function bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)