### PR TITLE
fix: honest tool reporting — pronunciation gate, batch promo results, retry floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Pronunciation gate no longer false-passes on words containing "Word"**
+  (#384). The table parser skipped ANY row whose line contained the
+  substring "Word", silently dropping data rows like "Wordsworth" — if
+  those were the only entries, `check_pronunciation_enforcement` reported
+  `all_applied: true` with the phonetic missing from the lyrics, defeating
+  the pronunciation hard rule. The header row is now matched by its first
+  cell only, and separator rows by cell content rather than substring.
+- **Batch promo-video generation reports real per-track results** (#382).
+  The handler globbed `*_promo.mp4` after the run and marked every file
+  `success: true` — stale files from previous runs counted as fresh
+  successes and per-track ffmpeg failures were invisible.
+  `batch_process_album` now returns its per-track outcomes and the
+  response includes `failed` / `failed_tracks`.
+- **`--retries` can no longer silently skip every upload** (#385).
+  `retry_upload` with a non-positive retry count never entered its
+  attempt loop and reported every file as failed (even in `--dry-run`).
+  It now always attempts at least once, and the CLI rejects
+  `--retries < 1` with a clear argparse error.
 - **IDEAS.md and status writes are crash-safe; rename failures are honest**
   (#381, #398, #383). Every mutating write in `ideas.py` (idea backlog,
   promoted-idea README injection) and the track/README status rewrites at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   substring "Word", silently dropping data rows like "Wordsworth" — if
   those were the only entries, `check_pronunciation_enforcement` reported
   `all_applied: true` with the phonetic missing from the lyrics, defeating
-  the pronunciation hard rule. The header row is now matched by its first
-  cell only, and separator rows by cell content rather than substring.
+  the pronunciation hard rule. The same parser bug lived in the BLOCKING
+  Gate 3 of `run_pre_generation_gates` — both sites now share one parser
+  (`_parse_pronunciation_table`) that matches the header row by its first
+  cell only and separator rows by cell content rather than substring. The
+  batch promo CLI also exits non-zero on per-track failures now, so
+  `generate_all_promos.py`'s error detection actually fires.
 - **Batch promo-video generation reports real per-track results** (#382).
   The handler globbed `*_promo.mp4` after the run and marked every file
   `success: true` — stale files from previous runs counted as fresh

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -363,6 +363,31 @@ def _find_album_or_error(album_slug: str) -> tuple[str, dict[str, Any] | None, s
     return normalized, album, None
 
 
+def _parse_pronunciation_table(section_text: str) -> list[dict[str, str]]:
+    """Parse ``| Word/Phrase | Pronunciation | Reason |`` table rows.
+
+    The header row is matched by its FIRST CELL only, and separator rows by
+    cell content — substring filters on the whole line drop legitimate data
+    rows like "Wordsworth" and false-pass the pronunciation checks (#384).
+    """
+    entries: list[dict[str, str]] = []
+    for line in section_text.split("\n"):
+        if not line.startswith("|"):
+            continue
+        # Separator row: cells made only of dashes/colons (|-----|:---:|)
+        if set(line) <= {"|", "-", ":", " "}:
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) >= 4:
+            word = parts[1].strip()
+            phonetic = parts[2].strip()
+            if word.lower() in ("word/phrase", "word"):
+                continue
+            if word and word != "—" and phonetic and phonetic != "—":
+                entries.append({"word": word, "phonetic": phonetic})
+    return entries
+
+
 def _find_slug_dirs(albums_root: Path, slug: str) -> list[Path]:
     """Find existing album dirs named exactly `slug` under every genre (#392).
 

--- a/servers/bitwize-music-server/handlers/gates.py
+++ b/servers/bitwize-music-server/handlers/gates.py
@@ -16,6 +16,7 @@ from handlers._shared import (
     _extract_markdown_section,
     _find_album_or_error,
     _find_track_or_error,
+    _parse_pronunciation_table,
     _safe_json,
 )
 
@@ -105,15 +106,7 @@ def _check_pre_gen_gates_for_track(
         pron_section = _extract_markdown_section(file_text, "Pronunciation Notes")
         pron_entries = []
         if pron_section:
-            for line in pron_section.split("\n"):
-                if not line.startswith("|") or "---" in line or "Word" in line:
-                    continue
-                parts = [p.strip() for p in line.split("|")]
-                if len(parts) >= 4:
-                    word = parts[1].strip()
-                    phonetic = parts[2].strip()
-                    if word and word != "—" and phonetic and phonetic != "—":
-                        pron_entries.append({"word": word, "phonetic": phonetic})
+            pron_entries = _parse_pronunciation_table(pron_section)
 
         if pron_entries and lyrics_content:
             unapplied = []

--- a/servers/bitwize-music-server/handlers/processing/video.py
+++ b/servers/bitwize-music-server/handlers/processing/video.py
@@ -170,7 +170,7 @@ async def generate_promo_videos(
             if content_dir_path.is_dir():
                 content_dir = content_dir_path
 
-        await loop.run_in_executor(
+        batch_results = await loop.run_in_executor(
             None,
             lambda: batch_process_album(
                 album_dir=audio_dir,
@@ -187,14 +187,25 @@ async def generate_promo_videos(
             ),
         )
 
-        # Collect results from output dir
-        output_files = sorted(output_dir.glob("*_promo.mp4"))
-        results = [{"filename": f.name, "output": str(f), "success": True} for f in output_files]
+        # Report the per-track outcomes from THIS run — globbing the output
+        # dir counted stale files from previous runs as fresh successes and
+        # hid failures entirely (#382).
+        results = [
+            {
+                "filename": audio_name,
+                "output": str(output_dir / out_name),
+                "success": success,
+            }
+            for audio_name, out_name, success in batch_results
+        ]
+        failed = [r["filename"] for r in results if not r["success"]]
 
         return _safe_json({
             "tracks": results,
             "summary": {
-                "success": len(results),
+                "success": len(results) - len(failed),
+                "failed": len(failed),
+                "failed_tracks": failed,
                 "output_dir": str(output_dir),
             },
         })

--- a/servers/bitwize-music-server/handlers/text_analysis.py
+++ b/servers/bitwize-music-server/handlers/text_analysis.py
@@ -315,12 +315,19 @@ async def check_pronunciation_enforcement(
     # Parse the pronunciation table: | Word/Phrase | Pronunciation | Reason |
     entries = []
     for line in pron_section.split("\n"):
-        if not line.startswith("|") or "---" in line or "Word" in line:
+        if not line.startswith("|"):
+            continue
+        # Separator row: cells made only of dashes/colons (|-----|:---:|)
+        if set(line) <= {"|", "-", ":", " "}:
             continue
         parts = [p.strip() for p in line.split("|")]
         if len(parts) >= 4:
             word = parts[1].strip()
             phonetic = parts[2].strip()
+            # Skip the header row by its FIRST CELL only — a substring match
+            # on the whole line drops data rows like "Wordsworth" (#384)
+            if word.lower() in ("word/phrase", "word"):
+                continue
             if word and word != "—" and phonetic and phonetic != "—":
                 entries.append({"word": word, "phonetic": phonetic})
 

--- a/servers/bitwize-music-server/handlers/text_analysis.py
+++ b/servers/bitwize-music-server/handlers/text_analysis.py
@@ -21,6 +21,7 @@ from handlers._shared import (
     _find_track_or_error,
     _is_path_confined,
     _normalize_slug,
+    _parse_pronunciation_table,
     _safe_json,
 )
 
@@ -313,23 +314,7 @@ async def check_pronunciation_enforcement(
         })
 
     # Parse the pronunciation table: | Word/Phrase | Pronunciation | Reason |
-    entries = []
-    for line in pron_section.split("\n"):
-        if not line.startswith("|"):
-            continue
-        # Separator row: cells made only of dashes/colons (|-----|:---:|)
-        if set(line) <= {"|", "-", ":", " "}:
-            continue
-        parts = [p.strip() for p in line.split("|")]
-        if len(parts) >= 4:
-            word = parts[1].strip()
-            phonetic = parts[2].strip()
-            # Skip the header row by its FIRST CELL only — a substring match
-            # on the whole line drops data rows like "Wordsworth" (#384)
-            if word.lower() in ("word/phrase", "word"):
-                continue
-            if word and word != "—" and phonetic and phonetic != "—":
-                entries.append({"word": word, "phonetic": phonetic})
+    entries = _parse_pronunciation_table(pron_section)
 
     if not entries:
         return _safe_json({

--- a/tests/unit/cloud/test_upload_to_cloud.py
+++ b/tests/unit/cloud/test_upload_to_cloud.py
@@ -415,3 +415,31 @@ class TestCloudEnabledGate:
         monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album"])
         with pytest.raises(SystemExit):
             mod.main()
+
+
+class TestRetriesValidation:
+    """--retries <= 0 must not silently skip every upload attempt (#385)."""
+
+    @pytest.fixture()
+    def fake_video(self, tmp_path):
+        f = tmp_path / "promo.mp4"
+        f.write_bytes(b"fake video content")
+        return f
+
+    def test_zero_retries_still_attempts_once(self, fake_video):
+        client = MagicMock()
+        result = mod.retry_upload(client, "bucket", fake_video, "key/f.mp4", max_retries=0)
+        assert result is True
+        assert client.upload_file.call_count == 1
+
+    def test_negative_retries_still_attempts_once(self, fake_video):
+        client = MagicMock()
+        result = mod.retry_upload(client, "bucket", fake_video, "key/f.mp4", max_retries=-3)
+        assert result is True
+        assert client.upload_file.call_count == 1
+
+    def test_cli_rejects_non_positive_retries(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album", "--retries", "0"])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 2  # argparse usage error, not silent failure

--- a/tests/unit/promotion/test_generate_promo_video.py
+++ b/tests/unit/promotion/test_generate_promo_video.py
@@ -219,3 +219,38 @@ class TestBatchProcessAlbum:
             output_dir=output_dir,
         )
         mock_gen.assert_not_called()
+
+
+class TestBatchCliExitCode:
+    """CLI --batch mode exits non-zero when any track fails (#382)."""
+
+    def _run_main(self, tmp_path, monkeypatch, results):
+        import tools.promotion.generate_promo_video as gpv
+        album = tmp_path / "album"
+        album.mkdir()
+        (album / "01-track.wav").write_bytes(b"")
+        art = tmp_path / "album.png"
+        art.write_bytes(b"")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["generate_promo_video.py", "--batch", str(album),
+             "--batch-artwork", str(art)],
+        )
+        monkeypatch.setattr(gpv, "batch_process_album", lambda **kw: results)
+        gpv.main()
+
+    def test_failure_exits_nonzero(self, tmp_path, monkeypatch):
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_main(
+                tmp_path, monkeypatch,
+                [("01-track.wav", "01-track_promo.mp4", True),
+                 ("02-track.wav", "02-track_promo.mp4", False)],
+            )
+        assert exc_info.value.code == 1
+
+    def test_all_success_exits_zero(self, tmp_path, monkeypatch):
+        # main() returns normally (no SystemExit) when every track succeeds
+        self._run_main(
+            tmp_path, monkeypatch,
+            [("01-track.wav", "01-track_promo.mp4", True)],
+        )

--- a/tests/unit/state/test_handlers_gates.py
+++ b/tests/unit/state/test_handlers_gates.py
@@ -479,6 +479,28 @@ class TestGate3PronunciationResolved:
         assert pron_gate["status"] == "FAIL"
         assert "lever" in pron_gate["detail"]
 
+    def test_word_substring_row_still_blocks(self):
+        """A 'Wordsworth' row must not be dropped by the header filter (#384).
+
+        The old substring filter skipped any line containing 'Word', so the
+        BLOCKING gate false-passed with 'No pronunciation entries to check'.
+        """
+        track = (
+            "---\ntitle: Wordsworth Track\nstatus: In Progress\n---\n\n"
+            "## Lyrics Box\n\n```\nplain lyrics without the phonetic\n```\n\n"
+            "## Pronunciation Notes\n\n"
+            "| Word/Phrase | Pronunciation | Reason |\n"
+            "|-------------|---------------|--------|\n"
+            "| Wordsworth | WURDZ-wurth | poet name |\n"
+        )
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, track, blocklist=[],
+        )
+        pron_gate = next(g for g in gates if g["gate"] == "Pronunciation Resolved")
+        assert pron_gate["status"] == "FAIL"
+        assert "Wordsworth" in pron_gate["detail"]
+
     def test_no_pronunciation_entries_passes(self):
         t_data = {"sources_verified": "N/A", "explicit": False}
         blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -3530,6 +3530,23 @@ F-B-I came knocking at his door
 | Linux | Lin-ucks | Tech term |
 """
 
+_TRACK_WITH_WORD_SUBSTRING = """\
+# Test Track
+
+## Suno Inputs
+
+### Lyrics Box
+```
+plain lyrics without any phonetic respelling
+```
+
+## Pronunciation Notes
+
+| Word/Phrase | Pronunciation | Reason |
+|-------------|---------------|--------|
+| Wordsworth | WURDZ-wurth | poet name |
+"""
+
 _TRACK_WITH_UNAPPLIED = """\
 # Test Track
 
@@ -3594,6 +3611,24 @@ class TestCheckPronunciationEnforcement:
             result = json.loads(_run(server.check_pronunciation_enforcement("test-album", "05-unapplied")))
         assert result["all_applied"] is False
         assert result["unapplied_count"] == 2  # Both Rah-mohs and F-B-I not in lyrics
+
+    def test_word_substring_rows_are_not_dropped(self, tmp_path):
+        """Rows whose Word cell contains 'Word' must not be skipped (#384)."""
+        track_file = tmp_path / "05-wordsworth.md"
+        track_file.write_text(_TRACK_WITH_WORD_SUBSTRING)
+        state = _fresh_state()
+        state["albums"]["test-album"]["tracks"]["05-wordsworth"] = {
+            "path": str(track_file),
+            "title": "Wordsworth Track",
+            "status": "In Progress",
+        }
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.check_pronunciation_enforcement("test-album", "05-wordsworth")))
+        # The phonetic is NOT in the lyrics — a dropped row would false-PASS.
+        assert result["all_applied"] is False
+        assert result["unapplied_count"] == 1
+        assert result["entries"][0]["word"] == "Wordsworth"
 
     def test_empty_pronunciation_table(self, tmp_path):
         track_file = tmp_path / "05-empty-pron.md"
@@ -9325,12 +9360,9 @@ class TestExtractCodeBlockEdgeCases:
 class TestCheckPronunciationEdgeCases:
     """Edge case tests for check_pronunciation_enforcement."""
 
-    def test_word_in_data_row_skipped(self, tmp_path):
-        """Table row containing 'Word' in data is skipped by the header filter.
-
-        Documents that the filter 'if "Word" in line' skips ANY row
-        containing 'Word', including legitimate data rows.
-        """
+    def test_word_in_data_row_parsed(self, tmp_path):
+        """Data rows containing 'Word' are parsed — only the header row is
+        skipped, matched by its first cell (#384)."""
         track_file = tmp_path / "01-test.md"
         track_file.write_text(
             "# Test\n\n"
@@ -9352,10 +9384,11 @@ class TestCheckPronunciationEdgeCases:
                 server.check_pronunciation_enforcement("test-album", "01-test")
             ))
 
