### PR TITLE
chore(deps): hold scipy/numpy at py3.11 ceiling; take 3.11-safe bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,13 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 10
+    # Plugin runs in the user's venv and supports Python 3.11 (see requirements.txt).
+    # scipy 1.18+ and numpy 2.5+ require Python >=3.12, so block those upgrades here.
+    ignore:
+      - dependency-name: "scipy"
+        versions: [">=1.18.0"]
+      - dependency-name: "numpy"
+        versions: [">=2.5.0"]
     groups:
       pip-all:
         patterns:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,13 +3,13 @@
 # Install:
 #   pip install -r requirements-test.txt
 
-pytest>=9.0.3
+pytest>=9.1.1
 pytest-cov>=7.1.0
 pytest-xdist>=3.8.0
 pyyaml>=6.0
 
 # Linting
-ruff>=0.15.16
+ruff>=0.15.19
 mypy>=2.1.0
 types-PyYAML>=6.0.12.20260518
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # =============================================================================
 # MCP SERVER (required for plugin core functionality)
 # =============================================================================
-mcp[cli]==1.27.2
+mcp[cli]==1.28.0
 pyyaml==6.0.3
 
 # =============================================================================
@@ -18,10 +18,12 @@ pyyaml==6.0.3
 # =============================================================================
 matchering==2.0.6
 pyloudnorm==0.2.0
+# Python 3.11 ceiling: scipy 1.18+ and numpy 2.5+ require Python >=3.12.
+# Do NOT bump past these lines while the plugin supports 3.11 (see dependabot.yml ignores).
 scipy==1.17.1
 numpy==2.4.6
 soundfile==0.14.0
-mutagen==1.47.0
+mutagen==1.48.0
 
 # =============================================================================
 # AUDIO MIXING / POLISH (required for /bitwize-music:mix-engineer)
@@ -38,13 +40,13 @@ librosa==0.11.0
 # =============================================================================
 # SHEET MUSIC (required for /bitwize-music:sheet-music-publisher)
 # =============================================================================
-pypdf==6.13.2
+pypdf==6.14.2
 reportlab==4.5.1
 
 # =============================================================================
 # CLOUD UPLOADS (required for /bitwize-music:cloud-uploader)
 # =============================================================================
-boto3==1.43.27
+boto3==1.43.36
 
 # =============================================================================
 # DATABASE (required for db_* MCP tools - tweet/promo management)


### PR DESCRIPTION
## Summary

Supersedes #424. Dependabot's grouped `pip-all` PR (#424) bumped `scipy` and `numpy` to versions that **require Python >=3.12**, which broke install on the plugin's supported **Python 3.11** floor (the plugin runs in the user's venv) — both its Tests and Security Scan jobs failed at the dependency-install step.

This PR keeps us on 3.11 while still taking everything from #424 that is 3.11-safe.

## Changes

**`requirements.txt`**
- Hold `scipy==1.17.1` / `numpy==2.4.6` (last 3.11-compatible lines) with a guard comment.
- Take the 3.11-safe bumps from #424:
  - `mcp[cli]` 1.27.2 → **1.28.0**
  - `pypdf` 6.13.2 → **6.14.2** — clears the `GHSA-jm82-fx9c-mx94` finding currently failing the Security Scan on `develop`
  - `boto3` 1.43.27 → **1.43.36**
  - `mutagen` 1.47.0 → **1.48.0**
- Hold `reportlab` at 4.5.1 — the 5.0.0 major bump is deferred to its own tested PR.

**`requirements-test.txt`**
- `pytest>=9.1.1`, `ruff>=0.15.19` (safe test-tool floor bumps from #424).

**`.github/dependabot.yml`**
- Ignore `scipy >=1.18.0` and `numpy >=2.5.0` so the Python-3.12-only releases aren't proposed again while 3.11 is supported.

## Validation

Ran the full `make check` equivalent locally (`.venv`):
- `ruff` ✅ · `bandit` ✅ · `mypy` ✅ (72 files)
- `pytest` ✅ **3793 passed, 2 xfailed**, coverage **85.42%** (gate 75%)
- Updated pins install with no dependency conflicts.

> Note: local box is Python 3.13; CI's 3.11 job is the authoritative gate for the version-floor behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)