### PR TITLE
fix: analyzer keys per-stem recs by canonical STEM_NAMES (unblocks excitation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Analyzer recommendations never reached polish** (root cause of
+  "9/10 dark_casualty" on Suno albums despite enabling
+  `adm_aware_excitation`). `analyze_mix_issues` keyed per-stem
+  analyses by raw WAV filename stem (`01-Vocals`, `lead_vocals`, …)
+  while `mix_track_stems` looked them up by canonical `STEM_NAMES`
+  category (`vocals`, `drums`, …) from `discover_stems`. Keys
+  never matched → `stem_recs = {}` → `overrides_applied: []` →
+  excitation (and every other analyzer rec) was silently dropped.
+  Bonus bug: `_analyze_one`'s
+  `MIX_PRESETS["defaults"][stem_name]["excitation_db_when_dark"]`
+  lookup also failed for the same reason, falling back to a
+  hardcoded 2.0 for every stem regardless of type. Fix: analyzer
+  now uses `discover_stems` to canonicalize before storing
+  results, matching what polish looks up.
 - ADM warn-fallback reporting was inaccurate when the loop
   short-circuited on the all-dark first check:
   - Warning text hardcoded `_ADM_MAX_CYCLES` (the configured max)

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -485,19 +485,37 @@ async def analyze_mix_issues(
 
     # If no root WAVs, check stems/ for per-track directories and analyze
     # every stem in each track (per-stem diagnostics).
+    #
+    # CRITICAL: key the per-stem analyses by the CANONICAL STEM_NAMES
+    # category (vocals, drums, ...) — not by the raw WAV filename stem.
+    # polish's `mix_track_stems` looks up `analyzer_recs[stem_name]` where
+    # stem_name is the canonical category from `discover_stems`. If the
+    # analyzer stored keys by filename stem (e.g. "01-Vocals"), polish
+    # would never match the lookup and `overrides_applied` would be empty
+    # even when the analyzer emitted recommendations (including the
+    # excitation_db rec that fixes dark-material ADM casualties).
     stems_mode = False
-    stem_track_map: list[tuple[str, list[Path]]] = []
+    # Per-track categorized stem list: (track_name, [(category, path), ...])
+    stem_track_map: list[tuple[str, list[tuple[str, Path]]]] = []
     if not wav_files:
         stems_dir = audio_dir / "stems"
         if stems_dir.is_dir():
+            from tools.mixing.mix_tracks import discover_stems
             track_dirs = sorted([d for d in stems_dir.iterdir() if d.is_dir()])
             for td in track_dirs:
-                stem_wavs = sorted([
-                    f for f in td.iterdir()
-                    if f.suffix.lower() == ".wav"
-                ])
-                if stem_wavs:
-                    stem_track_map.append((td.name, stem_wavs))
+                categorized = discover_stems(td)
+                if not categorized:
+                    continue
+                # Flatten: for each category, take the first file (multi-file
+                # categories like multiple drum stems share one analysis —
+                # polish combines them during processing).
+                entries: list[tuple[str, Path]] = []
+                for category, paths in categorized.items():
+                    path_list = [paths] if isinstance(paths, str) else list(paths)
+                    if path_list:
+                        entries.append((category, Path(path_list[0])))
+                if entries:
+                    stem_track_map.append((td.name, entries))
             if stem_track_map:
                 stems_mode = True
 
@@ -525,15 +543,18 @@ async def analyze_mix_issues(
 
     track_analyses: list[dict[str, Any]] = []
     if stems_mode:
-        for track_name, stem_wavs in stem_track_map:
+        for track_name, stem_entries in stem_track_map:
             stems_result: dict[str, dict[str, Any]] = {}
             track_issues: set[str] = set()
-            for stem_wav in stem_wavs:
-                stem_name = stem_wav.stem
+            for category, stem_wav in stem_entries:
+                # Pass the CATEGORY as stem_name so _analyze_one's
+                # MIX_PRESETS["defaults"][stem_name] lookup finds the
+                # per-stem config (e.g. vocals → excitation_db_when_dark
+                # 2.5, drums → 0.0) instead of falling back to defaults.
                 analysis = await loop.run_in_executor(
-                    None, _analyze_one, stem_wav, stem_name,
+                    None, _analyze_one, stem_wav, category,
                 )
-                stems_result[stem_name] = analysis
+                stems_result[category] = analysis
                 track_issues.update(
                     i for i in analysis["issues"] if i != "none_detected"
                 )

--- a/tests/unit/mixing/test_analyzer_canonical_stem_keys.py
+++ b/tests/unit/mixing/test_analyzer_canonical_stem_keys.py
@@ -1,0 +1,172 @@
+"""analyze_mix_issues must key per-stem analysis by canonical STEM_NAMES
+category (matching discover_stems' output), not by the raw WAV filename
+stem. Regression guard for the bridge bug between analyzer output and
+mix_track_stems' analyzer_recs lookup — previously keys didn't match,
+so overrides_applied was empty even when the analyzer emitted
+recommendations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+for p in (str(PROJECT_ROOT), str(SERVER_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+def _write_wav(path: Path, *, rate: int = 44100, seconds: float = 1.5) -> None:
+    """Write a minimal stereo WAV (white-noise-ish)."""
+    rng = np.random.default_rng(0)
+    n = int(seconds * rate)
+    data = (rng.standard_normal((n, 2)) * 0.05).astype(np.float64)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(str(path), data, rate, subtype="PCM_24")
+
+
+def _install_album(monkeypatch: pytest.MonkeyPatch, audio_path: Path,
+                   album_slug: str) -> None:
+    from handlers import _shared
+    fake_state = {
+        "albums": {
+            album_slug: {
+                "path": str(audio_path), "status": "In Progress", "tracks": {},
+            }
+        }
+    }
+
+    class _FakeCache:
+        def get_state(self):
+            return fake_state
+
+        def get_state_ref(self):
+            return fake_state
+
+    monkeypatch.setattr(_shared, "cache", _FakeCache())
+
+
+def test_analyzer_keys_stems_by_canonical_category(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """When stems are named like '01-Vocals.wav' / '02-Drums.wav',
+    analyze_mix_issues must still key the stems dict by canonical
+    STEM_NAMES categories ('vocals', 'drums'), not by the filename
+    stem ('01-Vocals', '02-Drums'). Otherwise mix_track_stems'
+    analyzer_recs lookup (which uses STEM_NAMES) finds nothing."""
+    from handlers.processing import _helpers as processing_helpers
+    from handlers.processing.mixing import analyze_mix_issues
+
+    album_slug = "canonical-key-test"
+    track_dir = tmp_path / "stems" / "01-mytrack"
+    _write_wav(track_dir / "01-Vocals.wav")
+    _write_wav(track_dir / "02-Drums.wav")
+    _write_wav(track_dir / "03-Bass.wav")
+    _write_wav(track_dir / "04-MysteryStem.wav")  # should route to "other"
+
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    def _fake_resolve(slug, subfolder=""):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(analyze_mix_issues(album_slug))
+
+    result = json.loads(result_json)
+    assert "error" not in result, (
+        f"Analyzer errored: {result.get('error')}"
+    )
+    tracks = result.get("tracks", [])
+    assert len(tracks) == 1
+    track = tracks[0]
+    assert track["track"] == "01-mytrack"
+    stems = track["stems"]
+    # Keys MUST be canonical categories from STEM_NAMES, not filename stems.
+    assert "vocals" in stems, (
+        f"Expected 'vocals' canonical key, got stems: {list(stems.keys())}"
+    )
+    assert "drums" in stems
+    assert "bass" in stems
+    assert "other" in stems  # MysteryStem falls through to other
+    # And the filename-based keys must NOT be present.
+    assert "01-Vocals" not in stems
+    assert "01-vocals" not in stems
+    assert "02-Drums" not in stems
+    assert "04-MysteryStem" not in stems
+
+
+def test_analyzer_recs_match_polish_stem_names(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """End-to-end: recs from the analyzer must be lookup-able by
+    mix_track_stems using STEM_NAMES. This is the full bridge regression."""
+    from handlers.processing import _helpers as processing_helpers
+    from handlers.processing.mixing import analyze_mix_issues
+    from tools.mixing.mix_tracks import STEM_NAMES
+
+    album_slug = "bridge-test"
+    track_dir = tmp_path / "stems" / "01-track"
+    _write_wav(track_dir / "lead_vocals.wav")
+    _write_wav(track_dir / "kick_drum.wav")
+
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    def _fake_resolve(slug, subfolder=""):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(analyze_mix_issues(album_slug))
+
+    result = json.loads(result_json)
+    tracks = result.get("tracks", [])
+    assert len(tracks) == 1
+    stems = tracks[0]["stems"]
+
+    # Every key in stems dict must be in STEM_NAMES — that's the
+    # contract polish relies on.
+    for key in stems.keys():
+        assert key in STEM_NAMES, (
+            f"Analyzer stored stem under non-canonical key {key!r}; "
+            f"polish won't find it. Valid keys: {STEM_NAMES}"
+        )
+
+
+def test_analyzer_multi_file_same_category_coalesces(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Multiple files in the same category (e.g., drums_kick.wav +
+    drums_snare.wav) land under a single 'drums' key. Analyzer should
+    produce one result per category — polish later combines the files
+    during processing."""
+    from handlers.processing import _helpers as processing_helpers
+    from handlers.processing.mixing import analyze_mix_issues
+
+    album_slug = "multi-file-cat"
+    track_dir = tmp_path / "stems" / "01-track"
+    _write_wav(track_dir / "drums_kick.wav")
+    _write_wav(track_dir / "drums_snare.wav")
+    _write_wav(track_dir / "drums_hats.wav")
+
+    _install_album(monkeypatch, tmp_path, album_slug)
+
+    def _fake_resolve(slug, subfolder=""):
+        return None, tmp_path
+
+    with patch.object(processing_helpers, "_resolve_audio_dir", _fake_resolve):
+        result_json = asyncio.run(analyze_mix_issues(album_slug))
+
+    result = json.loads(result_json)
+    stems = result["tracks"][0]["stems"]
+    # Only one "drums" entry; the three files all categorize to drums.
+    assert "drums" in stems
+    # No filename-stem keys leaked through.
+    for fname_stem in ("drums_kick", "drums_snare", "drums_hats"):
+        assert fname_stem not in stems


### PR DESCRIPTION
## Summary

Root cause of the \"9/10 dark_casualty, excitation never applied\" behavior despite \`adm_aware_excitation: true\` being set in your override preset.

## The bug

The analyzer and polish disagreed on how to key per-stem recommendations:

- \`analyze_mix_issues\` stored per-stem analyses under the **raw WAV filename stem** as the dict key — so a file named \`01-Vocals.wav\` got recs under key \`\"01-Vocals\"\`, \`lead_vocals.wav\` under \`\"lead_vocals\"\`, etc.
- \`mix_track_stems\` looked them up by the **canonical STEM_NAMES category** (via \`discover_stems\`) — \`\"vocals\"\`, \`\"drums\"\`, \`\"bass\"\`, etc.

Keys never matched. \`stem_recs\` was always empty. \`overrides_applied\` was always \`[]\`. Every analyzer recommendation — excitation_db, high_tame_db, mud_cut_db, noise_reduction, highpass_cutoff — was silently dropped. The Plan B analyzer-recs plumbing and the recent harmonic excitation feature both sat idle.

## Bonus bug found in the same place

\`_analyze_one\`'s \`MIX_PRESETS[\"defaults\"][stem_name][\"excitation_db_when_dark\"]\` lookup (line 400) used the same non-canonical \`stem_name\` and fell through to the hardcoded 2.0 fallback. That's why the user saw every stem get \`excitation_db: 2.0\` in manual analyzer output instead of the intended per-stem values (vocals 2.5, percussion/strings/woodwinds 2.0, guitar/keyboard/brass/synth 1.5, drums/bass 0.0).

## Fix

\`analyze_mix_issues\` now uses \`discover_stems\` (same categorization polish uses) to map WAV files to canonical categories BEFORE analysis. The per-stem analysis dict is keyed by category, and \`_analyze_one\` receives the category as its \`stem_name\` kwarg so its preset lookup finds the right per-stem config.

For multi-file categories (e.g., \`drums_kick.wav\` + \`drums_snare.wav\` + \`drums_hats.wav\`), the first file is analyzed — polish combines the files during processing anyway, so one representative analysis per category is correct.

## Test plan

- [x] New: \`tests/unit/mixing/test_analyzer_canonical_stem_keys.py\` (3 tests — canonical keys, bridge-match with STEM_NAMES, multi-file coalesce).
- [x] \`make check\` green: ruff + bandit + mypy + 3744 pytest @ 85.35% coverage.

## What you should see on your next polish run

With \`adm_aware_excitation: true\` in your override:
- \`overrides_applied\` populated per stem with entries like \`{parameter: \"excitation_db\", applied: 2.5, reason: \"already_dark\"}\`.
- Per-stem excitation values matching the preset (vocals 2.5, percussion 2.0, etc., not uniform 2.0).
- ADM casualties should drop significantly on the next master run if the material is genuinely dark-but-excitable. Tracks that are *extremely* dark (near-silent high-mid) may still flag — that's a DSP limit, not a pipeline bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)