### PR TITLE
fix(config): parse quoted YAML booleans instead of bool() truthiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Quoted YAML booleans no longer invert to True** (#388). `bool("false")`
+  is `True` in Python, so quoting a falsy boolean anywhere in user YAML
+  silently enabled the feature the user disabled: `mastering.
+  adm_validation_enabled: "false"` in config.yaml (or album frontmatter — the
+  only path that enables ADM since #353) turned Apple Digital Masters
+  validation ON, `archival_enabled: "no"` enabled archival output,
+  `database.enabled: "false"` still opened Postgres connections,
+  `cloud.public_read: "false"` uploaded files with a **public-read ACL**,
+  quoted `cloud.enabled`/`logging.enabled`/`sheet_music.section_headers`/
+  `require_suno_link_for_final`/`require_source_path_for_documentary`
+  flipped their gates, and a track or album `explicit: "false"` frontmatter
+  flag marked the content explicit. Shared `parse_yaml_bool()` /
+  `coerce_yaml_bool()` helpers (tools/shared/config.py) now parse YAML 1.1
+  boolean literals (`true/false/yes/no/on/off/1/0`, case-insensitive) at
+  every user-YAML boolean site; unrecognized values fall back to the key's
+  documented default with a warning instead of silently meaning True. State
+  schema bumps 1.3.0 → 1.4.0 with a migration that re-coerces cached
+  `explicit` flags stored as strings by the old parsers.
 - **Album slug collisions across genres no longer silently erase an album from
   the state cache** (#392). The indexer keyed the cache's `albums` map by bare
   directory name, ignoring the genre path segment — two albums with the same

--- a/reference/state-schema.md
+++ b/reference/state-schema.md
@@ -8,7 +8,7 @@ The state cache at `~/.bitwize-music/cache/state.json` is a JSON file built from
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | Yes | Schema version (currently `"1.3.0"`) |
+| `version` | string | Yes | Schema version (currently `"1.4.0"`) |
 | `generated_at` | string | Yes | ISO 8601 UTC timestamp of last build/update |
 | `plugin_version` | string\|null | Yes | Installed plugin version from `.claude-plugin/plugin.json`, refreshed every build (display only), or `null` if unreadable |
 | `last_migrated_version` | string\|null | No | Version through which migration notes have been processed. Only advances via `acknowledge_migrations`; preserved across rebuilds. `null`/absent = pre-tracking (surfaces the backlog once). Drives `get_pending_migrations`. See issue #320. |
@@ -206,5 +206,6 @@ The migration chain is defined in `tools/state/indexer.py` as `MIGRATIONS` dict.
 | 1.0.0 | 1.1.0 | Added `skills` top-level section with indexed skill metadata |
 | 1.1.0 | 1.2.0 | Added `plugin_version` top-level field for upgrade path tracking |
 | 1.2.0 | 1.3.0 | Added `album_collisions` top-level field (seeded to `[]`) for cross-genre slug collision detection (issue #392) |
+| 1.3.0 | 1.4.0 | Re-coerced cached album/track `explicit` flags that pre-#388 parsers stored as raw truthy strings (e.g. `"false"`) to real booleans |
 
 `last_migrated_version` was added as a **backward-compatible optional field** (no schema-version bump). Fresh builds include it (seeded to the installed version); states written earlier simply omit it and read as `null`, which `get_pending_migrations` treats as pre-tracking. Avoiding a version bump here is deliberate — bumping would force the live MCP path to auto-rebuild every existing state, erasing the very "behind" status migration detection depends on (issue #320).

--- a/servers/bitwize-music-server/handlers/processing/_helpers.py
+++ b/servers/bitwize-music-server/handlers/processing/_helpers.py
@@ -139,7 +139,7 @@ def _import_cloud_module(module_name: str) -> Any:
 def _check_cloud_enabled() -> str | None:
     """Return error message if cloud uploads not enabled, else None."""
     try:
-        from tools.shared.config import load_config
+        from tools.shared.config import coerce_yaml_bool, load_config
         config = load_config()
     except (ImportError, OSError, KeyError) as exc:
         logger.warning("Config load failed: %s", exc)
@@ -149,7 +149,9 @@ def _check_cloud_enabled() -> str | None:
     if not config:
         return "Config not found. Run /bitwize-music:configure first."
     cloud_config = config.get("cloud", {})
-    if not cloud_config.get("enabled", False):
+    if not coerce_yaml_bool(
+        cloud_config.get("enabled", False), default=False, context="cloud.enabled"
+    ):
         return (
             "Cloud uploads not enabled. "
             "Set cloud.enabled: true in ~/.bitwize-music/config.yaml. "

--- a/servers/bitwize-music-server/handlers/processing/sheet_music.py
+++ b/servers/bitwize-music-server/handlers/processing/sheet_music.py
@@ -539,7 +539,7 @@ async def publish_sheet_music(
             "suggestion": "Ensure boto3 is installed: pip install boto3",
         })
 
-    from tools.shared.config import load_config
+    from tools.shared.config import coerce_yaml_bool, load_config
     config = load_config()
     assert config is not None
 
@@ -559,7 +559,11 @@ async def publish_sheet_music(
             "suggestion": "Set cloud.r2.bucket or cloud.s3.bucket in ~/.bitwize-music/config.yaml",
         })
 
-    public_read = config.get("cloud", {}).get("public_read", False)
+    public_read = coerce_yaml_bool(
+        config.get("cloud", {}).get("public_read", False),
+        default=False,
+        context="cloud.public_read",
+    )
 
     uploaded: list[dict[str, Any]] = []
     failed: list[dict[str, Any]] = []

--- a/tests/unit/cloud/test_upload_to_cloud.py
+++ b/tests/unit/cloud/test_upload_to_cloud.py
@@ -399,3 +399,19 @@ class TestFindAlbumPath:
     def test_path_traversal_in_name_exits(self, tmp_path):
         with pytest.raises(SystemExit):
             mod.find_album_path(self._make_config(tmp_path), "../../../etc")
+
+
+class TestCloudEnabledGate:
+    """cloud.enabled honors quoted boolean strings (#388)."""
+
+    def test_quoted_false_exits(self, monkeypatch):
+        monkeypatch.setattr(mod, "load_config", lambda *a, **k: {"cloud": {"enabled": "false"}})
+        monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album"])
+        with pytest.raises(SystemExit):
+            mod.main()
+
+    def test_quoted_no_exits(self, monkeypatch):
+        monkeypatch.setattr(mod, "load_config", lambda *a, **k: {"cloud": {"enabled": "no"}})
+        monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album"])
+        with pytest.raises(SystemExit):
+            mod.main()

--- a/tests/unit/database/test_connection.py
+++ b/tests/unit/database/test_connection.py
@@ -1,0 +1,54 @@
+"""Unit tests for tools/database/connection.py."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _write_cfg(tmp_path, enabled_literal: str):
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        "database:\n"
+        f"  enabled: {enabled_literal}\n"
+        "  host: db.example\n"
+        "  port: 5432\n"
+        "  name: tweets\n"
+        "  user: u\n"
+        "  password: p\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+class TestGetDbConfigBooleanGate:
+    """database.enabled honors quoted boolean strings (#388)."""
+
+    def test_quoted_false_disables(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"false"'))
+        assert conn.get_db_config() is None
+
+    def test_quoted_no_disables(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"no"'))
+        assert conn.get_db_config() is None
+
+    def test_quoted_true_enables(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"true"'))
+        result = conn.get_db_config()
+        assert result is not None
+        assert result["host"] == "db.example"
+
+    def test_unquoted_bools_unchanged(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, "true"))
+        assert conn.get_db_config() is not None
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, "false"))
+        assert conn.get_db_config() is None
+
+    def test_garbage_string_disables(self, tmp_path, monkeypatch):
+        """Unparseable values fall back to the default (disabled)."""
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"maybe"'))
+        assert conn.get_db_config() is None

--- a/tests/unit/mastering/test_mastering_config.py
+++ b/tests/unit/mastering/test_mastering_config.py
@@ -79,6 +79,68 @@ class TestLoadMasteringConfig:
             result = load_mastering_config()
         assert result == DEFAULT_MASTERING_CONFIG
 
+    def test_quoted_false_strings_do_not_invert(self):
+        """Quoted falsy booleans must resolve False, not bool("false")==True (#388)."""
+        user_config = {
+            "mastering": {
+                "adm_validation_enabled": "false",
+                "archival_enabled": "no",
+            }
+        }
+        with patch(
+            "tools.mastering.config.load_config", return_value=user_config
+        ):
+            result = load_mastering_config()
+        assert result["adm_validation_enabled"] is False
+        assert result["archival_enabled"] is False
+
+    def test_quoted_true_strings_enable(self):
+        user_config = {
+            "mastering": {
+                "adm_validation_enabled": "true",
+                "archival_enabled": "yes",
+            }
+        }
+        with patch(
+            "tools.mastering.config.load_config", return_value=user_config
+        ):
+            result = load_mastering_config()
+        assert result["adm_validation_enabled"] is True
+        assert result["archival_enabled"] is True
+
+    def test_unparseable_boolean_string_uses_default(self, caplog):
+        """A boolean key set to garbage falls back to the default with a warning."""
+        user_config = {"mastering": {"archival_enabled": "maybe"}}
+        with patch(
+            "tools.mastering.config.load_config", return_value=user_config
+        ), caplog.at_level("WARNING", logger="tools.mastering.config"):
+            result = load_mastering_config()
+        assert result["archival_enabled"] is False  # default
+        assert any("archival_enabled" in r.message for r in caplog.records)
+
+
+class TestResolveAdmEnabled:
+    """Per-album frontmatter ADM flag honors quoted boolean strings (#388)."""
+
+    def test_quoted_false_does_not_enable(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": "false"}) is False
+
+    def test_quoted_true_enables(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": "true"}) is True
+
+    def test_garbage_string_stays_off(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": "maybe"}) is False
+
+    def test_real_bools_unchanged(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": True}) is True
+        assert _resolve_adm_enabled({"adm_validation_enabled": False}) is False
+        assert _resolve_adm_enabled(None) is False
+        assert _resolve_adm_enabled({}) is False
+
 
 class TestResolveMasteringTargets:
     def _base_cfg(self) -> dict:

--- a/tests/unit/shared/test_config.py
+++ b/tests/unit/shared/test_config.py
@@ -102,3 +102,54 @@ class TestLoadConfigYamlMissing:
             with mock.patch.object(config_module, 'yaml', None):
                 result = load_config(fallback={'default': True})
                 assert result == {'default': True}
+
+
+class TestParseYamlBool:
+    """parse_yaml_bool() honors quoted YAML boolean strings (#388)."""
+
+    def test_passes_through_bools(self):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(True) is True
+        assert parse_yaml_bool(False) is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "yes", "Yes", "on", "1", " true "])
+    def test_truthy_strings(self, value):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "no", "No", "off", "0", " false "])
+    def test_falsy_strings(self, value):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(value) is False
+
+    def test_zero_one_ints(self):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(0) is False
+        assert parse_yaml_bool(1) is True
+
+    @pytest.mark.parametrize("value", ["maybe", "", "2", "truthy", 2, 2.5, [], {}, None, ["true"]])
+    def test_unparseable_values_raise(self, value):
+        from tools.shared.config import parse_yaml_bool
+        with pytest.raises(ValueError):
+            parse_yaml_bool(value)
+
+
+class TestCoerceYamlBool:
+    """coerce_yaml_bool() = parse_yaml_bool with warn-and-default fallback."""
+
+    def test_parses_quoted_strings(self):
+        from tools.shared.config import coerce_yaml_bool
+        assert coerce_yaml_bool("false", default=True) is False
+        assert coerce_yaml_bool("yes", default=False) is True
+
+    def test_bool_passthrough(self):
+        from tools.shared.config import coerce_yaml_bool
+        assert coerce_yaml_bool(True, default=False) is True
+        assert coerce_yaml_bool(False, default=True) is False
+
+    def test_garbage_returns_default_with_warning(self, caplog):
+        from tools.shared.config import coerce_yaml_bool
+        with caplog.at_level("WARNING", logger="tools.shared.config"):
+            assert coerce_yaml_bool("maybe", default=True, context="cloud.enabled") is True
+            assert coerce_yaml_bool([], default=False, context="x") is False
+        assert any("cloud.enabled" in r.message for r in caplog.records)

--- a/tests/unit/shared/test_debug_logging.py
+++ b/tests/unit/shared/test_debug_logging.py
@@ -236,3 +236,17 @@ class TestSetupLoggingWithConfig:
             assert len(file_handlers) == 0
         finally:
             logging.getLogger(name).handlers.clear()
+
+
+class TestQuotedBooleanStrings:
+    """logging.enabled honors quoted boolean strings (#388)."""
+
+    def test_enabled_quoted_false_stays_off(self):
+        config = {"logging": {"enabled": "false"}}
+        assert configure_file_logging(config) is None
+
+    def test_enabled_quoted_true_turns_on(self, tmp_path):
+        log_file = str(tmp_path / "test.log")
+        config = {"logging": {"enabled": "true", "file": log_file}}
+        handler = configure_file_logging(config)
+        assert isinstance(handler, RotatingFileHandler)

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -594,6 +594,57 @@ class TestBuildConfigSection:
         section = build_config_section(config)
         assert section['artist_name'] == ''
 
+    def test_quoted_boolean_strings_do_not_invert(self, monkeypatch):
+        """Quoted "false"/"no" config booleans must not become True (#388)."""
+        config = {
+            'artist': {'name': 'test'},
+            'paths': {'content_root': '/tmp/c'},
+            'database': {'enabled': 'false', 'host': 'db.example', 'name': 'tweets'},
+            'generation': {
+                'require_suno_link_for_final': 'false',
+                'require_source_path_for_documentary': 'no',
+            },
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        section = build_config_section(config)
+        assert section['database']['enabled'] is False
+        # Credentials stay masked when the flag resolves False
+        assert section['database']['host'] == ''
+        assert section['database']['name'] == ''
+        assert section['generation']['require_suno_link_for_final'] is False
+        assert section['generation']['require_source_path_for_documentary'] is False
+
+    def test_quoted_true_boolean_strings_enable(self, monkeypatch):
+        config = {
+            'artist': {'name': 'test'},
+            'paths': {'content_root': '/tmp/c'},
+            'database': {'enabled': 'true', 'host': 'db.example', 'name': 'tweets'},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        section = build_config_section(config)
+        assert section['database']['enabled'] is True
+        assert section['database']['host'] == 'db.example'
+        assert section['database']['name'] == 'tweets'
+
+    def test_garbage_boolean_string_uses_default(self, monkeypatch):
+        """Unparseable boolean strings fall back to the key's default."""
+        config = {
+            'artist': {'name': 'test'},
+            'paths': {'content_root': '/tmp/c'},
+            'database': {'enabled': 'maybe'},
+            'generation': {'require_suno_link_for_final': 'sometimes'},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        section = build_config_section(config)
+        assert section['database']['enabled'] is False  # default False
+        assert section['generation']['require_suno_link_for_final'] is True  # default True
+
     def test_documents_root_derives_from_content_root(self, monkeypatch):
         config = {
             'artist': {'name': 'test'},
@@ -2409,8 +2460,8 @@ class TestMigrate1_0To1_1:
         }
         result = migrate_state(state)
         assert result is not None
-        # Full chain: 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0
-        assert result['version'] == '1.3.0'
+        # Full chain: 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0 → 1.4.0
+        assert result['version'] == '1.4.0'
         assert 'skills' in result
         assert result['skills']['count'] == 0
         assert result['skills']['items'] == {}
@@ -2687,7 +2738,7 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert 'plugin_version' in result
         assert result['plugin_version'] is None
 
@@ -2723,7 +2774,7 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['plugin_version'] == '0.43.0'
 
 
@@ -2767,7 +2818,7 @@ class TestMigrate1_2To1_3:
         """State from v1.2.0 gets album_collisions field via migration."""
         result = migrate_state(self._state_1_2())
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['album_collisions'] == []
 
     def test_migration_preserves_existing_album_collisions(self):
@@ -2779,7 +2830,7 @@ class TestMigrate1_2To1_3:
         }
         result = migrate_state(self._state_1_2(album_collisions=[collision]))
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['album_collisions'] == [collision]
 
     def test_full_chain_1_0_to_1_3(self):
@@ -2790,10 +2841,78 @@ class TestMigrate1_2To1_3:
         del state['skills']
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == CURRENT_VERSION == '1.3.0'
+        assert result['version'] == CURRENT_VERSION == '1.4.0'
         assert 'skills' in result
         assert 'plugin_version' in result
         assert result['album_collisions'] == []
+
+
+@pytest.mark.unit
+class TestMigrate13To14:
+    """Tests for the 1.3.0 → 1.4.0 migration (#388): re-coerce cached
+    explicit values that were stored as truthy strings by the old parsers."""
+
+    def _state_1_3(self, albums):
+        state = {
+            'version': '1.3.0',
+            'generated_at': '2026-01-01T00:00:00+00:00',
+            'plugin_version': None,
+            'config': {
+                'content_root': '/tmp/c',
+                'audio_root': '/tmp/a',
+                'documents_root': '/tmp/d',
+                'artist_name': 'test',
+                'config_mtime': 100.0,
+            },
+            'albums': albums,
+            'album_collisions': [],
+            'ideas': {'counts': {}, 'items': [], 'file_mtime': 0.0},
+            'skills': {
+                'skills_root': '/tmp/skills',
+                'skills_root_mtime': 0.0,
+                'count': 0,
+                'model_counts': {},
+                'items': {},
+            },
+            'session': {
+                'last_album': None,
+                'last_track': None,
+                'last_phase': None,
+                'pending_actions': [],
+                'updated_at': None,
+            },
+        }
+        return state
+
+    def test_recoerces_cached_string_explicit_values(self):
+        albums = {
+            'my-album': {
+                'explicit': 'false',
+                'tracks': {
+                    '01-track': {'explicit': 'false'},
+                    '02-track': {'explicit': 'true'},
+                },
+            },
+        }
+        result = migrate_state(self._state_1_3(albums))
+        assert result is not None
+        assert result['version'] == '1.4.0'
+        assert result['albums']['my-album']['explicit'] is False
+        assert result['albums']['my-album']['tracks']['01-track']['explicit'] is False
+        assert result['albums']['my-album']['tracks']['02-track']['explicit'] is True
+
+    def test_garbage_explicit_defaults_false(self):
+        albums = {'a': {'explicit': 'maybe', 'tracks': {}}}
+        result = migrate_state(self._state_1_3(albums))
+        assert result is not None
+        assert result['albums']['a']['explicit'] is False
+
+    def test_real_bools_untouched(self):
+        albums = {'a': {'explicit': True, 'tracks': {'t': {'explicit': False}}}}
+        result = migrate_state(self._state_1_3(albums))
+        assert result is not None
+        assert result['albums']['a']['explicit'] is True
+        assert result['albums']['a']['tracks']['t']['explicit'] is False
 
 
 @pytest.mark.unit
@@ -2866,7 +2985,7 @@ class TestFullMigrationChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         # From 1.0→1.1 migration
         assert 'skills' in result
         assert result['skills']['count'] == 0
@@ -3090,7 +3209,7 @@ class TestMigrateStateChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['plugin_version'] is None
 
     def test_migration_does_not_overwrite_existing_skills(self):

--- a/tests/unit/state/test_parsers.py
+++ b/tests/unit/state/test_parsers.py
@@ -85,6 +85,27 @@ class TestParseAlbumReadme:
         assert result['track_count'] == 8
         assert result['release_date'] is None or result['release_date'] == ''
 
+    def test_quoted_explicit_false_frontmatter(self, tmp_path):
+        """Frontmatter explicit: "false" (quoted string) must parse to False, not the truthy string (#388)."""
+        path = tmp_path / "README.md"
+        path.write_text(
+            '---\ntitle: "Quoted Album"\nexplicit: "false"\n---\n\n# Quoted Album\n',
+            encoding='utf-8',
+        )
+        result = parse_album_readme(path)
+        assert '_error' not in result
+        assert result['explicit'] is False
+
+    def test_quoted_explicit_true_frontmatter(self, tmp_path):
+        path = tmp_path / "README.md"
+        path.write_text(
+            '---\ntitle: "Quoted Album"\nexplicit: "true"\n---\n\n# Quoted Album\n',
+            encoding='utf-8',
+        )
+        result = parse_album_readme(path)
+        assert '_error' not in result
+        assert result['explicit'] is True
+
     def test_tracklist_parsing(self):
         path = FIXTURES_DIR / "album-readme.md"
         result = parse_album_readme(path)
@@ -251,6 +272,27 @@ class TestParseTrackFile:
         path = FIXTURES_DIR / "does-not-exist.md"
         result = parse_track_file(path)
         assert '_error' in result
+
+    def test_quoted_explicit_false_frontmatter_fallback(self, tmp_path):
+        """Frontmatter explicit: "false" (quoted string) must not mark explicit (#388)."""
+        path = tmp_path / "01-track.md"
+        path.write_text(
+            '---\ntitle: "Quoted Track"\nexplicit: "false"\n---\n\n# Quoted Track\n',
+            encoding='utf-8',
+        )
+        result = parse_track_file(path)
+        assert '_error' not in result
+        assert result['explicit'] is False
+
+    def test_quoted_explicit_true_frontmatter_fallback(self, tmp_path):
+        path = tmp_path / "01-track.md"
+        path.write_text(
+            '---\ntitle: "Quoted Track"\nexplicit: "true"\n---\n\n# Quoted Track\n',
+            encoding='utf-8',
+        )
+        result = parse_track_file(path)
+        assert '_error' not in result
+        assert result['explicit'] is True
 
 
 class TestParseIdeasFile:

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -15065,6 +15065,37 @@ class TestPublishSheetMusic:
         # Verify retry_upload called for each file
         assert mock_cloud_mod.retry_upload.call_count == 3
 
+    def test_quoted_public_read_false_stays_private(self, tmp_path):
+        """cloud.public_read: "false" (quoted) must not set a public ACL (#388)."""
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        singles_dir = audio_dir / "sheet-music" / "singles"
+        singles_dir.mkdir(parents=True)
+        (singles_dir / "01 - Track.pdf").write_bytes(b"pdf1")
+
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        state["config"]["artist_name"] = "test-artist"
+        mock_cache = MockStateCache(state)
+
+        mock_cloud_mod = MagicMock()
+        mock_cloud_mod.retry_upload.return_value = True
+        mock_cloud_mod.get_s3_client.return_value = MagicMock()
+        mock_cloud_mod.get_bucket_name.return_value = "test-bucket"
+
+        mock_config = {
+            "cloud": {"enabled": True, "provider": "r2", "public_read": "false"},
+        }
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_cloud_enabled", return_value=None), \
+             patch.object(_processing_helpers, "_import_cloud_module", return_value=mock_cloud_mod), \
+             patch("tools.shared.config.load_config", return_value=mock_config):
+            result = json.loads(_run(server.publish_sheet_music("test-album")))
+
+        assert result["summary"]["success"] == 1
+        _, kwargs = mock_cloud_mod.retry_upload.call_args
+        assert kwargs["public_read"] is False
+
     # ------------------------------------------------------------------
     # Frontmatter persistence tests
     # ------------------------------------------------------------------

--- a/tests/unit/state/test_server_integration.py
+++ b/tests/unit/state/test_server_integration.py
@@ -533,7 +533,7 @@ class TestStateRebuildPipeline:
     def test_state_json_has_correct_structure(self, integration_env):
         """state.json built from real files has all expected fields."""
         state = json.loads(integration_env["state_file"].read_text())
-        assert state["version"] == "1.3.0"
+        assert state["version"] == "1.4.0"
         assert "config" in state
         assert "albums" in state
         assert "session" in state

--- a/tests/unit/state/test_silent_exceptions.py
+++ b/tests/unit/state/test_silent_exceptions.py
@@ -291,6 +291,30 @@ class TestHelpersCloudConfigWarning:
             "Config load failed" in r.message for r in caplog.records
         ), f"Expected config load warning. Records: {[r.message for r in caplog.records]}"
 
+    def test_quoted_false_reports_not_enabled(self):
+        """cloud.enabled: "false" (quoted) must not pass the gate (#388)."""
+        from handlers.processing import _helpers as helpers_mod
+
+        with patch(
+            "tools.shared.config.load_config",
+            return_value={"cloud": {"enabled": "false"}},
+        ):
+            result = helpers_mod._check_cloud_enabled()
+
+        assert result is not None
+        assert "not enabled" in result
+
+    def test_quoted_true_passes_gate(self):
+        from handlers.processing import _helpers as helpers_mod
+
+        with patch(
+            "tools.shared.config.load_config",
+            return_value={"cloud": {"enabled": "true"}},
+        ):
+            result = helpers_mod._check_cloud_enabled()
+
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Test 5: _helpers.py — AnthemScore check

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -69,6 +69,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 import logging
 
+from tools.shared.config import coerce_yaml_bool
 from tools.shared.config import load_config as _load_config
 from tools.shared.logging_config import setup_logging
 from tools.shared.progress import ProgressBar
@@ -385,7 +386,9 @@ Examples:
 
     # Check if cloud is enabled
     cloud_config = config.get("cloud", {})
-    if not cloud_config.get("enabled", False):
+    if not coerce_yaml_bool(
+        cloud_config.get("enabled", False), default=False, context="cloud.enabled"
+    ):
         logger.error("Cloud uploads not enabled in config.")
         logger.error("Add 'cloud.enabled: true' to ~/.bitwize-music/config.yaml")
         logger.error("See /reference/cloud/setup-guide.md for setup instructions.")
@@ -393,7 +396,11 @@ Examples:
 
     # Get cloud settings
     provider = cloud_config.get("provider", "r2")
-    public_read = args.public or cloud_config.get("public_read", False)
+    public_read = args.public or coerce_yaml_bool(
+        cloud_config.get("public_read", False),
+        default=False,
+        context="cloud.public_read",
+    )
 
     # Find album
     album_path = find_album_path(config, args.album, args.audio_root)

--- a/tools/database/connection.py
+++ b/tools/database/connection.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 from typing import Any, cast
 
+from tools.shared.config import coerce_yaml_bool
+
 logger = logging.getLogger(__name__)
 
 CONFIG_PATH = Path.home() / ".bitwize-music" / "config.yaml"
@@ -47,7 +49,9 @@ def get_db_config() -> dict[str, Any] | None:
         return None
 
     db_config = cast(dict[str, Any], config.get("database", {}))
-    if not db_config or not db_config.get("enabled", False):
+    if not db_config or not coerce_yaml_bool(
+        db_config.get("enabled", False), default=False, context="database.enabled"
+    ):
         return None
 
     return db_config

--- a/tools/mastering/config.py
+++ b/tools/mastering/config.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from tools.shared.config import load_config
+from tools.shared.config import load_config, parse_yaml_bool
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +82,9 @@ def load_mastering_config() -> dict[str, Any]:
         expected_type = _KEY_TYPES[key]
         try:
             if expected_type is bool:
-                # YAML already gives us bools; don't coerce arbitrary strings
-                result[key] = bool(value)
+                # bool(value) would turn quoted strings like "false" into
+                # True (#388); parse YAML boolean literals instead.
+                result[key] = parse_yaml_bool(value)
             else:
                 result[key] = expected_type(value)
         except (TypeError, ValueError) as exc:
@@ -98,6 +99,19 @@ def load_mastering_config() -> dict[str, Any]:
     return result
 
 
+def _config_bool(config: dict[str, Any], key: str, default: bool) -> bool:
+    """Bool read tolerant of raw (un-coerced) config dicts passed to the
+    public build_delivery_targets API."""
+    value = config.get(key, default)
+    try:
+        return parse_yaml_bool(value)
+    except ValueError:
+        logger.warning(
+            "Config %s=%r is not a boolean — using %s", key, value, default
+        )
+        return default
+
+
 def _resolve_adm_enabled(album_mastering: dict[str, Any] | None) -> bool:
     """Per-album ADM resolution: frontmatter-required, default OFF.
 
@@ -109,7 +123,18 @@ def _resolve_adm_enabled(album_mastering: dict[str, Any] | None) -> bool:
         return False
     if "adm_validation_enabled" not in album_mastering:
         return False
-    return bool(album_mastering["adm_validation_enabled"])
+    value = album_mastering["adm_validation_enabled"]
+    try:
+        return parse_yaml_bool(value)
+    except ValueError:
+        # Frontmatter is hand-edited; a quoted "false" must not enable ADM
+        # (#388), and garbage stays at the documented default (OFF).
+        logger.warning(
+            "Album frontmatter mastering.adm_validation_enabled=%r is not a "
+            "boolean — ADM validation stays off",
+            value,
+        )
+        return False
 
 
 def build_delivery_targets(
@@ -178,7 +203,7 @@ def build_delivery_targets(
         "ceiling_db": ceiling_db,
         "output_bits": output_bits,
         "output_sample_rate": output_sample_rate,
-        "archival_enabled": bool(config.get("archival_enabled", False)),
+        "archival_enabled": _config_bool(config, "archival_enabled", False),
         "adm_aac_encoder": str(config.get("adm_aac_encoder", "aac")),
         # Per-album opt-in for ADM validation (issue #353). The album's
         # README frontmatter `mastering.adm_validation_enabled: true` is

--- a/tools/shared/config.py
+++ b/tools/shared/config.py
@@ -31,6 +31,53 @@ OVERRIDE_FILES: dict[str, dict[str, Any]] = {
 }
 
 
+# YAML 1.1 boolean literals. PyYAML converts these to bool when unquoted, so
+# a string here means the user quoted the value in config.yaml/frontmatter.
+_YAML_BOOL_LITERALS: dict[str, bool] = {
+    "true": True, "yes": True, "on": True, "1": True,
+    "false": False, "no": False, "off": False, "0": False,
+}
+
+
+def parse_yaml_bool(value: Any) -> bool:
+    """Coerce a YAML-sourced value to bool, honoring quoted boolean strings.
+
+    ``bool(value)`` treats any non-empty string as True, silently inverting
+    quoted YAML booleans like ``"false"`` or ``"no"`` (#388). Accepts real
+    bools, 0/1 numbers, and YAML 1.1 boolean literals (case-insensitive);
+    raises ValueError for anything else so callers can fall back to their
+    key's default with a warning.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        parsed = _YAML_BOOL_LITERALS.get(value.strip().lower())
+        if parsed is not None:
+            return parsed
+    raise ValueError(f"not a boolean: {value!r}")
+
+
+def coerce_yaml_bool(value: Any, *, default: bool = False, context: str = "") -> bool:
+    """parse_yaml_bool with a warn-and-default fallback for gate sites.
+
+    For boolean config gates where an unparseable value should fall back to
+    the key's documented default rather than raise. ``context`` names the
+    key in the warning (e.g. ``"cloud.enabled"``).
+    """
+    try:
+        return parse_yaml_bool(value)
+    except ValueError:
+        logger.warning(
+            "Cannot interpret %s=%r as a boolean — using default %s",
+            context or "value",
+            value,
+            default,
+        )
+        return default
+
+
 def load_config(
     required: bool = False,
     fallback: dict[str, Any] | None = None

--- a/tools/shared/logging_config.py
+++ b/tools/shared/logging_config.py
@@ -85,7 +85,14 @@ def configure_file_logging(config: dict[str, Any] | None) -> RotatingFileHandler
         return None
 
     log_config = config.get("logging")
-    if not log_config or not log_config.get("enabled", False):
+    if not log_config:
+        return None
+    # Local import: tools.shared.config logs via this module's setup, so a
+    # top-level import would be circular in spirit even though not in fact.
+    from tools.shared.config import coerce_yaml_bool
+    if not coerce_yaml_bool(
+        log_config.get("enabled", False), default=False, context="logging.enabled"
+    ):
         return None
 
     # Idempotent — don't add duplicate file handlers

--- a/tools/sheet-music/create_songbook.py
+++ b/tools/sheet-music/create_songbook.py
@@ -677,7 +677,12 @@ def main() -> None:
     section_headers = args.section_headers
     if not section_headers and config:
         try:
-            section_headers = config.get('sheet_music', {}).get('section_headers', False)
+            from tools.shared.config import coerce_yaml_bool
+            section_headers = coerce_yaml_bool(
+                config.get('sheet_music', {}).get('section_headers', False),
+                default=False,
+                context='sheet_music.section_headers',
+            )
             if section_headers:
                 logger.info("Using section headers from config: %s", section_headers)
         except (TypeError, AttributeError):

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -54,7 +54,7 @@ except ImportError:
     sys.exit(1)
 
 from tools.shared.colors import Colors
-from tools.shared.config import CONFIG_PATH
+from tools.shared.config import CONFIG_PATH, parse_yaml_bool
 from tools.shared.logging_config import setup_logging
 from tools.state.parsers import (
     parse_album_readme,
@@ -66,7 +66,7 @@ from tools.state.parsers import (
 logger = logging.getLogger(__name__)
 
 # Schema version for state.json
-CURRENT_VERSION = "1.3.0"
+CURRENT_VERSION = "1.4.0"
 
 # Cache location (constant, not configurable)
 CACHE_DIR = Path.home() / ".bitwize-music" / "cache"
@@ -124,12 +124,36 @@ def _migrate_1_2_to_1_3(state: dict[str, Any]) -> dict[str, Any]:
     return state
 
 
+def _migrate_1_3_to_1_4(state: dict[str, Any]) -> dict[str, Any]:
+    """Migrate state from 1.3.0 to 1.4.0: re-coerce cached explicit flags.
+
+    The pre-#388 parsers stored quoted frontmatter booleans (e.g.
+    explicit: "false") as raw truthy strings; re-coerce cached values so
+    they don't linger until the source file's mtime changes.
+    """
+    def _fix(entry: dict[str, Any]) -> None:
+        if 'explicit' in entry:
+            try:
+                entry['explicit'] = parse_yaml_bool(entry['explicit'])
+            except ValueError:
+                entry['explicit'] = False
+
+    for album in (state.get('albums') or {}).values():
+        if isinstance(album, dict):
+            _fix(album)
+            for track in (album.get('tracks') or {}).values():
+                if isinstance(track, dict):
+                    _fix(track)
+    return state
+
+
 # Migration chain for schema upgrades
 # Format: "from_version": (migration_fn, "to_version")
 MIGRATIONS: dict[str, tuple[Any, str]] = {
     "1.0.0": (_migrate_1_0_to_1_1, "1.1.0"),
     "1.1.0": (_migrate_1_1_to_1_2, "1.2.0"),
     "1.2.0": (_migrate_1_2_to_1_3, "1.3.0"),
+    "1.3.0": (_migrate_1_3_to_1_4, "1.4.0"),
 }
 
 
@@ -178,12 +202,25 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     overrides_raw = paths.get('overrides', '')
     overrides_dir = str(resolve_path(overrides_raw)) if overrides_raw else str(Path(content_root) / 'overrides')
 
+    def _cfg_bool(section: dict[str, Any], key: str, default: bool) -> bool:
+        # bool() would turn quoted strings like "false" into True (#388);
+        # parse YAML boolean literals, falling back to the key's default.
+        value = section.get(key, default)
+        try:
+            return parse_yaml_bool(value)
+        except ValueError:
+            logger.warning(
+                "Config %s=%r is not a boolean — using %s", key, value, default
+            )
+            return default
+
     # Database config (expose enabled flag, mask credentials)
     db_config = config.get('database') or {}
+    db_enabled = _cfg_bool(db_config, 'enabled', False)
     database_section = {
-        'enabled': bool(db_config.get('enabled', False)),
-        'host': db_config.get('host', '') if db_config.get('enabled') else '',
-        'name': db_config.get('name', '') if db_config.get('enabled') else '',
+        'enabled': db_enabled,
+        'host': db_config.get('host', '') if db_enabled else '',
+        'name': db_config.get('name', '') if db_enabled else '',
     }
 
     # Generation config (service settings and gates)
@@ -191,10 +228,10 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     additional_genres_raw = gen_config.get('additional_genres', [])
     generation_section = {
         'service': gen_config.get('service', 'suno'),
-        'require_suno_link_for_final': bool(gen_config.get('require_suno_link_for_final', True)),
+        'require_suno_link_for_final': _cfg_bool(gen_config, 'require_suno_link_for_final', True),
         'max_lyric_words': int(gen_config.get('max_lyric_words', 800)),
-        'require_source_path_for_documentary': bool(
-            gen_config.get('require_source_path_for_documentary', True)),
+        'require_source_path_for_documentary': _cfg_bool(
+            gen_config, 'require_source_path_for_documentary', True),
         'additional_genres': [str(g).lower().strip() for g in additional_genres_raw]
         if isinstance(additional_genres_raw, list) else [],
     }

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -32,6 +32,18 @@ _RE_IDEAS_SECTION = re.compile(r'^##\s+Ideas\b', re.MULTILINE)
 _RE_IDEAS_SPLIT = re.compile(r'^###\s+', re.MULTILINE)
 
 
+def _frontmatter_bool(value: Any, default: bool = False, context: str = "explicit") -> bool:
+    """Coerce a frontmatter boolean, honoring quoted strings.
+
+    bool() turns quoted YAML booleans like "false" into True (#388);
+    unrecognized values fall back to `default` with a warning rather than
+    aborting the parse — frontmatter is hand-edited and a bad flag
+    shouldn't drop the whole file from the cache.
+    """
+    from tools.shared.config import coerce_yaml_bool
+    return coerce_yaml_bool(value, default=default, context=context)
+
+
 def parse_frontmatter(text: str) -> dict[str, Any]:
     """Parse YAML frontmatter from markdown content.
 
@@ -170,7 +182,7 @@ def parse_album_readme(path: Path) -> dict[str, Any]:
     else:
         result['title'] = _extract_heading(text)
     result['release_date'] = fm.get('release_date') or None
-    result['explicit'] = fm.get('explicit', False)
+    result['explicit'] = _frontmatter_bool(fm.get('explicit', False))
 
     # Optional anchor-track override for album mastering (issue #290 phase 2).
     # Frontmatter uses 1-based track numbers. Non-int / null / missing → None,
@@ -384,7 +396,7 @@ def parse_track_file(path: Path) -> dict[str, Any]:
     if explicit_raw:
         result['explicit'] = explicit_raw.lower().strip() in ('yes', 'true')
     elif 'explicit' in fm:
-        result['explicit'] = bool(fm['explicit'])
+        result['explicit'] = _frontmatter_bool(fm['explicit'])
     else:
         result['explicit'] = False
 


### PR DESCRIPTION
Fixes #388.

## Problem

`bool("false")` is `True` in Python. Every user-YAML boolean read through `bool(value)` or raw truthiness silently **inverted** when the user quoted the value — the feature they disabled stayed (or turned) on, with no error:

| Site | Consequence of quoted `"false"`/`"no"` |
|---|---|
| `mastering.adm_validation_enabled` (config **and** album frontmatter — the only ADM enable path since #353) | ADM validation silently ON: AAC encode/decode + retry cycles, minutes per track |
| `mastering.archival_enabled` | archival output silently ON |
| `database.enabled` (the real gate in `tools/database/connection.py`) | DB tools still opened Postgres connections — while the state cache reported "disabled" |
| `cloud.public_read` (CLI upload + `publish_sheet_music`) | uploads got a **public-read ACL** against the user's explicit setting |
| `cloud.enabled`, `logging.enabled`, `sheet_music.section_headers`, `require_suno_link_for_final`, `require_source_path_for_documentary` | gates flipped |
| track/album `explicit` frontmatter | content marked explicit; album parse stored the raw *string* in the state cache |

## Fix

Two shared helpers in `tools/shared/config.py`:
- **`parse_yaml_bool()`** — strict: real bools, 0/1 numbers, YAML 1.1 literals (`true/false/yes/no/on/off/1/0`, case-insensitive); raises `ValueError` otherwise.
- **`coerce_yaml_bool()`** — warn-and-default wrapper for gate sites.

Applied at every user-YAML boolean site across `tools/mastering/config.py`, `tools/state/indexer.py` (incl. db credential masking now keyed to the coerced flag), `tools/state/parsers.py`, `tools/database/connection.py`, `tools/cloud/upload_to_cloud.py`, `handlers/processing/_helpers.py`, `handlers/processing/sheet_music.py`, `tools/shared/logging_config.py`, `tools/sheet-music/create_songbook.py`. Unrecognized values fall back to the key's documented default **with a warning** instead of silently meaning True.

**State schema 1.3.0 → 1.4.0** with a migration re-coercing cached `explicit` flags stored as strings by the old parsers (otherwise they'd linger until each file's mtime changed).

## Process & verification

- TDD throughout: 55 new tests written red-first (helper semantics, every gate site, migration, credential masking, public-ACL regression).
- Adversarial review round (2 lenses × 2 skeptics per finding): 7 confirmed findings — including 4 gate sites using raw truthiness that the original `bool(` sweep couldn't see, the database state/behavior split, and the missing migration — all fixed and re-verified; 3 claims refuted.
- Full gate: `ruff` + `bandit` + `mypy` clean; **3933 passed, 2 xfailed**, coverage **85.58%** (same flags as CI).

Noted, not fixed (different failure shape, out of scope): `_album_stages.py` uses `bool(int(cfg.get("codec_preview_enabled", 1)))` — quoted `"0"`/`"1"` work, but `"false"` would raise rather than invert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)