### PR TITLE
fix: batch of default/common-path bugs (#370, #373, #374, #376)

### DIFF
--- a/servers/bitwize-music-server/handlers/gates.py
+++ b/servers/bitwize-music-server/handlers/gates.py
@@ -27,6 +27,38 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
+def _resolve_explicit_decision(file_text: str | None) -> tuple[bool, bool]:
+    """Return ``(is_set, value)`` for a track's Explicit flag from its raw file.
+
+    The cached ``explicit`` bool can't distinguish a deliberate "No" from the
+    unset template placeholder ("Yes / No") — both parse to ``False`` — so the
+    pre-generation gate inspects the raw track file instead. A decision counts
+    as *set* only when the Explicit table cell holds a recognized yes/no token
+    (not the placeholder) or frontmatter carries an explicit boolean. (#370)
+
+    Returns ``(False, False)`` when the flag is unset or the file is unavailable
+    so the gate fails closed.
+    """
+    if not file_text:
+        return False, False
+    # Reuse the canonical parsing helpers (other handlers import from
+    # tools.state.parsers the same way) so detection matches parse_track_file.
+    from tools.state.parsers import _extract_table_value, parse_frontmatter
+
+    raw = _extract_table_value(file_text, "Explicit")
+    if raw is not None:
+        token = raw.strip().lower()
+        if token in ("yes", "true"):
+            return True, True
+        if token in ("no", "false"):
+            return True, False
+        # Placeholder ("Yes / No"), dash, or blank → not a conscious decision.
+    fm = parse_frontmatter(file_text)
+    if "_error" not in fm and isinstance(fm.get("explicit"), bool):
+        return True, fm["explicit"]
+    return False, False
+
+
 def _check_pre_gen_gates_for_track(
     t_data: dict[str, Any], file_text: str | None, blocklist: list[dict[str, str]],
     max_lyric_words: int = 800,
@@ -102,15 +134,19 @@ def _check_pre_gen_gates_for_track(
         gates.append({"gate": "Pronunciation Resolved", "status": "SKIP",
                       "detail": "Track file not readable"})
 
-    # Gate 4: Explicit Flag Set
-    explicit = t_data.get("explicit")
-    if explicit is None:
+    # Gate 4: Explicit Flag Set — re-derived from the raw track file. The cached
+    # t_data["explicit"] is always a bool (the "Yes / No" template placeholder
+    # resolves to False), so it can't distinguish "unset" from a deliberate "No"
+    # and the old `explicit is None` check could never fire. Fails closed when
+    # the field is unset or the file is unreadable. (#370)
+    explicit_set, explicit_val = _resolve_explicit_decision(file_text)
+    if explicit_set:
+        gates.append({"gate": "Explicit Flag Set", "status": "PASS",
+                      "detail": f"Explicit: {'Yes' if explicit_val else 'No'}"})
+    else:
         gates.append({"gate": "Explicit Flag Set", "status": "FAIL", "severity": "BLOCKING",
                       "detail": "Explicit field not set — set to Yes or No before generating"})
         blocking += 1
-    else:
-        gates.append({"gate": "Explicit Flag Set", "status": "PASS",
-                      "detail": f"Explicit: {'Yes' if explicit else 'No'}"})
 
     # Gate 5: Style Prompt Complete
     style_content = None

--- a/tests/unit/mastering/test_build_effective_preset.py
+++ b/tests/unit/mastering/test_build_effective_preset.py
@@ -58,6 +58,42 @@ class TestBuildEffectivePreset:
         assert ep["compress_ratio"] == 1.5
         assert ep["cut_highmid"] == 0.0
 
+    def test_empty_genre_dither_follows_output_bits(self):
+        """Regression for #373: a genreless master must dither at output_bits.
+
+        _PRESET_DEFAULTS hardcodes dither_bits=16, and the genreless
+        effective_preset previously omitted dither_bits, so master_track
+        resolved output_bits=24 but dither_bits=16 — injecting a 16-bit noise
+        floor into a 24-bit file. The effective_preset must carry a dither_bits
+        that follows output_bits.
+        """
+        result = build_effective_preset(
+            genre="",
+            cut_highmid_arg=0.0,
+            cut_highs_arg=0.0,
+            target_lufs_arg=-14.0,
+            ceiling_db_arg=-1.0,
+        )
+        ep = result["effective_preset"]
+        assert "dither_bits" in ep, "genreless preset must set dither_bits explicitly"
+        assert ep["dither_bits"] == ep["output_bits"], (
+            f"dither_bits ({ep['dither_bits']}) must follow output_bits "
+            f"({ep['output_bits']}) for a genreless master"
+        )
+
+    def test_genre_preset_dither_follows_output_bits(self):
+        """A genre preset's effective_preset should also carry a dither_bits
+        consistent with output_bits (genre-presets.yaml sets dither_bits=24)."""
+        result = build_effective_preset(
+            genre="pop",
+            cut_highmid_arg=0.0,
+            cut_highs_arg=0.0,
+            target_lufs_arg=-14.0,
+            ceiling_db_arg=-1.0,
+        )
+        ep = result["effective_preset"]
+        assert ep["dither_bits"] == ep["output_bits"]
+
     def test_unknown_genre_returns_error(self):
         result = build_effective_preset(
             genre="not-a-real-genre",

--- a/tests/unit/mixing/test_excitation.py
+++ b/tests/unit/mixing/test_excitation.py
@@ -118,6 +118,27 @@ class TestHarmonicExcitation:
         assert post_small > pre
         assert post_large > post_small
 
+    @pytest.mark.parametrize("n_samples", [1, 5, 10, 15])
+    def test_short_stem_does_not_crash(self, n_samples):
+        """Stems shorter than sosfiltfilt's padlen (15) must not raise.
+
+        Regression for #374: sosfiltfilt requires len > padlen, so a 1-15
+        sample stem (e.g. a truncated export) raised ValueError and aborted
+        the whole mix when excitation was enabled. Such fragments have no
+        meaningful harmonic content, so the signal is returned unchanged.
+        """
+        data = np.ones((n_samples, 2), dtype=np.float64) * 0.1
+        out = apply_harmonic_excitation(data, 48000, amount_db=3.0)
+        assert out.shape == data.shape
+        assert np.array_equal(out, data)
+
+    def test_mono_short_stem_does_not_crash(self):
+        """1-D (mono) short stems must also be handled gracefully (#374)."""
+        data = np.ones(8, dtype=np.float64) * 0.1
+        out = apply_harmonic_excitation(data, 48000, amount_db=3.0)
+        assert out.shape == data.shape
+        assert np.array_equal(out, data)
+
     def test_no_nans_or_infs(self):
         data = _pink_stereo()
         out = apply_harmonic_excitation(data, 48000, amount_db=4.0)

--- a/tests/unit/state/test_handlers_gates.py
+++ b/tests/unit/state/test_handlers_gates.py
@@ -358,6 +358,34 @@ Stars are shining bright
 
 
 # =============================================================================
+# Track file builder for Explicit-flag gate tests (#370)
+# =============================================================================
+
+
+def _make_track_file(*, table=None, fm_explicit=None):
+    """Build a gate-complete track file with a configurable Explicit field.
+
+    table: value for the `| **Explicit** | <value> |` table row, or None to omit.
+    fm_explicit: value for a frontmatter `explicit:` key, or None to omit.
+    """
+    fm_line = f"\nexplicit: {fm_explicit}" if fm_explicit is not None else ""
+    table_block = f"\n| **Explicit** | {table} |\n" if table is not None else "\n"
+    return (
+        "---\n"
+        "title: Track\n"
+        f"status: In Progress{fm_line}\n"
+        "---\n"
+        f"{table_block}"
+        "## Lyrics Box\n\n"
+        "```\n[Verse 1]\nWalking down the road tonight\nStars are shining bright\n```\n\n"
+        "## Style Box\n\n"
+        "```\nupbeat electronic pop, 120 BPM\n```\n\n"
+        "## Pronunciation Notes\n\n"
+        "| Word | Phonetic | Note |\n| --- | --- | --- |\n| — | — | — |\n"
+    )
+
+
+# =============================================================================
 # Tests for _check_pre_gen_gates_for_track
 # =============================================================================
 
@@ -470,34 +498,57 @@ class TestGate3PronunciationResolved:
 
 
 class TestGate4ExplicitFlagSet:
-    """Gate 4: Explicit Flag Set."""
+    """Gate 4: Explicit Flag Set.
 
-    def test_explicit_none_fails(self):
-        t_data = {"sources_verified": "N/A", "explicit": None}
-        blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
-            t_data, TRACK_FILE_COMPLETE, blocklist=[],
-        )
-        explicit_gate = next(g for g in gates if g["gate"] == "Explicit Flag Set")
-        assert explicit_gate["status"] == "FAIL"
-        assert explicit_gate["severity"] == "BLOCKING"
+    The conscious Yes/No decision is re-derived from the raw track file, not the
+    cached `explicit` bool — which can't distinguish a deliberate "No" from the
+    unset template placeholder ("Yes / No"), so it could never block. (#370)
+    The t_data["explicit"] value is deliberately set to the *opposite* of the
+    file in these tests to prove the cache no longer drives the gate.
+    """
 
-    def test_explicit_false_passes(self):
-        t_data = {"sources_verified": "N/A", "explicit": False}
-        blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
-            t_data, TRACK_FILE_COMPLETE, blocklist=[],
+    def _explicit_gate(self, file_text, cached_explicit=False):
+        t_data = {"sources_verified": "N/A", "explicit": cached_explicit}
+        _b, _w, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, file_text, blocklist=[],
         )
-        explicit_gate = next(g for g in gates if g["gate"] == "Explicit Flag Set")
-        assert explicit_gate["status"] == "PASS"
-        assert "No" in explicit_gate["detail"]
+        return next(g for g in gates if g["gate"] == "Explicit Flag Set")
 
-    def test_explicit_true_passes(self):
-        t_data = {"sources_verified": "N/A", "explicit": True}
-        blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
-            t_data, TRACK_FILE_COMPLETE, blocklist=[],
-        )
-        explicit_gate = next(g for g in gates if g["gate"] == "Explicit Flag Set")
-        assert explicit_gate["status"] == "PASS"
-        assert "Yes" in explicit_gate["detail"]
+    def test_template_placeholder_fails(self):
+        """The shipped '| Explicit | Yes / No |' placeholder is unset and must
+        block — the bug was that it silently passed as 'No'."""
+        gate = self._explicit_gate(_make_track_file(table="Yes / No"), cached_explicit=False)
+        assert gate["status"] == "FAIL"
+        assert gate["severity"] == "BLOCKING"
+
+    def test_table_no_passes(self):
+        gate = self._explicit_gate(_make_track_file(table="No"), cached_explicit=True)
+        assert gate["status"] == "PASS"
+        assert "No" in gate["detail"]
+
+    def test_table_yes_passes(self):
+        gate = self._explicit_gate(_make_track_file(table="Yes"), cached_explicit=False)
+        assert gate["status"] == "PASS"
+        assert "Yes" in gate["detail"]
+
+    def test_frontmatter_bool_passes(self):
+        # No table row; frontmatter explicit: false is a conscious decision.
+        gate = self._explicit_gate(_make_track_file(fm_explicit="false"), cached_explicit=True)
+        assert gate["status"] == "PASS"
+        assert "No" in gate["detail"]
+
+    def test_missing_field_fails(self):
+        """No Explicit table row and no frontmatter key — unset, must block."""
+        gate = self._explicit_gate(_make_track_file(), cached_explicit=False)
+        assert gate["status"] == "FAIL"
+        assert gate["severity"] == "BLOCKING"
+
+    def test_unreadable_file_fails_closed(self):
+        """A content-safety gate must block when the decision can't be
+        confirmed (file unreadable)."""
+        gate = self._explicit_gate(None, cached_explicit=False)
+        assert gate["status"] == "FAIL"
+        assert gate["severity"] == "BLOCKING"
 
 
 class TestGate5StylePromptComplete:
@@ -669,10 +720,11 @@ class TestBlockingAggregation:
         assert blocking == 0
 
     def test_multiple_failures_accumulate(self):
-        """Track with sources pending + no explicit flag = at least 2 blocking."""
-        t_data = {"sources_verified": "Pending", "explicit": None}
+        """Track with sources pending + unset explicit flag = at least 2 blocking."""
+        t_data = {"sources_verified": "Pending", "explicit": False}
+        # Placeholder Explicit field is unset, so the explicit gate also blocks.
         blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
-            t_data, TRACK_FILE_COMPLETE, blocklist=[],
+            t_data, _make_track_file(table="Yes / No"), blocklist=[],
         )
         assert blocking >= 2
 

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -600,6 +600,29 @@ class TestBuildConfigSection:
         assert section['artist_name'] == ''
         assert section['config_mtime'] == 0.0
 
+    def test_none_valued_sections_do_not_crash(self, monkeypatch):
+        """Empty YAML section headers parse to None, not {}.
+
+        Regression for #376: `paths:` with nothing indented under it yields
+        {'paths': None}, and config.get('paths', {}) returns None (the key
+        exists), so paths.get(...) raised AttributeError and aborted every
+        cache rebuild/update. None-valued sections must be treated as empty.
+        """
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        config = {
+            'paths': None,
+            'artist': None,
+            'database': None,
+            'generation': None,
+        }
+        section = build_config_section(config)
+        assert section['artist_name'] == ''
+        assert section['content_root'] == str(Path('.').resolve())
+        assert section['database']['enabled'] is False
+        assert section['generation']['service'] == 'suno'
+
 
 @pytest.mark.unit
 class TestReadConfig:

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -4304,14 +4304,16 @@ class TestRunPreGenerationGates:
         lyrics_gate = next(g for g in track["gates"] if g["gate"] == "Lyrics Reviewed")
         assert lyrics_gate["status"] == "FAIL"
 
-    def test_explicit_flag_true_passes(self, tmp_path):
-        """Track with explicit=True should pass the Explicit Flag gate."""
+    def test_explicit_flag_yes_passes(self, tmp_path):
+        """Track whose file sets Explicit to Yes passes the Explicit Flag gate."""
         track_file = tmp_path / "05-explicit.md"
-        track_file.write_text(_TRACK_ALL_GATES_PASS)
+        track_file.write_text(
+            _TRACK_ALL_GATES_PASS.replace("| **Explicit** | No |", "| **Explicit** | Yes |")
+        )
         state = _fresh_state()
         state["albums"]["test-album"]["tracks"]["05-explicit"] = {
             "path": str(track_file), "title": "Explicit Track",
-            "status": "In Progress", "explicit": True,
+            "status": "In Progress", "explicit": False,  # cache value must not drive the gate
             "sources_verified": "Verified",
         }
         mock_cache = MockStateCache(state)
@@ -4322,14 +4324,16 @@ class TestRunPreGenerationGates:
         assert explicit_gate["status"] == "PASS"
         assert "Yes" in explicit_gate["detail"]
 
-    def test_explicit_flag_none_blocks(self, tmp_path):
-        """Track with explicit=None should BLOCK for Explicit Flag gate."""
+    def test_explicit_flag_placeholder_blocks(self, tmp_path):
+        """Track whose file leaves the 'Yes / No' placeholder blocks (#370)."""
         track_file = tmp_path / "05-no-explicit.md"
-        track_file.write_text(_TRACK_ALL_GATES_PASS)
+        track_file.write_text(
+            _TRACK_ALL_GATES_PASS.replace("| **Explicit** | No |", "| **Explicit** | Yes / No |")
+        )
         state = _fresh_state()
         state["albums"]["test-album"]["tracks"]["05-no-explicit"] = {
             "path": str(track_file), "title": "No Explicit Track",
-            "status": "In Progress", "explicit": None,
+            "status": "In Progress", "explicit": False,  # cache says False, but flag is unset
             "sources_verified": "Verified",
         }
         mock_cache = MockStateCache(state)
@@ -4739,11 +4743,12 @@ class TestPreGenGateEnforcementInUpdateTrackField:
             )))
         assert result["success"] is True
 
