### PR TITLE
fix(promo): album sampler fails every clip on default auto-extracted color (#369)

### DIFF
--- a/tests/unit/promotion/test_generate_album_sampler.py
+++ b/tests/unit/promotion/test_generate_album_sampler.py
@@ -1,5 +1,6 @@
 """Tests for tools/promotion/generate_album_sampler.py."""
 
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -236,6 +237,45 @@ class TestGenerateAlbumSampler:
             font_path="/tmp/font.ttf",
         )
         assert result is False
+
+    @patch.object(mod, "get_audio_duration", return_value=60.0)
+    @patch.object(mod, "concatenate_with_crossfade", return_value=True)
+    @patch.object(mod, "generate_clip", return_value=True)
+    @patch.object(mod, "find_best_segment", return_value=5.0)
+    @patch.object(mod, "extract_dominant_color", return_value=(201, 169, 110))
+    def test_auto_extracted_color_passes_downstream_validation(
+        self, _color, _seg, mock_clip, _concat, _dur, tmp_path
+    ):
+        """Auto-extracted wave color (no color_hex given) must be a format that
+        generate_waveform_video's validation accepts. Regression for #369:
+        rgb_to_hex returns ffmpeg-style '0x...', which the '^#?[0-9a-fA-F]{3,8}$'
+        validator rejects, failing every clip."""
+        # Same validation regex generate_waveform_video applies to color_hex.
+        validator = re.compile(r"^#?[0-9a-fA-F]{3,8}$")
+
+        tracks = tmp_path / "tracks"
+        tracks.mkdir()
+        (tracks / "01-track.wav").write_bytes(b"audio")
+        output = tmp_path / "out.mp4"
+        output.write_bytes(b"video")
+
+        mod.generate_album_sampler(
+            tracks_dir=tracks,
+            artwork_path=tmp_path / "art.png",
+            output_path=output,
+            font_path="/tmp/font.ttf",
+            # color_hex omitted -> auto-extract path
+        )
+
+        passed_color = mock_clip.call_args[1]["color_hex"]
+        assert not passed_color.startswith("0x"), (
+            f"auto-extracted color {passed_color!r} uses ffmpeg '0x' format that "
+            "downstream validation rejects"
+        )
+        assert validator.match(passed_color), (
+            f"auto-extracted color {passed_color!r} fails generate_waveform_video "
+            "validation, so every clip would be rejected"
+        )
 
     @patch.object(mod, "get_audio_duration", return_value=60.0)
     @patch.object(mod, "concatenate_with_crossfade", return_value=True)

--- a/tools/promotion/generate_album_sampler.py
+++ b/tools/promotion/generate_album_sampler.py
@@ -272,7 +272,11 @@ def generate_album_sampler(
         logger.info("Extracting colors from artwork...")
         dominant = extract_dominant_color(artwork_path)
         complementary = get_complementary_color(dominant)
-        color_hex = rgb_to_hex(complementary)
+        # rgb_to_hex returns ffmpeg-style "0x..."; convert to "#..." so the value
+        # passes generate_waveform_video's color_hex validation. ffmpeg's showwaves
+        # accepts both formats, but the validator (^#?[0-9a-fA-F]{3,8}$) rejects the
+        # "0x" prefix, which would otherwise fail every clip. (#369)
+        color_hex = "#" + rgb_to_hex(complementary)[2:]
         logger.debug("Auto-extracted color: %s", color_hex)
 
     # Create temp directory for clips


### PR DESCRIPTION
## Summary

Fixes #369 — the album sampler produced **zero clips and failed entirely** in its default (no `--color`) configuration.

When no color is supplied, `generate_album_sampler` auto-extracts a wave color via `rgb_to_hex()`, which returns ffmpeg's native `0x...` format (e.g. `0xc9a96e`). That value was passed downstream as the `color_hex` parameter into `generate_waveform_video`, whose injection-guard validator `^#?[0-9a-fA-F]{3,8}$` rejects the `0x` prefix. Result: every per-clip call returned `False` → "No clips generated!" → "Album sampler generation failed."

The standalone `generate_promo_video` auto-extract path is unaffected because it feeds the `0x` color straight to ffmpeg (which accepts it) without re-validating; only the sampler routes it back through the validated parameter.

## Fix

Convert the auto-extracted color from `0x...` to `#...` before passing it to `generate_clip`. ffmpeg's `showwaves` accepts both formats, so rendering is unchanged; the value now passes validation.

```python
color_hex = "#" + rgb_to_hex(complementary)[2:]
```

## Test

Added a regression test (`test_auto_extracted_color_passes_downstream_validation`) that drives the real auto-extract path and asserts the color handed to `generate_clip` satisfies the **same** regex `generate_waveform_video` enforces. It fails before the fix (`0x4b83eb`) and passes after. The pre-existing sampler tests all mocked `generate_clip`, which is why this slipped through.

## Verification

`make check` — 3772 passed, 2 xfailed; ruff + bandit + mypy clean; coverage 85%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)