### PR TITLE
fix(state): enforce global album-slug uniqueness; detect and surface cross-genre collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **Album slug collisions across genres no longer silently erase an album from
+  the state cache** (#392). The indexer keyed the cache's `albums` map by bare
+  directory name, ignoring the genre path segment — two albums with the same
+  slug under different genres overwrote each other, so one album (and all its
+  tracks) vanished from every MCP tool, and `create_album_structure` only
+  checked the genre-scoped path, so it happily created the twin. Album slugs
+  are now globally unique across genres: `create_album_structure` (and
+  `promote_idea`, which inherits the guard) and `rename_album` reject a slug
+  that already exists under any other genre, naming the existing genre/path
+  and suggesting a different name or `/bitwize-music:rename`. Pre-existing
+  on-disk collisions are detected at index time instead of silently
+  overwriting — the lexicographically-first genre wins deterministically, and
+  the shadowed album(s) are recorded in a new `album_collisions` state field
+  (schema 1.2.0 → 1.3.0; migration seeds `[]`) and surfaced by `health_check`,
+  `find_album`, `list_albums`, `rebuild_state`, and the indexer CLI with the
+  fix guidance (rename or move the directory, then rebuild).
+
 ## [0.93.0] - 2026-07-01
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ This is an AI music generation workflow using Suno. Skills contain domain expert
 
 **DO NOT**: search from cwd, use complex globs, assume paths, or use `ls`/`find`.
 
+Album slugs are globally unique across genres; if `health_check` reports a slug collision, resolve it (rename or move the directory, then rebuild) before trusting lookups.
+
 ---
 
 ## Configuration & Path Resolution
@@ -82,6 +84,7 @@ At the beginning of a fresh session:
    - Skills `status: "ok"` → continue silently
    - Skills `status: "stale"` → warn with missing/ghost skill names and fix message, continue session
    - Skills `status: "no_cache"` → warn (plugin may not be installed via marketplace), continue
+   - Collisions `status: "collision"` → warn listing each slug + genres and the fix (rename one album with `/bitwize-music:rename` or move the directory, then `rebuild_state`), continue session
 2. **Load config** — Read `~/.bitwize-music/config.yaml`. If missing, tell user to run `/bitwize-music:configure`.
 3. **Load overrides** — Check `paths.overrides` (default: `{content_root}/overrides`):
    - `{overrides}/CLAUDE.md` → incorporate instructions

--- a/reference/state-schema.md
+++ b/reference/state-schema.md
@@ -1,4 +1,4 @@
-# State Cache Schema (v1.2.0)
+# State Cache Schema (v1.3.0)
 
 The state cache at `~/.bitwize-music/cache/state.json` is a JSON file built from markdown source files. It is a **disposable cache** — markdown files remain the source of truth and state can always be rebuilt with `python3 tools/state/indexer.py rebuild`.
 
@@ -8,12 +8,13 @@ The state cache at `~/.bitwize-music/cache/state.json` is a JSON file built from
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | Yes | Schema version (currently `"1.2.0"`) |
+| `version` | string | Yes | Schema version (currently `"1.3.0"`) |
 | `generated_at` | string | Yes | ISO 8601 UTC timestamp of last build/update |
 | `plugin_version` | string\|null | Yes | Installed plugin version from `.claude-plugin/plugin.json`, refreshed every build (display only), or `null` if unreadable |
 | `last_migrated_version` | string\|null | No | Version through which migration notes have been processed. Only advances via `acknowledge_migrations`; preserved across rebuilds. `null`/absent = pre-tracking (surfaces the backlog once). Drives `get_pending_migrations`. See issue #320. |
 | `config` | object | Yes | Resolved configuration snapshot |
 | `albums` | object | Yes | Map of album slug → album data |
+| `album_collisions` | array | Yes | Album slug collisions detected on disk (empty when none); see below |
 | `ideas` | object | Yes | Album ideas from IDEAS.md |
 | `skills` | object | Yes | Indexed skill metadata from SKILL.md files |
 | `session` | object | Yes | Session context for resume/continuity |
@@ -38,6 +39,8 @@ Snapshot of resolved paths and artist info from `~/.bitwize-music/config.yaml`.
 ## `albums` Object
 
 Map of album slug (string) → album data object.
+
+**Global uniqueness invariant**: album slugs are unique across genres — the map is keyed by bare slug, so the same slug under two genres cannot coexist. This is enforced at creation (`create_album_structure`) and rename (`rename_album`), both of which reject a slug that already exists under any other genre. Pre-existing on-disk collisions are detected at index time — the first genre (lexicographic order) whose README parses wins deterministically, and the shadowed album(s) are listed in `album_collisions`.
 
 ### Album Data
 
@@ -84,6 +87,32 @@ Map of album slug (string) → album data object.
 - `In Progress` — Lyrics being written
 - `Generated` — Track generated on Suno, audio exists
 - `Final` — Approved, ready for mastering
+
+---
+
+## `album_collisions` Array
+
+Added in 1.3.0 (issue #392). Always present; a list of collision records, empty when no collisions exist. Populated by the indexer when the same album slug is found under multiple genres on disk. The winner (`kept`) is the first genre (lexicographic order) whose README parses — deterministic, and always the entry actually indexed into `albums`; all others are `shadowed` (sorted by genre, parseable or not; supports 2+ way collisions) and are **not** indexed into `albums`. If no candidate's README parses, no album entry and no collision record are emitted.
+
+```json
+"album_collisions": [
+  {
+    "slug": "midnight",
+    "kept":     {"genre": "jazz", "path": "/abs/path/albums/jazz/midnight"},
+    "shadowed": [{"genre": "rock", "path": "/abs/path/albums/rock/midnight"}]
+  }
+]
+```
+
+### Collision Record
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | string | The colliding album slug (bare directory name) |
+| `kept` | object | The winning album: `{genre, path}` — this is the entry visible in `albums` |
+| `shadowed` | array | The hidden album(s): `[{genre, path}, ...]`, sorted by genre |
+
+**Fix**: rename one album with `/bitwize-music:rename`, or move the directory, then rebuild the state cache. Collisions are surfaced by `health_check`, `find_album`, `list_albums`, `rebuild_state`, and the indexer CLI (`rebuild`/`update`/`show`).
 
 ---
 
@@ -176,5 +205,6 @@ The migration chain is defined in `tools/state/indexer.py` as `MIGRATIONS` dict.
 |------|-----|---------|
 | 1.0.0 | 1.1.0 | Added `skills` top-level section with indexed skill metadata |
 | 1.1.0 | 1.2.0 | Added `plugin_version` top-level field for upgrade path tracking |
+| 1.2.0 | 1.3.0 | Added `album_collisions` top-level field (seeded to `[]`) for cross-genre slug collision detection (issue #392) |
 
 `last_migrated_version` was added as a **backward-compatible optional field** (no schema-version bump). Fresh builds include it (seeded to the installed version); states written earlier simply omit it and read as `null`, which `get_pending_migrations` treats as pre-tracking. Avoiding a version bump here is deliberate — bumping would force the live MCP path to auto-rebuild every existing state, erasing the very "behind" status migration detection depends on (issue #320).

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -358,6 +358,21 @@ def _find_album_or_error(album_slug: str) -> tuple[str, dict[str, Any] | None, s
     return normalized, album, None
 
 
+def _find_slug_dirs(albums_root: Path, slug: str) -> list[Path]:
+    """Find existing album dirs named exactly `slug` under every genre (#392).
+
+    Literal comparison via iterdir — glob() would treat metacharacters in
+    the slug (e.g. '*') as patterns and could match unrelated albums.
+    """
+    if not albums_root.is_dir():
+        return []
+    return sorted(
+        genre_dir / slug
+        for genre_dir in albums_root.iterdir()
+        if genre_dir.is_dir() and (genre_dir / slug).is_dir()
+    )
+
+
 def _find_track_or_error(tracks: dict[str, Any], track_slug: str, album_slug: str = "") -> tuple[str, dict[str, Any] | None, str | None]:
     """Find track in tracks dict by exact match or prefix match.
 

--- a/servers/bitwize-music-server/handlers/album_ops.py
+++ b/servers/bitwize-music-server/handlers/album_ops.py
@@ -18,6 +18,7 @@ from handlers._shared import (
     _extract_code_block,
     _extract_markdown_section,
     _find_album_or_error,
+    _find_slug_dirs,
     _find_wav_source_dir,
     _is_path_confined,
     _normalize_slug,
@@ -383,7 +384,24 @@ async def create_album_structure(
     assert _shared.PLUGIN_ROOT is not None
     templates_path = _shared.PLUGIN_ROOT / "templates"
 
-    # Check if already exists
+    # Album slugs are globally unique across genres (#392) — sweep the
+    # filesystem (cache may be stale) for the slug under every genre.
+    albums_root = Path(content_root) / "artists" / artist / "albums"
+    collisions = _find_slug_dirs(albums_root, normalized)
+    if collisions:
+        existing = collisions[0]
+        return _safe_json({
+            "created": False,
+            "error": (
+                f"Album slug '{normalized}' already exists under genre "
+                f"'{existing.parent.name}': {existing}. Album slugs are unique "
+                f"across all genres — choose a different name, or rename the "
+                f"existing album with /bitwize-music:rename."
+            ),
+            "path": str(existing),
+        })
+
+    # Check if already exists (belt-and-braces behind the cross-genre sweep)
     if album_path.exists():
         return _safe_json({
             "created": False,

--- a/servers/bitwize-music-server/handlers/core.py
+++ b/servers/bitwize-music-server/handlers/core.py
@@ -99,6 +99,34 @@ def _detect_phase(album: dict[str, Any]) -> str:
     return "In Progress"
 
 
+def _collision_warning(state: dict[str, Any], slug: str) -> dict[str, Any] | None:
+    """Build a collision warning for a resolved album slug, if any (#392).
+
+    Uses ``state.get`` throughout — pre-1.3.0 states lack album_collisions.
+    """
+    for record in state.get("album_collisions", []):
+        if record.get("slug") != slug:
+            continue
+        kept = record.get("kept", {})
+        shadowed = record.get("shadowed", [])
+        shadowed_desc = ", ".join(
+            f"{s.get('genre', '?')} ({s.get('path', '?')})" for s in shadowed
+        )
+        return {
+            "slug": slug,
+            "visible": kept,
+            "shadowed": shadowed,
+            "message": (
+                f"Album slug '{slug}' exists under multiple genres — showing "
+                f"the '{kept.get('genre', '?')}' album; shadowed: "
+                f"{shadowed_desc}. Rename one album with "
+                f"/bitwize-music:rename or move its directory, then run "
+                f"rebuild_state."
+            ),
+        }
+    return None
+
+
 # =============================================================================
 # Tool functions
 # =============================================================================
@@ -136,11 +164,15 @@ async def find_album(name: str) -> str:
 
     # Exact match first
     if normalized in albums:
-        return _safe_json({
+        response = {
             "found": True,
             "slug": normalized,
             "album": albums[normalized],
-        })
+        }
+        warning = _collision_warning(state, normalized)
+        if warning:
+            response["collision_warning"] = warning
+        return _safe_json(response)
 
     # Fuzzy match: check if input is substring of slug or vice versa
     matches = {
@@ -151,11 +183,15 @@ async def find_album(name: str) -> str:
 
     if len(matches) == 1:
         slug = next(iter(matches))
-        return _safe_json({
+        response = {
             "found": True,
             "slug": slug,
             "album": matches[slug],
-        })
+        }
+        warning = _collision_warning(state, slug)
+        if warning:
+            response["collision_warning"] = warning
+        return _safe_json(response)
     elif len(matches) > 1:
         return _safe_json({
             "found": False,
@@ -199,7 +235,21 @@ async def list_albums(status_filter: str = "") -> str:
             "tracks_completed": album.get("tracks_completed", 0),
         })
 
-    return _safe_json({"albums": result, "count": len(result)})
+    response: dict[str, Any] = {"albums": result, "count": len(result)}
+
+    # Shadowed albums are invisible above — make collisions unmissable (#392)
+    collisions = state.get("album_collisions", [])
+    if collisions:
+        slugs = ", ".join(c.get("slug", "?") for c in collisions)
+        response["collisions"] = collisions
+        response["warning"] = (
+            f"{len(collisions)} album slug collision(s) detected ({slugs}) — "
+            f"shadowed albums are hidden from this list. Rename one album "
+            f"with /bitwize-music:rename or move its directory, then run "
+            f"rebuild_state."
+        )
+
+    return _safe_json(response)
 
 
 async def get_track(album_slug: str, track_slug: str) -> str:
@@ -345,14 +395,25 @@ async def rebuild_state() -> str:
     )
     ideas_count = len(state.get("ideas", {}).get("items", []))
     skills_count = state.get("skills", {}).get("count", 0)
+    collisions = state.get("album_collisions", [])
 
-    return _safe_json({
+    result: dict[str, Any] = {
         "success": True,
         "albums": album_count,
         "tracks": track_count,
         "ideas": ideas_count,
         "skills": skills_count,
-    })
+        "collision_count": len(collisions),
+    }
+    if collisions:
+        slugs = ", ".join(c.get("slug", "?") for c in collisions)
+        result["collisions"] = collisions
+        result["warning"] = (
+            f"{len(collisions)} album slug collision(s) detected ({slugs}). "
+            f"Rename one album with /bitwize-music:rename or move its "
+            f"directory, then run rebuild_state."
+        )
+    return _safe_json(result)
 
 
 async def get_config() -> str:

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -311,7 +311,8 @@ async def health_check() -> str:
 
     Returns:
         JSON with overall status ("ok", "warn", "fail"), per-check
-        summaries, and raw results for venv and skills.
+        summaries, raw results for venv and skills, and an album slug
+        collision section ("ok" or "collision" with details and fix).
     """
     checks: list[dict[str, Any]] = []
 
@@ -357,6 +358,28 @@ async def health_check() -> str:
                         "detail": "No plugin cache found",
                         "fix": skills_raw.get("fix_message")})
 
+    # --- Album slug collision check (#392) ---
+    # .get: pre-1.3.0 states (and an unloadable cache) lack album_collisions.
+    state = _shared.cache.get_state() if _shared.cache is not None else {}
+    album_collisions = state.get("album_collisions", [])
+    if album_collisions:
+        slugs = ", ".join(c.get("slug", "?") for c in album_collisions)
+        fix = ("Rename one album with /bitwize-music:rename or move its "
+               "directory, then run rebuild_state.")
+        collisions_raw: dict[str, Any] = {
+            "status": "collision",
+            "collisions": album_collisions,
+            "fix": fix,
+        }
+        checks.append({"name": "collisions", "status": "warn",
+                        "detail": (f"{len(album_collisions)} album slug "
+                                   f"collision(s): {slugs}"),
+                        "fix": fix})
+    else:
+        collisions_raw = {"status": "ok"}
+        checks.append({"name": "collisions", "status": "ok",
+                        "detail": "No album slug collisions"})
+
     # --- Overall status ---
     statuses = [c["status"] for c in checks]
     if "fail" in statuses:
@@ -371,6 +394,7 @@ async def health_check() -> str:
         "checks": checks,
         "venv": venv_raw,
         "skills": skills_raw,
+        "collisions": collisions_raw,
     })
 
 

--- a/servers/bitwize-music-server/handlers/rename.py
+++ b/servers/bitwize-music-server/handlers/rename.py
@@ -13,6 +13,7 @@ from handlers._atomic import atomic_write_text
 from handlers._shared import (
     _derive_title_from_slug,
     _find_album_or_error,
+    _find_slug_dirs,
     _find_track_or_error,
     _is_path_confined,
     _normalize_slug,
@@ -96,6 +97,22 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     if not _is_path_confined(albums_content_base, normalized_new):
         return _safe_json({"error": "Invalid new slug: would escape album directory"})
 
+    # Album slugs are globally unique across genres (#392) — sweep the
+    # filesystem for the new slug under every genre; the cache-key check
+    # above misses twins that are stale or shadowed out of the cache.
+    albums_root = Path(content_root) / "artists" / artist / "albums"
+    collisions = _find_slug_dirs(albums_root, normalized_new)
+    if collisions:
+        existing = collisions[0]
+        return _safe_json({
+            "error": (
+                f"Album slug '{normalized_new}' already exists under genre "
+                f"'{existing.parent.name}': {existing}. Album slugs are unique "
+                f"across all genres — choose a different name, or rename the "
+                f"existing album with /bitwize-music:rename."
+            ),
+        })
+
     # Content directory MUST exist
     if not content_dir_old.is_dir():
         return _safe_json({
@@ -171,9 +188,35 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     except Exception as e:
         logger.warning("Directories moved but cache update failed: %s", e)
 
+    # Rename is the documented fix path for a slug collision (#392). If the
+    # freed slug has a collision record, the surgical cache patch above is
+    # not enough: the formerly-shadowed twin is still missing from the cache
+    # and album_collisions is stale. Rebuild from disk (same pattern as
+    # create_album_structure) so the twin is indexed and collisions are
+    # recomputed. Normal renames skip this and keep the cheap surgical path.
+    collision_resolved = False
+    rebuild_warning = ""
+    if any(
+        record.get("slug") == normalized_old
+        for record in state.get("album_collisions", [])
+    ):
+        try:
+            rebuilt = _shared.cache.rebuild()
+        except Exception as e:  # rename already succeeded — don't fail it
+            logger.warning("Album renamed but collision rebuild failed: %s", e)
+            rebuilt = {"error": str(e)}
+        if "error" in rebuilt:
+            rebuild_warning = (
+                f"Rename succeeded, but the state rebuild needed to surface "
+                f"the formerly-shadowed '{normalized_old}' album failed: "
+                f"{rebuilt['error']}. Run rebuild_state to index it."
+            )
+        else:
+            collision_resolved = True
+
     logger.info("Renamed album '%s' to '%s'", normalized_old, normalized_new)
 
-    return _safe_json({
+    result: dict[str, Any] = {
         "success": True,
         "old_slug": normalized_old,
         "new_slug": normalized_new,
@@ -182,7 +225,17 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
         "audio_moved": audio_moved,
         "documents_moved": documents_moved,
         "tracks_updated": tracks_updated,
-    })
+    }
+    if collision_resolved:
+        result["collision_resolved"] = True
+        result["note"] = (
+            f"Slug '{normalized_old}' had a cross-genre collision — state "
+            f"was rebuilt from disk, so the formerly-shadowed album is now "
+            f"visible and album_collisions is up to date."
+        )
+    elif rebuild_warning:
+        result["warning"] = rebuild_warning
+    return _safe_json(result)
 
 
 async def rename_track(

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: health-check
-description: Runs plugin health checks (venv packages and skill registration). Use when the user asks to check plugin health, verify setup, or troubleshoot missing skills.
+description: Runs plugin health checks (venv packages, skill registration, and album slug collisions). Use when the user asks to check plugin health, verify setup, or troubleshoot missing skills.
 model: haiku
 allowed-tools:
   - ToolSearch
@@ -29,6 +29,7 @@ Run the `health_check` MCP tool and report results to the user.
 HEALTH CHECK: OK
   Venv: N packages verified
   Skills: N skills registered
+  Collisions: no album slug collisions
 ```
 
 ### Warnings
@@ -45,6 +46,11 @@ SKILLS [warn]
   N missing from Claude Code: skill-a, skill-b
   N ghost (deleted but cached): skill-c
   Fix: claude plugin update bitwize-music
+
+COLLISIONS [warn]
+  N album slug collision(s):
+  slug-name: kept [genre-a], shadowed by [genre-b]
+  Fix: Rename one album with /bitwize-music:rename or move its directory, then run rebuild_state
 
 For comprehensive diagnostics, run the `diagnose` MCP tool.
 ```

--- a/skills/new-album/SKILL.md
+++ b/skills/new-album/SKILL.md
@@ -68,7 +68,7 @@ Call `create_album_structure(album_slug, genre, documentary)` — creates the co
 - Creates `tracks/` and `promo/` directories with templates
 - For documentary albums (`documentary: true`): also creates RESEARCH.md and SOURCES.md
 - Returns `{created: bool, path: str, files: [...]}`
-- If album already exists, returns an error
+- If the album slug already exists under ANY genre (slugs are globally unique), returns an error naming the existing genre and path
 
 **Note**: Audio and documents directories are NOT created (those are created when needed by import-audio/import-art).
 
@@ -116,9 +116,12 @@ No genre directory found at genres/{genre}/. Use a valid genre slug (e.g. hip-ho
 Check genres/INDEX.md for the full list.
 ```
 
-**Album already exists:**
+**Album already exists (any genre — slugs are globally unique):**
 ```
-Error: Album already exists at {album_path}
+Error: Album slug '{album-name}' already exists under genre '{existing-genre}': {existing_path}
+
+Album slugs are unique across all genres — choose a different name, or
+rename the existing album with /bitwize-music:rename.
 ```
 
 **Templates not found:**

--- a/skills/session-start/SKILL.md
+++ b/skills/session-start/SKILL.md
@@ -39,7 +39,7 @@ Quick dependency check:
 
 ## Step 1.5: Health Check
 
-Use the `health_check` MCP tool (checks venv packages + skill registration in one call):
+Use the `health_check` MCP tool (checks venv packages + skill registration + album slug collisions in one call):
 
 **Venv results** (from `result.venv`):
 - `status: "ok"` → continue silently
@@ -51,6 +51,10 @@ Use the `health_check` MCP tool (checks venv packages + skill registration in on
 - `status: "ok"` → continue silently
 - `status: "stale"` → warn: list missing and ghost skill names, show fix message
 - `status: "no_cache"` → warn that plugin cache not found, continue
+
+**Album slug collision results** (from `result.collisions`):
+- `status: "ok"` → continue silently
+- `status: "collision"` → warn: list each slug with its kept and shadowed genres, show the fix (rename one album with `/bitwize-music:rename` or move its directory, then run `rebuild_state`), continue session
 
 ## Step 2: Load Config
 
@@ -165,7 +169,7 @@ SESSION START
 =============
 
 Setup: MCP ready, config loaded
-Health: [venv ok, skills ok | warnings listed]
+Health: [venv ok, skills ok, no collisions | warnings listed]
 Overrides: [loaded from {path} | not found (optional)]
 State: [loaded | rebuilt | error]
 

--- a/tests/plugin/test_consistency.py
+++ b/tests/plugin/test_consistency.py
@@ -124,6 +124,38 @@ class TestNoDisableModelInvocation:
         assert not flagged or True  # soft check preserved
 
 
+class TestHealthCheckCollisionDocs:
+    """Skills documenting health_check must surface the collisions section (#392)."""
+
+    def test_session_start_documents_collisions(self, skills_dir):
+        skill_path = skills_dir / "session-start" / "SKILL.md"
+        content = skill_path.read_text()
+
+        step_15 = re.search(r'## Step 1\.5.*?(?=\n## Step 2)', content, re.DOTALL)
+        assert step_15, "session-start SKILL.md missing Step 1.5 section"
+        assert "collision" in step_15.group().lower(), (
+            "session-start Step 1.5 does not handle the health_check "
+            "collisions section — agents following it would drop the warning"
+        )
+
+        report = re.search(r'## Report Format.*?```.*?```', content, re.DOTALL)
+        assert report, "session-start SKILL.md missing Report Format template"
+        assert "collision" in report.group().lower(), (
+            "session-start Report Format Health line omits collisions"
+        )
+
+    def test_health_check_documents_collisions(self, skills_dir):
+        skill_path = skills_dir / "health-check" / "SKILL.md"
+        content = skill_path.read_text()
+
+        report = re.search(r'## Report Format.*?(?=\n## Remember|$)', content, re.DOTALL)
+        assert report, "health-check SKILL.md missing Report Format section"
+        assert "COLLISIONS" in report.group(), (
+            "health-check Report Format has no COLLISIONS section slot "
+            "alongside VENV/SKILLS"
+        )
+
+
 class TestGitignore:
     """Required .gitignore entries must be present."""
 

--- a/tests/unit/state/test_handlers_promote_idea.py
+++ b/tests/unit/state/test_handlers_promote_idea.py
@@ -415,6 +415,37 @@ class TestPromoteIdeaErrors:
         assert "error" in result
         assert "exists" in result["error"].lower()
 
+    def test_cross_genre_duplicate_slug_returns_error(self, content_root: Path, setup_handler):
+        """Slug already used under a DIFFERENT genre blocks promotion (#392)."""
+        setup_handler([{
+            "title": "Kleine Welt",
+            "genre": "electronic",
+            "concept": "Inner journey.",
+            "status": "Pending",
+        }])
+        ideas_path = _write_ideas_md(
+            content_root,
+            _standard_ideas_md("Kleine Welt", "electronic", "Inner journey."),
+        )
+        # Same slug exists under another genre
+        existing = (content_root / "artists" / "test-artist" / "albums"
+                    / "rock" / "kleine-welt")
+        existing.mkdir(parents=True)
+
+        result = json.loads(_run(_ideas_mod.promote_idea("Kleine Welt")))
+
+        assert "error" in result
+        assert "exists" in result["error"].lower()
+        assert "rock" in result["error"]
+        # No twin created under the idea's genre
+        twin = (content_root / "artists" / "test-artist" / "albums"
+                / "electronic" / "kleine-welt")
+        assert not twin.exists()
+        # Idea must not be marked promoted
+        text = ideas_path.read_text(encoding="utf-8")
+        assert "**Status**: Pending" in text
+        assert "**Promoted To**" not in text
+
 
 # ---------------------------------------------------------------------------
 # Documentary flag

--- a/tests/unit/state/test_handlers_rename.py
+++ b/tests/unit/state/test_handlers_rename.py
@@ -91,11 +91,16 @@ class MockStateCache:
     def __init__(self, state: dict) -> None:
         self._state = state
         self.write_calls = 0
+        self.rebuild_calls = 0
 
     def get_state(self) -> dict:
         return self._state
 
     def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        self.rebuild_calls += 1
         return self._state
 
 
@@ -357,6 +362,28 @@ class TestRenameAlbumErrors:
         assert "error" in result
         assert "already exists" in result["error"].lower()
 
+    def test_cross_genre_disk_collision_returns_error(self, cache_with_album):
+        """New slug existing on disk under ANOTHER genre — and absent from the
+        cache — must block the rename (#392: cache can be stale or shadowed)."""
+        state, content_root, _audio, _docs = cache_with_album
+        twin = (content_root / "artists" / "test-artist" / "albums"
+                / "rock" / "shadow-album")
+        twin.mkdir(parents=True)
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "shadow-album")
+        ))
+
+        assert "error" in result
+        assert "already exists" in result["error"].lower()
+        assert "rock" in result["error"]
+        assert "rename" in result["error"].lower()
+        # Source album untouched on disk and in cache
+        orig = (content_root / "artists" / "test-artist" / "albums"
+                / "electronic" / "original-album")
+        assert orig.is_dir()
+        assert "original-album" in state["albums"]
+
     def test_same_slug_after_normalization_returns_error(self, cache_with_album):
         # "Original-Album" normalizes to "original-album" which equals the source
         result = json.loads(_run(
@@ -457,6 +484,128 @@ class TestRenameAlbumMissingAuxDirs:
 
         assert result["success"] is True
         assert result["documents_moved"] is False
+
+
+class TestRenameAlbumCollisionRebuild:
+    """Rename is the documented fix path for a slug collision (#392).
+
+    Renaming the kept/winner album must trigger a full cache rebuild so the
+    formerly-shadowed twin is indexed and album_collisions is recomputed from
+    disk — the surgical cache patch alone leaves a stale collision record and
+    an invisible twin. Normal renames keep the cheap surgical path.
+    """
+
+    def _seed_collision(self, state, content_root, audio_root, documents_root):
+        """Add jazz/midnight (kept, in cache) + rock/midnight (shadowed,
+        disk-only) and the matching album_collisions record."""
+        kept = _make_album_on_disk(
+            content_root, audio_root, documents_root,
+            artist="test-artist", genre="jazz", slug="midnight",
+            title="Midnight",
+            tracks=[("01-blue-hour", "Blue Hour")],
+        )
+        state["albums"]["midnight"] = kept
+        # Shadowed twin exists on disk only — NOT in the cache (the indexer
+        # kept jazz and shadowed rock).
+        shadow_dir = (content_root / "artists" / "test-artist" / "albums"
+                      / "rock" / "midnight")
+        (shadow_dir / "tracks").mkdir(parents=True)
+        (shadow_dir / "README.md").write_text("# Midnight\n", encoding="utf-8")
+        state["album_collisions"] = [{
+            "slug": "midnight",
+            "kept": {"genre": "jazz", "path": kept["path"]},
+            "shadowed": [{"genre": "rock", "path": str(shadow_dir)}],
+        }]
+        return shadow_dir
+
+    def test_renaming_collided_album_triggers_rebuild(self, cache_with_album):
+        state, content_root, audio_root, documents_root = cache_with_album
+        shadow_dir = self._seed_collision(
+            state, content_root, audio_root, documents_root
+        )
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("midnight", "midnight-jazz")
+        ))
+
+        assert result["success"] is True
+        assert result["content_moved"] is True
+        # Full rebuild triggered so the formerly-shadowed twin gets indexed
+        # and album_collisions is recomputed from disk.
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert result["collision_resolved"] is True
+        assert "note" in result
+        # Directories: kept album moved, shadowed twin untouched
+        new_dir = (content_root / "artists" / "test-artist" / "albums"
+                   / "jazz" / "midnight-jazz")
+        assert new_dir.is_dir()
+        assert shadow_dir.is_dir()
+
+    def test_normal_rename_skips_rebuild(self, cache_with_album):
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "new-album")
+        ))
+
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 0
+        assert "collision_resolved" not in result
+        assert "warning" not in result
+
+    def test_collision_record_for_other_slug_skips_rebuild(self, cache_with_album):
+        state, *_ = cache_with_album
+        state["album_collisions"] = [{
+            "slug": "some-other-slug",
+            "kept": {"genre": "jazz", "path": "/nowhere/jazz/some-other-slug"},
+            "shadowed": [{"genre": "rock", "path": "/nowhere/rock/some-other-slug"}],
+        }]
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "new-album")
+        ))
+
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 0
+        assert "collision_resolved" not in result
+
+    def test_rebuild_error_result_degrades_to_warning(self, cache_with_album):
+        state, content_root, audio_root, documents_root = cache_with_album
+        self._seed_collision(state, content_root, audio_root, documents_root)
+
+        class FailingRebuildCache(MockStateCache):
+            def rebuild(self) -> dict:
+                self.rebuild_calls += 1
+                return {"error": "rebuild exploded"}
+
+        _shared_mod.cache = FailingRebuildCache(state)
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("midnight", "midnight-jazz")
+        ))
+
+        # Directories DID move — the rename itself must stay a success.
+        assert result["success"] is True
+        assert result["content_moved"] is True
+        assert "collision_resolved" not in result
+        assert "rebuild exploded" in result["warning"]
+
+    def test_rebuild_exception_degrades_to_warning(self, cache_with_album):
+        state, content_root, audio_root, documents_root = cache_with_album
+        self._seed_collision(state, content_root, audio_root, documents_root)
+
+        class RaisingRebuildCache(MockStateCache):
+            def rebuild(self) -> dict:
+                self.rebuild_calls += 1
+                raise RuntimeError("disk on fire")
+
+        _shared_mod.cache = RaisingRebuildCache(state)
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("midnight", "midnight-jazz")
+        ))
+
+        assert result["success"] is True
+        assert "collision_resolved" not in result
+        assert "disk on fire" in result["warning"]
 
 
 # ===========================================================================

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -71,6 +71,7 @@ def _make_minimal_state(**overrides):
             'config_mtime': 1000.0,
         },
         'albums': {},
+        'album_collisions': [],
         'ideas': {'counts': {}, 'items': [], 'file_mtime': 0.0},
         'skills': {
             'skills_root': '/tmp/skills',
@@ -442,6 +443,43 @@ class TestValidateState:
         errors = validate_state(state)
         assert errors == []
 
+    def test_album_collisions_valid_entries(self):
+        state = _make_minimal_state(album_collisions=[
+            {
+                'slug': 'midnight',
+                'kept': {'genre': 'jazz', 'path': '/tmp/albums/jazz/midnight'},
+                'shadowed': [
+                    {'genre': 'rock', 'path': '/tmp/albums/rock/midnight'},
+                ],
+            }
+        ])
+        errors = validate_state(state)
+        assert errors == [], f"Unexpected errors: {errors}"
+
+    def test_album_collisions_missing_field_ok(self):
+        """Old states lack album_collisions — not an error (migration adds it)."""
+        state = _make_minimal_state()
+        del state['album_collisions']
+        errors = validate_state(state)
+        assert not any('album_collisions' in e for e in errors)
+
+    def test_album_collisions_not_a_list(self):
+        state = _make_minimal_state(album_collisions="bad")
+        errors = validate_state(state)
+        assert any('album_collisions should be a list' in e for e in errors)
+
+    def test_album_collisions_entry_not_dict(self):
+        state = _make_minimal_state(album_collisions=["bad"])
+        errors = validate_state(state)
+        assert any('album_collisions' in e and 'should be a dict' in e
+                   for e in errors)
+
+    def test_album_collisions_entry_missing_keys(self):
+        state = _make_minimal_state(album_collisions=[{'slug': 'midnight'}])
+        errors = validate_state(state)
+        assert any("missing 'kept'" in e for e in errors)
+        assert any("missing 'shadowed'" in e for e in errors)
+
 
 @pytest.mark.unit
 class TestMigrateState:
@@ -477,7 +515,7 @@ class TestMigrateState:
         assert result is None
 
     def test_same_major_minor_difference_no_rebuild(self):
-        # Same major, migration chain applies 1.0.0 → 1.1.0 → 1.2.0
+        # Same major, migration chain applies 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0
         state = {'version': '1.0.0'}
         result = migrate_state(state)
         assert result is not None
@@ -1031,6 +1069,109 @@ mastering:
         assert "no-mastering-album" in result
         assert result["no-mastering-album"]["mastering"] == {}
 
+    def test_slug_collision_lexicographic_genre_wins(self, tmp_path):
+        """#392: same slug under two genres — lexicographically-first genre
+        wins, the other is recorded as shadowed, never overwritten."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(
+            content_root, "testartist", "rock", "midnight",
+            tracks={"01-rock.md": _make_track_content("Rock Track")})
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        assert list(result.keys()) == ["midnight"]
+        album = result["midnight"]
+        assert album["genre"] == "jazz"
+        assert album["path"] == str(jazz_dir)
+        assert "01-jazz" in album["tracks"]
+        assert "01-rock" not in album["tracks"]
+
+        assert collisions == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }]
+
+    def test_slug_collision_without_out_param_no_overwrite(self, tmp_path):
+        """#392: even without the collisions out-param, the winner is
+        never overwritten by a later genre."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "midnight")
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+
+        result = scan_albums(content_root, "testartist")
+        assert result["midnight"]["genre"] == "jazz"
+        assert result["midnight"]["path"] == str(jazz_dir)
+
+    def test_three_way_collision_accumulates_shadowed(self, tmp_path):
+        """#392: 3-way collision yields one record with two shadowed
+        entries sorted by genre."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+        ambient_dir = _make_album_tree(
+            content_root, "testartist", "ambient", "midnight")
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        assert result["midnight"]["genre"] == "ambient"
+        assert len(collisions) == 1
+        record = collisions[0]
+        assert record['kept'] == {'genre': 'ambient', 'path': str(ambient_dir)}
+        assert record['shadowed'] == [
+            {'genre': 'jazz', 'path': str(jazz_dir)},
+            {'genre': 'rock', 'path': str(rock_dir)},
+        ]
+
+    def test_slug_collision_unreadable_first_twin_records_actual_winner(
+            self, tmp_path):
+        """#392: when the lexicographically-first twin's README is
+        unreadable, the next parseable twin wins AND the collision is
+        still recorded with kept = the twin actually indexed."""
+        content_root = tmp_path / "content"
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        # Invalid UTF-8 makes parse_album_readme fail even when running
+        # as root (unlike chmod-based unreadability).
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+        b_dir = _make_album_tree(
+            content_root, "testartist", "b-genre", "midnight",
+            tracks={"01-b.md": _make_track_content("B Track")})
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        album = result["midnight"]
+        assert album["genre"] == "b-genre"
+        assert album["path"] == str(b_dir)
+        assert "01-b" in album["tracks"]
+        assert collisions == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'b-genre', 'path': str(b_dir)},
+            'shadowed': [{'genre': 'a-genre', 'path': str(a_dir)}],
+        }]
+        # Invariant: the record's kept entry is the entry in the map.
+        assert collisions[0]['kept']['path'] == album['path']
+
+    def test_slug_collision_no_parseable_twin_no_entry_no_record(self, tmp_path):
+        """#392: when NO same-slug candidate parses, there is no album
+        entry and no collision record (parse warnings already fire)."""
+        content_root = tmp_path / "content"
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+        b_dir = _make_album_tree(content_root, "testartist", "b-genre", "midnight")
+        (b_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        assert result == {}
+        assert collisions == []
+
 
 @pytest.mark.unit
 class TestScanTracks:
@@ -1255,6 +1396,49 @@ class TestBuildState:
         assert state['config']['artist_name'] == 'myartist'
         assert state['config']['content_root'] == str(content_root)
         assert state['config']['config_mtime'] == 42.0
+
+    def test_build_state_album_collisions_empty_when_clean(self, tmp_path, monkeypatch):
+        """#392: album_collisions is always present, [] with no collisions."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "solo-album")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        state = build_state(config)
+        assert state['album_collisions'] == []
+
+    def test_build_state_album_collisions_populated(self, tmp_path, monkeypatch):
+        """#392: on-disk collision surfaces in album_collisions and the
+        winner's tracks stay intact."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(
+            content_root, "testartist", "rock", "midnight",
+            tracks={"01-rock.md": _make_track_content("Rock Track")})
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        state = build_state(config)
+        assert state['album_collisions'] == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }]
+        album = state['albums']['midnight']
+        assert album['genre'] == 'jazz'
+        assert '01-jazz' in album['tracks']
 
 
 @pytest.mark.unit
@@ -1536,6 +1720,234 @@ anchor_track: 3
 
         updated = incremental_update(existing, config)
         assert updated['albums']['my-album']['anchor_track'] == 3
+
+    def test_collision_detected_on_incremental_update(self, tmp_path, monkeypatch):
+        """#392: a cross-genre twin appearing after the initial build is
+        detected and the winner (with its tracks) survives the removal loop."""
+        content_root = tmp_path / "content"
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['album_collisions'] == []
+
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        updated = incremental_update(existing, config)
+        assert updated['album_collisions'] == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }]
+        album = updated['albums']['midnight']
+        assert album['genre'] == 'jazz'
+        assert '01-jazz' in album['tracks']
+
+    def test_collision_winner_deterministic_on_update(self, tmp_path, monkeypatch):
+        """#392: the lexicographically-first genre wins even when the
+        cached entry points at the other genre (deterministic regardless
+        of dict/filesystem order)."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['albums']['midnight']['genre'] == 'rock'
+
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+
+        updated = incremental_update(existing, config)
+        assert 'midnight' in updated['albums']
+        assert updated['albums']['midnight']['genre'] == 'jazz'
+        assert updated['albums']['midnight']['path'] == str(jazz_dir)
+        assert updated['album_collisions'][0]['kept']['genre'] == 'jazz'
+        assert updated['album_collisions'][0]['shadowed'][0]['genre'] == 'rock'
+
+    def test_collision_cleared_when_resolved_on_disk(self, tmp_path, monkeypatch):
+        """#392: removing the shadowed twin clears album_collisions on
+        the next incremental update."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "jazz", "midnight")
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert len(existing['album_collisions']) == 1
+
+        shutil.rmtree(rock_dir)
+
+        updated = incremental_update(existing, config)
+        assert updated['album_collisions'] == []
+        assert updated['albums']['midnight']['genre'] == 'jazz'
+
+    def test_collision_path_mismatch_triggers_reparse(self, tmp_path, monkeypatch):
+        """#392: a cached entry whose path points at the shadowed twin
+        must be fully re-parsed even when README mtimes match — otherwise
+        the twin's data is wrongly reused for the winner."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['albums']['midnight']['path'] == str(rock_dir)
+
+        jazz_readme = """---
+title: "Jazz Midnight"
+genres: ["jazz"]
+explicit: false
+---
+
+# Jazz Midnight
+
+## Album Details
+
+| Attribute | Detail |
+|-----------|--------|
+| **Status** | Concept |
+| **Tracks** | 0 |
+"""
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            readme_text=jazz_readme,
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+        # Force the winner's README mtime to equal the cached (rock)
+        # mtime so only the path check can trigger the re-parse.
+        cached_mtime = existing['albums']['midnight']['readme_mtime']
+        os.utime(jazz_dir / "README.md", (cached_mtime, cached_mtime))
+
+        updated = incremental_update(existing, config)
+        album = updated['albums']['midnight']
+        assert album['path'] == str(jazz_dir)
+        assert album['genre'] == 'jazz'
+        assert album['title'] == 'Jazz Midnight'
+        assert '01-jazz' in album['tracks']
+
+    def test_collision_unreadable_new_twin_keeps_cached_winner(
+            self, tmp_path, monkeypatch):
+        """#392: cached winner is b-genre; an unreadable a-genre twin
+        appears. The record must report kept = the entry actually in the
+        albums map (b-genre), not claim the unreadable a-genre won."""
+        content_root = tmp_path / "content"
+        b_dir = _make_album_tree(content_root, "testartist", "b-genre", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['albums']['midnight']['path'] == str(b_dir)
+
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+
+        updated = incremental_update(existing, config)
+        album = updated['albums']['midnight']
+        assert album['path'] == str(b_dir)
+        assert album['genre'] == 'b-genre'
+        assert updated['album_collisions'] == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'b-genre', 'path': str(b_dir)},
+            'shadowed': [{'genre': 'a-genre', 'path': str(a_dir)}],
+        }]
+        assert updated['album_collisions'][0]['kept']['path'] == album['path']
+
+    def test_collision_unreadable_first_twin_incremental_agrees_with_rebuild(
+            self, tmp_path, monkeypatch):
+        """#392: with the first twin's README unreadable, incremental
+        update picks the SAME winner and emits the SAME collision record
+        as a full rebuild, and kept.path matches the albums map."""
+        content_root = tmp_path / "content"
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+        b_dir = _make_album_tree(content_root, "testartist", "b-genre", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        expected_record = {
+            'slug': 'midnight',
+            'kept': {'genre': 'b-genre', 'path': str(b_dir)},
+            'shadowed': [{'genre': 'a-genre', 'path': str(a_dir)}],
+        }
+        assert existing['albums']['midnight']['path'] == str(b_dir)
+        assert existing['album_collisions'] == [expected_record]
+
+        updated = incremental_update(existing, config)
+        album = updated['albums']['midnight']
+        assert album['path'] == str(b_dir)
+        assert album['genre'] == 'b-genre'
+        assert updated['album_collisions'] == [expected_record]
+        assert updated['album_collisions'][0]['kept']['path'] == album['path']
+
+    def test_collision_both_parseable_first_genre_wins_both_paths(
+            self, tmp_path, monkeypatch):
+        """#392: with both READMEs parseable the lexicographically-first
+        genre still wins on both the rebuild and incremental paths."""
+        content_root = tmp_path / "content"
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        expected_record = {
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }
+        assert existing['albums']['midnight']['path'] == str(jazz_dir)
+        assert existing['album_collisions'] == [expected_record]
+
+        updated = incremental_update(existing, config)
+        assert updated['albums']['midnight']['path'] == str(jazz_dir)
+        assert updated['albums']['midnight']['genre'] == 'jazz'
+        assert updated['album_collisions'] == [expected_record]
 
 
 @pytest.mark.unit
@@ -1997,8 +2409,8 @@ class TestMigrate1_0To1_1:
         }
         result = migrate_state(state)
         assert result is not None
-        # Full chain: 1.0.0 → 1.1.0 → 1.2.0
-        assert result['version'] == '1.2.0'
+        # Full chain: 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0
+        assert result['version'] == '1.3.0'
         assert 'skills' in result
         assert result['skills']['count'] == 0
         assert result['skills']['items'] == {}
@@ -2275,7 +2687,7 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         assert 'plugin_version' in result
         assert result['plugin_version'] is None
 
@@ -2311,8 +2723,77 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         assert result['plugin_version'] == '0.43.0'
+
+
+@pytest.mark.unit
+class TestMigrate1_2To1_3:
+    """Tests for the 1.2.0 → 1.3.0 migration (#392)."""
+
+    def _state_1_2(self, **overrides):
+        state = {
+            'version': '1.2.0',
+            'generated_at': '2026-01-01T00:00:00+00:00',
+            'plugin_version': None,
+            'config': {
+                'content_root': '/tmp/c',
+                'audio_root': '/tmp/a',
+                'documents_root': '/tmp/d',
+                'artist_name': 'test',
+                'config_mtime': 100.0,
+            },
+            'albums': {},
+            'ideas': {'counts': {}, 'items': [], 'file_mtime': 0.0},
+            'skills': {
+                'skills_root': '/tmp/skills',
+                'skills_root_mtime': 0.0,
+                'count': 0,
+                'model_counts': {},
+                'items': {},
+            },
+            'session': {
+                'last_album': None,
+                'last_track': None,
+                'last_phase': None,
+                'pending_actions': [],
+                'updated_at': None,
+            },
+        }
+        state.update(overrides)
+        return state
+
+    def test_migration_adds_album_collisions(self):
+        """State from v1.2.0 gets album_collisions field via migration."""
+        result = migrate_state(self._state_1_2())
+        assert result is not None
+        assert result['version'] == '1.3.0'
+        assert result['album_collisions'] == []
+
+    def test_migration_preserves_existing_album_collisions(self):
+        """If album_collisions already exists, migration preserves it."""
+        collision = {
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': '/tmp/jazz/midnight'},
+            'shadowed': [{'genre': 'rock', 'path': '/tmp/rock/midnight'}],
+        }
+        result = migrate_state(self._state_1_2(album_collisions=[collision]))
+        assert result is not None
+        assert result['version'] == '1.3.0'
+        assert result['album_collisions'] == [collision]
+
+    def test_full_chain_1_0_to_1_3(self):
+        """Existing 1.0 → 1.2 chain still works and now ends at 1.3.0."""
+        state = self._state_1_2()
+        state['version'] = '1.0.0'
+        del state['plugin_version']
+        del state['skills']
+        result = migrate_state(state)
+        assert result is not None
+        assert result['version'] == CURRENT_VERSION == '1.3.0'
+        assert 'skills' in result
+        assert 'plugin_version' in result
+        assert result['album_collisions'] == []
 
 
 @pytest.mark.unit
@@ -2359,7 +2840,7 @@ class TestValidateStatePluginVersion:
 
 @pytest.mark.unit
 class TestFullMigrationChain:
-    """Tests for the complete migration chain 1.0.0 → 1.2.0."""
+    """Tests for the complete migration chain 1.0.0 → 1.3.0."""
 
     def test_1_0_to_1_2_adds_both_skills_and_plugin_version(self):
         """Full chain from 1.0.0 adds skills AND plugin_version."""
@@ -2385,7 +2866,7 @@ class TestFullMigrationChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         # From 1.0→1.1 migration
         assert 'skills' in result
         assert result['skills']['count'] == 0
@@ -2609,7 +3090,7 @@ class TestMigrateStateChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         assert result['plugin_version'] is None
 
     def test_migration_does_not_overwrite_existing_skills(self):
@@ -3057,6 +3538,45 @@ class TestIncrementalUpdateAlbumsDirMissing:
         # Stale album should still be in state since albums_dir doesn't exist
         # (the code only cleans up when albums_dir.exists() is True)
         assert 'albums' in updated
+
+    def test_albums_dir_missing_preserves_collisions(self, tmp_path, monkeypatch):
+        """#392: when albums dir doesn't exist the albums map is
+        deliberately preserved — album_collisions must be preserved with
+        it, not wiped to []."""
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        # Don't create artists/testartist/albums/
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        collision = {
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': '/tmp/gone/jazz/midnight'},
+            'shadowed': [{'genre': 'rock', 'path': '/tmp/gone/rock/midnight'}],
+        }
+        existing = _make_minimal_state(album_collisions=[collision])
+        existing['config']['config_mtime'] = 100.0
+        existing['config']['content_root'] = str(content_root)
+        existing['config']['artist_name'] = 'testartist'
+        existing['albums'] = {
+            'midnight': {
+                'path': '/tmp/gone/jazz/midnight',
+                'genre': 'jazz',
+                'title': 'Midnight',
+                'status': 'Concept',
+                'tracks': {},
+                'readme_mtime': 100.0,
+            }
+        }
+
+        updated = incremental_update(existing, config)
+        assert 'midnight' in updated['albums']
+        assert updated['album_collisions'] == [collision]
 
 
 @pytest.mark.unit

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -216,6 +216,23 @@ def _fresh_state():
     return copy.deepcopy(SAMPLE_STATE)
 
 
+def _state_with_collision(slug="test-album"):
+    """Sample state with an album_collisions record for the given slug (#392)."""
+    state = _fresh_state()
+    state["album_collisions"] = [{
+        "slug": slug,
+        "kept": {
+            "genre": "electronic",
+            "path": f"/tmp/test/artists/test-artist/albums/electronic/{slug}",
+        },
+        "shadowed": [{
+            "genre": "rock",
+            "path": f"/tmp/test/artists/test-artist/albums/rock/{slug}",
+        }],
+    }]
+    return state
+
+
 # ---------------------------------------------------------------------------
 # Re-export completeness — ensure server.py re-exports all registered tools
 # ---------------------------------------------------------------------------
@@ -926,6 +943,46 @@ class TestFindAlbum:
         assert "No albums found" in result["error"]
         assert result.get("rebuilt") is True
 
+    def test_collision_warning_on_collided_slug(self):
+        """Exact match on a collided slug includes a collision_warning."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("test-album")))
+        assert result["found"] is True
+        warning = result["collision_warning"]
+        assert warning["visible"]["genre"] == "electronic"
+        assert warning["shadowed"][0]["genre"] == "rock"
+        assert "rock" in warning["shadowed"][0]["path"]
+        assert "/bitwize-music:rename" in warning["message"]
+        assert "rebuild_state" in warning["message"]
+
+    def test_collision_warning_on_fuzzy_match(self):
+        """Fuzzy-resolved slug also gets the collision warning."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("test")))
+        assert result["found"] is True
+        assert result["slug"] == "test-album"
+        assert "collision_warning" in result
+
+    def test_no_collision_warning_on_clean_slug(self):
+        """A slug absent from album_collisions gets no warning."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("another-album")))
+        assert result["found"] is True
+        assert "collision_warning" not in result
+
+    def test_missing_collisions_field_does_not_crash(self):
+        """Pre-1.3.0 states without album_collisions work unchanged."""
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("test-album")))
+        assert result["found"] is True
+        assert "collision_warning" not in result
+
 
 # =============================================================================
 # Tests for MCP tool: list_albums
@@ -983,6 +1040,36 @@ class TestListAlbums:
         assert album["status"] == "In Progress"
         assert album["track_count"] == 2
         assert album["tracks_completed"] == 1
+
+    def test_collisions_surfaced_when_present(self):
+        """Non-empty album_collisions is echoed with a warning string."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.list_albums()))
+        assert result["collisions"][0]["slug"] == "test-album"
+        assert "test-album" in result["warning"]
+        assert "/bitwize-music:rename" in result["warning"]
+
+    def test_no_collisions_keys_when_clean(self):
+        """Empty album_collisions adds neither collisions nor warning."""
+        state = _fresh_state()
+        state["album_collisions"] = []
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.list_albums()))
+        assert "collisions" not in result
+        assert "warning" not in result
+
+    def test_missing_collisions_field_does_not_crash(self):
+        """Pre-1.3.0 states without album_collisions work unchanged."""
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.list_albums()))
+        assert result["count"] == 2
+        assert "collisions" not in result
+        assert "warning" not in result
 
 
 # =============================================================================
@@ -1163,6 +1250,38 @@ class TestRebuildStateTool:
             result = json.loads(_run(server.rebuild_state()))
         assert "error" in result
         assert "Config not found" in result["error"]
+
+    def test_collision_count_reported(self):
+        """A rebuild that detects collisions says so immediately."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.rebuild_state()))
+        assert result["success"] is True
+        assert result["collision_count"] == 1
+        assert result["collisions"][0]["slug"] == "test-album"
+        assert "/bitwize-music:rename" in result["warning"]
+
+    def test_collision_count_zero_when_clean(self):
+        """Empty album_collisions reports zero without a details list."""
+        state = _fresh_state()
+        state["album_collisions"] = []
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.rebuild_state()))
+        assert result["collision_count"] == 0
+        assert "collisions" not in result
+        assert "warning" not in result
+
+    def test_missing_collisions_field_reports_zero(self):
+        """Rebuild result without album_collisions still reports a count."""
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.rebuild_state()))
+        assert result["success"] is True
+        assert result["collision_count"] == 0
+        assert "collisions" not in result
 
 
 # =============================================================================
@@ -4091,6 +4210,47 @@ class TestCreateAlbumStructure:
             result = json.loads(_run(server.create_album_structure("existing", "rock")))
         assert result["created"] is False
         assert "already exists" in result["error"]
+
+    def test_cross_genre_collision_rejected(self, tmp_path):
+        """Same slug under a DIFFERENT genre blocks creation (#392)."""
+        mock_cache, content = self._make_state_with_tmp(tmp_path)
+        existing = content / "artists" / "test-artist" / "albums" / "rock" / "existing"
+        existing.mkdir(parents=True)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.create_album_structure("existing", "electronic")))
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        assert "rock" in result["error"]
+        assert str(existing) in result["error"]
+        assert "rename" in result["error"].lower()
+        # The colliding twin must NOT be created
+        twin = content / "artists" / "test-artist" / "albums" / "electronic" / "existing"
+        assert not twin.exists()
+
+    def test_glob_metachars_in_slug_do_not_false_collide(self, tmp_path):
+        """The collision sweep is literal — 'alb*m' must not match 'album' (#392)."""
+        mock_cache, content = self._make_state_with_tmp(tmp_path)
+        existing = content / "artists" / "test-artist" / "albums" / "rock" / "album"
+        existing.mkdir(parents=True)
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_shared_mod, "PLUGIN_ROOT", Path(__file__).resolve().parent.parent.parent.parent):
+            result = json.loads(_run(server.create_album_structure("alb*m", "electronic")))
+        # Under fnmatch semantics 'alb*m' matches 'album'; a literal sweep must not.
+        assert "already exists" not in result.get("error", "")
+
+    def test_new_slug_unaffected_by_other_albums(self, tmp_path):
+        """A genuinely new slug still succeeds when other albums exist (regression)."""
+        mock_cache, content = self._make_state_with_tmp(tmp_path)
+        other = content / "artists" / "test-artist" / "albums" / "rock" / "other-album"
+        other.mkdir(parents=True)
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_shared_mod, "PLUGIN_ROOT", Path(__file__).resolve().parent.parent.parent.parent):
+            result = json.loads(_run(server.create_album_structure("fresh-album", "electronic")))
+        assert result["created"] is True
+        assert Path(result["path"]).is_dir()
 
     def test_no_config(self):
         state = {"albums": {}, "ideas": {}, "session": {}}
@@ -7510,15 +7670,18 @@ class TestHealthCheck:
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
              patch("importlib.metadata.version", side_effect=mock_version), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert result["status"] == "ok"
-        assert len(result["checks"]) == 2
+        assert len(result["checks"]) == 3
         assert result["checks"][0]["name"] == "venv"
         assert result["checks"][0]["status"] == "ok"
         assert result["checks"][1]["name"] == "skills"
         assert result["checks"][1]["status"] == "ok"
+        assert result["checks"][2]["name"] == "collisions"
+        assert result["checks"][2]["status"] == "ok"
 
     def test_stale_skills_returns_warn(self, tmp_path):
         """Stale skills with ok venv returns overall warn."""
@@ -7548,7 +7711,8 @@ class TestHealthCheck:
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
              patch("importlib.metadata.version", return_value="2.31.0"), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert result["status"] == "warn"
@@ -7567,7 +7731,8 @@ class TestHealthCheck:
         # No venv
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
-             patch.object(Path, "home", return_value=fakehome):
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert result["status"] == "fail"
@@ -7584,13 +7749,107 @@ class TestHealthCheck:
         (fakehome / ".bitwize-music").mkdir(parents=True)
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
-             patch.object(Path, "home", return_value=fakehome):
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert "venv" in result
         assert "skills" in result
         assert "status" in result["venv"]
         assert "status" in result["skills"]
+
+    def test_collisions_ok_shape(self, tmp_path):
+        """Empty album_collisions yields the {"status": "ok"} section."""
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "skills").mkdir(parents=True)
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        state = _fresh_state()
+        state["album_collisions"] = []
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["collisions"] == {"status": "ok"}
+        collisions_check = next(
+            c for c in result["checks"] if c["name"] == "collisions")
+        assert collisions_check["status"] == "ok"
+
+    def test_collisions_missing_field_is_ok(self, tmp_path):
+        """Pre-1.3.0 states without album_collisions don't crash health_check."""
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "skills").mkdir(parents=True)
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["collisions"] == {"status": "ok"}
+
+    def test_collisions_detected_shape(self, tmp_path):
+        """Collisions yield status "collision" with details and a fix."""
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "skills").mkdir(parents=True)
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache",
+                          MockStateCache(_state_with_collision("test-album"))):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["collisions"]["status"] == "collision"
+        assert result["collisions"]["collisions"][0]["slug"] == "test-album"
+        assert "/bitwize-music:rename" in result["collisions"]["fix"]
+        collisions_check = next(
+            c for c in result["checks"] if c["name"] == "collisions")
+        assert collisions_check["status"] == "warn"
+        assert "test-album" in collisions_check["detail"]
+
+    def test_collisions_alone_warn_overall(self, tmp_path):
+        """Venv and skills ok + collisions present → overall warn."""
+        # Set up matching skills (same scaffolding as test_all_ok)
+        plugin_root = tmp_path / "plugin"
+        skill_dir = plugin_root / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+
+        cache_dir = (tmp_path / "fakehome" / ".claude" / "plugins" / "cache"
+                     / "bitwize-music" / "bitwize-music" / "1.0.0")
+        cache_skills_dir = cache_dir / "skills" / "test-skill"
+        cache_skills_dir.mkdir(parents=True)
+        (cache_skills_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+        pj = cache_dir / ".claude-plugin"
+        pj.mkdir(parents=True)
+        (pj / "plugin.json").write_text('{"version": "1.0.0"}')
+
+        # Set up venv
+        req = plugin_root / "requirements.txt"
+        req.write_text("requests==2.31.0\n")
+        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "python3").touch()
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch("importlib.metadata.version", return_value="2.31.0"), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"), \
+             patch.object(_shared_mod, "cache",
+                          MockStateCache(_state_with_collision("test-album"))):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["status"] == "warn"
+        assert result["checks"][0]["status"] == "ok"
+        assert result["checks"][1]["status"] == "ok"
+        assert result["checks"][2]["name"] == "collisions"
+        assert result["checks"][2]["status"] == "warn"
 
 
 # =============================================================================

--- a/tests/unit/state/test_server_integration.py
+++ b/tests/unit/state/test_server_integration.py
@@ -533,7 +533,7 @@ class TestStateRebuildPipeline:
     def test_state_json_has_correct_structure(self, integration_env):
         """state.json built from real files has all expected fields."""
         state = json.loads(integration_env["state_file"].read_text())
-        assert state["version"] == "1.2.0"
+        assert state["version"] == "1.3.0"
         assert "config" in state
         assert "albums" in state
         assert "session" in state

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -66,7 +66,7 @@ from tools.state.parsers import (
 logger = logging.getLogger(__name__)
 
 # Schema version for state.json
-CURRENT_VERSION = "1.2.0"
+CURRENT_VERSION = "1.3.0"
 
 # Cache location (constant, not configurable)
 CACHE_DIR = Path.home() / ".bitwize-music" / "cache"
@@ -117,11 +117,19 @@ def _migrate_1_1_to_1_2(state: dict[str, Any]) -> dict[str, Any]:
     return state
 
 
+def _migrate_1_2_to_1_3(state: dict[str, Any]) -> dict[str, Any]:
+    """Migrate state from 1.2.0 to 1.3.0: add album_collisions field."""
+    if 'album_collisions' not in state:
+        state['album_collisions'] = []
+    return state
+
+
 # Migration chain for schema upgrades
 # Format: "from_version": (migration_fn, "to_version")
 MIGRATIONS: dict[str, tuple[Any, str]] = {
     "1.0.0": (_migrate_1_0_to_1_1, "1.1.0"),
     "1.1.0": (_migrate_1_1_to_1_2, "1.2.0"),
+    "1.2.0": (_migrate_1_2_to_1_3, "1.3.0"),
 }
 
 
@@ -203,12 +211,18 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def scan_albums(content_root: Path, artist_name: str) -> dict[str, dict[str, Any]]:
+def scan_albums(
+    content_root: Path,
+    artist_name: str,
+    collisions: list[dict[str, Any]] | None = None,
+) -> dict[str, dict[str, Any]]:
     """Scan all album READMEs and their tracks.
 
     Args:
         content_root: Root content directory.
         artist_name: Artist name from config.
+        collisions: Optional out-param; collision records are appended
+            when the same album slug exists under multiple genres (#392).
 
     Returns:
         Dict mapping album slug to album data.
@@ -219,41 +233,77 @@ def scan_albums(content_root: Path, artist_name: str) -> dict[str, dict[str, Any
     if not albums_dir.exists():
         return albums
 
-    # Glob for album READMEs: albums/{genre}/{album}/README.md
+    # Group same-slug dirs structurally first (the sorted glob keeps
+    # genre order deterministic): albums/{genre}/{album}/README.md.
+    # The winner of a collision is the FIRST candidate that actually
+    # indexes — i.e. whose README parses — not merely the first dir, so
+    # an unreadable first twin never silently hands the slug to a later
+    # twin without a collision record (#392).
+    readmes_by_slug: dict[str, list[Path]] = {}
     for readme_path in sorted(albums_dir.glob("*/*/README.md")):
-        album_dir = readme_path.parent
-        album_slug = album_dir.name
-        genre = album_dir.parent.name
+        readmes_by_slug.setdefault(
+            readme_path.parent.name, []).append(readme_path)
 
-        album_data = parse_album_readme(readme_path)
-        if '_error' in album_data:
-            logger.warning("Skipping %s: %s", readme_path, album_data['_error'])
-            continue
+    for album_slug, readme_paths in readmes_by_slug.items():
+        winner_dir: Path | None = None
+        for readme_path in readme_paths:
+            album_dir = readme_path.parent
 
-        # Scan tracks
-        tracks = scan_tracks(album_dir)
+            album_data = parse_album_readme(readme_path)
+            if '_error' in album_data:
+                logger.warning("Skipping %s: %s", readme_path, album_data['_error'])
+                continue  # try the next same-slug candidate, if any
 
-        try:
-            readme_mtime = readme_path.stat().st_mtime
-        except OSError:
-            continue  # File removed between glob and stat
+            # Scan tracks
+            tracks = scan_tracks(album_dir)
 
-        albums[album_slug] = {
-            'path': str(album_dir),
-            'genre': genre,
-            'title': album_data.get('title', album_slug),
-            'status': album_data.get('status', 'Unknown'),
-            'explicit': album_data.get('explicit', False),
-            'anchor_track': album_data.get('anchor_track'),
-            'layout': album_data.get('layout'),
-            'mastering': album_data.get('mastering') or {},
-            'release_date': album_data.get('release_date'),
-            'track_count': album_data.get('track_count', len(tracks)),
-            'tracks_completed': album_data.get('tracks_completed', 0),
-            'streaming_urls': album_data.get('streaming_urls', {}),
-            'readme_mtime': readme_mtime,
-            'tracks': tracks,
-        }
+            try:
+                readme_mtime = readme_path.stat().st_mtime
+            except OSError:
+                continue  # File removed between glob and stat
+
+            albums[album_slug] = {
+                'path': str(album_dir),
+                'genre': album_dir.parent.name,
+                'title': album_data.get('title', album_slug),
+                'status': album_data.get('status', 'Unknown'),
+                'explicit': album_data.get('explicit', False),
+                'anchor_track': album_data.get('anchor_track'),
+                'layout': album_data.get('layout'),
+                'mastering': album_data.get('mastering') or {},
+                'release_date': album_data.get('release_date'),
+                'track_count': album_data.get('track_count', len(tracks)),
+                'tracks_completed': album_data.get('tracks_completed', 0),
+                'streaming_urls': album_data.get('streaming_urls', {}),
+                'readme_mtime': readme_mtime,
+                'tracks': tracks,
+            }
+            winner_dir = album_dir
+            break  # remaining same-slug dirs are shadowed, never parsed
+
+        if len(readme_paths) > 1 and winner_dir is not None:
+            # Emit the record only with kept = the entry actually present
+            # in the albums map. If no candidate indexed, there is no
+            # entry and no record (the parse warnings above already fired).
+            kept = albums[album_slug]
+            shadowed = sorted(
+                ({'genre': p.parent.parent.name, 'path': str(p.parent)}
+                 for p in readme_paths if p.parent != winner_dir),
+                key=lambda s: s['genre'],
+            )
+            logger.warning(
+                "Album slug collision: '%s' — keeping %s, shadowing %s. "
+                "Rename one album (/bitwize-music:rename) or move the "
+                "directory, then rebuild the state cache.",
+                album_slug, kept['path'],
+                ', '.join(s['path'] for s in shadowed),
+            )
+            if collisions is not None:
+                collisions.append({
+                    'slug': album_slug,
+                    'kept': {'genre': kept['genre'], 'path': kept['path']},
+                    'shadowed': shadowed,
+                })
 
     return albums
 
@@ -408,6 +458,8 @@ def build_state(config: dict[str, Any],
     artist_name = config_section['artist_name']
 
     installed_version = _read_plugin_version(plugin_root)
+    album_collisions: list[dict[str, Any]] = []
+    albums = scan_albums(content_root, artist_name, album_collisions)
     return {
         'version': CURRENT_VERSION,
         'generated_at': datetime.now(UTC).isoformat(),
@@ -421,7 +473,8 @@ def build_state(config: dict[str, Any],
         'plugin_version': installed_version,
         'last_migrated_version': installed_version,
         'config': config_section,
-        'albums': scan_albums(content_root, artist_name),
+        'albums': albums,
+        'album_collisions': album_collisions,
         'ideas': scan_ideas(config, content_root),
         'skills': scan_skills(plugin_root),
         'session': {
@@ -475,7 +528,9 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
 
         if path_fields_changed:
             # Content root or artist name changed — full album rescan required
-            state['albums'] = scan_albums(content_root, artist_name)
+            rescan_collisions: list[dict[str, Any]] = []
+            state['albums'] = scan_albums(content_root, artist_name, rescan_collisions)
+            state['album_collisions'] = rescan_collisions
         # else: only non-path config changed (urls, generation, etc.) — keep albums
 
         if ideas_path_changed:
@@ -491,60 +546,124 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
     existing_albums = state.get('albums', {})
 
     if albums_dir.exists():
-        # Find current albums on disk
-        current_album_slugs = set()
-        for readme_path in albums_dir.glob("*/*/README.md"):
-            album_dir = readme_path.parent
-            slug = album_dir.name
-            current_album_slugs.add(slug)
+        collisions: list[dict[str, Any]] = []
+        # Group same-slug dirs structurally first (the sorted glob keeps
+        # genre order deterministic). The winner of a collision is the
+        # FIRST candidate that actually indexes — a cache-valid entry
+        # (path+mtime match) or a successful re-parse — mirroring
+        # scan_albums, so record['kept'] always matches the albums
+        # map (#392).
+        readmes_by_slug: dict[str, list[Path]] = {}
+        for readme_path in sorted(albums_dir.glob("*/*/README.md")):
+            readmes_by_slug.setdefault(
+                readme_path.parent.name, []).append(readme_path)
 
+        current_album_slugs = set()
+        for slug, readme_paths in readmes_by_slug.items():
+            current_album_slugs.add(slug)
             existing_album = existing_albums.get(slug)
 
-            # Check if README changed
-            try:
-                readme_mtime = readme_path.stat().st_mtime
-            except OSError:
-                continue  # File removed between glob and stat
-            if existing_album and existing_album.get('readme_mtime') == readme_mtime:
-                # README unchanged, check individual tracks only
-                _update_tracks_incremental(existing_album, album_dir)
-            else:
-                # README changed or new album — re-parse album-level data
+            winner_dir: Path | None = None
+            for readme_path in readme_paths:
+                album_dir = readme_path.parent
+
+                # Check if README changed
+                try:
+                    readme_mtime = readme_path.stat().st_mtime
+                except OSError:
+                    continue  # File removed between glob and stat
+                # The path must match too — a cross-genre twin's cached
+                # entry must never be reused for the winner (#392).
+                if (existing_album
+                        and existing_album.get('path') == str(album_dir)
+                        and existing_album.get('readme_mtime') == readme_mtime):
+                    # README unchanged — the cache-valid entry counts as
+                    # successfully indexed without re-parsing; check
+                    # individual tracks only. Documented corner: a README
+                    # that becomes unreadable WITHOUT an mtime change keeps
+                    # its cached entry here, while a full rebuild would
+                    # skip it.
+                    _update_tracks_incremental(existing_album, album_dir)
+                    winner_dir = album_dir
+                    break  # remaining same-slug dirs are shadowed
+
+                # README changed, new album, or cached entry points at a
+                # different path — re-parse album-level data
                 album_data = parse_album_readme(readme_path)
-                if '_error' not in album_data:
-                    genre = album_dir.parent.name
+                if '_error' in album_data:
+                    logger.warning(
+                        "Skipping %s: %s", readme_path, album_data['_error'])
+                    continue  # try the next same-slug candidate, if any
 
-                    # Preserve existing tracks and update incrementally
-                    # (README change doesn't mean track files changed)
-                    if existing_album and existing_album.get('tracks'):
-                        tracks = existing_album['tracks']
-                        _update_tracks_incremental(
-                            {'tracks': tracks}, album_dir
-                        )
-                    else:
-                        tracks = scan_tracks(album_dir)
+                genre = album_dir.parent.name
 
-                    existing_albums[slug] = {
-                        'path': str(album_dir),
-                        'genre': genre,
-                        'title': album_data.get('title', slug),
-                        'status': album_data.get('status', 'Unknown'),
-                        'explicit': album_data.get('explicit', False),
-                        'anchor_track': album_data.get('anchor_track'),
-                        'layout': album_data.get('layout'),
-                        'mastering': album_data.get('mastering') or {},
-                        'release_date': album_data.get('release_date'),
-                        'track_count': album_data.get('track_count', len(tracks)),
-                        'tracks_completed': album_data.get('tracks_completed', 0),
-                        'streaming_urls': album_data.get('streaming_urls', {}),
-                        'readme_mtime': readme_mtime,
-                        'tracks': tracks,
-                    }
+                # Preserve existing tracks and update incrementally
+                # (README change doesn't mean track files changed) —
+                # but only when the cached entry is for this same
+                # directory, not a cross-genre twin.
+                if (existing_album
+                        and existing_album.get('path') == str(album_dir)
+                        and existing_album.get('tracks')):
+                    tracks = existing_album['tracks']
+                    _update_tracks_incremental(
+                        {'tracks': tracks}, album_dir
+                    )
+                else:
+                    tracks = scan_tracks(album_dir)
+
+                existing_albums[slug] = {
+                    'path': str(album_dir),
+                    'genre': genre,
+                    'title': album_data.get('title', slug),
+                    'status': album_data.get('status', 'Unknown'),
+                    'explicit': album_data.get('explicit', False),
+                    'anchor_track': album_data.get('anchor_track'),
+                    'layout': album_data.get('layout'),
+                    'mastering': album_data.get('mastering') or {},
+                    'release_date': album_data.get('release_date'),
+                    'track_count': album_data.get('track_count', len(tracks)),
+                    'tracks_completed': album_data.get('tracks_completed', 0),
+                    'streaming_urls': album_data.get('streaming_urls', {}),
+                    'readme_mtime': readme_mtime,
+                    'tracks': tracks,
+                }
+                winner_dir = album_dir
+                break  # remaining same-slug dirs are shadowed
+
+            if len(readme_paths) > 1 and winner_dir is not None:
+                # Emit the record only with kept = the entry actually
+                # present in the albums map. If no candidate indexed,
+                # there is no record (the parse warnings above already
+                # fired).
+                kept = existing_albums[slug]
+                shadowed = sorted(
+                    ({'genre': p.parent.parent.name, 'path': str(p.parent)}
+                     for p in readme_paths if p.parent != winner_dir),
+                    key=lambda s: s['genre'],
+                )
+                collisions.append({
+                    'slug': slug,
+                    'kept': {'genre': kept['genre'], 'path': kept['path']},
+                    'shadowed': shadowed,
+                })
+                logger.warning(
+                    "Album slug collision: '%s' — keeping %s, shadowing %s. "
+                    "Rename one album (/bitwize-music:rename) or move the "
+                    "directory, then rebuild the state cache.",
+                    slug, kept['path'],
+                    ', '.join(s['path'] for s in shadowed),
+                )
 
         # Remove albums that no longer exist on disk
         for slug in list(existing_albums.keys()):
             if slug not in current_album_slugs:
                 del existing_albums[slug]
+
+        # Collisions are recomputed only when the albums dir was actually
+        # scanned — when it's missing, the albums map is deliberately
+        # preserved above, so preserve the matching collision records
+        # too (#392).
+        state['album_collisions'] = collisions
 
     state['albums'] = existing_albums
 
@@ -1018,6 +1137,21 @@ def validate_state(state: dict[str, Any]) -> list[str]:
     else:
         errors.append("albums should be a dict")
 
+    # Album collisions section (added in 1.3.0; absent on older states is
+    # fine — the migration adds it)
+    if 'album_collisions' in state:
+        album_collisions = state['album_collisions']
+        if isinstance(album_collisions, list):
+            for i, entry in enumerate(album_collisions):
+                if not isinstance(entry, dict):
+                    errors.append(f"album_collisions[{i}] should be a dict")
+                    continue
+                for key in ('slug', 'kept', 'shadowed'):
+                    if key not in entry:
+                        errors.append(f"album_collisions[{i}] missing '{key}'")
+        else:
+            errors.append("album_collisions should be a list")
+
     # Ideas section
     ideas = state.get('ideas', {})
     if isinstance(ideas, dict):
@@ -1094,6 +1228,14 @@ def cmd_rebuild(args: argparse.Namespace) -> int:
     print(f"  Tracks: {track_count}")
     print(f"  Ideas: {ideas_count}")
     print(f"  Skills: {skills_count}")
+    collisions = state.get('album_collisions', [])
+    if collisions:
+        print(f"  Collisions: {len(collisions)}")
+        logger.warning(
+            "%d album slug collision(s) detected — run 'show' for details; "
+            "rename with /bitwize-music:rename or move the directory",
+            len(collisions),
+        )
     print(f"  Saved to: {STATE_FILE}")
     return 0
 
@@ -1119,6 +1261,13 @@ def cmd_update(args: argparse.Namespace) -> int:
     state = incremental_update(migrated, config)
     write_state(state)
 
+    collisions = state.get('album_collisions', [])
+    if collisions:
+        logger.warning(
+            "%d album slug collision(s) detected — run 'show' for details; "
+            "rename with /bitwize-music:rename or move the directory",
+            len(collisions),
+        )
     logger.info("State cache updated")
     return 0
 
@@ -1292,6 +1441,18 @@ def cmd_show(args: argparse.Namespace) -> int:
                 suno = ' [suno]' if track.get('has_suno_link') else ''
                 print(f"    {track_slug}: {t_status}{suno}")
     print()
+
+    # Album slug collisions (#392)
+    collisions = state.get('album_collisions', [])
+    if collisions:
+        print(f"{Colors.BOLD}{Colors.YELLOW}Album slug collisions ({len(collisions)}):{Colors.NC}")
+        for collision in collisions:
+            kept = collision.get('kept', {})
+            print(f"  {collision.get('slug', '?')}: keeping {kept.get('genre', '?')} ({kept.get('path', '?')})")
+            for s in collision.get('shadowed', []):
+                print(f"    shadowed: {s.get('genre', '?')} ({s.get('path', '?')})")
+        print("  Fix: rename one album (/bitwize-music:rename) or move the directory, then rebuild.")
+        print()
 
     # Ideas
     ideas = state.get('ideas', {})


### PR DESCRIPTION
Fixes #392.

## Problem

The state cache keyed albums by bare directory name (`album_dir.name`), ignoring the genre path segment. Two albums with the same slug under different genres silently overwrote each other — one album and all its tracks vanished from every MCP tool (`resume`, `list_albums`, `find_album`, all mastering/processing tools) with **no error**, and the winner was nondeterministic on the incremental path. `create_album_structure` only checked the genre-scoped path, so the collision was reachable through normal use.

## Design

Album slugs are now **globally unique across genres** (bare-slug keys stay — they're load-bearing in ~40 lookups, the Postgres schema, and slug validation rejects `/`):

1. **Guards** — `create_album_structure` and `rename_album` reject a slug that already exists under any other genre, via a literal (glob-metachar-safe) filesystem sweep (`_find_slug_dirs` in `_shared.py`). Error names the existing genre + path and points at `/bitwize-music:rename`.
2. **Detection** — the indexer detects existing on-disk collisions in **both** scan and incremental paths with one deterministic winner rule: *first genre in lexicographic order whose README parses*. No album is ever silently dropped; shadowed twins are recorded in a new top-level state field:
   ```json
   "album_collisions": [{"slug": "...", "kept": {"genre","path"}, "shadowed": [{"genre","path"}]}]
   ```
   with the invariant `kept.path == albums[slug].path`. State schema bumps 1.2.0 → 1.3.0 with a chained migration.
3. **Surfacing** — `health_check` (new collisions section, flips overall status to `warn` — loudest channel, runs at session start), `find_album` (`collision_warning`), `list_albums` (`collisions` + `warning`), `rebuild_state` (`collision_count`), CLI `rebuild`/`update`/`show`, plus the `session-start` and `health-check` skill docs.
4. **Fix path** — renaming the visible twin (the documented remedy) now triggers a cache rebuild so the formerly-shadowed album becomes visible immediately and the collision record is recomputed; normal renames keep the cheap surgical path.

## Process & verification

- Implemented via staged multi-agent workflows: blast-radius mapping (5 readers) → spec → 4 implementation tasks each with independent spec-compliance review → whole-diff adversarial review (4 lenses, every finding attacked by 2 independent skeptics; 13 confirmed findings across 4 root causes, all fixed and re-verified).
- Full gate: `ruff` + `bandit` + `mypy` clean; **3873 passed, 2 xfailed**, coverage **85.47%** (gate 75%) with the same flags as CI.
- Docs: `reference/state-schema.md`, `skills/new-album`, `CLAUDE.md`, `CHANGELOG.md` under `[Unreleased]`.

Known corner (documented in code): a README that becomes unreadable *without* an mtime change can keep its cached entry on the incremental path while a full rebuild would skip it — inherent to mtime-based caching, noted in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)