-        # The entry with "Word" in the word column is skipped by the header filter
         assert result["found"] is True
-        # "Wordplay" entry is skipped because the line contains "Word"
-        assert len(result["entries"]) == 0
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["word"] == "Wordplay"
+        # The phonetic IS in the lyrics, so the check passes honestly
+        assert result["all_applied"] is True
 
     def test_no_pronunciation_section(self, tmp_path):
         """Track with no Pronunciation Notes section reports all applied."""
@@ -12556,6 +12589,41 @@ class TestGeneratePromoVideos:
         assert "error" in result
         assert "artwork" in result["error"].lower()
 
+    def test_batch_reports_failures_and_ignores_stale_files(self, tmp_path):
+        """Batch mode must report per-track failures, not glob stale files (#382)."""
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "album.png").write_bytes(b"")
+        (audio_dir / "01-track.wav").write_bytes(b"")
+        (audio_dir / "02-track.wav").write_bytes(b"")
+        output_dir = audio_dir / "promo_videos"
+        output_dir.mkdir()
+        (output_dir / "99-stale_promo.mp4").write_bytes(b"old run leftover")
+
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        state["config"]["artist_name"] = "test-artist"
+        mock_cache = MockStateCache(state)
+
+        def fake_batch(**kwargs):
+            return [
+                ("01-track.wav", "01-track_promo.mp4", True),
+                ("02-track.wav", "02-track_promo.mp4", False),
+            ]
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \
+             patch("tools.promotion.generate_promo_video.batch_process_album",
+                   side_effect=fake_batch):
+            result = json.loads(_run(server.generate_promo_videos("test-album")))
+
+        assert result["summary"]["success"] == 1
+        assert result["summary"]["failed"] == 1
+        by_file = {t["filename"]: t["success"] for t in result["tracks"]}
+        assert by_file == {"01-track.wav": True, "02-track.wav": False}
+        # Stale leftovers from previous runs are not reported as new successes
+        assert "99-stale_promo.mp4" not in json.dumps(result)
+
     def test_single_track_not_found(self, tmp_path):
         audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
         audio_dir.mkdir(parents=True)
