### PR TITLE
fix: transcribe album-name resolution, codec-preview ffmpeg timeout, genre-cache poisoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **`transcribe.py` album-name resolution works again** (#375). The
+  documented `python3 transcribe.py <album-name>` invocation built
+  `{audio_root}/{artist}/{album}` — omitting the `artists/` and
+  `albums/{genre}/` segments of the mirrored layout — so it never found a
+  real album and always fell through to "Source not found". It now sweeps
+  genre directories under `{audio_root}/artists/{artist}/albums/` (literal
+  comparison, no glob), warns if legacy same-name twins exist under
+  multiple genres, and the "Tried:" error hint prints the correct path
+  shape.
+- **Genre-list cache no longer poisons on a degenerate scan**. The
+  `_get_valid_genres()` cache stored whatever the first call computed —
+  including an empty set from a broken or mocked plugin root — and served
+  it for the life of the process, making `create_album_structure` reject
+  every genre from then on (the source of an intermittent xdist test
+  failure). The cache is now keyed by `PLUGIN_ROOT` and only stores
+  non-empty results.
+- **Codec-preview ffmpeg can no longer hang `master_album` forever** (#387).
+  `render_aac_preview` ran ffmpeg with no timeout, so a wedged subprocess
+  blocked the samples stage (and the whole `master_album` call)
+  indefinitely. The invocation is now bounded at 120s (mirroring
+  `adm_validation.py`); a timeout raises `CodecPreviewError`, which the
+  samples stage already degrades to a per-track warning.
 - **Quoted YAML booleans no longer invert to True** (#388). `bool("false")`
   is `True` in Python, so quoting a falsy boolean anywhere in user YAML
   silently enabled the feature the user disabled: `mastering.

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -55,30 +55,35 @@ STATUS_UNKNOWN = "Unknown"
 # Markdown link pattern — used for source verification gates
 _MARKDOWN_LINK_RE = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')
 
-# Valid genres for album creation — derived from genres/ directory at runtime
-_VALID_GENRES: frozenset[str] | None = None
+# Valid genres for album creation — derived from genres/ directory at runtime.
+# Cached per PLUGIN_ROOT value, and only when non-empty: an empty scan means
+# a broken (or test-mocked) plugin root, and caching it would poison every
+# later genre check in the process.
+_VALID_GENRES: tuple[Path | None, frozenset[str]] | None = None
 
 
 def _get_valid_genres() -> frozenset[str]:
     """Return valid genre slugs by scanning the genres/ directory.
 
-    Results are cached after the first call.
+    Non-empty results are cached per PLUGIN_ROOT.
     """
     global _VALID_GENRES
-    if _VALID_GENRES is not None:
-        return _VALID_GENRES
+    if _VALID_GENRES is not None and _VALID_GENRES[0] == PLUGIN_ROOT:
+        return _VALID_GENRES[1]
     if PLUGIN_ROOT is None:
         # Fallback if called before init (shouldn't happen)
         return frozenset()
     genres_dir = PLUGIN_ROOT / "genres"
     if genres_dir.is_dir():
-        _VALID_GENRES = frozenset(
+        genres = frozenset(
             d.name for d in genres_dir.iterdir()
             if d.is_dir() and (d / "README.md").exists()
         )
     else:
-        _VALID_GENRES = frozenset()
-    return _VALID_GENRES
+        genres = frozenset()
+    if genres:
+        _VALID_GENRES = (PLUGIN_ROOT, genres)
+    return genres
 
 _GENRE_ALIASES = {
     "r&b": "rnb", "rb": "rnb", "r-and-b": "rnb",

--- a/tests/unit/handlers/test_shared_helpers.py
+++ b/tests/unit/handlers/test_shared_helpers.py
@@ -67,3 +67,49 @@ def test_is_album_released_false_when_cache_raises():
             raise OSError("simulated disk failure")
     _shared.cache = _RaisingCache()
     assert _shared.is_album_released("my-album") is False
+
+
+class TestGetValidGenresCachePoisoning:
+    """A degenerate genre scan must not poison the process-wide cache.
+
+    Regression for the xdist flake where a test patching PLUGIN_ROOT (or
+    blanket-mocking Path.exists) primed _VALID_GENRES with an empty set,
+    making every later create_album_structure reject valid genres.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_genre_cache(self):
+        original = _shared._VALID_GENRES
+        _shared._VALID_GENRES = None
+        yield
+        _shared._VALID_GENRES = original
+
+    def _real_plugin_root(self):
+        return PROJECT_ROOT
+
+    def test_fake_plugin_root_does_not_poison_cache(self, tmp_path, monkeypatch):
+        fake_root = tmp_path / "fake-plugin"
+        fake_root.mkdir()
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", fake_root)
+        assert _shared._get_valid_genres() == frozenset()
+
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", self._real_plugin_root())
+        assert "rock" in _shared._get_valid_genres()
+
+    def test_cache_rekeys_when_plugin_root_changes(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", self._real_plugin_root())
+        real_genres = _shared._get_valid_genres()
+        assert real_genres  # non-empty and now cached
+
+        other_root = tmp_path / "other-plugin"
+        (other_root / "genres" / "onlygenre").mkdir(parents=True)
+        (other_root / "genres" / "onlygenre" / "README.md").write_text("# g")
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", other_root)
+        assert _shared._get_valid_genres() == frozenset({"onlygenre"})
+
+    def test_empty_scan_is_not_cached(self, tmp_path, monkeypatch):
+        fake_root = tmp_path / "fake-plugin"
+        fake_root.mkdir()
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", fake_root)
+        _shared._get_valid_genres()
+        assert _shared._VALID_GENRES is None  # degenerate result not stored

--- a/tests/unit/mastering/test_codec_preview.py
+++ b/tests/unit/mastering/test_codec_preview.py
@@ -142,3 +142,38 @@ class TestFfmpegTimeout:
         monkeypatch.setattr(cp.subprocess, "run", fake_run)
         with pytest.raises(cp.CodecPreviewError, match="timed out"):
             cp.render_aac_preview(wav, out)
+
+    def test_timeout_removes_partial_output(self, tmp_path, monkeypatch):
+        """A SIGKILLed ffmpeg leaves a truncated m4a — it must be removed."""
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            out.write_bytes(b"partial")
+            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=120)
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        with pytest.raises(cp.CodecPreviewError):
+            cp.render_aac_preview(wav, out)
+        assert not out.exists()
+
+    def test_failed_encode_removes_partial_output(self, tmp_path, monkeypatch):
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            out.write_bytes(b"partial")
+
+            class R:
+                returncode = 1
+                stderr = "boom"
+            return R()
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        with pytest.raises(cp.CodecPreviewError):
+            cp.render_aac_preview(wav, out)
+        assert not out.exists()

--- a/tests/unit/mastering/test_codec_preview.py
+++ b/tests/unit/mastering/test_codec_preview.py
@@ -100,3 +100,45 @@ class TestRenderAacPreview:
             render_aac_preview(in_wav, out, bitrate_kbps=0)
         with pytest.raises(CodecPreviewError, match="bitrate"):
             render_aac_preview(in_wav, out, bitrate_kbps=-64)
+
+
+class TestFfmpegTimeout:
+    """render_aac_preview bounds the ffmpeg subprocess (#387)."""
+
+    def _wav(self, tmp_path):
+        wav = tmp_path / "in.wav"
+        wav.write_bytes(b"RIFF")
+        return wav
+
+    def test_timeout_passed_to_subprocess(self, tmp_path, monkeypatch):
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            assert kwargs.get("timeout") == cp._FFMPEG_TIMEOUT_SEC
+            assert cp._FFMPEG_TIMEOUT_SEC > 0
+            out.write_bytes(b"m4a")
+
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        result = cp.render_aac_preview(wav, out)
+        assert result["output_path"] == str(out)
+
+    def test_timeout_expired_raises_codec_preview_error(self, tmp_path, monkeypatch):
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=kwargs.get("timeout", 0))
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        with pytest.raises(cp.CodecPreviewError, match="timed out"):
+            cp.render_aac_preview(wav, out)

--- a/tests/unit/sheet_music/test_transcribe.py
+++ b/tests/unit/sheet_music/test_transcribe.py
@@ -187,12 +187,7 @@ class TestTranscribeTrack:
 
 @pytest.mark.unit
 class TestResolveAlbumPath:
-    """Tests for album name to path resolution."""
-
-    @patch.object(mod, "read_config", return_value=None)
-    def test_no_config_returns_none(self, _mock_config):
-        result = mod.resolve_album_path("my-album")
-        assert result is None
+    """resolve_album_path builds the canonical mirrored audio path (#375)."""
 
     @patch.object(mod, "read_config")
     def test_missing_key_returns_none(self, mock_config):
@@ -201,54 +196,22 @@ class TestResolveAlbumPath:
         assert result is None
 
     @patch.object(mod, "read_config")
-    def test_nonexistent_path_returns_none(self, mock_config, tmp_path):
-        mock_config.return_value = {
-            "paths": {"audio_root": str(tmp_path / "audio")},
-            "artist": {"name": "TestArtist"},
-        }
-        result = mod.resolve_album_path("no-such-album")
-        assert result is None
-
-    @patch.object(mod, "read_config")
-    def test_valid_album_returns_path(self, mock_config, tmp_path):
-        album = tmp_path / "audio" / "TestArtist" / "my-album"
-        album.mkdir(parents=True)
-        mock_config.return_value = {
-            "paths": {"audio_root": str(tmp_path / "audio")},
-            "artist": {"name": "TestArtist"},
-        }
-        result = mod.resolve_album_path("my-album")
-        assert result == album
-
-    @patch.object(mod, "read_config")
     def test_path_traversal_rejected(self, mock_config, tmp_path):
-        """Symlink or .. that escapes audio_root should be rejected."""
+        """Symlink under a genre dir that escapes audio_root is rejected."""
         audio_root = tmp_path / "audio"
-        audio_root.mkdir()
-        # Create a path that resolves outside audio_root
         outside = tmp_path / "outside"
         outside.mkdir()
-        artist_dir = audio_root / "TestArtist"
-        artist_dir.mkdir()
-        # Symlink: audio/TestArtist/evil -> ../../outside
-        evil = artist_dir / "evil"
-        evil.symlink_to(outside)
+        genre_dir = audio_root / "artists" / "test-artist" / "albums" / "rock"
+        genre_dir.mkdir(parents=True)
+        # Symlink: .../albums/rock/evil -> {tmp}/outside
+        (genre_dir / "evil").symlink_to(outside)
 
         mock_config.return_value = {
             "paths": {"audio_root": str(audio_root)},
-            "artist": {"name": "TestArtist"},
+            "artist": {"name": "test-artist"},
         }
         result = mod.resolve_album_path("evil")
         assert result is None
-
-
-# ---------------------------------------------------------------------------
-# resolve_album_path (#375)
-# ---------------------------------------------------------------------------
-
-
-class TestResolveAlbumPath:
-    """resolve_album_path builds the canonical mirrored audio path (#375)."""
 
     def _config(self, tmp_path):
         return {

--- a/tests/unit/sheet_music/test_transcribe.py
+++ b/tests/unit/sheet_music/test_transcribe.py
@@ -240,3 +240,44 @@ class TestResolveAlbumPath:
         }
         result = mod.resolve_album_path("evil")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_album_path (#375)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAlbumPath:
+    """resolve_album_path builds the canonical mirrored audio path (#375)."""
+
+    def _config(self, tmp_path):
+        return {
+            "paths": {"audio_root": str(tmp_path)},
+            "artist": {"name": "test-artist"},
+        }
+
+    def test_resolves_album_by_name(self, tmp_path):
+        album_dir = tmp_path / "artists" / "test-artist" / "albums" / "rock" / "my-album"
+        album_dir.mkdir(parents=True)
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            assert mod.resolve_album_path("my-album") == album_dir
+
+    def test_returns_none_when_album_missing(self, tmp_path):
+        (tmp_path / "artists" / "test-artist" / "albums" / "rock").mkdir(parents=True)
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            assert mod.resolve_album_path("nope") is None
+
+    def test_missing_albums_root_returns_none(self, tmp_path):
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            assert mod.resolve_album_path("anything") is None
+
+    def test_multiple_genre_twins_picks_first_sorted(self, tmp_path):
+        for genre in ("rock", "jazz"):
+            (tmp_path / "artists" / "test-artist" / "albums" / genre / "twin").mkdir(parents=True)
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            result = mod.resolve_album_path("twin")
+        assert result == tmp_path / "artists" / "test-artist" / "albums" / "jazz" / "twin"
+
+    def test_no_config_returns_none(self):
+        with patch.object(mod, "read_config", return_value=None):
+            assert mod.resolve_album_path("x") is None

--- a/tests/unit/state/test_handlers_album_ops.py
+++ b/tests/unit/state/test_handlers_album_ops.py
@@ -385,6 +385,10 @@ class TestCreateAlbumStructure:
         self._orig_plugin_root = _shared_mod.PLUGIN_ROOT
         _shared_mod.cache = MockStateCache()
         _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+        # Prime the genre cache with the real genres/ scan BEFORE tests apply
+        # blanket Path.exists/Path.is_dir mocks — a cold-cache scan under
+        # those mocks comes back empty and every genre would be rejected.
+        _shared_mod._get_valid_genres()
 
     def teardown_method(self):
         _shared_mod.cache = self._orig_cache

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -4281,7 +4281,10 @@ class TestCreateAlbumStructure:
         """Album is still created even when templates directory doesn't exist."""
         mock_cache, content = self._make_state_with_tmp(tmp_path)
         fake_plugin = tmp_path / "fake-plugin"
-        fake_plugin.mkdir()
+        # Genre validation scans {PLUGIN_ROOT}/genres — the fake root needs a
+        # valid genre so this test exercises only the missing-templates path.
+        (fake_plugin / "genres" / "rock").mkdir(parents=True)
+        (fake_plugin / "genres" / "rock" / "README.md").write_text("# Rock")
         # No templates/ dir under fake_plugin
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_shared_mod, "PLUGIN_ROOT", fake_plugin):

--- a/tools/mastering/codec_preview.py
+++ b/tools/mastering/codec_preview.py
@@ -14,6 +14,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Bound every ffmpeg invocation — a wedged subprocess would otherwise hang
+# master_album's samples stage forever (#387). Mirrors adm_validation.py.
+_FFMPEG_TIMEOUT_SEC = 120
+
 
 class CodecPreviewError(RuntimeError):
     """Raised when the codec preview cannot be produced."""
@@ -63,7 +67,14 @@ def render_aac_preview(
         str(out_path),
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_FFMPEG_TIMEOUT_SEC
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise CodecPreviewError(
+            f"ffmpeg timed out after {_FFMPEG_TIMEOUT_SEC}s encoding {in_path.name}"
+        ) from exc
     if result.returncode != 0 or not out_path.exists():
         raise CodecPreviewError(
             f"ffmpeg failed encoding {in_path.name}: {result.stderr.strip()}"

--- a/tools/mastering/codec_preview.py
+++ b/tools/mastering/codec_preview.py
@@ -72,10 +72,14 @@ def render_aac_preview(
             cmd, capture_output=True, text=True, timeout=_FFMPEG_TIMEOUT_SEC
         )
     except subprocess.TimeoutExpired as exc:
+        # A killed ffmpeg leaves a truncated file that would sit in the
+        # operator-audition folder indistinguishable from a good preview.
+        out_path.unlink(missing_ok=True)
         raise CodecPreviewError(
             f"ffmpeg timed out after {_FFMPEG_TIMEOUT_SEC}s encoding {in_path.name}"
         ) from exc
     if result.returncode != 0 or not out_path.exists():
+        out_path.unlink(missing_ok=True)
         raise CodecPreviewError(
             f"ffmpeg failed encoding {in_path.name}: {result.stderr.strip()}"
         )

--- a/tools/sheet-music/transcribe.py
+++ b/tools/sheet-music/transcribe.py
@@ -147,13 +147,28 @@ def resolve_album_path(album_name: str) -> Path | None:
         # Expand ~ to home directory
         audio_root = Path(audio_root_str).expanduser()
 
-        # Construct: {audio_root}/artists/{artist}/albums/{genre}/{album}/
-        album_path = audio_root / artist / album_name
+        # Mirrored audio layout: {audio_root}/artists/{artist}/albums/{genre}/{album}/
+        # The genre segment isn't part of the album name, so sweep genre dirs.
+        # iterdir, not glob — album names may contain glob metacharacters.
+        albums_root = audio_root / "artists" / artist / "albums"
+        matches = sorted(
+            genre_dir / album_name
+            for genre_dir in albums_root.iterdir()
+            if genre_dir.is_dir() and (genre_dir / album_name).is_dir()
+        ) if albums_root.is_dir() else []
 
-        if not album_path.exists():
-            logger.warning("Album path not found: %s", album_path)
+        if not matches:
+            logger.warning("Album not found under %s: %s", albums_root, album_name)
             logger.warning("Treating as direct path instead.")
             return None
+        if len(matches) > 1:
+            logger.warning(
+                "Album '%s' exists under multiple genres (%s) — using %s",
+                album_name,
+                ", ".join(m.parent.name for m in matches),
+                matches[0],
+            )
+        album_path = matches[0]
 
         # Validate resolved path stays within audio_root (prevent path traversal)
         try:
@@ -353,7 +368,10 @@ Examples:
                 try:
                     audio_root = Path(config['paths']['audio_root']).expanduser()
                     artist = config['artist']['name']
-                    logger.error("  2. Album path: %s/%s/%s", audio_root, artist, args.source)
+                    logger.error(
+                        "  2. Album path: %s/artists/%s/albums/<genre>/%s",
+                        audio_root, artist, args.source,
+                    )
                 except (KeyError, TypeError):
                     pass
             sys.exit(1)


### PR DESCRIPTION
Fixes #375, fixes #387. Batch of small verified fixes (house precedent: #416), plus a test-suite flake root-caused along the way.

## 1. `transcribe.py` album-name resolution (#375)

The documented `python3 transcribe.py <album-name>` built `{audio_root}/{artist}/{album}` — missing the `artists/` and `albums/{genre}/` segments of the mirrored layout — so it **always** failed with "Source not found". Now sweeps genre dirs under `{audio_root}/artists/{artist}/albums/` (literal `iterdir`, no glob — album names may contain metacharacters), warns on legacy same-name twins across genres, and the `Tried:` error hint prints the correct path shape.

## 2. Codec-preview ffmpeg timeout (#387)

`render_aac_preview` ran ffmpeg with no `timeout=`; a wedged subprocess hung `master_album`'s samples stage **forever** (process + executor-thread leak, no recovery). Now bounded at 120s (`_FFMPEG_TIMEOUT_SEC`, mirroring `adm_validation.py`); a timeout raises `CodecPreviewError`, which `_stage_mastering_samples` already degrades to a per-track warning.

## 3. Genre-list cache poisoning (found while gating this PR)

Full-suite runs under `-n auto` were intermittently failing in the `create_album_structure` test family with run-to-run-varying failure sets. Root cause (pre-existing, not this branch): `_get_valid_genres()` cached its **first** result for the life of the process — including an empty set computed under a test-mocked `PLUGIN_ROOT` or blanket `Path.exists=False` patch — after which every genre was rejected in that worker. One test (`test_missing_templates_graceful`) only ever passed by riding the stale cache in the benign direction.

Fix: cache keyed by `PLUGIN_ROOT`, degenerate empty scans never stored (prod-safe: an empty genre set means a broken install; recompute costs one `iterdir`). Test side: blanket-mock tests prime the cache in `setup_method`; the fake plugin root in `test_missing_templates_graceful` gains a real `genres/rock` entry. New regression tests cover cache re-keying and empty-scan non-caching.

## Verification

- TDD: red-first tests for all three fixes (path resolution incl. multi-genre twins, timeout kwarg + `TimeoutExpired` mapping, cache poisoning/re-keying).
- Previously-flaky tests now pass **cold** in isolated processes (the poisoning was made deterministic, then fixed).
- Full gate: `ruff` + `bandit` + `mypy` clean; full suite green **twice consecutively** under `-n auto`: **3938 passed, 2 xfailed**, coverage 85.55%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)