### PR TITLE
fix(state): atomic IDEAS.md/status writes; honest rename cache-failure recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **IDEAS.md and status writes are crash-safe; rename failures are honest**
+  (#381, #398, #383). Every mutating write in `ideas.py` (idea backlog,
+  promoted-idea README injection) and the track/README status rewrites at
+  the end of `master_album` used truncate-then-write `write_text` — a crash
+  mid-write could leave the entire idea backlog or a source-of-truth
+  markdown file empty. All now go through the existing `atomic_write_text`
+  helper (temp file + fsync + atomic rename). And when `rename_album` /
+  `rename_track` move files successfully but the state-cache write fails,
+  they no longer report a silently-clean success with a divergent in-memory
+  cache: they rebuild the cache from disk (ground truth — the files did
+  move) and report `cache_rebuilt`, or degrade to an explicit `warning`
+  telling you to run `rebuild_state` if the rebuild also fails.
 - **`transcribe.py` album-name resolution works again** (#375). The
   documented `python3 transcribe.py <album-name>` invocation built
   `{audio_root}/{artist}/{album}` — omitting the `artists/` and

--- a/servers/bitwize-music-server/handlers/ideas.py
+++ b/servers/bitwize-music-server/handlers/ideas.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from handlers import _shared
+from handlers._atomic import atomic_write_text
 from handlers._shared import _safe_json
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ def _inject_concept_into_readme(
         new_text = text.rstrip() + block
 
     try:
-        readme_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(readme_path, new_text)
     except OSError:
         return False
     return True
@@ -137,7 +138,7 @@ def _set_promoted_to_field(title: str, slug: str) -> bool:
 
     new_text = text[:section_start] + new_section + text[section_end:]
     try:
-        ideas_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(ideas_path, new_text)
     except OSError:
         return False
     return True
@@ -206,8 +207,7 @@ async def create_idea(
     updated = text.rstrip() + "\n" + new_block
 
     try:
-        ideas_path.parent.mkdir(parents=True, exist_ok=True)
-        ideas_path.write_text(updated, encoding="utf-8")
+        atomic_write_text(ideas_path, updated)
     except OSError as e:
         return _safe_json({"error": f"Cannot write IDEAS.md: {e}"})
 
@@ -301,7 +301,7 @@ async def update_idea(title: str, field: str, value: str) -> str:
     updated_text = text[:abs_start] + new_line + text[abs_end:]
 
     try:
-        ideas_path.write_text(updated_text, encoding="utf-8")
+        atomic_write_text(ideas_path, updated_text)
     except OSError as e:
         return _safe_json({"error": f"Cannot write IDEAS.md: {e}"})
 

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2097,7 +2097,7 @@ async def _stage_status_update(ctx: MasterAlbumCtx) -> str | None:
                     updated_text = (
                         text[:match.start()] + new_row + text[match.end():]
                     )
-                    track_path.write_text(updated_text, encoding="utf-8")
+                    atomic_write_text(track_path, updated_text)
                     parsed = parse_track_file(track_path)
                     track_info.update({
                         "status": parsed.get("status", TRACK_FINAL),
@@ -2144,7 +2144,7 @@ async def _stage_status_update(ctx: MasterAlbumCtx) -> str | None:
                             updated_text = (
                                 text[:match.start()] + new_row + text[match.end():]
                             )
-                            readme_path.write_text(updated_text, encoding="utf-8")
+                            atomic_write_text(readme_path, updated_text)
                             album_data["status"] = ALBUM_COMPLETE
                             album_status = ALBUM_COMPLETE
                     except Exception as e:

--- a/servers/bitwize-music-server/handlers/rename.py
+++ b/servers/bitwize-music-server/handlers/rename.py
@@ -24,6 +24,32 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rebuild_after_cache_failure(cause: Exception) -> tuple[bool, str]:
+    """Recover from a failed surgical cache update by rebuilding from disk.
+
+    The rename already happened on disk, so a rebuild restores a consistent
+    cache. Returns (rebuilt, warning): rebuilt=True on success; otherwise a
+    user-facing warning telling them to run rebuild_state (#383).
+    """
+    try:
+        rebuilt = _shared.cache.rebuild()
+    except Exception as exc:
+        rebuilt = {"error": str(exc)}
+    if "error" in rebuilt:
+        return False, (
+            f"Files were renamed, but updating the state cache failed "
+            f"({cause}) and the recovery rebuild also failed: "
+            f"{rebuilt['error']}. Run rebuild_state before trusting "
+            f"album lookups."
+        )
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
 # Tool functions
 # ---------------------------------------------------------------------------
 
@@ -169,6 +195,8 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
 
     # Update state cache
     tracks_updated = 0
+    cache_rebuilt = False
+    cache_warning = ""
     try:
         album_data = albums.pop(normalized_old)
         album_data["path"] = str(content_dir_new)
@@ -187,6 +215,10 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
         write_state(state)
     except Exception as e:
         logger.warning("Directories moved but cache update failed: %s", e)
+        # The in-memory cache may now diverge from disk (#383). The rename
+        # itself succeeded (directories moved), so recover by rebuilding
+        # from disk instead of returning a silently-clean success.
+        cache_rebuilt, cache_warning = _rebuild_after_cache_failure(e)
 
     # Rename is the documented fix path for a slug collision (#392). If the
     # freed slug has a collision record, the surgical cache patch above is
@@ -194,9 +226,12 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     # and album_collisions is stale. Rebuild from disk (same pattern as
     # create_album_structure) so the twin is indexed and collisions are
     # recomputed. Normal renames skip this and keep the cheap surgical path.
+    # A recovery rebuild above already re-indexed everything from disk, so
+    # skip the second rebuild in that case (and don't retry after a failed
+    # recovery — it would fail the same way).
     collision_resolved = False
     rebuild_warning = ""
-    if any(
+    if not (cache_rebuilt or cache_warning) and any(
         record.get("slug") == normalized_old
         for record in state.get("album_collisions", [])
     ):
@@ -235,6 +270,10 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
         )
     elif rebuild_warning:
         result["warning"] = rebuild_warning
+    if cache_rebuilt:
+        result["cache_rebuilt"] = True
+    elif cache_warning:
+        result["warning"] = cache_warning
     return _safe_json(result)
 
 
@@ -334,6 +373,8 @@ async def rename_track(
     # Update state cache — use the same state object that _find_album_or_error
     # returned references into; do NOT re-fetch via cache.get_state() which
     # could return a different object if the cache was invalidated.
+    cache_rebuilt = False
+    cache_warning = ""
     try:
         old_track_data = tracks.pop(matched_slug)
         old_track_data["path"] = str(new_path)
@@ -356,10 +397,13 @@ async def rename_track(
             write_state(state)
     except Exception as e:
         logger.warning("File renamed but cache update failed: %s", e)
+        # Same recovery as rename_album (#383): the file DID move, so
+        # rebuild the cache from disk rather than report a clean success.
+        cache_rebuilt, cache_warning = _rebuild_after_cache_failure(e)
 
     logger.info("Renamed track '%s' to '%s' in album '%s'", matched_slug, normalized_new, normalized_album)
 
-    return _safe_json({
+    result: dict[str, Any] = {
         "success": True,
         "album_slug": normalized_album,
         "old_slug": matched_slug,
@@ -367,7 +411,12 @@ async def rename_track(
         "title": title,
         "old_path": str(old_path),
         "new_path": str(new_path),
-    })
+    }
+    if cache_rebuilt:
+        result["cache_rebuilt"] = True
+    elif cache_warning:
+        result["warning"] = cache_warning
+    return _safe_json(result)
 
 
 # ---------------------------------------------------------------------------

--- a/servers/bitwize-music-server/handlers/rename.py
+++ b/servers/bitwize-music-server/handlers/rename.py
@@ -189,7 +189,7 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
             match = heading_pattern.search(text)
             if match:
                 updated_text = text[:match.start()] + f"# {title}" + text[match.end():]
-                readme_path.write_text(updated_text, encoding="utf-8")
+                atomic_write_text(readme_path, updated_text)
         except OSError as e:
             logger.warning("Directories moved but README title update failed: %s", e)
 

--- a/tests/unit/mastering/test_stage_status_update.py
+++ b/tests/unit/mastering/test_stage_status_update.py
@@ -454,3 +454,35 @@ class TestAlbumStatusTransition:
         assert state["albums"]["test-album"]["status"] == "In Progress"
         # Warning / error recorded
         assert ctx.stages["status_update"].get("errors")
+
+
+# ===========================================================================
+# Status writes are atomic (#398)
+# ===========================================================================
+
+
+class TestStatusWritesAreAtomic:
+    """Track and README status rewrites go through atomic_write_text (#398)."""
+
+    def test_track_and_readme_written_atomically(self, filesystem, _install_cache):
+        from unittest.mock import patch
+
+        import handlers.processing._album_stages as stages_mod
+
+        state, ctx, _audio_dir = _setup(
+            filesystem, _install_cache, album_status="In Progress",
+            tracks=[("01-track-one", "Track One", "Generated")],
+        )
+
+        with patch.object(
+            stages_mod, "atomic_write_text", wraps=stages_mod.atomic_write_text
+        ) as spy:
+            _run(_stage_status_update(ctx))
+
+        written = {str(call.args[0]) for call in spy.call_args_list}
+        track_path = state["albums"]["test-album"]["tracks"]["01-track-one"]["path"]
+        album_readme = str(Path(state["albums"]["test-album"]["path"]) / "README.md")
+        assert track_path in written, f"track file not atomically written: {written}"
+        assert album_readme in written, f"README not atomically written: {written}"
+        # And the writes actually landed
+        assert "**Status** | Final |" in Path(track_path).read_text(encoding="utf-8")

--- a/tests/unit/state/test_handlers_rename.py
+++ b/tests/unit/state/test_handlers_rename.py
@@ -771,3 +771,86 @@ class TestRenameTrackPathTraversal:
             "original-album", "01-first-track", "01\\evil"
         )))
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Cache-write failure honesty (#383)
+# ---------------------------------------------------------------------------
+
+
+class _RebuildFailsCache(MockStateCache):
+    def rebuild(self) -> dict:
+        self.rebuild_calls += 1
+        return {"error": "rebuild boom"}
+
+
+class TestCacheWriteFailureHonesty:
+    """write_state failure must not produce a silently-clean success (#383)."""
+
+    def _fail_write_state(self, monkeypatch):
+        import tools.state.indexer as indexer_mod
+
+        def boom(_state):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(indexer_mod, "write_state", boom)
+
+    def test_album_rename_recovers_via_rebuild(self, cache_with_album, monkeypatch):
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "renamed-album")
+        ))
+        assert result["success"] is True
+        # Recovery rebuild from disk (directories DID move) instead of a
+        # silently divergent in-memory cache.
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert result.get("cache_rebuilt") is True
+
+    def test_album_rename_warns_when_rebuild_also_fails(self, cache_with_album, monkeypatch):
+        state, *_ = cache_with_album
+        _shared_mod.cache = _RebuildFailsCache(state)
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "renamed-album")
+        ))
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert "rebuild_state" in result.get("warning", "")
+
+    def test_cache_failure_with_collision_rebuilds_only_once(self, cache_with_album, monkeypatch):
+        """Recovery rebuild covers the collision path — no double rebuild."""
+        state, content_root, audio_root, documents_root = cache_with_album
+        state["album_collisions"] = [{
+            "slug": "original-album",
+            "kept": {"genre": "electronic", "path": state["albums"]["original-album"]["path"]},
+            "shadowed": [{"genre": "rock", "path": "/nowhere/rock/original-album"}],
+        }]
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "renamed-album")
+        ))
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 1
+
+    def test_track_rename_recovers_via_rebuild(self, cache_with_album, monkeypatch):
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_track(
+                "original-album", "01-first-track", "01-renamed-track"
+            )
+        ))
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert result.get("cache_rebuilt") is True
+
+    def test_track_rename_warns_when_rebuild_also_fails(self, cache_with_album, monkeypatch):
+        state, *_ = cache_with_album
+        _shared_mod.cache = _RebuildFailsCache(state)
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_track(
+                "original-album", "01-first-track", "01-renamed-track"
+            )
+        ))
+        assert result["success"] is True
+        assert "rebuild_state" in result.get("warning", "")

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -8011,8 +8011,10 @@ class TestCreateIdea:
         mock_cache, content_root = self._make_cache_with_ideas(
             tmp_path, "# Album Ideas\n\n## Ideas\n"
         )