-    def test_generated_blocked_explicit_none(self, tmp_path):
-        """Status→Generated blocked when explicit flag is None (gate 4)."""
+    def test_generated_blocked_explicit_unset(self, tmp_path):
+        """Status→Generated blocked when the Explicit flag is unset (gate 4, #370)."""
         mock_cache, _ = self._make_cache_with_track(
-            tmp_path, _TRACK_ALL_GATES_PASS,
-            sources_verified="Verified", explicit=None,
+            tmp_path,
+            _TRACK_ALL_GATES_PASS.replace("| **Explicit** | No |", "| **Explicit** | Yes / No |"),
+            sources_verified="Verified", explicit=False,
         )
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_text_analysis_mod, "_artist_blocklist_cache", None):

--- a/tools/mastering/config.py
+++ b/tools/mastering/config.py
@@ -290,6 +290,11 @@ def build_effective_preset(
         **(preset_dict or {}),
         "target_lufs": effective_lufs,
         "output_bits": targets["output_bits"],
+        # dither_bits follows output_bits unless a genre preset overrides it.
+        # Without this, a genreless master (preset_dict is None) inherits the
+        # _PRESET_DEFAULTS dither_bits=16 in master_track while output_bits
+        # resolves to 24, dithering a 24-bit file to a 16-bit noise floor. (#373)
+        "dither_bits": (preset_dict or {}).get("dither_bits", targets["output_bits"]),
         "output_sample_rate": targets["output_sample_rate"],
         "cut_highmid": effective_highmid,
         "cut_highs": effective_highs,

--- a/tools/mixing/excitation.py
+++ b/tools/mixing/excitation.py
@@ -85,6 +85,14 @@ def apply_harmonic_excitation(
     # High-pass both signals at the lower excitation band boundary.
     # Using sosfiltfilt (zero-phase) to avoid phase delay artifacts.
     sos_hp = signal.butter(4, low / nyq, btype="high", output="sos")
+    # sosfiltfilt pads each edge by padlen samples (default 3*(2*n_sections+1)
+    # = 15 for this 4th-order filter) and requires len(signal) > padlen. Very
+    # short stem fragments (1-15 samples, e.g. a truncated export) carry no
+    # meaningful harmonic content; return them unchanged instead of raising
+    # ValueError and aborting the whole mix. (#374)
+    min_len = 3 * (2 * sos_hp.shape[0] + 1)
+    if data.shape[0] <= min_len:
+        return data
     hp_saturated = signal.sosfiltfilt(sos_hp, saturated, axis=0)
     hp_original = signal.sosfiltfilt(sos_hp, data, axis=0)
 

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -155,8 +155,12 @@ def get_config_mtime() -> float:
 
 def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     """Build the config section of state.json."""
-    paths = config.get('paths', {})
-    artist = config.get('artist', {})
+    # An empty YAML section header (e.g. `paths:` with nothing under it) parses
+    # to None, not {}. config.get('paths', {}) returns that None (the key
+    # exists), so `... or {}` is required to normalize None-valued sections —
+    # otherwise .get() on None aborts every cache rebuild/update. (#376)
+    paths = config.get('paths') or {}
+    artist = config.get('artist') or {}
 
     content_root_raw = paths.get('content_root', '.')
     content_root = str(resolve_path(content_root_raw))
@@ -166,7 +170,7 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     overrides_dir = str(resolve_path(overrides_raw)) if overrides_raw else str(Path(content_root) / 'overrides')
 
     # Database config (expose enabled flag, mask credentials)
-    db_config = config.get('database', {})
+    db_config = config.get('database') or {}
     database_section = {
         'enabled': bool(db_config.get('enabled', False)),
         'host': db_config.get('host', '') if db_config.get('enabled') else '',
@@ -174,7 +178,7 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     }
 
     # Generation config (service settings and gates)
-    gen_config = config.get('generation', {})
+    gen_config = config.get('generation') or {}
     additional_genres_raw = gen_config.get('additional_genres', [])
     generation_section = {
         'service': gen_config.get('service', 'suno'),


### PR DESCRIPTION
Batch of four verified default-/common-path bug fixes from the triage of the open `bug` backlog. Each is its own commit with a regression test written test-first (RED → GREEN).

## Fixes

### #373 — genreless masters dithered to a 16-bit noise floor 🟠
`build_effective_preset` omitted `dither_bits` when no genre was supplied, so `master_track` resolved `output_bits=24` but inherited `dither_bits=16` from `_PRESET_DEFAULTS` — injecting ~48 dB louder TPDF dither into every genreless 24-bit deliverable. Now `dither_bits` follows `output_bits` (honoring the documented invariant), preserving any genre-preset override.

### #374 — harmonic excitation crashed on sub-padlen stems 🟠
`sosfiltfilt` requires `len > padlen` (15 for the 4th-order Butterworth). A 1–15 sample stem (e.g. a truncated export) raised `ValueError` and aborted the whole stem-mix run whenever excitation was enabled. Such fragments are now returned unchanged; the minimum length is derived from the SOS section count.

### #376 — None-valued config sections crashed every cache build 🟠
An empty YAML section header (`paths:` with nothing under it) parses to `{'paths': None}`, and `config.get('paths', {})` returns that `None`, so `.get()` on it raised `AttributeError` and aborted every `rebuild`/`update`. Normalized `paths`/`artist`/`database`/`generation` with `config.get(name) or {}`.

### #370 — explicit-flag pre-generation gate was dead code 🟠
Gate 4 checked `t_data.get("explicit") is None`, but the state producer always normalizes `explicit` to a bool (the `Yes / No` template placeholder resolves to `False`), so the FAIL branch could never fire — a track with no conscious explicit decision silently passed as "Explicit: No" to generation/release. The gate now re-derives the decision from the raw track file (already passed in as `file_text`): set only when the Explicit table cell holds a real Yes/No token (not the placeholder) or frontmatter carries an explicit boolean. **Fails closed** when unset or unreadable. The old tests drove the gate via an artificial `explicit=None` cache value that never occurs in real state; they're rewritten to exercise the real file-based contract.

## Verification

`make check` — 3782 passed, 2 xfailed; ruff + bandit + mypy clean; coverage 85%.

Closes #373, closes #374, closes #376, closes #370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)