### PR TITLE
fix(state): null/non-string README title crashes the entire cache rebuild (#377)

### DIFF
--- a/tests/unit/state/test_parsers.py
+++ b/tests/unit/state/test_parsers.py
@@ -186,6 +186,41 @@ class TestParseAlbumReadme:
         # Malformed value must not crash and must not poison downstream code.
         assert result.get("anchor_track") is None
 
+    def test_null_title_falls_back_to_heading(self, tmp_path):
+        """A blank `title:` (YAML null) must not crash the parser (#377).
+
+        fm.get('title', '') returns the present None value, so the old
+        `.strip()` raised AttributeError and aborted the whole cache rebuild.
+        It must fall back to the H1 heading instead.
+        """
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            '---\n'
+            'title:\n'
+            '---\n'
+            '# My Album\n'
+            '## Album Details\n'
+            '| **Status** | Concept |\n'
+        )
+        result = parse_album_readme(readme)
+        assert '_error' not in result
+        assert result['title'] == 'My Album'
+
+    def test_numeric_title_does_not_crash(self, tmp_path):
+        """An unquoted numeric `title:` (YAML int) must not crash (#377)."""
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            '---\n'
+            'title: 2024\n'
+            '---\n'
+            '# Fallback Heading\n'
+            '## Album Details\n'
+            '| **Status** | Concept |\n'
+        )
+        result = parse_album_readme(readme)
+        assert '_error' not in result
+        assert result['title'] == '2024'
+
 
 class TestParseTrackFile:
     """Tests for parse_track_file()."""

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -160,7 +160,15 @@ def parse_album_readme(path: Path) -> dict[str, Any]:
         result['_warning'] = fm['_error']
         fm = {}
 
-    result['title'] = fm.get('title', '').strip('"').strip("'") or _extract_heading(text)
+    # fm.get('title', '') returns the present value even when it is null or a
+    # non-string scalar (`title:` → None, `title: 2024` → int), so .strip() on
+    # it raised AttributeError and aborted the whole cache rebuild. Coerce via
+    # str() and short-circuit on falsy values, mirroring parse_track_file. (#377)
+    fm_title = fm.get('title')
+    if fm_title:
+        result['title'] = str(fm_title).strip('"').strip("'") or _extract_heading(text)
+    else:
+        result['title'] = _extract_heading(text)
     result['release_date'] = fm.get('release_date') or None
     result['explicit'] = fm.get('explicit', False)
 


### PR DESCRIPTION
## Summary

Fixes #377 — a single malformed album `README.md` could take down the **whole** state cache, breaking `rebuild_state`, `list_albums`, and **session start**.

`parse_album_readme` resolved the title with:

```python
result['title'] = fm.get('title', '').strip('"').strip("'") or _extract_heading(text)
```

The `''` default only fires when the `title` key is **absent**. If it's present but null (`title:` → YAML `None`) or an unquoted scalar (`title: 2024` → `int`), `fm.get(...)` returns that value and `.strip()` raises `AttributeError`. That call is outside the file-read `try/except`, and callers (`scan_albums`) only check for an `'_error'` key — so the exception propagates and **aborts the entire cache rebuild**. One blank or numeric README title makes the cache unbuildable.

## Fix

Coerce via `str()` and short-circuit on falsy values, falling back to the H1 heading — mirroring the guard already in the sibling `parse_track_file`:

```python
fm_title = fm.get('title')
if fm_title:
    result['title'] = str(fm_title).strip('"').strip("'") or _extract_heading(text)
else:
    result['title'] = _extract_heading(text)
```

- `title:` (null) → falls back to the `# Heading`
- `title: 2024` (int) → `"2024"` (no crash)
- valid/empty strings → unchanged behavior

## Tests

Two regression tests (null title → heading fallback; numeric title → no crash). Both fail with `AttributeError` before the fix, pass after.

## Verification

`make check` — 3773 passed, 2 xfailed; ruff + bandit + mypy clean; coverage 85%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)