### PR TITLE
fix(mastering): sanitize non-finite LUFS so analyze_audio emits valid JSON (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **`analyze_audio` no longer emits invalid JSON for silent tracks** (#371). A
+  fully/near-silent WAV made `analyze_track` return `-inf` LUFS (and `nan`
+  dynamic range), which poisoned `avg_lufs`/`lufs_range` and serialized as the
+  invalid tokens `Infinity`/`-Infinity`/`NaN` — rejected by strict parsers (JS
+  `JSON.parse`, the MCP client), so the whole album response failed to parse.
+  Fixed at two layers: `_safe_json` now sanitizes non-finite floats to `null`
+  (protects every MCP tool, mirroring `JSON.stringify(Infinity) === "null"`),
+  and `analyze_audio` computes its summary over finite LUFS only, reporting
+  silent tracks in a new `summary.silent_tracks` field plus a recommendation
+  instead of a nonsensical "Average LUFS is -inf".
+
 ## [0.92.0] - 2026-06-01
 
 ### Changed

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -7,6 +7,7 @@ module's ``register()`` function is called.
 from __future__ import annotations
 
 import json
+import math
 import re
 from pathlib import Path
 from typing import Any
@@ -123,15 +124,43 @@ def _normalize_slug(name: str) -> str:
     return slug
 
 
+def _json_sanitize(value: Any) -> Any:
+    """Recursively replace non-finite floats (inf/-inf/nan) with None.
+
+    json.dumps emits the literal tokens ``Infinity``/``-Infinity``/``NaN``
+    for these by default (allow_nan=True), and ``default=`` never fires for
+    floats (only for non-serializable *types*). Those tokens are invalid per
+    the JSON spec and are rejected by strict parsers — JavaScript
+    ``JSON.parse`` and the MCP client — so a single non-finite float (e.g. a
+    silent track's -inf LUFS) corrupts the entire response. ``null`` is the
+    standard JS replacement (``JSON.stringify(Infinity) === "null"``).
+
+    numpy float64 is a subclass of ``float``, so the ``isinstance`` check
+    covers the values produced by the mastering/analysis tools.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _json_sanitize(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_sanitize(v) for v in value]
+    return value
+
+
 def _safe_json(data: Any) -> str:
     """Serialize data to JSON with error fallback.
 
-    If json.dumps() fails (e.g., circular references, non-serializable types),
-    returns a JSON error object instead of crashing.
+    Non-finite floats are sanitized to ``null`` first (see _json_sanitize)
+    so the output is always valid JSON for strict parsers. If json.dumps()
+    still fails (e.g., circular references, non-serializable types), returns
+    a JSON error object instead of crashing.
     """
     try:
-        return json.dumps(data, default=str)
-    except (TypeError, ValueError, OverflowError) as e:
+        return json.dumps(_json_sanitize(data), default=str)
+    except (TypeError, ValueError, OverflowError, RecursionError) as e:
+        # RecursionError: _json_sanitize walks the structure before dumps, so a
+        # circular reference trips it here rather than as the ValueError that
+        # json.dumps would otherwise raise. Catch it to keep the no-crash contract.
         return json.dumps({"error": f"JSON serialization failed: {e}"})
 
 

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -365,6 +365,8 @@ async def _stage_analysis(ctx: MasterAlbumCtx) -> str | None:
     Sets ctx:  analysis_results (also appends to ctx.warnings for tinny tracks)
     Returns: None always (analysis never halts the pipeline).
     """
+    import math
+
     import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
 
@@ -373,19 +375,38 @@ async def _stage_analysis(ctx: MasterAlbumCtx) -> str | None:
         result = await ctx.loop.run_in_executor(None, analyze_track, str(wav))
         analysis_results.append(result)
 
-    lufs_values = [r["lufs"] for r in analysis_results]
-    avg_lufs = float(np.mean(lufs_values))
-    lufs_range = float(max(lufs_values) - min(lufs_values))
+    # A silent / near-silent track makes analyze_track return -inf LUFS, which
+    # poisons the np.mean / max-min aggregates with non-finite values (the same
+    # class of bug as #371 in analyze_audio). Aggregate over finite LUFS only,
+    # and surface silent tracks so the operator isn't left with null aggregates
+    # under a "pass" status. (Silent tracks are skipped later in
+    # _stage_mastering, so no mastering-side action is needed here.)
+    finite_lufs = [
+        r["lufs"] for r in analysis_results
+        if isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"])
+    ]
+    silent_tracks = [
+        r["filename"] for r in analysis_results
+        if not (isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"]))
+    ]
+    avg_lufs = float(np.mean(finite_lufs)) if finite_lufs else None
+    lufs_range = float(max(finite_lufs) - min(finite_lufs)) if finite_lufs else None
     tinny_tracks = [r["filename"] for r in analysis_results if r["tinniness_ratio"] > 0.6]
 
     for t in tinny_tracks:
         ctx.warnings.append(f"Pre-master: {t} — tinny (high-mid spike)")
+    for s in silent_tracks:
+        ctx.warnings.append(
+            f"Pre-master: {s} — silent/unmeasurable (no valid LUFS); "
+            f"will be skipped during mastering"
+        )
 
     ctx.stages["analysis"] = {
         "status": "pass",
-        "avg_lufs": round(avg_lufs, 1),
-        "lufs_range": round(lufs_range, 1),
+        "avg_lufs": round(avg_lufs, 1) if avg_lufs is not None else None,
+        "lufs_range": round(lufs_range, 1) if lufs_range is not None else None,
         "tinny_tracks": tinny_tracks,
+        "silent_tracks": silent_tracks,
     }
     ctx.analysis_results = analysis_results
 

--- a/servers/bitwize-music-server/handlers/processing/audio.py
+++ b/servers/bitwize-music-server/handlers/processing/audio.py
@@ -74,15 +74,29 @@ async def analyze_audio(album_slug: str, subfolder: str = "") -> str:
         result = await loop.run_in_executor(None, analyze_track, str(wav))
         results.append(result)
 
-    # Build summary
+    # Build summary. A silent / near-silent track makes analyze_track return
+    # -inf LUFS (pyln.Meter.integrated_loudness never skips it, unlike
+    # master_track). Aggregating over -inf poisons avg_lufs/lufs_range with
+    # non-finite values and emits a nonsensical "Average LUFS is -inf"
+    # recommendation, so compute only over finite LUFS and report the silent
+    # tracks separately (mirrors master_audio's np.isfinite guard). See #371.
+    import math
+
     import numpy as np
-    lufs_values = [r["lufs"] for r in results]
-    avg_lufs = float(np.mean(lufs_values))
-    lufs_range = float(max(lufs_values) - min(lufs_values))
+    finite_lufs = [
+        r["lufs"] for r in results
+        if isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"])
+    ]
+    silent_tracks = [
+        r["filename"] for r in results
+        if not (isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"]))
+    ]
+    avg_lufs = float(np.mean(finite_lufs)) if finite_lufs else None
+    lufs_range = float(max(finite_lufs) - min(finite_lufs)) if finite_lufs else None
     tinny_tracks = [r["filename"] for r in results if r["tinniness_ratio"] > 0.6]
 
     recommendations = []
-    if lufs_range > 2.0:
+    if lufs_range is not None and lufs_range > 2.0:
         recommendations.append(
             f"LUFS range is {lufs_range:.1f} dB — target < 2 dB for album consistency."
         )
@@ -90,9 +104,14 @@ async def analyze_audio(album_slug: str, subfolder: str = "") -> str:
         recommendations.append(
             f"Tinny tracks needing high-mid EQ cut (2-6kHz): {', '.join(tinny_tracks)}"
         )
-    if avg_lufs < -16:
+    if avg_lufs is not None and avg_lufs < -16:
         recommendations.append(
             f"Average LUFS is {avg_lufs:.1f} — consider boosting toward -14 LUFS for streaming."
+        )
+    if silent_tracks:
+        recommendations.append(
+            "Silent or unmeasurable tracks (no valid LUFS): "
+            f"{', '.join(silent_tracks)}. Check for failed renders or empty files."
         )
 
     return _safe_json({
@@ -102,6 +121,7 @@ async def analyze_audio(album_slug: str, subfolder: str = "") -> str:
             "avg_lufs": avg_lufs,
             "lufs_range": lufs_range,
             "tinny_tracks": tinny_tracks,
+            "silent_tracks": silent_tracks,
         },
         "recommendations": recommendations,
     })

--- a/tests/unit/mastering/test_stage_analysis_silent_tracks.py
+++ b/tests/unit/mastering/test_stage_analysis_silent_tracks.py
@@ -1,0 +1,87 @@
+"""_stage_analysis (the master_album pre-flight analysis stage) must not let
+a silent track's -inf LUFS poison its aggregates or hide the silent track
+from the operator.
+
+Parallel-site regression for issue #371: analyze_audio was fixed to filter
+non-finite LUFS, but _stage_analysis in the master_album pipeline carried the
+same unguarded ``np.mean`` / ``max-min`` aggregation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def _write_silent(path: Path, seconds: float = 3.0, rate: int = 48000) -> None:
+    sf.write(str(path), np.zeros((int(seconds * rate), 2), dtype="float32"), rate)
+
+
+def _write_normal(path: Path, seconds: float = 3.0, rate: int = 48000) -> None:
+    rng = np.random.default_rng(7)
+    n = int(seconds * rate)
+    data = (rng.standard_normal((n, 2)) * 0.1).astype(np.float64)
+    sf.write(str(path), data, rate, subtype="PCM_24")
+
+
+def _run_stage(source_dir: Path):
+    from handlers.processing._album_stages import MasterAlbumCtx, _stage_analysis
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    ctx = MasterAlbumCtx(
+        album_slug="test", genre="pop", target_lufs=-14.0, ceiling_db=-1.0,
+        cut_highmid=0.0, cut_highs=0.0, source_subfolder="",
+        freeze_signature=False, new_anchor=False, loop=loop,
+        source_dir=source_dir, wav_files=sorted(source_dir.glob("*.wav")),
+    )
+    try:
+        loop.run_until_complete(_stage_analysis(ctx))
+    finally:
+        loop.close()
+    return ctx
+
+
+def test_silent_track_does_not_poison_analysis_aggregates(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    _write_normal(source_dir / "01-normal.wav")
+    _write_silent(source_dir / "02-silent.wav")
+
+    ctx = _run_stage(source_dir)
+    analysis = ctx.stages["analysis"]
+
+    # Aggregates computed over the finite (non-silent) track only.
+    assert analysis["avg_lufs"] is not None
+    assert math.isfinite(analysis["avg_lufs"])
+    assert analysis["lufs_range"] is not None
+    assert math.isfinite(analysis["lufs_range"])
+    # The silent track is surfaced to the operator, not hidden under "pass".
+    assert "02-silent.wav" in analysis["silent_tracks"]
+    assert any("02-silent.wav" in w for w in ctx.warnings)
+
+
+def test_all_silent_analysis_yields_none_aggregates(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    _write_silent(source_dir / "01-silent.wav")
+    _write_silent(source_dir / "02-silent.wav")
+
+    # Must not raise — None aggregates require a round() guard.
+    ctx = _run_stage(source_dir)
+    analysis = ctx.stages["analysis"]
+    assert analysis["avg_lufs"] is None
+    assert analysis["lufs_range"] is None
+    assert len(analysis["silent_tracks"]) == 2

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -338,6 +338,20 @@ class TestNormalizeSlug:
 # =============================================================================
 
 
+def _strict_json_loads(raw: str):
+    """json.loads that rejects Infinity/-Infinity/NaN like a strict parser.
+
+    Python's json.loads is lenient and silently accepts these non-finite
+    tokens, which is exactly why issue #371 slipped past the existing
+    tests. Strict consumers (JS JSON.parse, the MCP client) reject them.
+    ``parse_constant`` fires only for those three tokens.
+    """
+    def _reject(token: str) -> float:
+        raise AssertionError(f"invalid non-finite JSON token emitted: {token!r}")
+
+    return json.loads(raw, parse_constant=_reject)
+
+
 class TestSafeJson:
     """Tests for the _safe_json() helper function."""
 
@@ -415,6 +429,57 @@ class TestSafeJson:
         result = json.loads(server._safe_json(data))
         assert result["flag"] is True
         assert result["other"] is False
+
+    def test_non_finite_floats_become_null(self):
+        """inf/-inf/nan must serialize as null, not invalid JSON tokens.
+
+        json.dumps emits the literal tokens Infinity/-Infinity/NaN by
+        default; these are invalid per the JSON spec and rejected by
+        strict parsers. _safe_json must replace them with null
+        (JSON.stringify(Infinity) === "null"). Regression test for #371.
+        """
+        data = {
+            "pos": float("inf"),
+            "neg": float("-inf"),
+            "nan": float("nan"),
+            "ok": -14.5,
+        }
+        result = _strict_json_loads(server._safe_json(data))
+        assert result["pos"] is None
+        assert result["neg"] is None
+        assert result["nan"] is None
+        assert result["ok"] == -14.5
+
+    def test_non_finite_nested_in_list_and_dict(self):
+        """Sanitization must recurse into nested lists and dicts."""
+        data = {
+            "tracks": [
+                {"lufs": float("-inf"), "peak_db": -0.5},
+                {"lufs": -14.0, "dynamic_range": float("nan")},
+            ],
+            "summary": {"avg_lufs": float("-inf")},
+        }
+        result = _strict_json_loads(server._safe_json(data))
+        assert result["tracks"][0]["lufs"] is None
+        assert result["tracks"][0]["peak_db"] == -0.5
+        assert result["tracks"][1]["lufs"] == -14.0
+        assert result["tracks"][1]["dynamic_range"] is None
+        assert result["summary"]["avg_lufs"] is None
+
+    def test_numpy_non_finite_becomes_null(self):
+        """numpy float64 inf/nan (the real runtime type) is also sanitized."""
+        import numpy as np
+
+        data = {"lufs": np.float64("-inf"), "x": np.float64(2.5)}
+        result = _strict_json_loads(server._safe_json(data))
+        assert result["lufs"] is None
+        assert result["x"] == 2.5
+
+    def test_finite_floats_unchanged(self):
+        """Regression: finite floats still round-trip unchanged."""
+        data = {"a": 1.5, "b": -14.0, "c": 0.0}
+        result = _strict_json_loads(server._safe_json(data))
+        assert result == data
 
 
 # =============================================================================
@@ -12343,6 +12408,77 @@ class TestAnalyzeAudioComprehensive:
             result = json.loads(_run(server.analyze_audio("test-album")))
 
         assert result["recommendations"] == []
+
+    def _silent_result(self, filename):
+        """A fully-silent track as analyze_track returns it: pyln gives
+        -inf LUFS, peak/rms are -inf (log10 of 0), and dynamic_range is
+        nan (-inf minus -inf). Mirrors analyze_track on silence."""
+        return {
+            "filename": filename,
+            "duration": 180.0,
+            "sample_rate": 44100,
+            "lufs": float("-inf"),
+            "peak_db": float("-inf"),
+            "rms_db": float("-inf"),
+            "dynamic_range": float("nan"),
+            "band_energy": {"sub_bass": 0.0, "bass": 0.0, "low_mid": 0.0,
+                            "mid": 0.0, "high_mid": 0.0, "high": 0.0, "air": 0.0},
+            "tinniness_ratio": 0.0,
+        }
+
+    def test_silent_track_emits_valid_json(self, tmp_path):
+        """One silent track must not invalidate the whole album response.
+
+        Regression for #371: a -inf LUFS track poisoned avg_lufs/lufs_range
+        and serialized as Infinity/NaN, breaking strict JSON parsers.
+        """
+        audio_dir, state = self._make_audio_dir(tmp_path, 3)
+        mock_cache = MockStateCache(state)
+
+        def mock_analyze(filepath):
+            name = Path(filepath).name
+            if "02" in name:
+                return self._silent_result(name)
+            return self._mock_result(name, lufs=-14.0)
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \
+             patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze):
+            raw = _run(server.analyze_audio("test-album"))
+
+        # Strict parse mirrors the MCP/JS client: rejects Infinity/NaN.
+        result = _strict_json_loads(raw)
+
+        # Aggregates computed over finite tracks only → meaningful numbers.
+        assert result["summary"]["avg_lufs"] == pytest.approx(-14.0)
+        assert result["summary"]["lufs_range"] == pytest.approx(0.0)
+        # The silent track is named so operators know which file is bad.
+        assert "02-track-2.wav" in result["summary"]["silent_tracks"]
+        # Per-track non-finite fields serialize as null, not Infinity/NaN.
+        silent = next(t for t in result["tracks"] if t["filename"] == "02-track-2.wav")
+        assert silent["lufs"] is None
+        assert silent["dynamic_range"] is None
+        # A recommendation names the silent track, and none says "-inf".
+        assert any("02-track-2.wav" in r for r in result["recommendations"])
+        assert not any("inf" in r.lower() for r in result["recommendations"])
+
+    def test_all_silent_tracks_no_crash(self, tmp_path):
+        """An all-silent album yields null aggregates and valid JSON."""
+        audio_dir, state = self._make_audio_dir(tmp_path, 2)
+        mock_cache = MockStateCache(state)
+
+        def mock_analyze(filepath):
+            return self._silent_result(Path(filepath).name)
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_mastering_deps", return_value=None), \
+             patch("tools.mastering.analyze_tracks.analyze_track", side_effect=mock_analyze):
+            raw = _run(server.analyze_audio("test-album"))
+
+        result = _strict_json_loads(raw)
+        assert result["summary"]["avg_lufs"] is None
+        assert result["summary"]["lufs_range"] is None
+        assert len(result["summary"]["silent_tracks"]) == 2
 
 
 class TestMasterAudioComprehensive:


### PR DESCRIPTION
## Description

A silent / near-silent WAV makes `analyze_track` return `-inf` LUFS (and `-inf` peak/rms, `nan` dynamic range — `pyln.Meter.integrated_loudness` never skips it, unlike `master_track`). `analyze_audio` aggregated those values unguarded, and `_safe_json`'s `json.dumps(default=str)` serialized them as the literal tokens `Infinity` / `-Infinity` / `NaN` — invalid per the JSON spec and rejected by strict parsers (JS `JSON.parse`, the MCP client). One silent track therefore made the **entire** album response unparseable rather than flagging the one bad track.

Fixed at three sites (defense in depth):

| Site | Change |
|---|---|
| `handlers/_shared.py` | New `_json_sanitize()` recursively maps non-finite floats → `null` (the standard JS behavior, `JSON.stringify(Infinity) === "null"`) at the `_safe_json` serialization boundary — protects **every** MCP tool. `+RecursionError` in the `except` preserves the no-crash contract for circular inputs. |
| `handlers/processing/audio.py` | `analyze_audio` aggregates `avg_lufs`/`lufs_range` over **finite** LUFS only (`None` when none finite), guards the recommendation conditions, and reports silent tracks via a new `summary.silent_tracks` field + a recommendation (kills the nonsensical "Average LUFS is -inf"). |
| `handlers/processing/_album_stages.py` | `_stage_analysis` (master_album pre-flight) carried the identical unguarded aggregation — same finite-only fix plus an operator warning for silent tracks. Surfaced by an adversarial multi-agent review of the first two fixes. |

The verification/mastering stages were checked and intentionally left unchanged: they aggregate already-filtered **mastered** output (silent tracks are skipped by `_stage_mastering`), and `_json_sanitize` is the universal safety net regardless.

## Type of Change

- [x] fix: Bug fix (patch version bump)

## Related Issues

Closes #371

## Testing

**Why it slipped through:** the existing tests used Python's lenient `json.loads`, which silently accepts `Infinity`/`NaN`. New tests parse with a strict helper (`parse_constant`) that mirrors the JS/MCP client.

- TDD: every new test was watched failing first (`invalid non-finite JSON token emitted: '-Infinity'`), then passing after the fix.
- 8 new regression tests: `_safe_json` non-finite handling (incl. nested + numpy `float64`), `analyze_audio` silent-track behavior, and `_stage_analysis` finite aggregation.
- Real-audio end-to-end: a genuinely silent WAV → real `analyze_track` → `_safe_json` → strict-valid JSON (silent fields = `null`).
- `make check` (ruff + bandit + mypy + pytest) on this branch rebased onto current `develop`: **3793 passed, 2 xfailed**, coverage 85.4%.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Co-author line included
- [x] Relevant tests pass locally (`make check`)
- [x] Updated CHANGELOG.md under "Unreleased"
- [ ] Version files — n/a (patch fix, no plugin version bump in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)