### PR TITLE
docs(suno): document vocal-age control troubleshooting for Style Box prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   in favor of inherently mature-vocal-coded genres ("torch song", "vintage
   soul", "cabaret"), with Persona/Voice cloning (Pro/Premier) as the final
   fallback.
+- **Suno generic-vocal troubleshooting** (`reference/suno/tips-and-tricks.md`).
+  A related but distinct failure mode: Style Box text using emotion/character
+  words ("powerful and defiant", "sultry") instead of concrete vocal
+  range/texture tags produces a technically correct but generic, characterless
+  voice, since Suno has no reliable mapping from mood words to timbre. Fix
+  mirrors the vocal-age entry — swap or supplement emotion words with range
+  (`mezzo-soprano`, `contralto`) and texture (`gritty`, `raspy`, `commanding`)
+  tags, plus an explicit `no generic or polished studio pop vocal` exclude.
 
 ## [0.93.0] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,20 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   `find_album`, `list_albums`, `rebuild_state`, and the indexer CLI with the
   fix guidance (rename or move the directory, then rebuild).
 
+### Docs
+- **Suno vocal-age control troubleshooting** (`reference/suno/tips-and-tricks.md`).
+  Vague age adjectives ("mature and deep") in the Style Box are weak signals
+  that get outcompeted by breathy/soft-coded words ("intimate", "whispered")
+  sitting nearby, so Suno keeps generating a young-sounding vocal even when
+  age is explicitly requested. Documents the escalation path found in
+  production: concrete vocal-range/texture tags (`alto`, `contralto`,
+  `smoky`, `weathered`) first, then — if a fresh generation still skews
+  young — inline lyrical metatags per section (`[Verse 1: Raspy older female
+  vocal, husky contralto]`) plus dropping youth-coded genre words like "pop"
+  in favor of inherently mature-vocal-coded genres ("torch song", "vintage
+  soul", "cabaret"), with Persona/Voice cloning (Pro/Premier) as the final
+  fallback.
+
 ## [0.93.0] - 2026-07-01
 
 ### Fixed

--- a/reference/suno/tips-and-tricks.md
+++ b/reference/suno/tips-and-tricks.md
@@ -45,6 +45,26 @@ If all of the above still fails, the underlying genre/instrumentation combo may 
 
 ---
 
+## Vocal Sounds Generic Despite "Powerful"/"Defiant"/Character Descriptors
+
+**Symptom:** Style box describes the intended vocal character with emotion or personality words (e.g. "powerful and defiant," "sultry," "heartbroken") but Suno generates a generic, characterless voice — technically competent, on-genre, but indistinguishable from any other pop vocal.
+
+**Likely cause:** Emotion and character adjectives describe *what the performance should feel like*, not *what the voice should sound like*. Suno has no reliable mapping from an emotion word to a specific timbre, so it falls back to a default voice for the genre and just sings the notes "correctly." This is a different failure mode from the youth/age issue above — it isn't fighting a competing signal, it's simply not giving Suno enough to grab onto.
+
+**Fix:** Same principle as the age issue — replace or supplement emotion/character words with concrete vocal range and texture tags:
+1. Add a specific vocal range: `mezzo-soprano`, `alto`, `contralto` (female) or `baritone`, `tenor` (male) — see [voice-tags.md](voice-tags.md)
+2. Add texture tags that are actually audible qualities, not moods: `gritty`, `raspy`, `rasp on the belted notes`, `raw chest voice`, `commanding`, `weathered` — these describe grain and register, which Suno can render; "defiant" and "powerful" describe intent, which it can't
+3. Add an explicit exclude: `no generic or polished studio pop vocal` appended to the Style Box (see [Negative Prompting](v5-best-practices.md#negative-prompting))
+4. Keep one or two emotion words if they help set the performance arc (e.g. "controlled and low in the verses, breaking open into a full-throated belt on the chorus") — the fix isn't to strip emotion language entirely, it's to make sure concrete texture/range tags are doing the actual work
+
+**Example fix:**
+- ❌ Generic: `Female character vocal, powerful and defiant`
+- ✅ Specific: `Female mezzo-soprano, gritty and raw, rasp on the belted notes, commanding chest voice, weathered and fierce — not a polished or generic pop voice`
+
+If this still comes back generic after a regeneration, escalate the same way as the age issue: inline per-section lyrical metatags in the Lyrics Box (`[Chorus: Gritty, raw, commanding female belt]`), and check whether the genre tag itself (e.g. "pop") is pulling toward a generic default that no amount of texture stacking fully overcomes.
+
+---
+
 ## Extending Songs
 
 ### Basic Workflow

--- a/reference/suno/tips-and-tricks.md
+++ b/reference/suno/tips-and-tricks.md
@@ -20,6 +20,31 @@ Operational techniques and troubleshooting for Suno. For prompting guidance, see
 
 ---
 
+## Vocal Sounds Too Young Despite "Mature"/"Deep" Descriptors
+
+**Symptom:** Style box includes an age adjective like "mature and deep" but Suno still generates a young/light-sounding vocal.
+
+**Likely cause:** Vague age adjectives are weak signals and get outcompeted by other descriptors in the same prompt — especially breathy/soft-coded words like "intimate," "whispered," or "delicate" sitting nearby. Suno responds more reliably to concrete vocal-range and texture tags than to age adjectives alone.
+
+**Fix:**
+1. Replace the age adjective with a specific vocal range: `alto`, `contralto`, `low register` (female) or `baritone`, `bass-baritone` (male) — see [voice-tags.md](voice-tags.md)
+2. Add texture tags that connote maturity/experience rather than youth: `smoky`, `weathered`, `resonant`, `gravelly` — avoid `breathy`, `whispered`, `delicate`, `intimate` if you want an older-sounding voice, since those skew young in Suno's training data
+3. Add an explicit exclude: `no youthful or breathy vocals` appended to the Style Box (see [Negative Prompting](v5-best-practices.md#negative-prompting) — Suno excludes via "no X" phrasing in the prompt text, not a separate bare-terms field)
+4. Still expect 2–3 regenerations — vocal-age control is inconsistent even with well-chosen tags, this narrows the odds rather than guaranteeing the result
+
+**Example fix:**
+- ❌ Weak: `Female character vocal, mature and deep, aching and intimate`
+- ✅ Stronger: `Female alto vocal, low register, smoky and weathered, resonant and world-weary — not breathy, not youthful`
+
+**If concrete range/texture tags in the Style Box still aren't enough** (confirmed on a fresh generation, ruling out session/caching carryover), escalate with two more levers:
+
+1. **Inline lyrical metatags** — place a vocal descriptor directly in the Lyrics Box before each section, not just in the Style Box: `[Verse 1: Raspy older female vocal, husky contralto]`, `[Chorus: Raspy older female vocal, husky contralto]`, etc. This is a different mechanism from the Style Box and Suno may weight it independently — repeat the tag on every section, not just the first.
+2. **Check whether the genre tag itself is fighting you.** "Pop" as a genre descriptor can carry a bright/youthful bias that no amount of vocal adjectives fully cancels. Swap genre-of-record words that skew young/bright (`pop`, `bright`, `modern electronic`) for genre words that are inherently mature-vocal-coded: `torch song`, `vintage soul`, `cabaret`, `1940s jazz`, `vintage country`. Keep other identity-defining tags (mode, instrumentation) unchanged.
+
+If all of the above still fails, the underlying genre/instrumentation combo may carry a strong young-vocalist bias in Suno's training data that text prompting can't fully overcome. At that point, [Personas](#personas-for-vocal-consistency) (Pro/Premier, for a consistent vocal identity) or [Voices/voice cloning](#voices--custom-models-v55) (Pro/Premier, referencing a real vocal sample) are more reliable than any further style-box iteration.
+
+---
+
 ## Extending Songs
 
 ### Basic Workflow


### PR DESCRIPTION
## Summary
- Documents a Suno prompting failure mode found during real album production: vague age adjectives ("mature and deep") in the Style Box get outcompeted by breathy/soft-coded words ("intimate", "whispered") sitting nearby, so Suno keeps generating a young-sounding vocal even when age is explicitly requested.
- New `reference/suno/tips-and-tricks.md` section documents the escalation path that actually worked: concrete vocal-range/texture tags (`alto`, `contralto`, `smoky`, `weathered`) first, then — if a fresh generation still skews young — inline per-section lyrical metatags plus dropping youth-coded genre words like "pop" in favor of inherently mature-vocal-coded genres, with Persona/Voice cloning (Pro/Premier) as the final fallback.
- Cross-links the new section to the file's existing `Personas for Vocal Consistency` and `Voices & Custom Models (V5.5)` sections instead of re-explaining them, to avoid fact drift.
- `CHANGELOG.md` updated under `[Unreleased] → Docs`.

## Type of change
- [x] Documentation only (no code changes)

## Testing performed
- `make check` (ruff + bandit + mypy + full pytest suite) passed clean: 3933 passed, 85.57% coverage.
- Verified all internal/cross-file markdown anchors resolve (`#personas-for-vocal-consistency`, `#voices--custom-models-v55`, `v5-best-practices.md#negative-prompting`, `voice-tags.md`).
- Self-reviewed via `code-reviewer` agent; one medium-severity finding (Exclude Styles field syntax) was investigated against `v5-best-practices.md` § Negative Prompting and found to be based on an incorrect assumption about Suno's UI — no change needed there. Two low-severity polish suggestions (cross-links, en-dash consistency) were applied.

## Deployment notes
None — documentation only, no migration required (no filesystem/dependency/config/template changes per CONTRIBUTING.md's migration trigger list).

## Breaking changes
None.

## Reviewer checklist
- [ ] Confirm the "no X" Exclude Styles phrasing matches your understanding of Suno's actual prompt-box mechanic (documented in `v5-best-practices.md` § Negative Prompting, referenced from the new section)
- [ ] Confirm cross-linked anchors render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)