### PR TITLE
docs: fix plugin install identifier across docs; credit @DaveMatNat

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Concept to released album. You generate on Suno, everything else happens in the 
 
 ```bash
 /plugin marketplace add bitwize-music-studio/claude-ai-music-skills
-/plugin install bitwize-music@claude-ai-music-skills
+/plugin install bitwize-music@bitwize-music
 ```
 
 Then run `/bitwize-music:setup` to detect your environment and install dependencies. Run `/bitwize-music:configure` to set your artist name and workspace paths.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ config/              Example config and setup docs
 <a href="https://github.com/markus-michalski"><img src="https://images.weserv.nl/?url=github.com/markus-michalski.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@markus-michalski"></a>
 <a href="https://github.com/zeel2104"><img src="https://images.weserv.nl/?url=github.com/zeel2104.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@zeel2104"></a>
 <a href="https://github.com/alijahak"><img src="https://images.weserv.nl/?url=github.com/alijahak.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@alijahak"></a>
+<a href="https://github.com/DaveMatNat"><img src="https://images.weserv.nl/?url=github.com/DaveMatNat.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@DaveMatNat"></a>
 
 If you make something with this, I'd genuinely love to hear it — [@bitwizemusic](https://x.com/bitwizemusic) on X, [join the Discord](https://discord.gg/dMURByGF), or [open a discussion](https://github.com/bitwize-music-studio/claude-ai-music-skills/discussions).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -68,7 +68,7 @@ playwright install chromium
 
 **Check:**
 1. Plugin installed correctly: `/plugin list`
-2. Skill files exist: `ls ~/.claude/plugins/bitwize-music@claude-ai-music-skills/skills/`
+2. Skill files exist: `ls ~/.claude/plugins/cache/bitwize-music/bitwize-music/*/skills/`
 3. Try restarting Claude Code
 
 ## Still Stuck?

--- a/skills/test/test-definitions.md
+++ b/skills/test/test-definitions.md
@@ -1005,8 +1005,8 @@ All references should use `suno` (lowercase) not `Suno` when referring to the co
 
 ### TEST: Consistent plugin name
 Plugin should be referred to as:
-- `claude-ai-music-skills` (in plugin.json name)
-- `bitwize-music@claude-ai-music-skills` (install command)
+- `bitwize-music` (in plugin.json name)
+- `bitwize-music@bitwize-music` (install command)
 
 ### TEST: Consistent brand casing
 Search for "Bitwize Music" (title case) - should not exist.


### PR DESCRIPTION
## Description

The plugin install identifier is `bitwize-music@bitwize-music` — the marketplace name comes from `.claude-plugin/marketplace.json`'s `name` field (`bitwize-music`), **not** the repo name `claude-ai-music-skills`. Verified against the local install registry (`~/.claude/plugins/installed_plugins.json` keys the plugin as `bitwize-music@bitwize-music`; `known_marketplaces.json` registers the marketplace as `bitwize-music`). The old `@claude-ai-music-skills` form references a marketplace name that doesn't exist and would fail to install.

[PR #426](https://github.com/bitwize-music-studio/claude-ai-music-skills/pull/426) (by @DaveMatNat) fixes this in the README against `main`. This PR:

- **README.md** — mirrors the install-command fix onto `develop` so the branch stays consistent regardless of when #426 merges into `main`.
- **skills/test/test-definitions.md** — the "Consistent plugin name" checklist test was asserting the wrong canonical values for *both* the plugin.json name (`claude-ai-music-skills` → `bitwize-music`) and the install command (`@claude-ai-music-skills` → `@bitwize-music`).
- **docs/troubleshooting.md** — the `ls` path used the wrong identifier and a directory layout that doesn't exist; repointed to the real version-nested cache path `~/.claude/plugins/cache/bitwize-music/bitwize-music/*/skills/`.
- **README.md Contributors** — adds external contributor @DaveMatNat.

## Type of Change

- [x] docs: Documentation only

## Testing

- `tests/plugin/` → 273 passed, 2 xfailed (doc/terminology/structure tests). Doc-only changes; no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)