### PR TITLE
fix: quote argument-hint YAML to keep it a string for Copilot CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **`argument-hint` YAML frontmatter now parses as a string across all runtimes**.
+  Three skill files (`configure`, `next-step`, `test`) declared
+  `argument-hint: [ ... ]` with an unquoted `[`, which YAML parses as a
+  flow sequence (array). Claude Code tolerates this, but Copilot CLI
+  1.0.65+ requires `argument-hint` to be a string and fails skill load
+  otherwise. Values are now wrapped in double quotes so both runtimes
+  receive a string. See [anthropics/claude-code#22161] for the upstream
+  spec clarification.
 - **Pronunciation gate no longer false-passes on words containing "Word"**
   (#384). The table parser skipped ANY row whose line contained the
   substring "Word", silently dropping data rows like "Wordsworth" — if

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: configure
 description: Sets up or edits the plugin configuration file interactively. Use on first-time setup, when config is missing, or when the user wants to change settings.
-argument-hint: [setup | edit | show | validate | reset]
+argument-hint: "[setup | edit | show | validate | reset]"
 model: sonnet
 effort: low
 allowed-tools:

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next-step
 description: Analyzes album state and recommends the optimal next action. Use when the user asks "what should I do next?" or "what's left to do?"
-argument-hint: [album-name]
+argument-hint: "[album-name]"
 model: haiku
 prerequisites:
   - resume

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test
 description: Runs automated tests to validate plugin integrity across 14 categories. Use before creating PRs, after making changes to skills or templates, or to verify plugin health.
-argument-hint: [all | config | skills | templates | workflow | suno | research | mastering | sheet-music | release | consistency | terminology | behavior | quality | quick]
+argument-hint: "[all | config | skills | templates | workflow | suno | research | mastering | sheet-music | release | consistency | terminology | behavior | quality | quick]"
 model: haiku
 context: fork
 allowed-tools:


### PR DESCRIPTION
## Description

Three `SKILL.md` files declare `argument-hint` with an unquoted `[` prefix:

```yaml
argument-hint: [setup | edit | show | validate | reset]
argument-hint: [album-name]
argument-hint: [all | config | skills | ... | quick]
```

YAML parses those values as **flow sequences** (arrays), not strings. Claude Code's skill loader is lenient and accepts either shape, but Copilot CLI 1.0.65+ tightened its schema and now requires `argument-hint` to be a string — the affected skills fail to load with a type-mismatch error.

Wrapping each value in double quotes forces YAML to parse it as a string on both runtimes. The user-visible hint text is unchanged.

### YAML rule

| Written                         | YAML type      | Copilot CLI 1.0.65+ |
|---------------------------------|----------------|---------------------|
| `argument-hint: [X]`            | array          | rejected            |
| `argument-hint: "[X]"`          | string         | accepted            |
| `argument-hint: <X>`            | string         | accepted            |

Rule of thumb: any `argument-hint` value that starts with `[` must be quoted. `<...>` forms already parse as strings and are unaffected.

### Files changed

- `skills/configure/SKILL.md`
- `skills/next-step/SKILL.md`
- `skills/test/SKILL.md`
- `CHANGELOG.md` (Unreleased / Fixed)

A repo-wide `rg '^argument-hint:\s*\[' skills/` sweep confirms these were the only three affected files.

Reference: [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) for the upstream spec clarification.

## Type of Change

- [x] fix: Bug fix (patch version bump)

## Test plan

- [x] `rg '^argument-hint:\s*\[' skills/` returns no matches after the fix
- [x] `python3 -c "import yaml; yaml.safe_load(open('skills/configure/SKILL.md').read().split('---',2)[1])"` returns `argument-hint` as `str` (verified for all three files)
- [x] Diff is quote-only within the three SKILL.md files — no other fields changed, indentation preserved
- [x] Existing test fixtures in `tests/unit/state/test_parsers.py` and `test_server_integration.py` use `<...>` form and are unaffected
- [ ] Maintainer: load `/bitwize-music:configure`, `/bitwize-music:next-step`, `/bitwize-music:test` under Copilot CLI 1.0.65+ to confirm they load without the type-mismatch error

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My commit message follows [Conventional Commits](https://conventionalcommits.org/)
- [x] I have updated CHANGELOG.md under "Unreleased" section

## Related Issues

Refs anthropics/claude-code#22161