+        from handlers import ideas as ideas_mod
         with patch.object(_shared_mod, "cache", mock_cache), \
-             patch.object(Path, "write_text", side_effect=OSError("permission denied")):
+             patch.object(ideas_mod, "atomic_write_text",
+                          side_effect=OSError("permission denied")):
             result = json.loads(_run(server.create_idea("New Idea")))
         assert "error" in result
 
@@ -8237,15 +8239,13 @@ class TestUpdateIdea:
         mock_cache, content_root = self._make_cache_with_ideas(tmp_path)
         # Make file read-only after first read
         with patch.object(_shared_mod, "cache", mock_cache):
-            # Use patch on Path.write_text to simulate write failure
-            original_write = Path.write_text
+            from handlers import ideas as ideas_mod
 
-            def fail_write(self, *args, **kwargs):
-                if str(self).endswith("IDEAS.md"):
+            def fail_write(path, *args, **kwargs):
+                if str(path).endswith("IDEAS.md"):
                     raise OSError("disk full")
-                return original_write(self, *args, **kwargs)
 
-            with patch.object(Path, "write_text", fail_write):
+            with patch.object(ideas_mod, "atomic_write_text", fail_write):
                 result = json.loads(_run(server.update_idea(
                     "Cyberpunk Dreams", "status", "Complete"
                 )))