@@ -13766,6 +13834,10 @@ class TestGeneratePromoVideosComprehensive:
             output_dir.mkdir(exist_ok=True)
             (output_dir / "01-track-1_promo.mp4").write_bytes(b"")
             (output_dir / "02-track-2_promo.mp4").write_bytes(b"")
+            return [
+                ("01-track-1.wav", "01-track-1_promo.mp4", True),
+                ("02-track-2.wav", "02-track-2_promo.mp4", True),
+            ]
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \
@@ -13931,6 +14003,7 @@ class TestGeneratePromoVideosComprehensive:
 
         def mock_batch(**kwargs):
             captured_kwargs.append(kwargs)
+            return []
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \
@@ -14265,6 +14338,10 @@ class TestPromoVideoNewParams:
             output_dir.mkdir(exist_ok=True)
             (output_dir / "01-track-1_promo.mp4").write_bytes(b"")
             (output_dir / "02-track-2_promo.mp4").write_bytes(b"")
+            return [
+                ("01-track-1.wav", "01-track-1_promo.mp4", True),
+                ("02-track-2.wav", "02-track-2_promo.mp4", True),
+            ]
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -309,6 +309,9 @@ def retry_upload(
     Retries on transient errors (network issues, server errors).
     Does not retry on auth errors (403, 404, missing credentials).
     """
+    # max_retries <= 0 would make the loop body never run — no upload
+    # attempted, silently reported as failure (#385). Always try once.
+    max_retries = max(1, max_retries)
     for attempt in range(1, max_retries + 1):
         result = upload_file(s3_client, bucket, file_path, s3_key, public_read, dry_run)
         if result or dry_run:
@@ -324,6 +327,14 @@ def retry_upload(
         time.sleep(delay)
 
     return False
+
+
+def _positive_int(value: str) -> int:
+    """argparse type: reject values < 1 loudly instead of silently no-op'ing (#385)."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {parsed}")
+    return parsed
 
 
 def main() -> None:
@@ -372,9 +383,9 @@ Examples:
     )
     parser.add_argument(
         "--retries",
-        type=int,
+        type=_positive_int,
         default=3,
-        help="Max retry attempts per file on failure (default: 3)",
+        help="Max retry attempts per file on failure (default: 3, minimum: 1)",
     )
 
     args = parser.parse_args()

