### PR TITLE
fix(test): isolate analyzer thresholds test from user config

### DIFF
--- a/tests/unit/mixing/test_analyze_mix_issues.py
+++ b/tests/unit/mixing/test_analyze_mix_issues.py
@@ -15,9 +15,15 @@ if str(SERVER_DIR) not in sys.path:
     sys.path.insert(0, str(SERVER_DIR))
 
 
-def test_resolve_analyzer_thresholds_defaults():
+def test_resolve_analyzer_thresholds_defaults(monkeypatch):
     """With no preset overrides, resolver returns (0.10, 0.25, False)."""
+    import tools.mixing.mix_tracks as mix_tracks
     from handlers.processing.mixing import _resolve_analyzer_thresholds
+
+    # Stub load_mix_presets so the test doesn't read the host's
+    # ~/bitwize-music/overrides/mix-presets.yaml — see #360.
+    monkeypatch.setattr(mix_tracks, "load_mix_presets", lambda: {"defaults": {}})
+
     dark, harsh, adm_aware = _resolve_analyzer_thresholds()
     assert dark == pytest.approx(0.10)
     assert harsh == pytest.approx(0.25)


### PR DESCRIPTION
## Summary

- `test_resolve_analyzer_thresholds_defaults` was calling the resolver directly, which loads bundled presets and deep-merges `~/bitwize-music/overrides/mix-presets.yaml` on top. Hosts whose override sets `defaults.analyzer.adm_aware_excitation: true` saw the test fail even though the bundled defaults are correct.
- Stub `tools.mixing.mix_tracks.load_mix_presets` via `monkeypatch` so the test exercises the fallback path (analyzer block absent → `(0.10, 0.25, False)`).

Fixes #360

## Test plan

- [x] `pytest tests/unit/mixing/test_analyze_mix_issues.py` — all 5 pass with the override file still on disk
- [x] `make check` — ruff + bandit + mypy clean, 3768/3768 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)