@@ -15515,3 +15515,41 @@ class TestDiagnose:
         assert result["status"] == "fail"
         assert result["ok"] + result["warn"] + result["fail"] == result["total"]
 
+
+
+class TestIdeasAtomicWrites:
+    """All IDEAS.md / README.md mutations go through atomic_write_text (#381)."""
+
+    IDEAS = TestUpdateIdea.IDEAS_WITH_ENTRIES
+
+    def _make_cache_with_ideas(self, tmp_path):
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        (content_root / "IDEAS.md").write_text(self.IDEAS)
+        state = _fresh_state()
+        state["config"]["content_root"] = str(content_root)
+        return MockStateCache(state), content_root
+
+    def _spy(self):
+        from handlers import ideas as ideas_mod
+        return patch.object(
+            ideas_mod, "atomic_write_text", wraps=ideas_mod.atomic_write_text
+        )
+
+    def test_create_idea_writes_atomically(self, tmp_path):
+        mock_cache, content_root = self._make_cache_with_ideas(tmp_path)
+        with patch.object(_shared_mod, "cache", mock_cache), self._spy() as spy:
+            result = json.loads(_run(server.create_idea("Fresh Idea")))
+        assert result["created"] is True
+        assert spy.called
+        assert "### Fresh Idea" in (content_root / "IDEAS.md").read_text()
+
+    def test_update_idea_writes_atomically(self, tmp_path):
+        mock_cache, content_root = self._make_cache_with_ideas(tmp_path)
+        with patch.object(_shared_mod, "cache", mock_cache), self._spy() as spy:
+            result = json.loads(_run(server.update_idea(
+                "Cyberpunk Dreams", field="status", value="Planned"
+            )))
+        assert result["success"] is True
+        assert spy.called
+        assert "**Status**: Planned" in (content_root / "IDEAS.md").read_text()