--- a/tools/promotion/generate_all_promos.py
+++ b/tools/promotion/generate_all_promos.py
@@ -214,9 +214,11 @@ Examples:
 
     if not args.sampler_only:
         promo_dir = album_dir / "promo_videos"
-        promo_count = sum(1 for f in promo_dir.glob("*.mp4")) if promo_dir.exists() else 0
+        # Count only track promos (not the sampler), and say what the number
+        # is — files present in the dir, which may include earlier runs (#382).
+        promo_count = sum(1 for f in promo_dir.glob("*_promo.mp4")) if promo_dir.exists() else 0
         print(f"Track promos: {promo_dir}")
-        print(f"  {promo_count} videos generated")
+        print(f"  {promo_count} promo videos in directory")
 
     if not args.tracks_only:
         sampler = album_dir / "promo_videos" / "album_sampler.mp4"

--- a/tools/promotion/generate_promo_video.py
+++ b/tools/promotion/generate_promo_video.py
@@ -636,7 +636,7 @@ Examples:
 
         output_dir = args.output or args.batch / 'promo_videos'
 
-        batch_process_album(
+        batch_results = batch_process_album(
             album_dir=args.batch,
             artwork_path=artwork,
             output_dir=output_dir,
@@ -650,6 +650,17 @@ Examples:
             glow=args.glow,
             text_color=args.text_color,
         )
+
+        # Per-track failures must surface as a non-zero exit, matching
+        # single-file mode — callers (generate_all_promos.py) key off the
+        # return code (#382).
+        failed = [name for name, _out, ok in batch_results if not ok]
+        if failed:
+            logger.error(
+                "%d of %d tracks failed: %s",
+                len(failed), len(batch_results), ", ".join(failed),
+            )
+            sys.exit(1)
 
     else:
         # Single file mode

--- a/tools/promotion/generate_promo_video.py
+++ b/tools/promotion/generate_promo_video.py
@@ -407,8 +407,12 @@ def batch_process_album(
     color_hex: str = "",
     glow: float = 0.6,
     text_color: str = "",
-) -> None:
-    """Process all audio files in an album directory."""
+) -> list[tuple[str, str, bool]]:
+    """Process all audio files in an album directory.
+
+    Returns one (audio_filename, output_filename, success) tuple per track
+    so callers can report real per-track outcomes (#382).
+    """
     audio_extensions = {'.wav', '.mp3', '.flac', '.m4a'}
 
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -420,7 +424,7 @@ def batch_process_album(
 
     if not audio_files:
         logger.warning("No audio files found in %s", album_dir)
-        return
+        return []
 
     logger.info("Found %d tracks", len(audio_files))
     if content_dir:
@@ -470,10 +474,12 @@ def batch_process_album(
     workers = jobs if jobs > 0 else (os.cpu_count() or 1)
     progress = ProgressBar(len(sorted_audio), prefix="Generating")
 
+    results: list[tuple[str, str, bool]] = []
     if workers == 1:
         for audio_file in sorted_audio:
             progress.update(audio_file.name)
-            _, out_name, success = _process_one(audio_file)
+            name, out_name, success = _process_one(audio_file)
+            results.append((name, out_name, success))
             if success:
                 logger.info("  [OK] %s", out_name)
             else:
@@ -485,11 +491,13 @@ def batch_process_album(
             for future in as_completed(futures):
                 af = futures[future]
                 progress.update(af.name)
-                _, out_name, success = future.result()
+                name, out_name, success = future.result()
+                results.append((name, out_name, success))
                 if success:
                     logger.info("  [OK] %s", out_name)
                 else:
                     logger.error("  [FAIL] %s", af.name)
+    return sorted(results)
 
 
 def main() -> None:


### PR DESCRIPTION
Fixes #384, fixes #382, fixes #385. Three fixes for tools that reported something other than what actually happened.

## #384 — pronunciation gate false PASS (the important one)

`check_pronunciation_enforcement` skipped any table row whose **line contained the substring "Word"** — meant to drop the `| Word/Phrase | ... |` header, it also silently dropped legitimate data rows ("Wordsworth", "WordPress", …). If those were the only entries, the tool returned `all_applied: true` with the phonetic respelling missing from the lyrics — a silent false PASS on the pronunciation hard rule that CLAUDE.md treats as non-negotiable. The header row is now matched by its **first cell** only, and separator rows by cell content (`|---|`) rather than a `"---"` substring (which could also eat a data row). An existing edge-case test that had pinned the buggy behavior as documentation is inverted to pin the fix.

## #382 — batch promo videos reported stale/failed files as success

Batch mode ran `batch_process_album` (which returned `None`), then globbed `*_promo.mp4` and marked **every file found** as `success: true` — leftovers from previous runs counted as fresh successes, and per-track ffmpeg failures vanished. `batch_process_album` already computed per-track outcomes internally and discarded them; it now returns `(audio, output, success)` tuples (sorted, `[]` for empty dirs — CLI behavior unchanged), and the handler reports real `success`/`failed` counts plus `failed_tracks`.

## #385 — `--retries 0` silently uploaded nothing

`retry_upload`'s loop body never ran for a non-positive count, so every file was "failed" without a single attempt — even in `--dry-run`. The function now floors at one attempt, and the CLI rejects `--retries < 1` with a loud argparse error.

## Verification

- TDD: red-first tests for all three (Wordsworth false-PASS repro, stale-file/failure batch matrix, zero/negative retry attempts + CLI rejection).
- Three existing mocks updated for the new `batch_process_album` return contract.
- Full gate post-rebase on current `develop`: `ruff` + `mypy` clean; **3955 passed, 2 xfailed**, coverage 85.6%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)