### PR DESCRIPTION
Fixes #381, fixes #398, fixes #383. The data-safety cluster from the critical-bug triage, as one coherent PR.

## #381 — `ideas.py` non-atomic writes

All four mutating writes (idea backlog appends/updates, promoted-idea README injection) used truncate-then-write `Path.write_text` — a crash, kill, or ENOSPC mid-write could leave **the entire IDEAS.md backlog empty** or corrupt a freshly-promoted album README. `ideas.py` was the only handler cluster that never adopted the `atomic_write_text` helper (temp file + fsync + `os.replace`); it does now, with the existing OSError→error-JSON contracts unchanged.

## #398 — non-atomic status writes at the end of `master_album`

`_stage_status_update` rewrote each track markdown file and the album README with plain `write_text`, while the same module already writes its other artifacts (LAYOUT.md, ADM report, signature sidecar) atomically. Interruption during the final status promotion could truncate source-of-truth markdown. Both writes now go through `atomic_write_text` (spy-verified by test).

## #383 — rename success with a divergent cache

`rename_album` (and `rename_track`, same pattern) swallowed `write_state` failures with a log line and returned a **silently-clean success** while the in-memory cache diverged from disk — the split-brain where an album is findable under neither slug. Since the directories *did* move, disk is ground truth: both handlers now recover by rebuilding the cache from disk and report `cache_rebuilt: true`; if the rebuild also fails, the response carries an explicit `warning` directing the user to `rebuild_state`. The #392 collision rebuild is skipped when a recovery rebuild already ran (no double rebuild — pinned by test).

## Scope notes

- Test seams that simulated write failures by patching `Path.write_text` were moved to patch `atomic_write_text`.
- The `MONO_FOLD.md` sidecar in the samples stage still uses plain `write_text` — converting it surfaced a pre-existing question (whether a sidecar write failure should halt the samples stage) that's out of scope for #398's named sites; left as-is deliberately.

## Verification

- TDD: red-first tests for all three (atomic-write spies for ideas + status stage; rename recovery/rebuild-failure/single-rebuild matrix for both handlers).
- Full gate: `ruff` + `bandit` + `mypy` clean; **3950 passed, 2 xfailed**, coverage **85.65%** (CI flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)