### PR TITLE
chore: release 0.94.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.93.0",
+      "version": "0.94.0-dev",
       "source": "./"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.94.0-dev",
+      "version": "0.94.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.94.0-dev",
+  "version": "0.94.0",
   "author": {
     "name": "bitwize-music"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.93.0",
+  "version": "0.94.0-dev",
   "author": {
     "name": "bitwize-music"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.94.0] - 2026-07-03
+
 ### Fixed
 - **`load_config` no longer returns non-mapping YAML that crashes every caller**
   (#389). A config file whose top level is a list or scalar (e.g. `- foo` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
-- **`argument-hint` YAML frontmatter now parses as a string across all runtimes**.
-  Three skill files (`configure`, `next-step`, `test`) declared
+- **`argument-hint` YAML frontmatter now parses as a string across all runtimes**
+  (#439). Three skill files (`configure`, `next-step`, `test`) declared
   `argument-hint: [ ... ]` with an unquoted `[`, which YAML parses as a
-  flow sequence (array). Claude Code tolerates this, but Copilot CLI
-  1.0.65+ requires `argument-hint` to be a string and fails skill load
-  otherwise. Values are now wrapped in double quotes so both runtimes
-  receive a string. See [anthropics/claude-code#22161] for the upstream
-  spec clarification.
+  flow sequence (array). Claude Code tolerates this, but GitHub Copilot CLI
+  silently skips such skills — they never appear in `copilot skill list`,
+  with no error even at debug log level (reproduced on 1.0.64 and 1.0.68;
+  the field was added in 1.0.64 and has required a string ever since).
+  Bracket forms containing a colon can also crash Claude Code's TUI
+  ([anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161)).
+  Values are now wrapped in double quotes so every runtime receives a string.
 - **Pronunciation gate no longer false-passes on words containing "Word"**
   (#384). The table parser skipped ANY row whose line contained the
   substring "Word", silently dropping data rows like "Wordsworth" — if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Pronunciation gate no longer false-passes on words containing "Word"**
+  (#384). The table parser skipped ANY row whose line contained the
+  substring "Word", silently dropping data rows like "Wordsworth" — if
+  those were the only entries, `check_pronunciation_enforcement` reported
+  `all_applied: true` with the phonetic missing from the lyrics, defeating
+  the pronunciation hard rule. The same parser bug lived in the BLOCKING
+  Gate 3 of `run_pre_generation_gates` — both sites now share one parser
+  (`_parse_pronunciation_table`) that matches the header row by its first
+  cell only and separator rows by cell content rather than substring. The
+  batch promo CLI also exits non-zero on per-track failures now, so
+  `generate_all_promos.py`'s error detection actually fires.
+- **Batch promo-video generation reports real per-track results** (#382).
+  The handler globbed `*_promo.mp4` after the run and marked every file
+  `success: true` — stale files from previous runs counted as fresh
+  successes and per-track ffmpeg failures were invisible.
+  `batch_process_album` now returns its per-track outcomes and the
+  response includes `failed` / `failed_tracks`.
+- **`--retries` can no longer silently skip every upload** (#385).
+  `retry_upload` with a non-positive retry count never entered its
+  attempt loop and reported every file as failed (even in `--dry-run`).
+  It now always attempts at least once, and the CLI rejects
+  `--retries < 1` with a clear argparse error.
 - **IDEAS.md and status writes are crash-safe; rename failures are honest**
   (#381, #398, #383). Every mutating write in `ideas.py` (idea backlog,
   promoted-idea README injection) and the track/README status rewrites at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **`load_config` no longer returns non-mapping YAML that crashes every caller**
+  (#389). A config file whose top level is a list or scalar (e.g. `- foo` or
+  `42`) was passed through as-is, so the first `.get()` in `resolve_path`,
+  `resolve_overrides_dir`, or any other consumer died with `AttributeError`.
+  Non-mapping configs now log a clear error naming the file and the actual
+  type, exit cleanly when `required=True`, and return the fallback otherwise.
+  The indexer's own `read_config` had the same defect (feeding the CLI
+  `rebuild`/`update` commands and the MCP server's state cache) and is
+  hardened identically.
+- **State rebuilds no longer crash on malformed config value types** (#391).
+  `build_config_section` called bare `int()` on `generation.max_lyric_words`
+  (ValueError/TypeError on `lots` or `[800]`, OverflowError on `.inf`) and
+  concatenated `paths.content_root` as a string (TypeError on numeric values,
+  first surfacing inside `resolve_path`). New `_cfg_int`/`_cfg_str`/
+  `_cfg_section` guards — following the `_cfg_bool` pattern from #388 — warn
+  and fall back to defaults for wrong-typed ints, path strings, section
+  mappings (`paths`/`artist`/`database`/`generation`), `artist.name`, and the
+  ideas file path, so CLI rebuilds and incremental updates degrade gracefully
+  instead of aborting with a traceback. Blank keys (`overrides:` with no
+  value) default silently as before; warnings log only the key and type,
+  never raw values, so misshapen `database` sections cannot leak credentials
+  into logs. A wrong-typed `logging:` section (or non-numeric
+  `logging.max_size_mb`) now disables file logging with a warning instead of
+  crashing MCP server startup.
+- **`migrate_state` no longer crashes when `state.json` has a non-string
+  version** (#393). A JSON-valid state file with `"version": 1.2` (float,
+  int, null, or list) raised `AttributeError` inside version comparison.
+  Non-string versions now log a warning and return `None`, triggering the
+  documented full-rebuild path. Same treatment for the surrounding state
+  shape: a JSON-valid non-object `state.json` is quarantined like corrupt
+  JSON (backed up, rebuilt), wrong-typed `config`/`albums` sections trigger a
+  full rebuild instead of crashing `incremental_update`, and a non-string
+  `last_migrated_version` is dropped on rebuild and treated as untracked by
+  `get_pending_migrations` instead of crashing every subsequent
+  `health_check`.
 - **`argument-hint` YAML frontmatter now parses as a string across all runtimes**
   (#439). Three skill files (`configure`, `next-step`, `test`) declared
   `argument-hint: [ ... ]` with an unquoted `[`, which YAML parses as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **Album slug collisions across genres no longer silently erase an album from
+  the state cache** (#392). The indexer keyed the cache's `albums` map by bare
+  directory name, ignoring the genre path segment — two albums with the same
+  slug under different genres overwrote each other, so one album (and all its
+  tracks) vanished from every MCP tool, and `create_album_structure` only
+  checked the genre-scoped path, so it happily created the twin. Album slugs
+  are now globally unique across genres: `create_album_structure` (and
+  `promote_idea`, which inherits the guard) and `rename_album` reject a slug
+  that already exists under any other genre, naming the existing genre/path
+  and suggesting a different name or `/bitwize-music:rename`. Pre-existing
+  on-disk collisions are detected at index time instead of silently
+  overwriting — the lexicographically-first genre wins deterministically, and
+  the shadowed album(s) are recorded in a new `album_collisions` state field
+  (schema 1.2.0 → 1.3.0; migration seeds `[]`) and surfaced by `health_check`,
+  `find_album`, `list_albums`, `rebuild_state`, and the indexer CLI with the
+  fix guidance (rename or move the directory, then rebuild).
+
 ## [0.93.0] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **IDEAS.md and status writes are crash-safe; rename failures are honest**
+  (#381, #398, #383). Every mutating write in `ideas.py` (idea backlog,
+  promoted-idea README injection) and the track/README status rewrites at
+  the end of `master_album` used truncate-then-write `write_text` — a crash
+  mid-write could leave the entire idea backlog or a source-of-truth
+  markdown file empty. All now go through the existing `atomic_write_text`
+  helper (temp file + fsync + atomic rename). And when `rename_album` /
+  `rename_track` move files successfully but the state-cache write fails,
+  they no longer report a silently-clean success with a divergent in-memory
+  cache: they rebuild the cache from disk (ground truth — the files did
+  move) and report `cache_rebuilt`, or degrade to an explicit `warning`
+  telling you to run `rebuild_state` if the rebuild also fails.
 - **`transcribe.py` album-name resolution works again** (#375). The
   documented `python3 transcribe.py <album-name>` invocation built
   `{audio_root}/{artist}/{album}` — omitting the `artists/` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,28 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   `find_album`, `list_albums`, `rebuild_state`, and the indexer CLI with the
   fix guidance (rename or move the directory, then rebuild).
 
+### Docs
+- **Suno vocal-age control troubleshooting** (`reference/suno/tips-and-tricks.md`).
+  Vague age adjectives ("mature and deep") in the Style Box are weak signals
+  that get outcompeted by breathy/soft-coded words ("intimate", "whispered")
+  sitting nearby, so Suno keeps generating a young-sounding vocal even when
+  age is explicitly requested. Documents the escalation path found in
+  production: concrete vocal-range/texture tags (`alto`, `contralto`,
+  `smoky`, `weathered`) first, then — if a fresh generation still skews
+  young — inline lyrical metatags per section (`[Verse 1: Raspy older female
+  vocal, husky contralto]`) plus dropping youth-coded genre words like "pop"
+  in favor of inherently mature-vocal-coded genres ("torch song", "vintage
+  soul", "cabaret"), with Persona/Voice cloning (Pro/Premier) as the final
+  fallback.
+- **Suno generic-vocal troubleshooting** (`reference/suno/tips-and-tricks.md`).
+  A related but distinct failure mode: Style Box text using emotion/character
+  words ("powerful and defiant", "sultry") instead of concrete vocal
+  range/texture tags produces a technically correct but generic, characterless
+  voice, since Suno has no reliable mapping from mood words to timbre. Fix
+  mirrors the vocal-age entry — swap or supplement emotion words with range
+  (`mezzo-soprano`, `contralto`) and texture (`gritty`, `raspy`, `commanding`)
+  tags, plus an explicit `no generic or polished studio pop vocal` exclude.
+
 ## [0.93.0] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **`argument-hint` YAML frontmatter now parses as a string across all runtimes**.
+  Three skill files (`configure`, `next-step`, `test`) declared
+  `argument-hint: [ ... ]` with an unquoted `[`, which YAML parses as a
+  flow sequence (array). Claude Code tolerates this, but Copilot CLI
+  1.0.65+ requires `argument-hint` to be a string and fails skill load
+  otherwise. Values are now wrapped in double quotes so both runtimes
+  receive a string. See [anthropics/claude-code#22161] for the upstream
+  spec clarification.
 - **Pronunciation gate no longer false-passes on words containing "Word"**
   (#384). The table parser skipped ANY row whose line contained the
   substring "Word", silently dropping data rows like "Wordsworth" — if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **`transcribe.py` album-name resolution works again** (#375). The
+  documented `python3 transcribe.py <album-name>` invocation built
+  `{audio_root}/{artist}/{album}` — omitting the `artists/` and
+  `albums/{genre}/` segments of the mirrored layout — so it never found a
+  real album and always fell through to "Source not found". It now sweeps
+  genre directories under `{audio_root}/artists/{artist}/albums/` (literal
+  comparison, no glob), warns if legacy same-name twins exist under
+  multiple genres, and the "Tried:" error hint prints the correct path
+  shape.
+- **Genre-list cache no longer poisons on a degenerate scan**. The
+  `_get_valid_genres()` cache stored whatever the first call computed —
+  including an empty set from a broken or mocked plugin root — and served
+  it for the life of the process, making `create_album_structure` reject
+  every genre from then on (the source of an intermittent xdist test
+  failure). The cache is now keyed by `PLUGIN_ROOT` and only stores
+  non-empty results.
+- **Codec-preview ffmpeg can no longer hang `master_album` forever** (#387).
+  `render_aac_preview` ran ffmpeg with no timeout, so a wedged subprocess
+  blocked the samples stage (and the whole `master_album` call)
+  indefinitely. The invocation is now bounded at 120s (mirroring
+  `adm_validation.py`); a timeout raises `CodecPreviewError`, which the
+  samples stage already degrades to a per-track warning.
 - **Quoted YAML booleans no longer invert to True** (#388). `bool("false")`
   is `True` in Python, so quoting a falsy boolean anywhere in user YAML
   silently enabled the feature the user disabled: `mastering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Quoted YAML booleans no longer invert to True** (#388). `bool("false")`
+  is `True` in Python, so quoting a falsy boolean anywhere in user YAML
+  silently enabled the feature the user disabled: `mastering.
+  adm_validation_enabled: "false"` in config.yaml (or album frontmatter — the
+  only path that enables ADM since #353) turned Apple Digital Masters
+  validation ON, `archival_enabled: "no"` enabled archival output,
+  `database.enabled: "false"` still opened Postgres connections,
+  `cloud.public_read: "false"` uploaded files with a **public-read ACL**,
+  quoted `cloud.enabled`/`logging.enabled`/`sheet_music.section_headers`/
+  `require_suno_link_for_final`/`require_source_path_for_documentary`
+  flipped their gates, and a track or album `explicit: "false"` frontmatter
+  flag marked the content explicit. Shared `parse_yaml_bool()` /
+  `coerce_yaml_bool()` helpers (tools/shared/config.py) now parse YAML 1.1
+  boolean literals (`true/false/yes/no/on/off/1/0`, case-insensitive) at
+  every user-YAML boolean site; unrecognized values fall back to the key's
+  documented default with a warning instead of silently meaning True. State
+  schema bumps 1.3.0 → 1.4.0 with a migration that re-coerces cached
+  `explicit` flags stored as strings by the old parsers.
 - **Album slug collisions across genres no longer silently erase an album from
   the state cache** (#392). The indexer keyed the cache's `albums` map by bare
   directory name, ignoring the genre path segment — two albums with the same

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ This is an AI music generation workflow using Suno. Skills contain domain expert
 
 **DO NOT**: search from cwd, use complex globs, assume paths, or use `ls`/`find`.
 
+Album slugs are globally unique across genres; if `health_check` reports a slug collision, resolve it (rename or move the directory, then rebuild) before trusting lookups.
+
 ---
 
 ## Configuration & Path Resolution
@@ -82,6 +84,7 @@ At the beginning of a fresh session:
    - Skills `status: "ok"` → continue silently
    - Skills `status: "stale"` → warn with missing/ghost skill names and fix message, continue session
    - Skills `status: "no_cache"` → warn (plugin may not be installed via marketplace), continue
+   - Collisions `status: "collision"` → warn listing each slug + genres and the fix (rename one album with `/bitwize-music:rename` or move the directory, then `rebuild_state`), continue session
 2. **Load config** — Read `~/.bitwize-music/config.yaml`. If missing, tell user to run `/bitwize-music:configure`.
 3. **Load overrides** — Check `paths.overrides` (default: `{content_root}/overrides`):
    - `{overrides}/CLAUDE.md` → incorporate instructions

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ config/              Example config and setup docs
 <a href="https://github.com/zeel2104"><img src="https://images.weserv.nl/?url=github.com/zeel2104.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@zeel2104"></a>
 <a href="https://github.com/alijahak"><img src="https://images.weserv.nl/?url=github.com/alijahak.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@alijahak"></a>
 <a href="https://github.com/DaveMatNat"><img src="https://images.weserv.nl/?url=github.com/DaveMatNat.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@DaveMatNat"></a>
+<a href="https://github.com/thejesh23"><img src="https://images.weserv.nl/?url=github.com/thejesh23.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@thejesh23"></a>
 
 If you make something with this, I'd genuinely love to hear it — [@bitwizemusic](https://x.com/bitwizemusic) on X, [join the Discord](https://discord.gg/dMURByGF), or [open a discussion](https://github.com/bitwize-music-studio/claude-ai-music-skills/discussions).
 

--- a/reference/state-schema.md
+++ b/reference/state-schema.md
@@ -1,4 +1,4 @@
-# State Cache Schema (v1.2.0)
+# State Cache Schema (v1.3.0)
 
 The state cache at `~/.bitwize-music/cache/state.json` is a JSON file built from markdown source files. It is a **disposable cache** — markdown files remain the source of truth and state can always be rebuilt with `python3 tools/state/indexer.py rebuild`.
 
@@ -8,12 +8,13 @@ The state cache at `~/.bitwize-music/cache/state.json` is a JSON file built from
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | Yes | Schema version (currently `"1.2.0"`) |
+| `version` | string | Yes | Schema version (currently `"1.3.0"`) |
 | `generated_at` | string | Yes | ISO 8601 UTC timestamp of last build/update |
 | `plugin_version` | string\|null | Yes | Installed plugin version from `.claude-plugin/plugin.json`, refreshed every build (display only), or `null` if unreadable |
 | `last_migrated_version` | string\|null | No | Version through which migration notes have been processed. Only advances via `acknowledge_migrations`; preserved across rebuilds. `null`/absent = pre-tracking (surfaces the backlog once). Drives `get_pending_migrations`. See issue #320. |
 | `config` | object | Yes | Resolved configuration snapshot |
 | `albums` | object | Yes | Map of album slug → album data |
+| `album_collisions` | array | Yes | Album slug collisions detected on disk (empty when none); see below |
 | `ideas` | object | Yes | Album ideas from IDEAS.md |
 | `skills` | object | Yes | Indexed skill metadata from SKILL.md files |
 | `session` | object | Yes | Session context for resume/continuity |
@@ -38,6 +39,8 @@ Snapshot of resolved paths and artist info from `~/.bitwize-music/config.yaml`.
 ## `albums` Object
 
 Map of album slug (string) → album data object.
+
+**Global uniqueness invariant**: album slugs are unique across genres — the map is keyed by bare slug, so the same slug under two genres cannot coexist. This is enforced at creation (`create_album_structure`) and rename (`rename_album`), both of which reject a slug that already exists under any other genre. Pre-existing on-disk collisions are detected at index time — the first genre (lexicographic order) whose README parses wins deterministically, and the shadowed album(s) are listed in `album_collisions`.
 
 ### Album Data
 
@@ -84,6 +87,32 @@ Map of album slug (string) → album data object.
 - `In Progress` — Lyrics being written
 - `Generated` — Track generated on Suno, audio exists
 - `Final` — Approved, ready for mastering
+
+---
+
+## `album_collisions` Array
+
+Added in 1.3.0 (issue #392). Always present; a list of collision records, empty when no collisions exist. Populated by the indexer when the same album slug is found under multiple genres on disk. The winner (`kept`) is the first genre (lexicographic order) whose README parses — deterministic, and always the entry actually indexed into `albums`; all others are `shadowed` (sorted by genre, parseable or not; supports 2+ way collisions) and are **not** indexed into `albums`. If no candidate's README parses, no album entry and no collision record are emitted.
+
+```json
+"album_collisions": [
+  {
+    "slug": "midnight",
+    "kept":     {"genre": "jazz", "path": "/abs/path/albums/jazz/midnight"},
+    "shadowed": [{"genre": "rock", "path": "/abs/path/albums/rock/midnight"}]
+  }
+]
+```
+
+### Collision Record
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | string | The colliding album slug (bare directory name) |
+| `kept` | object | The winning album: `{genre, path}` — this is the entry visible in `albums` |
+| `shadowed` | array | The hidden album(s): `[{genre, path}, ...]`, sorted by genre |
+
+**Fix**: rename one album with `/bitwize-music:rename`, or move the directory, then rebuild the state cache. Collisions are surfaced by `health_check`, `find_album`, `list_albums`, `rebuild_state`, and the indexer CLI (`rebuild`/`update`/`show`).
 
 ---
 
@@ -176,5 +205,6 @@ The migration chain is defined in `tools/state/indexer.py` as `MIGRATIONS` dict.
 |------|-----|---------|
 | 1.0.0 | 1.1.0 | Added `skills` top-level section with indexed skill metadata |
 | 1.1.0 | 1.2.0 | Added `plugin_version` top-level field for upgrade path tracking |
+| 1.2.0 | 1.3.0 | Added `album_collisions` top-level field (seeded to `[]`) for cross-genre slug collision detection (issue #392) |
 
 `last_migrated_version` was added as a **backward-compatible optional field** (no schema-version bump). Fresh builds include it (seeded to the installed version); states written earlier simply omit it and read as `null`, which `get_pending_migrations` treats as pre-tracking. Avoiding a version bump here is deliberate — bumping would force the live MCP path to auto-rebuild every existing state, erasing the very "behind" status migration detection depends on (issue #320).

--- a/reference/state-schema.md
+++ b/reference/state-schema.md
@@ -8,7 +8,7 @@ The state cache at `~/.bitwize-music/cache/state.json` is a JSON file built from
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `version` | string | Yes | Schema version (currently `"1.3.0"`) |
+| `version` | string | Yes | Schema version (currently `"1.4.0"`) |
 | `generated_at` | string | Yes | ISO 8601 UTC timestamp of last build/update |
 | `plugin_version` | string\|null | Yes | Installed plugin version from `.claude-plugin/plugin.json`, refreshed every build (display only), or `null` if unreadable |
 | `last_migrated_version` | string\|null | No | Version through which migration notes have been processed. Only advances via `acknowledge_migrations`; preserved across rebuilds. `null`/absent = pre-tracking (surfaces the backlog once). Drives `get_pending_migrations`. See issue #320. |
@@ -206,5 +206,6 @@ The migration chain is defined in `tools/state/indexer.py` as `MIGRATIONS` dict.
 | 1.0.0 | 1.1.0 | Added `skills` top-level section with indexed skill metadata |
 | 1.1.0 | 1.2.0 | Added `plugin_version` top-level field for upgrade path tracking |
 | 1.2.0 | 1.3.0 | Added `album_collisions` top-level field (seeded to `[]`) for cross-genre slug collision detection (issue #392) |
+| 1.3.0 | 1.4.0 | Re-coerced cached album/track `explicit` flags that pre-#388 parsers stored as raw truthy strings (e.g. `"false"`) to real booleans |
 
 `last_migrated_version` was added as a **backward-compatible optional field** (no schema-version bump). Fresh builds include it (seeded to the installed version); states written earlier simply omit it and read as `null`, which `get_pending_migrations` treats as pre-tracking. Avoiding a version bump here is deliberate — bumping would force the live MCP path to auto-rebuild every existing state, erasing the very "behind" status migration detection depends on (issue #320).

--- a/reference/suno/tips-and-tricks.md
+++ b/reference/suno/tips-and-tricks.md
@@ -20,6 +20,51 @@ Operational techniques and troubleshooting for Suno. For prompting guidance, see
 
 ---
 
+## Vocal Sounds Too Young Despite "Mature"/"Deep" Descriptors
+
+**Symptom:** Style box includes an age adjective like "mature and deep" but Suno still generates a young/light-sounding vocal.
+
+**Likely cause:** Vague age adjectives are weak signals and get outcompeted by other descriptors in the same prompt — especially breathy/soft-coded words like "intimate," "whispered," or "delicate" sitting nearby. Suno responds more reliably to concrete vocal-range and texture tags than to age adjectives alone.
+
+**Fix:**
+1. Replace the age adjective with a specific vocal range: `alto`, `contralto`, `low register` (female) or `baritone`, `bass-baritone` (male) — see [voice-tags.md](voice-tags.md)
+2. Add texture tags that connote maturity/experience rather than youth: `smoky`, `weathered`, `resonant`, `gravelly` — avoid `breathy`, `whispered`, `delicate`, `intimate` if you want an older-sounding voice, since those skew young in Suno's training data
+3. Add an explicit exclude: `no youthful or breathy vocals` appended to the Style Box (see [Negative Prompting](v5-best-practices.md#negative-prompting) — Suno excludes via "no X" phrasing in the prompt text, not a separate bare-terms field)
+4. Still expect 2–3 regenerations — vocal-age control is inconsistent even with well-chosen tags, this narrows the odds rather than guaranteeing the result
+
+**Example fix:**
+- ❌ Weak: `Female character vocal, mature and deep, aching and intimate`
+- ✅ Stronger: `Female alto vocal, low register, smoky and weathered, resonant and world-weary — not breathy, not youthful`
+
+**If concrete range/texture tags in the Style Box still aren't enough** (confirmed on a fresh generation, ruling out session/caching carryover), escalate with two more levers:
+
+1. **Inline lyrical metatags** — place a vocal descriptor directly in the Lyrics Box before each section, not just in the Style Box: `[Verse 1: Raspy older female vocal, husky contralto]`, `[Chorus: Raspy older female vocal, husky contralto]`, etc. This is a different mechanism from the Style Box and Suno may weight it independently — repeat the tag on every section, not just the first.
+2. **Check whether the genre tag itself is fighting you.** "Pop" as a genre descriptor can carry a bright/youthful bias that no amount of vocal adjectives fully cancels. Swap genre-of-record words that skew young/bright (`pop`, `bright`, `modern electronic`) for genre words that are inherently mature-vocal-coded: `torch song`, `vintage soul`, `cabaret`, `1940s jazz`, `vintage country`. Keep other identity-defining tags (mode, instrumentation) unchanged.
+
+If all of the above still fails, the underlying genre/instrumentation combo may carry a strong young-vocalist bias in Suno's training data that text prompting can't fully overcome. At that point, [Personas](#personas-for-vocal-consistency) (Pro/Premier, for a consistent vocal identity) or [Voices/voice cloning](#voices--custom-models-v55) (Pro/Premier, referencing a real vocal sample) are more reliable than any further style-box iteration.
+
+---
+
+## Vocal Sounds Generic Despite "Powerful"/"Defiant"/Character Descriptors
+
+**Symptom:** Style box describes the intended vocal character with emotion or personality words (e.g. "powerful and defiant," "sultry," "heartbroken") but Suno generates a generic, characterless voice — technically competent, on-genre, but indistinguishable from any other pop vocal.
+
+**Likely cause:** Emotion and character adjectives describe *what the performance should feel like*, not *what the voice should sound like*. Suno has no reliable mapping from an emotion word to a specific timbre, so it falls back to a default voice for the genre and just sings the notes "correctly." This is a different failure mode from the youth/age issue above — it isn't fighting a competing signal, it's simply not giving Suno enough to grab onto.
+
+**Fix:** Same principle as the age issue — replace or supplement emotion/character words with concrete vocal range and texture tags:
+1. Add a specific vocal range: `mezzo-soprano`, `alto`, `contralto` (female) or `baritone`, `tenor` (male) — see [voice-tags.md](voice-tags.md)
+2. Add texture tags that are actually audible qualities, not moods: `gritty`, `raspy`, `rasp on the belted notes`, `raw chest voice`, `commanding`, `weathered` — these describe grain and register, which Suno can render; "defiant" and "powerful" describe intent, which it can't
+3. Add an explicit exclude: `no generic or polished studio pop vocal` appended to the Style Box (see [Negative Prompting](v5-best-practices.md#negative-prompting))
+4. Keep one or two emotion words if they help set the performance arc (e.g. "controlled and low in the verses, breaking open into a full-throated belt on the chorus") — the fix isn't to strip emotion language entirely, it's to make sure concrete texture/range tags are doing the actual work
+
+**Example fix:**
+- ❌ Generic: `Female character vocal, powerful and defiant`
+- ✅ Specific: `Female mezzo-soprano, gritty and raw, rasp on the belted notes, commanding chest voice, weathered and fierce — not a polished or generic pop voice`
+
+If this still comes back generic after a regeneration, escalate the same way as the age issue: inline per-section lyrical metatags in the Lyrics Box (`[Chorus: Gritty, raw, commanding female belt]`), and check whether the genre tag itself (e.g. "pop") is pulling toward a generic default that no amount of texture stacking fully overcomes.
+
+---
+
 ## Extending Songs
 
 ### Basic Workflow

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@ pytest-xdist>=3.8.0
 pyyaml>=6.0
 
 # Linting
-ruff>=0.15.19
+ruff>=0.15.20
 mypy>=2.1.0
 types-PyYAML>=6.0.12.20260518
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # =============================================================================
 # MCP SERVER (required for plugin core functionality)
 # =============================================================================
-mcp[cli]==1.28.0
+mcp[cli]==1.28.1
 pyyaml==6.0.3
 
 # =============================================================================
@@ -23,7 +23,7 @@ pyloudnorm==0.2.0
 scipy==1.17.1
 numpy==2.4.6
 soundfile==0.14.0
-mutagen==1.48.0
+mutagen==1.48.1
 
 # =============================================================================
 # AUDIO MIXING / POLISH (required for /bitwize-music:mix-engineer)
@@ -34,19 +34,19 @@ noisereduce==3.0.3
 # =============================================================================
 # PROMO VIDEOS (required for /bitwize-music:promo-director)
 # =============================================================================
-pillow==12.2.0
+pillow==12.3.0
 librosa==0.11.0
 
 # =============================================================================
 # SHEET MUSIC (required for /bitwize-music:sheet-music-publisher)
 # =============================================================================
 pypdf==6.14.2
-reportlab==4.5.1
+reportlab==5.0.0
 
 # =============================================================================
 # CLOUD UPLOADS (required for /bitwize-music:cloud-uploader)
 # =============================================================================
-boto3==1.43.36
+boto3==1.43.39
 
 # =============================================================================
 # DATABASE (required for db_* MCP tools - tweet/promo management)
@@ -57,4 +57,4 @@ psycopg2-binary==2.9.12
 # DOCUMENT HUNTING (required for /bitwize-music:document-hunter)
 # After pip install, also run: playwright install chromium
 # =============================================================================
-playwright==1.60.0
+playwright==1.61.0

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -358,6 +358,21 @@ def _find_album_or_error(album_slug: str) -> tuple[str, dict[str, Any] | None, s
     return normalized, album, None
 
 
+def _find_slug_dirs(albums_root: Path, slug: str) -> list[Path]:
+    """Find existing album dirs named exactly `slug` under every genre (#392).
+
+    Literal comparison via iterdir — glob() would treat metacharacters in
+    the slug (e.g. '*') as patterns and could match unrelated albums.
+    """
+    if not albums_root.is_dir():
+        return []
+    return sorted(
+        genre_dir / slug
+        for genre_dir in albums_root.iterdir()
+        if genre_dir.is_dir() and (genre_dir / slug).is_dir()
+    )
+
+
 def _find_track_or_error(tracks: dict[str, Any], track_slug: str, album_slug: str = "") -> tuple[str, dict[str, Any] | None, str | None]:
     """Find track in tracks dict by exact match or prefix match.
 

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -55,30 +55,35 @@ STATUS_UNKNOWN = "Unknown"
 # Markdown link pattern — used for source verification gates
 _MARKDOWN_LINK_RE = re.compile(r'\[([^\]]+)\]\(([^)]+)\)')
 
-# Valid genres for album creation — derived from genres/ directory at runtime
-_VALID_GENRES: frozenset[str] | None = None
+# Valid genres for album creation — derived from genres/ directory at runtime.
+# Cached per PLUGIN_ROOT value, and only when non-empty: an empty scan means
+# a broken (or test-mocked) plugin root, and caching it would poison every
+# later genre check in the process.
+_VALID_GENRES: tuple[Path | None, frozenset[str]] | None = None
 
 
 def _get_valid_genres() -> frozenset[str]:
     """Return valid genre slugs by scanning the genres/ directory.
 
-    Results are cached after the first call.
+    Non-empty results are cached per PLUGIN_ROOT.
     """
     global _VALID_GENRES
-    if _VALID_GENRES is not None:
-        return _VALID_GENRES
+    if _VALID_GENRES is not None and _VALID_GENRES[0] == PLUGIN_ROOT:
+        return _VALID_GENRES[1]
     if PLUGIN_ROOT is None:
         # Fallback if called before init (shouldn't happen)
         return frozenset()
     genres_dir = PLUGIN_ROOT / "genres"
     if genres_dir.is_dir():
-        _VALID_GENRES = frozenset(
+        genres = frozenset(
             d.name for d in genres_dir.iterdir()
             if d.is_dir() and (d / "README.md").exists()
         )
     else:
-        _VALID_GENRES = frozenset()
-    return _VALID_GENRES
+        genres = frozenset()
+    if genres:
+        _VALID_GENRES = (PLUGIN_ROOT, genres)
+    return genres
 
 _GENRE_ALIASES = {
     "r&b": "rnb", "rb": "rnb", "r-and-b": "rnb",

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -363,6 +363,31 @@ def _find_album_or_error(album_slug: str) -> tuple[str, dict[str, Any] | None, s
     return normalized, album, None
 
 
+def _parse_pronunciation_table(section_text: str) -> list[dict[str, str]]:
+    """Parse ``| Word/Phrase | Pronunciation | Reason |`` table rows.
+
+    The header row is matched by its FIRST CELL only, and separator rows by
+    cell content — substring filters on the whole line drop legitimate data
+    rows like "Wordsworth" and false-pass the pronunciation checks (#384).
+    """
+    entries: list[dict[str, str]] = []
+    for line in section_text.split("\n"):
+        if not line.startswith("|"):
+            continue
+        # Separator row: cells made only of dashes/colons (|-----|:---:|)
+        if set(line) <= {"|", "-", ":", " "}:
+            continue
+        parts = [p.strip() for p in line.split("|")]
+        if len(parts) >= 4:
+            word = parts[1].strip()
+            phonetic = parts[2].strip()
+            if word.lower() in ("word/phrase", "word"):
+                continue
+            if word and word != "—" and phonetic and phonetic != "—":
+                entries.append({"word": word, "phonetic": phonetic})
+    return entries
+
+
 def _find_slug_dirs(albums_root: Path, slug: str) -> list[Path]:
     """Find existing album dirs named exactly `slug` under every genre (#392).
 

--- a/servers/bitwize-music-server/handlers/album_ops.py
+++ b/servers/bitwize-music-server/handlers/album_ops.py
@@ -18,6 +18,7 @@ from handlers._shared import (
     _extract_code_block,
     _extract_markdown_section,
     _find_album_or_error,
+    _find_slug_dirs,
     _find_wav_source_dir,
     _is_path_confined,
     _normalize_slug,
@@ -383,7 +384,24 @@ async def create_album_structure(
     assert _shared.PLUGIN_ROOT is not None
     templates_path = _shared.PLUGIN_ROOT / "templates"
 
-    # Check if already exists
+    # Album slugs are globally unique across genres (#392) — sweep the
+    # filesystem (cache may be stale) for the slug under every genre.
+    albums_root = Path(content_root) / "artists" / artist / "albums"
+    collisions = _find_slug_dirs(albums_root, normalized)
+    if collisions:
+        existing = collisions[0]
+        return _safe_json({
+            "created": False,
+            "error": (
+                f"Album slug '{normalized}' already exists under genre "
+                f"'{existing.parent.name}': {existing}. Album slugs are unique "
+                f"across all genres — choose a different name, or rename the "
+                f"existing album with /bitwize-music:rename."
+            ),
+            "path": str(existing),
+        })
+
+    # Check if already exists (belt-and-braces behind the cross-genre sweep)
     if album_path.exists():
         return _safe_json({
             "created": False,

--- a/servers/bitwize-music-server/handlers/core.py
+++ b/servers/bitwize-music-server/handlers/core.py
@@ -99,6 +99,34 @@ def _detect_phase(album: dict[str, Any]) -> str:
     return "In Progress"
 
 
+def _collision_warning(state: dict[str, Any], slug: str) -> dict[str, Any] | None:
+    """Build a collision warning for a resolved album slug, if any (#392).
+
+    Uses ``state.get`` throughout — pre-1.3.0 states lack album_collisions.
+    """
+    for record in state.get("album_collisions", []):
+        if record.get("slug") != slug:
+            continue
+        kept = record.get("kept", {})
+        shadowed = record.get("shadowed", [])
+        shadowed_desc = ", ".join(
+            f"{s.get('genre', '?')} ({s.get('path', '?')})" for s in shadowed
+        )
+        return {
+            "slug": slug,
+            "visible": kept,
+            "shadowed": shadowed,
+            "message": (
+                f"Album slug '{slug}' exists under multiple genres — showing "
+                f"the '{kept.get('genre', '?')}' album; shadowed: "
+                f"{shadowed_desc}. Rename one album with "
+                f"/bitwize-music:rename or move its directory, then run "
+                f"rebuild_state."
+            ),
+        }
+    return None
+
+
 # =============================================================================
 # Tool functions
 # =============================================================================
@@ -136,11 +164,15 @@ async def find_album(name: str) -> str:
 
     # Exact match first
     if normalized in albums:
-        return _safe_json({
+        response = {
             "found": True,
             "slug": normalized,
             "album": albums[normalized],
-        })
+        }
+        warning = _collision_warning(state, normalized)
+        if warning:
+            response["collision_warning"] = warning
+        return _safe_json(response)
 
     # Fuzzy match: check if input is substring of slug or vice versa
     matches = {
@@ -151,11 +183,15 @@ async def find_album(name: str) -> str:
 
     if len(matches) == 1:
         slug = next(iter(matches))
-        return _safe_json({
+        response = {
             "found": True,
             "slug": slug,
             "album": matches[slug],
-        })
+        }
+        warning = _collision_warning(state, slug)
+        if warning:
+            response["collision_warning"] = warning
+        return _safe_json(response)
     elif len(matches) > 1:
         return _safe_json({
             "found": False,
@@ -199,7 +235,21 @@ async def list_albums(status_filter: str = "") -> str:
             "tracks_completed": album.get("tracks_completed", 0),
         })
 
-    return _safe_json({"albums": result, "count": len(result)})
+    response: dict[str, Any] = {"albums": result, "count": len(result)}
+
+    # Shadowed albums are invisible above — make collisions unmissable (#392)
+    collisions = state.get("album_collisions", [])
+    if collisions:
+        slugs = ", ".join(c.get("slug", "?") for c in collisions)
+        response["collisions"] = collisions
+        response["warning"] = (
+            f"{len(collisions)} album slug collision(s) detected ({slugs}) — "
+            f"shadowed albums are hidden from this list. Rename one album "
+            f"with /bitwize-music:rename or move its directory, then run "
+            f"rebuild_state."
+        )
+
+    return _safe_json(response)
 
 
 async def get_track(album_slug: str, track_slug: str) -> str:
@@ -345,14 +395,25 @@ async def rebuild_state() -> str:
     )
     ideas_count = len(state.get("ideas", {}).get("items", []))
     skills_count = state.get("skills", {}).get("count", 0)
+    collisions = state.get("album_collisions", [])
 
-    return _safe_json({
+    result: dict[str, Any] = {
         "success": True,
         "albums": album_count,
         "tracks": track_count,
         "ideas": ideas_count,
         "skills": skills_count,
-    })
+        "collision_count": len(collisions),
+    }
+    if collisions:
+        slugs = ", ".join(c.get("slug", "?") for c in collisions)
+        result["collisions"] = collisions
+        result["warning"] = (
+            f"{len(collisions)} album slug collision(s) detected ({slugs}). "
+            f"Rename one album with /bitwize-music:rename or move its "
+            f"directory, then run rebuild_state."
+        )
+    return _safe_json(result)
 
 
 async def get_config() -> str:

--- a/servers/bitwize-music-server/handlers/gates.py
+++ b/servers/bitwize-music-server/handlers/gates.py
@@ -16,6 +16,7 @@ from handlers._shared import (
     _extract_markdown_section,
     _find_album_or_error,
     _find_track_or_error,
+    _parse_pronunciation_table,
     _safe_json,
 )
 
@@ -105,15 +106,7 @@ def _check_pre_gen_gates_for_track(
         pron_section = _extract_markdown_section(file_text, "Pronunciation Notes")
         pron_entries = []
         if pron_section:
-            for line in pron_section.split("\n"):
-                if not line.startswith("|") or "---" in line or "Word" in line:
-                    continue
-                parts = [p.strip() for p in line.split("|")]
-                if len(parts) >= 4:
-                    word = parts[1].strip()
-                    phonetic = parts[2].strip()
-                    if word and word != "—" and phonetic and phonetic != "—":
-                        pron_entries.append({"word": word, "phonetic": phonetic})
+            pron_entries = _parse_pronunciation_table(pron_section)
 
         if pron_entries and lyrics_content:
             unapplied = []

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -311,7 +311,8 @@ async def health_check() -> str:
 
     Returns:
         JSON with overall status ("ok", "warn", "fail"), per-check
-        summaries, and raw results for venv and skills.
+        summaries, raw results for venv and skills, and an album slug
+        collision section ("ok" or "collision" with details and fix).
     """
     checks: list[dict[str, Any]] = []
 
@@ -357,6 +358,28 @@ async def health_check() -> str:
                         "detail": "No plugin cache found",
                         "fix": skills_raw.get("fix_message")})
 
+    # --- Album slug collision check (#392) ---
+    # .get: pre-1.3.0 states (and an unloadable cache) lack album_collisions.
+    state = _shared.cache.get_state() if _shared.cache is not None else {}
+    album_collisions = state.get("album_collisions", [])
+    if album_collisions:
+        slugs = ", ".join(c.get("slug", "?") for c in album_collisions)
+        fix = ("Rename one album with /bitwize-music:rename or move its "
+               "directory, then run rebuild_state.")
+        collisions_raw: dict[str, Any] = {
+            "status": "collision",
+            "collisions": album_collisions,
+            "fix": fix,
+        }
+        checks.append({"name": "collisions", "status": "warn",
+                        "detail": (f"{len(album_collisions)} album slug "
+                                   f"collision(s): {slugs}"),
+                        "fix": fix})
+    else:
+        collisions_raw = {"status": "ok"}
+        checks.append({"name": "collisions", "status": "ok",
+                        "detail": "No album slug collisions"})
+
     # --- Overall status ---
     statuses = [c["status"] for c in checks]
     if "fail" in statuses:
@@ -371,6 +394,7 @@ async def health_check() -> str:
         "checks": checks,
         "venv": venv_raw,
         "skills": skills_raw,
+        "collisions": collisions_raw,
     })
 
 

--- a/servers/bitwize-music-server/handlers/ideas.py
+++ b/servers/bitwize-music-server/handlers/ideas.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from handlers import _shared
+from handlers._atomic import atomic_write_text
 from handlers._shared import _safe_json
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,7 @@ def _inject_concept_into_readme(
         new_text = text.rstrip() + block
 
     try:
-        readme_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(readme_path, new_text)
     except OSError:
         return False
     return True
@@ -137,7 +138,7 @@ def _set_promoted_to_field(title: str, slug: str) -> bool:
 
     new_text = text[:section_start] + new_section + text[section_end:]
     try:
-        ideas_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(ideas_path, new_text)
     except OSError:
         return False
     return True
@@ -206,8 +207,7 @@ async def create_idea(
     updated = text.rstrip() + "\n" + new_block
 
     try:
-        ideas_path.parent.mkdir(parents=True, exist_ok=True)
-        ideas_path.write_text(updated, encoding="utf-8")
+        atomic_write_text(ideas_path, updated)
     except OSError as e:
         return _safe_json({"error": f"Cannot write IDEAS.md: {e}"})
 
@@ -301,7 +301,7 @@ async def update_idea(title: str, field: str, value: str) -> str:
     updated_text = text[:abs_start] + new_line + text[abs_end:]
 
     try:
-        ideas_path.write_text(updated_text, encoding="utf-8")
+        atomic_write_text(ideas_path, updated_text)
     except OSError as e:
         return _safe_json({"error": f"Cannot write IDEAS.md: {e}"})
 

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2097,7 +2097,7 @@ async def _stage_status_update(ctx: MasterAlbumCtx) -> str | None:
                     updated_text = (
                         text[:match.start()] + new_row + text[match.end():]
                     )
-                    track_path.write_text(updated_text, encoding="utf-8")
+                    atomic_write_text(track_path, updated_text)
                     parsed = parse_track_file(track_path)
                     track_info.update({
                         "status": parsed.get("status", TRACK_FINAL),
@@ -2144,7 +2144,7 @@ async def _stage_status_update(ctx: MasterAlbumCtx) -> str | None:
                             updated_text = (
                                 text[:match.start()] + new_row + text[match.end():]
                             )
-                            readme_path.write_text(updated_text, encoding="utf-8")
+                            atomic_write_text(readme_path, updated_text)
                             album_data["status"] = ALBUM_COMPLETE
                             album_status = ALBUM_COMPLETE
                     except Exception as e:

--- a/servers/bitwize-music-server/handlers/processing/_helpers.py
+++ b/servers/bitwize-music-server/handlers/processing/_helpers.py
@@ -139,7 +139,7 @@ def _import_cloud_module(module_name: str) -> Any:
 def _check_cloud_enabled() -> str | None:
     """Return error message if cloud uploads not enabled, else None."""
     try:
-        from tools.shared.config import load_config
+        from tools.shared.config import coerce_yaml_bool, load_config
         config = load_config()
     except (ImportError, OSError, KeyError) as exc:
         logger.warning("Config load failed: %s", exc)
@@ -149,7 +149,9 @@ def _check_cloud_enabled() -> str | None:
     if not config:
         return "Config not found. Run /bitwize-music:configure first."
     cloud_config = config.get("cloud", {})
-    if not cloud_config.get("enabled", False):
+    if not coerce_yaml_bool(
+        cloud_config.get("enabled", False), default=False, context="cloud.enabled"
+    ):
         return (
             "Cloud uploads not enabled. "
             "Set cloud.enabled: true in ~/.bitwize-music/config.yaml. "

--- a/servers/bitwize-music-server/handlers/processing/sheet_music.py
+++ b/servers/bitwize-music-server/handlers/processing/sheet_music.py
@@ -539,7 +539,7 @@ async def publish_sheet_music(
             "suggestion": "Ensure boto3 is installed: pip install boto3",
         })
 
-    from tools.shared.config import load_config
+    from tools.shared.config import coerce_yaml_bool, load_config
     config = load_config()
     assert config is not None
 
@@ -559,7 +559,11 @@ async def publish_sheet_music(
             "suggestion": "Set cloud.r2.bucket or cloud.s3.bucket in ~/.bitwize-music/config.yaml",
         })
 
-    public_read = config.get("cloud", {}).get("public_read", False)
+    public_read = coerce_yaml_bool(
+        config.get("cloud", {}).get("public_read", False),
+        default=False,
+        context="cloud.public_read",
+    )
 
     uploaded: list[dict[str, Any]] = []
     failed: list[dict[str, Any]] = []

--- a/servers/bitwize-music-server/handlers/processing/video.py
+++ b/servers/bitwize-music-server/handlers/processing/video.py
@@ -170,7 +170,7 @@ async def generate_promo_videos(
             if content_dir_path.is_dir():
                 content_dir = content_dir_path
 
-        await loop.run_in_executor(
+        batch_results = await loop.run_in_executor(
             None,
             lambda: batch_process_album(
                 album_dir=audio_dir,
@@ -187,14 +187,25 @@ async def generate_promo_videos(
             ),
         )
 
-        # Collect results from output dir
-        output_files = sorted(output_dir.glob("*_promo.mp4"))
-        results = [{"filename": f.name, "output": str(f), "success": True} for f in output_files]
+        # Report the per-track outcomes from THIS run — globbing the output
+        # dir counted stale files from previous runs as fresh successes and
+        # hid failures entirely (#382).
+        results = [
+            {
+                "filename": audio_name,
+                "output": str(output_dir / out_name),
+                "success": success,
+            }
+            for audio_name, out_name, success in batch_results
+        ]
+        failed = [r["filename"] for r in results if not r["success"]]
 
         return _safe_json({
             "tracks": results,
             "summary": {
-                "success": len(results),
+                "success": len(results) - len(failed),
+                "failed": len(failed),
+                "failed_tracks": failed,
                 "output_dir": str(output_dir),
             },
         })

--- a/servers/bitwize-music-server/handlers/rename.py
+++ b/servers/bitwize-music-server/handlers/rename.py
@@ -13,6 +13,7 @@ from handlers._atomic import atomic_write_text
 from handlers._shared import (
     _derive_title_from_slug,
     _find_album_or_error,
+    _find_slug_dirs,
     _find_track_or_error,
     _is_path_confined,
     _normalize_slug,
@@ -96,6 +97,22 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     if not _is_path_confined(albums_content_base, normalized_new):
         return _safe_json({"error": "Invalid new slug: would escape album directory"})
 
+    # Album slugs are globally unique across genres (#392) — sweep the
+    # filesystem for the new slug under every genre; the cache-key check
+    # above misses twins that are stale or shadowed out of the cache.
+    albums_root = Path(content_root) / "artists" / artist / "albums"
+    collisions = _find_slug_dirs(albums_root, normalized_new)
+    if collisions:
+        existing = collisions[0]
+        return _safe_json({
+            "error": (
+                f"Album slug '{normalized_new}' already exists under genre "
+                f"'{existing.parent.name}': {existing}. Album slugs are unique "
+                f"across all genres — choose a different name, or rename the "
+                f"existing album with /bitwize-music:rename."
+            ),
+        })
+
     # Content directory MUST exist
     if not content_dir_old.is_dir():
         return _safe_json({
@@ -171,9 +188,35 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     except Exception as e:
         logger.warning("Directories moved but cache update failed: %s", e)
 
+    # Rename is the documented fix path for a slug collision (#392). If the
+    # freed slug has a collision record, the surgical cache patch above is
+    # not enough: the formerly-shadowed twin is still missing from the cache
+    # and album_collisions is stale. Rebuild from disk (same pattern as
+    # create_album_structure) so the twin is indexed and collisions are
+    # recomputed. Normal renames skip this and keep the cheap surgical path.
+    collision_resolved = False
+    rebuild_warning = ""
+    if any(
+        record.get("slug") == normalized_old
+        for record in state.get("album_collisions", [])
+    ):
+        try:
+            rebuilt = _shared.cache.rebuild()
+        except Exception as e:  # rename already succeeded — don't fail it
+            logger.warning("Album renamed but collision rebuild failed: %s", e)
+            rebuilt = {"error": str(e)}
+        if "error" in rebuilt:
+            rebuild_warning = (
+                f"Rename succeeded, but the state rebuild needed to surface "
+                f"the formerly-shadowed '{normalized_old}' album failed: "
+                f"{rebuilt['error']}. Run rebuild_state to index it."
+            )
+        else:
+            collision_resolved = True
+
     logger.info("Renamed album '%s' to '%s'", normalized_old, normalized_new)
 
-    return _safe_json({
+    result: dict[str, Any] = {
         "success": True,
         "old_slug": normalized_old,
         "new_slug": normalized_new,
@@ -182,7 +225,17 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
         "audio_moved": audio_moved,
         "documents_moved": documents_moved,
         "tracks_updated": tracks_updated,
-    })
+    }
+    if collision_resolved:
+        result["collision_resolved"] = True
+        result["note"] = (
+            f"Slug '{normalized_old}' had a cross-genre collision — state "
+            f"was rebuilt from disk, so the formerly-shadowed album is now "
+            f"visible and album_collisions is up to date."
+        )
+    elif rebuild_warning:
+        result["warning"] = rebuild_warning
+    return _safe_json(result)
 
 
 async def rename_track(

--- a/servers/bitwize-music-server/handlers/rename.py
+++ b/servers/bitwize-music-server/handlers/rename.py
@@ -24,6 +24,32 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rebuild_after_cache_failure(cause: Exception) -> tuple[bool, str]:
+    """Recover from a failed surgical cache update by rebuilding from disk.
+
+    The rename already happened on disk, so a rebuild restores a consistent
+    cache. Returns (rebuilt, warning): rebuilt=True on success; otherwise a
+    user-facing warning telling them to run rebuild_state (#383).
+    """
+    try:
+        rebuilt = _shared.cache.rebuild()
+    except Exception as exc:
+        rebuilt = {"error": str(exc)}
+    if "error" in rebuilt:
+        return False, (
+            f"Files were renamed, but updating the state cache failed "
+            f"({cause}) and the recovery rebuild also failed: "
+            f"{rebuilt['error']}. Run rebuild_state before trusting "
+            f"album lookups."
+        )
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
 # Tool functions
 # ---------------------------------------------------------------------------
 
@@ -163,12 +189,14 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
             match = heading_pattern.search(text)
             if match:
                 updated_text = text[:match.start()] + f"# {title}" + text[match.end():]
-                readme_path.write_text(updated_text, encoding="utf-8")
+                atomic_write_text(readme_path, updated_text)
         except OSError as e:
             logger.warning("Directories moved but README title update failed: %s", e)
 
     # Update state cache
     tracks_updated = 0
+    cache_rebuilt = False
+    cache_warning = ""
     try:
         album_data = albums.pop(normalized_old)
         album_data["path"] = str(content_dir_new)
@@ -187,6 +215,10 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
         write_state(state)
     except Exception as e:
         logger.warning("Directories moved but cache update failed: %s", e)
+        # The in-memory cache may now diverge from disk (#383). The rename
+        # itself succeeded (directories moved), so recover by rebuilding
+        # from disk instead of returning a silently-clean success.
+        cache_rebuilt, cache_warning = _rebuild_after_cache_failure(e)
 
     # Rename is the documented fix path for a slug collision (#392). If the
     # freed slug has a collision record, the surgical cache patch above is
@@ -194,9 +226,12 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
     # and album_collisions is stale. Rebuild from disk (same pattern as
     # create_album_structure) so the twin is indexed and collisions are
     # recomputed. Normal renames skip this and keep the cheap surgical path.
+    # A recovery rebuild above already re-indexed everything from disk, so
+    # skip the second rebuild in that case (and don't retry after a failed
+    # recovery — it would fail the same way).
     collision_resolved = False
     rebuild_warning = ""
-    if any(
+    if not (cache_rebuilt or cache_warning) and any(
         record.get("slug") == normalized_old
         for record in state.get("album_collisions", [])
     ):
@@ -235,6 +270,10 @@ async def rename_album(old_slug: str, new_slug: str, new_title: str = "") -> str
         )
     elif rebuild_warning:
         result["warning"] = rebuild_warning
+    if cache_rebuilt:
+        result["cache_rebuilt"] = True
+    elif cache_warning:
+        result["warning"] = cache_warning
     return _safe_json(result)
 
 
@@ -334,6 +373,8 @@ async def rename_track(
     # Update state cache — use the same state object that _find_album_or_error
     # returned references into; do NOT re-fetch via cache.get_state() which
     # could return a different object if the cache was invalidated.
+    cache_rebuilt = False
+    cache_warning = ""
     try:
         old_track_data = tracks.pop(matched_slug)
         old_track_data["path"] = str(new_path)
@@ -356,10 +397,13 @@ async def rename_track(
             write_state(state)
     except Exception as e:
         logger.warning("File renamed but cache update failed: %s", e)
+        # Same recovery as rename_album (#383): the file DID move, so
+        # rebuild the cache from disk rather than report a clean success.
+        cache_rebuilt, cache_warning = _rebuild_after_cache_failure(e)
 
     logger.info("Renamed track '%s' to '%s' in album '%s'", matched_slug, normalized_new, normalized_album)
 
-    return _safe_json({
+    result: dict[str, Any] = {
         "success": True,
         "album_slug": normalized_album,
         "old_slug": matched_slug,
@@ -367,7 +411,12 @@ async def rename_track(
         "title": title,
         "old_path": str(old_path),
         "new_path": str(new_path),
-    })
+    }
+    if cache_rebuilt:
+        result["cache_rebuilt"] = True
+    elif cache_warning:
+        result["warning"] = cache_warning
+    return _safe_json(result)
 
 
 # ---------------------------------------------------------------------------

--- a/servers/bitwize-music-server/handlers/text_analysis.py
+++ b/servers/bitwize-music-server/handlers/text_analysis.py
@@ -21,6 +21,7 @@ from handlers._shared import (
     _find_track_or_error,
     _is_path_confined,
     _normalize_slug,
+    _parse_pronunciation_table,
     _safe_json,
 )
 
@@ -313,16 +314,7 @@ async def check_pronunciation_enforcement(
         })
 
     # Parse the pronunciation table: | Word/Phrase | Pronunciation | Reason |
-    entries = []
-    for line in pron_section.split("\n"):
-        if not line.startswith("|") or "---" in line or "Word" in line:
-            continue
-        parts = [p.strip() for p in line.split("|")]
-        if len(parts) >= 4:
-            word = parts[1].strip()
-            phonetic = parts[2].strip()
-            if word and word != "—" and phonetic and phonetic != "—":
-                entries.append({"word": word, "phonetic": phonetic})
+    entries = _parse_pronunciation_table(pron_section)
 
     if not entries:
         return _safe_json({

--- a/skills/configure/SKILL.md
+++ b/skills/configure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: configure
 description: Sets up or edits the plugin configuration file interactively. Use on first-time setup, when config is missing, or when the user wants to change settings.
-argument-hint: [setup | edit | show | validate | reset]
+argument-hint: "[setup | edit | show | validate | reset]"
 model: sonnet
 effort: low
 allowed-tools:

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: health-check
-description: Runs plugin health checks (venv packages and skill registration). Use when the user asks to check plugin health, verify setup, or troubleshoot missing skills.
+description: Runs plugin health checks (venv packages, skill registration, and album slug collisions). Use when the user asks to check plugin health, verify setup, or troubleshoot missing skills.
 model: haiku
 allowed-tools:
   - ToolSearch
@@ -29,6 +29,7 @@ Run the `health_check` MCP tool and report results to the user.
 HEALTH CHECK: OK
   Venv: N packages verified
   Skills: N skills registered
+  Collisions: no album slug collisions
 ```
 
 ### Warnings
@@ -45,6 +46,11 @@ SKILLS [warn]
   N missing from Claude Code: skill-a, skill-b
   N ghost (deleted but cached): skill-c
   Fix: claude plugin update bitwize-music
+
+COLLISIONS [warn]
+  N album slug collision(s):
+  slug-name: kept [genre-a], shadowed by [genre-b]
+  Fix: Rename one album with /bitwize-music:rename or move its directory, then run rebuild_state
 
 For comprehensive diagnostics, run the `diagnose` MCP tool.
 ```

--- a/skills/new-album/SKILL.md
+++ b/skills/new-album/SKILL.md
@@ -68,7 +68,7 @@ Call `create_album_structure(album_slug, genre, documentary)` — creates the co
 - Creates `tracks/` and `promo/` directories with templates
 - For documentary albums (`documentary: true`): also creates RESEARCH.md and SOURCES.md
 - Returns `{created: bool, path: str, files: [...]}`
-- If album already exists, returns an error
+- If the album slug already exists under ANY genre (slugs are globally unique), returns an error naming the existing genre and path
 
 **Note**: Audio and documents directories are NOT created (those are created when needed by import-audio/import-art).
 
@@ -116,9 +116,12 @@ No genre directory found at genres/{genre}/. Use a valid genre slug (e.g. hip-ho
 Check genres/INDEX.md for the full list.
 ```
 
-**Album already exists:**
+**Album already exists (any genre — slugs are globally unique):**
 ```
-Error: Album already exists at {album_path}
+Error: Album slug '{album-name}' already exists under genre '{existing-genre}': {existing_path}
+
+Album slugs are unique across all genres — choose a different name, or
+rename the existing album with /bitwize-music:rename.
 ```
 
 **Templates not found:**

--- a/skills/next-step/SKILL.md
+++ b/skills/next-step/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: next-step
 description: Analyzes album state and recommends the optimal next action. Use when the user asks "what should I do next?" or "what's left to do?"
-argument-hint: [album-name]
+argument-hint: "[album-name]"
 model: haiku
 prerequisites:
   - resume

--- a/skills/session-start/SKILL.md
+++ b/skills/session-start/SKILL.md
@@ -39,7 +39,7 @@ Quick dependency check:
 
 ## Step 1.5: Health Check
 
-Use the `health_check` MCP tool (checks venv packages + skill registration in one call):
+Use the `health_check` MCP tool (checks venv packages + skill registration + album slug collisions in one call):
 
 **Venv results** (from `result.venv`):
 - `status: "ok"` → continue silently
@@ -51,6 +51,10 @@ Use the `health_check` MCP tool (checks venv packages + skill registration in on
 - `status: "ok"` → continue silently
 - `status: "stale"` → warn: list missing and ghost skill names, show fix message
 - `status: "no_cache"` → warn that plugin cache not found, continue
+
+**Album slug collision results** (from `result.collisions`):
+- `status: "ok"` → continue silently
+- `status: "collision"` → warn: list each slug with its kept and shadowed genres, show the fix (rename one album with `/bitwize-music:rename` or move its directory, then run `rebuild_state`), continue session
 
 ## Step 2: Load Config
 
@@ -165,7 +169,7 @@ SESSION START
 =============
 
 Setup: MCP ready, config loaded
-Health: [venv ok, skills ok | warnings listed]
+Health: [venv ok, skills ok, no collisions | warnings listed]
 Overrides: [loaded from {path} | not found (optional)]
 State: [loaded | rebuilt | error]
 

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: test
 description: Runs automated tests to validate plugin integrity across 14 categories. Use before creating PRs, after making changes to skills or templates, or to verify plugin health.
-argument-hint: [all | config | skills | templates | workflow | suno | research | mastering | sheet-music | release | consistency | terminology | behavior | quality | quick]
+argument-hint: "[all | config | skills | templates | workflow | suno | research | mastering | sheet-music | release | consistency | terminology | behavior | quality | quick]"
 model: haiku
 context: fork
 allowed-tools:

--- a/tests/plugin/test_consistency.py
+++ b/tests/plugin/test_consistency.py
@@ -124,6 +124,38 @@ class TestNoDisableModelInvocation:
         assert not flagged or True  # soft check preserved
 
 
+class TestHealthCheckCollisionDocs:
+    """Skills documenting health_check must surface the collisions section (#392)."""
+
+    def test_session_start_documents_collisions(self, skills_dir):
+        skill_path = skills_dir / "session-start" / "SKILL.md"
+        content = skill_path.read_text()
+
+        step_15 = re.search(r'## Step 1\.5.*?(?=\n## Step 2)', content, re.DOTALL)
+        assert step_15, "session-start SKILL.md missing Step 1.5 section"
+        assert "collision" in step_15.group().lower(), (
+            "session-start Step 1.5 does not handle the health_check "
+            "collisions section — agents following it would drop the warning"
+        )
+
+        report = re.search(r'## Report Format.*?```.*?```', content, re.DOTALL)
+        assert report, "session-start SKILL.md missing Report Format template"
+        assert "collision" in report.group().lower(), (
+            "session-start Report Format Health line omits collisions"
+        )
+
+    def test_health_check_documents_collisions(self, skills_dir):
+        skill_path = skills_dir / "health-check" / "SKILL.md"
+        content = skill_path.read_text()
+
+        report = re.search(r'## Report Format.*?(?=\n## Remember|$)', content, re.DOTALL)
+        assert report, "health-check SKILL.md missing Report Format section"
+        assert "COLLISIONS" in report.group(), (
+            "health-check Report Format has no COLLISIONS section slot "
+            "alongside VENV/SKILLS"
+        )
+
+
 class TestGitignore:
     """Required .gitignore entries must be present."""
 

--- a/tests/unit/cloud/test_upload_to_cloud.py
+++ b/tests/unit/cloud/test_upload_to_cloud.py
@@ -415,3 +415,31 @@ class TestCloudEnabledGate:
         monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album"])
         with pytest.raises(SystemExit):
             mod.main()
+
+
+class TestRetriesValidation:
+    """--retries <= 0 must not silently skip every upload attempt (#385)."""
+
+    @pytest.fixture()
+    def fake_video(self, tmp_path):
+        f = tmp_path / "promo.mp4"
+        f.write_bytes(b"fake video content")
+        return f
+
+    def test_zero_retries_still_attempts_once(self, fake_video):
+        client = MagicMock()
+        result = mod.retry_upload(client, "bucket", fake_video, "key/f.mp4", max_retries=0)
+        assert result is True
+        assert client.upload_file.call_count == 1
+
+    def test_negative_retries_still_attempts_once(self, fake_video):
+        client = MagicMock()
+        result = mod.retry_upload(client, "bucket", fake_video, "key/f.mp4", max_retries=-3)
+        assert result is True
+        assert client.upload_file.call_count == 1
+
+    def test_cli_rejects_non_positive_retries(self, monkeypatch):
+        monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album", "--retries", "0"])
+        with pytest.raises(SystemExit) as exc_info:
+            mod.main()
+        assert exc_info.value.code == 2  # argparse usage error, not silent failure

--- a/tests/unit/cloud/test_upload_to_cloud.py
+++ b/tests/unit/cloud/test_upload_to_cloud.py
@@ -399,3 +399,19 @@ class TestFindAlbumPath:
     def test_path_traversal_in_name_exits(self, tmp_path):
         with pytest.raises(SystemExit):
             mod.find_album_path(self._make_config(tmp_path), "../../../etc")
+
+
+class TestCloudEnabledGate:
+    """cloud.enabled honors quoted boolean strings (#388)."""
+
+    def test_quoted_false_exits(self, monkeypatch):
+        monkeypatch.setattr(mod, "load_config", lambda *a, **k: {"cloud": {"enabled": "false"}})
+        monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album"])
+        with pytest.raises(SystemExit):
+            mod.main()
+
+    def test_quoted_no_exits(self, monkeypatch):
+        monkeypatch.setattr(mod, "load_config", lambda *a, **k: {"cloud": {"enabled": "no"}})
+        monkeypatch.setattr("sys.argv", ["upload_to_cloud.py", "some-album"])
+        with pytest.raises(SystemExit):
+            mod.main()

--- a/tests/unit/database/test_connection.py
+++ b/tests/unit/database/test_connection.py
@@ -1,0 +1,54 @@
+"""Unit tests for tools/database/connection.py."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _write_cfg(tmp_path, enabled_literal: str):
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        "database:\n"
+        f"  enabled: {enabled_literal}\n"
+        "  host: db.example\n"
+        "  port: 5432\n"
+        "  name: tweets\n"
+        "  user: u\n"
+        "  password: p\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+class TestGetDbConfigBooleanGate:
+    """database.enabled honors quoted boolean strings (#388)."""
+
+    def test_quoted_false_disables(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"false"'))
+        assert conn.get_db_config() is None
+
+    def test_quoted_no_disables(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"no"'))
+        assert conn.get_db_config() is None
+
+    def test_quoted_true_enables(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"true"'))
+        result = conn.get_db_config()
+        assert result is not None
+        assert result["host"] == "db.example"
+
+    def test_unquoted_bools_unchanged(self, tmp_path, monkeypatch):
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, "true"))
+        assert conn.get_db_config() is not None
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, "false"))
+        assert conn.get_db_config() is None
+
+    def test_garbage_string_disables(self, tmp_path, monkeypatch):
+        """Unparseable values fall back to the default (disabled)."""
+        import tools.database.connection as conn
+        monkeypatch.setattr(conn, "CONFIG_PATH", _write_cfg(tmp_path, '"maybe"'))
+        assert conn.get_db_config() is None

--- a/tests/unit/handlers/test_shared_helpers.py
+++ b/tests/unit/handlers/test_shared_helpers.py
@@ -67,3 +67,49 @@ def test_is_album_released_false_when_cache_raises():
             raise OSError("simulated disk failure")
     _shared.cache = _RaisingCache()
     assert _shared.is_album_released("my-album") is False
+
+
+class TestGetValidGenresCachePoisoning:
+    """A degenerate genre scan must not poison the process-wide cache.
+
+    Regression for the xdist flake where a test patching PLUGIN_ROOT (or
+    blanket-mocking Path.exists) primed _VALID_GENRES with an empty set,
+    making every later create_album_structure reject valid genres.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_genre_cache(self):
+        original = _shared._VALID_GENRES
+        _shared._VALID_GENRES = None
+        yield
+        _shared._VALID_GENRES = original
+
+    def _real_plugin_root(self):
+        return PROJECT_ROOT
+
+    def test_fake_plugin_root_does_not_poison_cache(self, tmp_path, monkeypatch):
+        fake_root = tmp_path / "fake-plugin"
+        fake_root.mkdir()
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", fake_root)
+        assert _shared._get_valid_genres() == frozenset()
+
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", self._real_plugin_root())
+        assert "rock" in _shared._get_valid_genres()
+
+    def test_cache_rekeys_when_plugin_root_changes(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", self._real_plugin_root())
+        real_genres = _shared._get_valid_genres()
+        assert real_genres  # non-empty and now cached
+
+        other_root = tmp_path / "other-plugin"
+        (other_root / "genres" / "onlygenre").mkdir(parents=True)
+        (other_root / "genres" / "onlygenre" / "README.md").write_text("# g")
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", other_root)
+        assert _shared._get_valid_genres() == frozenset({"onlygenre"})
+
+    def test_empty_scan_is_not_cached(self, tmp_path, monkeypatch):
+        fake_root = tmp_path / "fake-plugin"
+        fake_root.mkdir()
+        monkeypatch.setattr(_shared, "PLUGIN_ROOT", fake_root)
+        _shared._get_valid_genres()
+        assert _shared._VALID_GENRES is None  # degenerate result not stored

--- a/tests/unit/mastering/test_codec_preview.py
+++ b/tests/unit/mastering/test_codec_preview.py
@@ -100,3 +100,80 @@ class TestRenderAacPreview:
             render_aac_preview(in_wav, out, bitrate_kbps=0)
         with pytest.raises(CodecPreviewError, match="bitrate"):
             render_aac_preview(in_wav, out, bitrate_kbps=-64)
+
+
+class TestFfmpegTimeout:
+    """render_aac_preview bounds the ffmpeg subprocess (#387)."""
+
+    def _wav(self, tmp_path):
+        wav = tmp_path / "in.wav"
+        wav.write_bytes(b"RIFF")
+        return wav
+
+    def test_timeout_passed_to_subprocess(self, tmp_path, monkeypatch):
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            assert kwargs.get("timeout") == cp._FFMPEG_TIMEOUT_SEC
+            assert cp._FFMPEG_TIMEOUT_SEC > 0
+            out.write_bytes(b"m4a")
+
+            class R:
+                returncode = 0
+                stderr = ""
+            return R()
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        result = cp.render_aac_preview(wav, out)
+        assert result["output_path"] == str(out)
+
+    def test_timeout_expired_raises_codec_preview_error(self, tmp_path, monkeypatch):
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=kwargs.get("timeout", 0))
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        with pytest.raises(cp.CodecPreviewError, match="timed out"):
+            cp.render_aac_preview(wav, out)
+
+    def test_timeout_removes_partial_output(self, tmp_path, monkeypatch):
+        """A SIGKILLed ffmpeg leaves a truncated m4a — it must be removed."""
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            out.write_bytes(b"partial")
+            raise subprocess.TimeoutExpired(cmd="ffmpeg", timeout=120)
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        with pytest.raises(cp.CodecPreviewError):
+            cp.render_aac_preview(wav, out)
+        assert not out.exists()
+
+    def test_failed_encode_removes_partial_output(self, tmp_path, monkeypatch):
+        import tools.mastering.codec_preview as cp
+        wav = self._wav(tmp_path)
+        out = tmp_path / "out.aac.m4a"
+
+        def fake_run(cmd, **kwargs):
+            out.write_bytes(b"partial")
+
+            class R:
+                returncode = 1
+                stderr = "boom"
+            return R()
+
+        monkeypatch.setattr(cp.shutil, "which", lambda _: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(cp.subprocess, "run", fake_run)
+        with pytest.raises(cp.CodecPreviewError):
+            cp.render_aac_preview(wav, out)
+        assert not out.exists()

--- a/tests/unit/mastering/test_mastering_config.py
+++ b/tests/unit/mastering/test_mastering_config.py
@@ -79,6 +79,68 @@ class TestLoadMasteringConfig:
             result = load_mastering_config()
         assert result == DEFAULT_MASTERING_CONFIG
 
+    def test_quoted_false_strings_do_not_invert(self):
+        """Quoted falsy booleans must resolve False, not bool("false")==True (#388)."""
+        user_config = {
+            "mastering": {
+                "adm_validation_enabled": "false",
+                "archival_enabled": "no",
+            }
+        }
+        with patch(
+            "tools.mastering.config.load_config", return_value=user_config
+        ):
+            result = load_mastering_config()
+        assert result["adm_validation_enabled"] is False
+        assert result["archival_enabled"] is False
+
+    def test_quoted_true_strings_enable(self):
+        user_config = {
+            "mastering": {
+                "adm_validation_enabled": "true",
+                "archival_enabled": "yes",
+            }
+        }
+        with patch(
+            "tools.mastering.config.load_config", return_value=user_config
+        ):
+            result = load_mastering_config()
+        assert result["adm_validation_enabled"] is True
+        assert result["archival_enabled"] is True
+
+    def test_unparseable_boolean_string_uses_default(self, caplog):
+        """A boolean key set to garbage falls back to the default with a warning."""
+        user_config = {"mastering": {"archival_enabled": "maybe"}}
+        with patch(
+            "tools.mastering.config.load_config", return_value=user_config
+        ), caplog.at_level("WARNING", logger="tools.mastering.config"):
+            result = load_mastering_config()
+        assert result["archival_enabled"] is False  # default
+        assert any("archival_enabled" in r.message for r in caplog.records)
+
+
+class TestResolveAdmEnabled:
+    """Per-album frontmatter ADM flag honors quoted boolean strings (#388)."""
+
+    def test_quoted_false_does_not_enable(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": "false"}) is False
+
+    def test_quoted_true_enables(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": "true"}) is True
+
+    def test_garbage_string_stays_off(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": "maybe"}) is False
+
+    def test_real_bools_unchanged(self):
+        from tools.mastering.config import _resolve_adm_enabled
+        assert _resolve_adm_enabled({"adm_validation_enabled": True}) is True
+        assert _resolve_adm_enabled({"adm_validation_enabled": False}) is False
+        assert _resolve_adm_enabled(None) is False
+        assert _resolve_adm_enabled({}) is False
+
 
 class TestResolveMasteringTargets:
     def _base_cfg(self) -> dict:

--- a/tests/unit/mastering/test_stage_status_update.py
+++ b/tests/unit/mastering/test_stage_status_update.py
@@ -454,3 +454,35 @@ class TestAlbumStatusTransition:
         assert state["albums"]["test-album"]["status"] == "In Progress"
         # Warning / error recorded
         assert ctx.stages["status_update"].get("errors")
+
+
+# ===========================================================================
+# Status writes are atomic (#398)
+# ===========================================================================
+
+
+class TestStatusWritesAreAtomic:
+    """Track and README status rewrites go through atomic_write_text (#398)."""
+
+    def test_track_and_readme_written_atomically(self, filesystem, _install_cache):
+        from unittest.mock import patch
+
+        import handlers.processing._album_stages as stages_mod
+
+        state, ctx, _audio_dir = _setup(
+            filesystem, _install_cache, album_status="In Progress",
+            tracks=[("01-track-one", "Track One", "Generated")],
+        )
+
+        with patch.object(
+            stages_mod, "atomic_write_text", wraps=stages_mod.atomic_write_text
+        ) as spy:
+            _run(_stage_status_update(ctx))
+
+        written = {str(call.args[0]) for call in spy.call_args_list}
+        track_path = state["albums"]["test-album"]["tracks"]["01-track-one"]["path"]
+        album_readme = str(Path(state["albums"]["test-album"]["path"]) / "README.md")
+        assert track_path in written, f"track file not atomically written: {written}"
+        assert album_readme in written, f"README not atomically written: {written}"
+        # And the writes actually landed
+        assert "**Status** | Final |" in Path(track_path).read_text(encoding="utf-8")

--- a/tests/unit/promotion/test_generate_promo_video.py
+++ b/tests/unit/promotion/test_generate_promo_video.py
@@ -219,3 +219,38 @@ class TestBatchProcessAlbum:
             output_dir=output_dir,
         )
         mock_gen.assert_not_called()
+
+
+class TestBatchCliExitCode:
+    """CLI --batch mode exits non-zero when any track fails (#382)."""
+
+    def _run_main(self, tmp_path, monkeypatch, results):
+        import tools.promotion.generate_promo_video as gpv
+        album = tmp_path / "album"
+        album.mkdir()
+        (album / "01-track.wav").write_bytes(b"")
+        art = tmp_path / "album.png"
+        art.write_bytes(b"")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["generate_promo_video.py", "--batch", str(album),
+             "--batch-artwork", str(art)],
+        )
+        monkeypatch.setattr(gpv, "batch_process_album", lambda **kw: results)
+        gpv.main()
+
+    def test_failure_exits_nonzero(self, tmp_path, monkeypatch):
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_main(
+                tmp_path, monkeypatch,
+                [("01-track.wav", "01-track_promo.mp4", True),
+                 ("02-track.wav", "02-track_promo.mp4", False)],
+            )
+        assert exc_info.value.code == 1
+
+    def test_all_success_exits_zero(self, tmp_path, monkeypatch):
+        # main() returns normally (no SystemExit) when every track succeeds
+        self._run_main(
+            tmp_path, monkeypatch,
+            [("01-track.wav", "01-track_promo.mp4", True)],
+        )

--- a/tests/unit/shared/test_config.py
+++ b/tests/unit/shared/test_config.py
@@ -90,6 +90,50 @@ class TestLoadConfig:
         assert config_module.CONFIG_PATH == expected
 
 
+class TestLoadConfigNonMapping:
+    """load_config() rejects valid YAML whose top level is not a mapping (#389)."""
+
+    def test_top_level_list_returns_fallback_with_error(self, tmp_path, caplog):
+        """Top-level YAML list returns fallback and logs an error naming path and type."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("- foo\n- bar\n")
+
+        with mock.patch.object(config_module, 'CONFIG_PATH', config_path):
+            with caplog.at_level("ERROR", logger="tools.shared.config"):
+                result = load_config(fallback={'default': True})
+        assert result == {'default': True}
+        assert any(
+            str(config_path) in r.message and "list" in r.message
+            for r in caplog.records
+        )
+
+    def test_top_level_scalar_returns_fallback(self, tmp_path):
+        """Top-level YAML scalar returns fallback."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("42\n")
+
+        with mock.patch.object(config_module, 'CONFIG_PATH', config_path):
+            result = load_config(fallback={'default': True})
+            assert result == {'default': True}
+
+    def test_non_mapping_returns_none_without_fallback(self, tmp_path):
+        """Non-mapping YAML returns None when no fallback is given."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("just a string\n")
+
+        with mock.patch.object(config_module, 'CONFIG_PATH', config_path):
+            assert load_config() is None
+
+    def test_non_mapping_required_exits(self, tmp_path):
+        """Non-mapping YAML exits when required=True."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("- foo\n")
+
+        with mock.patch.object(config_module, 'CONFIG_PATH', config_path):
+            with pytest.raises(SystemExit):
+                load_config(required=True)
+
+
 class TestLoadConfigYamlMissing:
     """Tests for config loading when PyYAML is not available."""
 

--- a/tests/unit/shared/test_config.py
+++ b/tests/unit/shared/test_config.py
@@ -102,3 +102,54 @@ class TestLoadConfigYamlMissing:
             with mock.patch.object(config_module, 'yaml', None):
                 result = load_config(fallback={'default': True})
                 assert result == {'default': True}
+
+
+class TestParseYamlBool:
+    """parse_yaml_bool() honors quoted YAML boolean strings (#388)."""
+
+    def test_passes_through_bools(self):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(True) is True
+        assert parse_yaml_bool(False) is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "yes", "Yes", "on", "1", " true "])
+    def test_truthy_strings(self, value):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "False", "FALSE", "no", "No", "off", "0", " false "])
+    def test_falsy_strings(self, value):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(value) is False
+
+    def test_zero_one_ints(self):
+        from tools.shared.config import parse_yaml_bool
+        assert parse_yaml_bool(0) is False
+        assert parse_yaml_bool(1) is True
+
+    @pytest.mark.parametrize("value", ["maybe", "", "2", "truthy", 2, 2.5, [], {}, None, ["true"]])
+    def test_unparseable_values_raise(self, value):
+        from tools.shared.config import parse_yaml_bool
+        with pytest.raises(ValueError):
+            parse_yaml_bool(value)
+
+
+class TestCoerceYamlBool:
+    """coerce_yaml_bool() = parse_yaml_bool with warn-and-default fallback."""
+
+    def test_parses_quoted_strings(self):
+        from tools.shared.config import coerce_yaml_bool
+        assert coerce_yaml_bool("false", default=True) is False
+        assert coerce_yaml_bool("yes", default=False) is True
+
+    def test_bool_passthrough(self):
+        from tools.shared.config import coerce_yaml_bool
+        assert coerce_yaml_bool(True, default=False) is True
+        assert coerce_yaml_bool(False, default=True) is False
+
+    def test_garbage_returns_default_with_warning(self, caplog):
+        from tools.shared.config import coerce_yaml_bool
+        with caplog.at_level("WARNING", logger="tools.shared.config"):
+            assert coerce_yaml_bool("maybe", default=True, context="cloud.enabled") is True
+            assert coerce_yaml_bool([], default=False, context="x") is False
+        assert any("cloud.enabled" in r.message for r in caplog.records)

--- a/tests/unit/shared/test_debug_logging.py
+++ b/tests/unit/shared/test_debug_logging.py
@@ -58,6 +58,64 @@ class TestConfigureFileLoggingDisabled:
         assert after == before
 
 
+class TestWrongTypedLoggingConfig:
+    """Wrong-typed logging config disables/defaults instead of crashing."""
+
+    def test_string_logging_section_disabled_with_warning(self, caplog):
+        # `logging: yes-please` (a scalar) is truthy — without a type guard
+        # it crashes .get() on server startup and every CLI
+        with caplog.at_level(logging.WARNING):
+            assert configure_file_logging({"logging": "yes-please"}) is None
+        assert "logging" in caplog.text
+        assert "str" in caplog.text
+
+    def test_list_logging_section_disabled(self):
+        assert configure_file_logging({"logging": ["enabled"]}) is None
+
+    def test_no_root_handlers_added_for_wrong_typed_section(self):
+        root = logging.getLogger()
+        before = len([h for h in root.handlers if isinstance(h, RotatingFileHandler)])
+        configure_file_logging({"logging": "yes-please"})
+        after = len([h for h in root.handlers if isinstance(h, RotatingFileHandler)])
+        assert after == before
+
+    def test_max_size_mb_string_uses_default(self, tmp_path, caplog):
+        log_file = str(tmp_path / "test.log")
+        config = {"logging": {"enabled": True, "file": log_file,
+                              "max_size_mb": "big"}}
+        with caplog.at_level(logging.WARNING):
+            handler = configure_file_logging(config)
+        assert handler is not None
+        assert handler.maxBytes == 5 * 1024 * 1024
+        assert "max_size_mb" in caplog.text
+
+    def test_max_size_mb_bool_uses_default(self, tmp_path):
+        # True * 1024 * 1024 == 1048576 would silently shrink the log cap
+        log_file = str(tmp_path / "test.log")
+        config = {"logging": {"enabled": True, "file": log_file,
+                              "max_size_mb": True}}
+        handler = configure_file_logging(config)
+        assert handler is not None
+        assert handler.maxBytes == 5 * 1024 * 1024
+
+    def test_max_size_mb_inf_uses_default(self, tmp_path):
+        # YAML `.inf` parses to float('inf'); int() raises OverflowError
+        log_file = str(tmp_path / "test.log")
+        config = {"logging": {"enabled": True, "file": log_file,
+                              "max_size_mb": float("inf")}}
+        handler = configure_file_logging(config)
+        assert handler is not None
+        assert handler.maxBytes == 5 * 1024 * 1024
+
+    def test_max_size_mb_float_accepted(self, tmp_path):
+        log_file = str(tmp_path / "test.log")
+        config = {"logging": {"enabled": True, "file": log_file,
+                              "max_size_mb": 2.5}}
+        handler = configure_file_logging(config)
+        assert handler is not None
+        assert handler.maxBytes == int(2.5 * 1024 * 1024)
+
+
 class TestConfigureFileLoggingEnabled:
     """Tests that logging works correctly when enabled."""
 

--- a/tests/unit/shared/test_debug_logging.py
+++ b/tests/unit/shared/test_debug_logging.py
@@ -236,3 +236,17 @@ class TestSetupLoggingWithConfig:
             assert len(file_handlers) == 0
         finally:
             logging.getLogger(name).handlers.clear()
+
+
+class TestQuotedBooleanStrings:
+    """logging.enabled honors quoted boolean strings (#388)."""
+
+    def test_enabled_quoted_false_stays_off(self):
+        config = {"logging": {"enabled": "false"}}
+        assert configure_file_logging(config) is None
+
+    def test_enabled_quoted_true_turns_on(self, tmp_path):
+        log_file = str(tmp_path / "test.log")
+        config = {"logging": {"enabled": "true", "file": log_file}}
+        handler = configure_file_logging(config)
+        assert isinstance(handler, RotatingFileHandler)

--- a/tests/unit/sheet_music/test_transcribe.py
+++ b/tests/unit/sheet_music/test_transcribe.py
@@ -187,12 +187,7 @@ class TestTranscribeTrack:
 
 @pytest.mark.unit
 class TestResolveAlbumPath:
-    """Tests for album name to path resolution."""
-
-    @patch.object(mod, "read_config", return_value=None)
-    def test_no_config_returns_none(self, _mock_config):
-        result = mod.resolve_album_path("my-album")
-        assert result is None
+    """resolve_album_path builds the canonical mirrored audio path (#375)."""
 
     @patch.object(mod, "read_config")
     def test_missing_key_returns_none(self, mock_config):
@@ -201,42 +196,51 @@ class TestResolveAlbumPath:
         assert result is None
 
     @patch.object(mod, "read_config")
-    def test_nonexistent_path_returns_none(self, mock_config, tmp_path):
-        mock_config.return_value = {
-            "paths": {"audio_root": str(tmp_path / "audio")},
-            "artist": {"name": "TestArtist"},
-        }
-        result = mod.resolve_album_path("no-such-album")
-        assert result is None
-
-    @patch.object(mod, "read_config")
-    def test_valid_album_returns_path(self, mock_config, tmp_path):
-        album = tmp_path / "audio" / "TestArtist" / "my-album"
-        album.mkdir(parents=True)
-        mock_config.return_value = {
-            "paths": {"audio_root": str(tmp_path / "audio")},
-            "artist": {"name": "TestArtist"},
-        }
-        result = mod.resolve_album_path("my-album")
-        assert result == album
-
-    @patch.object(mod, "read_config")
     def test_path_traversal_rejected(self, mock_config, tmp_path):
-        """Symlink or .. that escapes audio_root should be rejected."""
+        """Symlink under a genre dir that escapes audio_root is rejected."""
         audio_root = tmp_path / "audio"
-        audio_root.mkdir()
-        # Create a path that resolves outside audio_root
         outside = tmp_path / "outside"
         outside.mkdir()
-        artist_dir = audio_root / "TestArtist"
-        artist_dir.mkdir()
-        # Symlink: audio/TestArtist/evil -> ../../outside
-        evil = artist_dir / "evil"
-        evil.symlink_to(outside)
+        genre_dir = audio_root / "artists" / "test-artist" / "albums" / "rock"
+        genre_dir.mkdir(parents=True)
+        # Symlink: .../albums/rock/evil -> {tmp}/outside
+        (genre_dir / "evil").symlink_to(outside)
 
         mock_config.return_value = {
             "paths": {"audio_root": str(audio_root)},
-            "artist": {"name": "TestArtist"},
+            "artist": {"name": "test-artist"},
         }
         result = mod.resolve_album_path("evil")
         assert result is None
+
+    def _config(self, tmp_path):
+        return {
+            "paths": {"audio_root": str(tmp_path)},
+            "artist": {"name": "test-artist"},
+        }
+
+    def test_resolves_album_by_name(self, tmp_path):
+        album_dir = tmp_path / "artists" / "test-artist" / "albums" / "rock" / "my-album"
+        album_dir.mkdir(parents=True)
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            assert mod.resolve_album_path("my-album") == album_dir
+
+    def test_returns_none_when_album_missing(self, tmp_path):
+        (tmp_path / "artists" / "test-artist" / "albums" / "rock").mkdir(parents=True)
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            assert mod.resolve_album_path("nope") is None
+
+    def test_missing_albums_root_returns_none(self, tmp_path):
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            assert mod.resolve_album_path("anything") is None
+
+    def test_multiple_genre_twins_picks_first_sorted(self, tmp_path):
+        for genre in ("rock", "jazz"):
+            (tmp_path / "artists" / "test-artist" / "albums" / genre / "twin").mkdir(parents=True)
+        with patch.object(mod, "read_config", return_value=self._config(tmp_path)):
+            result = mod.resolve_album_path("twin")
+        assert result == tmp_path / "artists" / "test-artist" / "albums" / "jazz" / "twin"
+
+    def test_no_config_returns_none(self):
+        with patch.object(mod, "read_config", return_value=None):
+            assert mod.resolve_album_path("x") is None

--- a/tests/unit/state/test_handlers_album_ops.py
+++ b/tests/unit/state/test_handlers_album_ops.py
@@ -385,6 +385,10 @@ class TestCreateAlbumStructure:
         self._orig_plugin_root = _shared_mod.PLUGIN_ROOT
         _shared_mod.cache = MockStateCache()
         _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+        # Prime the genre cache with the real genres/ scan BEFORE tests apply
+        # blanket Path.exists/Path.is_dir mocks — a cold-cache scan under
+        # those mocks comes back empty and every genre would be rejected.
+        _shared_mod._get_valid_genres()
 
     def teardown_method(self):
         _shared_mod.cache = self._orig_cache

--- a/tests/unit/state/test_handlers_gates.py
+++ b/tests/unit/state/test_handlers_gates.py
@@ -479,6 +479,28 @@ class TestGate3PronunciationResolved:
         assert pron_gate["status"] == "FAIL"
         assert "lever" in pron_gate["detail"]
 
+    def test_word_substring_row_still_blocks(self):
+        """A 'Wordsworth' row must not be dropped by the header filter (#384).
+
+        The old substring filter skipped any line containing 'Word', so the
+        BLOCKING gate false-passed with 'No pronunciation entries to check'.
+        """
+        track = (
+            "---\ntitle: Wordsworth Track\nstatus: In Progress\n---\n\n"
+            "## Lyrics Box\n\n```\nplain lyrics without the phonetic\n```\n\n"
+            "## Pronunciation Notes\n\n"
+            "| Word/Phrase | Pronunciation | Reason |\n"
+            "|-------------|---------------|--------|\n"
+            "| Wordsworth | WURDZ-wurth | poet name |\n"
+        )
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, track, blocklist=[],
+        )
+        pron_gate = next(g for g in gates if g["gate"] == "Pronunciation Resolved")
+        assert pron_gate["status"] == "FAIL"
+        assert "Wordsworth" in pron_gate["detail"]
+
     def test_no_pronunciation_entries_passes(self):
         t_data = {"sources_verified": "N/A", "explicit": False}
         blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(

--- a/tests/unit/state/test_handlers_promote_idea.py
+++ b/tests/unit/state/test_handlers_promote_idea.py
@@ -415,6 +415,37 @@ class TestPromoteIdeaErrors:
         assert "error" in result
         assert "exists" in result["error"].lower()
 
+    def test_cross_genre_duplicate_slug_returns_error(self, content_root: Path, setup_handler):
+        """Slug already used under a DIFFERENT genre blocks promotion (#392)."""
+        setup_handler([{
+            "title": "Kleine Welt",
+            "genre": "electronic",
+            "concept": "Inner journey.",
+            "status": "Pending",
+        }])
+        ideas_path = _write_ideas_md(
+            content_root,
+            _standard_ideas_md("Kleine Welt", "electronic", "Inner journey."),
+        )
+        # Same slug exists under another genre
+        existing = (content_root / "artists" / "test-artist" / "albums"
+                    / "rock" / "kleine-welt")
+        existing.mkdir(parents=True)
+
+        result = json.loads(_run(_ideas_mod.promote_idea("Kleine Welt")))
+
+        assert "error" in result
+        assert "exists" in result["error"].lower()
+        assert "rock" in result["error"]
+        # No twin created under the idea's genre
+        twin = (content_root / "artists" / "test-artist" / "albums"
+                / "electronic" / "kleine-welt")
+        assert not twin.exists()
+        # Idea must not be marked promoted
+        text = ideas_path.read_text(encoding="utf-8")
+        assert "**Status**: Pending" in text
+        assert "**Promoted To**" not in text
+
 
 # ---------------------------------------------------------------------------
 # Documentary flag

--- a/tests/unit/state/test_handlers_rename.py
+++ b/tests/unit/state/test_handlers_rename.py
@@ -91,11 +91,16 @@ class MockStateCache:
     def __init__(self, state: dict) -> None:
         self._state = state
         self.write_calls = 0
+        self.rebuild_calls = 0
 
     def get_state(self) -> dict:
         return self._state
 
     def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        self.rebuild_calls += 1
         return self._state
 
 
@@ -357,6 +362,28 @@ class TestRenameAlbumErrors:
         assert "error" in result
         assert "already exists" in result["error"].lower()
 
+    def test_cross_genre_disk_collision_returns_error(self, cache_with_album):
+        """New slug existing on disk under ANOTHER genre — and absent from the
+        cache — must block the rename (#392: cache can be stale or shadowed)."""
+        state, content_root, _audio, _docs = cache_with_album
+        twin = (content_root / "artists" / "test-artist" / "albums"
+                / "rock" / "shadow-album")
+        twin.mkdir(parents=True)
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "shadow-album")
+        ))
+
+        assert "error" in result
+        assert "already exists" in result["error"].lower()
+        assert "rock" in result["error"]
+        assert "rename" in result["error"].lower()
+        # Source album untouched on disk and in cache
+        orig = (content_root / "artists" / "test-artist" / "albums"
+                / "electronic" / "original-album")
+        assert orig.is_dir()
+        assert "original-album" in state["albums"]
+
     def test_same_slug_after_normalization_returns_error(self, cache_with_album):
         # "Original-Album" normalizes to "original-album" which equals the source
         result = json.loads(_run(
@@ -457,6 +484,128 @@ class TestRenameAlbumMissingAuxDirs:
 
         assert result["success"] is True
         assert result["documents_moved"] is False
+
+
+class TestRenameAlbumCollisionRebuild:
+    """Rename is the documented fix path for a slug collision (#392).
+
+    Renaming the kept/winner album must trigger a full cache rebuild so the
+    formerly-shadowed twin is indexed and album_collisions is recomputed from
+    disk — the surgical cache patch alone leaves a stale collision record and
+    an invisible twin. Normal renames keep the cheap surgical path.
+    """
+
+    def _seed_collision(self, state, content_root, audio_root, documents_root):
+        """Add jazz/midnight (kept, in cache) + rock/midnight (shadowed,
+        disk-only) and the matching album_collisions record."""
+        kept = _make_album_on_disk(
+            content_root, audio_root, documents_root,
+            artist="test-artist", genre="jazz", slug="midnight",
+            title="Midnight",
+            tracks=[("01-blue-hour", "Blue Hour")],
+        )
+        state["albums"]["midnight"] = kept
+        # Shadowed twin exists on disk only — NOT in the cache (the indexer
+        # kept jazz and shadowed rock).
+        shadow_dir = (content_root / "artists" / "test-artist" / "albums"
+                      / "rock" / "midnight")
+        (shadow_dir / "tracks").mkdir(parents=True)
+        (shadow_dir / "README.md").write_text("# Midnight\n", encoding="utf-8")
+        state["album_collisions"] = [{
+            "slug": "midnight",
+            "kept": {"genre": "jazz", "path": kept["path"]},
+            "shadowed": [{"genre": "rock", "path": str(shadow_dir)}],
+        }]
+        return shadow_dir
+
+    def test_renaming_collided_album_triggers_rebuild(self, cache_with_album):
+        state, content_root, audio_root, documents_root = cache_with_album
+        shadow_dir = self._seed_collision(
+            state, content_root, audio_root, documents_root
+        )
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("midnight", "midnight-jazz")
+        ))
+
+        assert result["success"] is True
+        assert result["content_moved"] is True
+        # Full rebuild triggered so the formerly-shadowed twin gets indexed
+        # and album_collisions is recomputed from disk.
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert result["collision_resolved"] is True
+        assert "note" in result
+        # Directories: kept album moved, shadowed twin untouched
+        new_dir = (content_root / "artists" / "test-artist" / "albums"
+                   / "jazz" / "midnight-jazz")
+        assert new_dir.is_dir()
+        assert shadow_dir.is_dir()
+
+    def test_normal_rename_skips_rebuild(self, cache_with_album):
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "new-album")
+        ))
+
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 0
+        assert "collision_resolved" not in result
+        assert "warning" not in result
+
+    def test_collision_record_for_other_slug_skips_rebuild(self, cache_with_album):
+        state, *_ = cache_with_album
+        state["album_collisions"] = [{
+            "slug": "some-other-slug",
+            "kept": {"genre": "jazz", "path": "/nowhere/jazz/some-other-slug"},
+            "shadowed": [{"genre": "rock", "path": "/nowhere/rock/some-other-slug"}],
+        }]
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "new-album")
+        ))
+
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 0
+        assert "collision_resolved" not in result
+
+    def test_rebuild_error_result_degrades_to_warning(self, cache_with_album):
+        state, content_root, audio_root, documents_root = cache_with_album
+        self._seed_collision(state, content_root, audio_root, documents_root)
+
+        class FailingRebuildCache(MockStateCache):
+            def rebuild(self) -> dict:
+                self.rebuild_calls += 1
+                return {"error": "rebuild exploded"}
+
+        _shared_mod.cache = FailingRebuildCache(state)
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("midnight", "midnight-jazz")
+        ))
+
+        # Directories DID move — the rename itself must stay a success.
+        assert result["success"] is True
+        assert result["content_moved"] is True
+        assert "collision_resolved" not in result
+        assert "rebuild exploded" in result["warning"]
+
+    def test_rebuild_exception_degrades_to_warning(self, cache_with_album):
+        state, content_root, audio_root, documents_root = cache_with_album
+        self._seed_collision(state, content_root, audio_root, documents_root)
+
+        class RaisingRebuildCache(MockStateCache):
+            def rebuild(self) -> dict:
+                self.rebuild_calls += 1
+                raise RuntimeError("disk on fire")
+
+        _shared_mod.cache = RaisingRebuildCache(state)
+
+        result = json.loads(_run(
+            _rename_mod.rename_album("midnight", "midnight-jazz")
+        ))
+
+        assert result["success"] is True
+        assert "collision_resolved" not in result
+        assert "disk on fire" in result["warning"]
 
 
 # ===========================================================================

--- a/tests/unit/state/test_handlers_rename.py
+++ b/tests/unit/state/test_handlers_rename.py
@@ -771,3 +771,86 @@ class TestRenameTrackPathTraversal:
             "original-album", "01-first-track", "01\\evil"
         )))
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Cache-write failure honesty (#383)
+# ---------------------------------------------------------------------------
+
+
+class _RebuildFailsCache(MockStateCache):
+    def rebuild(self) -> dict:
+        self.rebuild_calls += 1
+        return {"error": "rebuild boom"}
+
+
+class TestCacheWriteFailureHonesty:
+    """write_state failure must not produce a silently-clean success (#383)."""
+
+    def _fail_write_state(self, monkeypatch):
+        import tools.state.indexer as indexer_mod
+
+        def boom(_state):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(indexer_mod, "write_state", boom)
+
+    def test_album_rename_recovers_via_rebuild(self, cache_with_album, monkeypatch):
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "renamed-album")
+        ))
+        assert result["success"] is True
+        # Recovery rebuild from disk (directories DID move) instead of a
+        # silently divergent in-memory cache.
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert result.get("cache_rebuilt") is True
+
+    def test_album_rename_warns_when_rebuild_also_fails(self, cache_with_album, monkeypatch):
+        state, *_ = cache_with_album
+        _shared_mod.cache = _RebuildFailsCache(state)
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "renamed-album")
+        ))
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert "rebuild_state" in result.get("warning", "")
+
+    def test_cache_failure_with_collision_rebuilds_only_once(self, cache_with_album, monkeypatch):
+        """Recovery rebuild covers the collision path — no double rebuild."""
+        state, content_root, audio_root, documents_root = cache_with_album
+        state["album_collisions"] = [{
+            "slug": "original-album",
+            "kept": {"genre": "electronic", "path": state["albums"]["original-album"]["path"]},
+            "shadowed": [{"genre": "rock", "path": "/nowhere/rock/original-album"}],
+        }]
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_album("original-album", "renamed-album")
+        ))
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 1
+
+    def test_track_rename_recovers_via_rebuild(self, cache_with_album, monkeypatch):
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_track(
+                "original-album", "01-first-track", "01-renamed-track"
+            )
+        ))
+        assert result["success"] is True
+        assert _shared_mod.cache.rebuild_calls == 1
+        assert result.get("cache_rebuilt") is True
+
+    def test_track_rename_warns_when_rebuild_also_fails(self, cache_with_album, monkeypatch):
+        state, *_ = cache_with_album
+        _shared_mod.cache = _RebuildFailsCache(state)
+        self._fail_write_state(monkeypatch)
+        result = json.loads(_run(
+            _rename_mod.rename_track(
+                "original-album", "01-first-track", "01-renamed-track"
+            )
+        ))
+        assert result["success"] is True
+        assert "rebuild_state" in result.get("warning", "")

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -12,6 +12,7 @@ Usage:
 import copy
 import errno
 import json
+import logging
 import os
 import shutil
 import sys
@@ -714,6 +715,175 @@ class TestBuildConfigSection:
 
 
 @pytest.mark.unit
+class TestBuildConfigSectionTypeGuards:
+    """Mistyped config values must fall back to defaults, not crash (#391)."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_mtime(self, monkeypatch):
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+    def test_max_lyric_words_garbage_string_uses_default(self, caplog):
+        config = {'generation': {'max_lyric_words': 'lots'}}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['generation']['max_lyric_words'] == 800
+        assert 'max_lyric_words' in caplog.text
+
+    def test_max_lyric_words_list_uses_default(self):
+        config = {'generation': {'max_lyric_words': [800]}}
+        section = build_config_section(config)
+        assert section['generation']['max_lyric_words'] == 800
+
+    def test_max_lyric_words_numeric_string_parses(self):
+        config = {'generation': {'max_lyric_words': '750'}}
+        section = build_config_section(config)
+        assert section['generation']['max_lyric_words'] == 750
+
+    def test_max_lyric_words_bool_uses_default(self):
+        # int(True) == 1 would silently mangle the limit
+        config = {'generation': {'max_lyric_words': True}}
+        section = build_config_section(config)
+        assert section['generation']['max_lyric_words'] == 800
+
+    def test_max_lyric_words_inf_uses_default(self, caplog):
+        # YAML `.inf` parses to float('inf'); int() raises OverflowError
+        config = {'generation': {'max_lyric_words': yaml.safe_load('.inf')}}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['generation']['max_lyric_words'] == 800
+        assert 'max_lyric_words' in caplog.text
+
+    def test_max_lyric_words_negative_inf_uses_default(self, caplog):
+        config = {'generation': {'max_lyric_words': yaml.safe_load('-.inf')}}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['generation']['max_lyric_words'] == 800
+        assert 'max_lyric_words' in caplog.text
+
+    def test_numeric_content_root_uses_default(self):
+        config = {'paths': {'content_root': 42}}
+        section = build_config_section(config)
+        assert section['content_root'] == str(Path('.').resolve())
+        assert section['audio_root'] == str(Path('./audio').resolve())
+        assert section['documents_root'] == str(Path('./documents').resolve())
+
+    def test_non_dict_paths_section_uses_defaults(self, caplog):
+        config = {'paths': ['a', 'b']}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['content_root'] == str(Path('.').resolve())
+        assert section['audio_root'] == str(Path('./audio').resolve())
+        assert section['documents_root'] == str(Path('./documents').resolve())
+        assert 'paths' in caplog.text
+
+    def test_non_string_audio_root_falls_back(self):
+        config = {'paths': {'content_root': '/tmp/c', 'audio_root': {'oops': 1}}}
+        section = build_config_section(config)
+        assert section['audio_root'] == str(Path('/tmp/c/audio').resolve())
+
+    def test_non_string_overrides_falls_back(self):
+        config = {'paths': {'content_root': '/tmp/c', 'overrides': 123}}
+        section = build_config_section(config)
+        assert section['overrides_dir'] == str(Path('/tmp/c').resolve() / 'overrides')
+
+    def test_non_dict_generation_section_uses_defaults(self):
+        config = {'generation': 'text'}
+        section = build_config_section(config)
+        assert section['generation']['service'] == 'suno'
+        assert section['generation']['max_lyric_words'] == 800
+        assert section['generation']['require_suno_link_for_final'] is True
+        assert section['generation']['additional_genres'] == []
+
+    def test_non_dict_artist_and_database_sections_use_defaults(self):
+        config = {'artist': ['band'], 'database': 'yes'}
+        section = build_config_section(config)
+        assert section['artist_name'] == ''
+        assert section['database']['enabled'] is False
+
+    def test_falsy_non_dict_section_warns(self, caplog):
+        # Falsy non-mappings (`paths: []`, `paths: false`) must warn like
+        # truthy ones do, not slip through normalization silently
+        config = {'paths': []}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['content_root'] == str(Path('.').resolve())
+        assert 'paths' in caplog.text
+
+    def test_non_string_artist_name_uses_default(self, caplog):
+        config = {'artist': {'name': 42}}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['artist_name'] == ''
+        assert 'name' in caplog.text
+
+    def test_build_state_non_string_artist_name_does_not_crash(self, tmp_path):
+        # content_root / "artists" / 42 raises TypeError without the guard
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+
+        config = {
+            'artist': {'name': 42},
+            'paths': {'content_root': str(content_root)},
+        }
+        state = build_state(config)
+        assert state['config']['artist_name'] == ''
+        assert state['albums'] == {}
+
+    def test_non_string_ideas_file_falls_back(self, tmp_path):
+        # scan_ideas resolves paths.ideas_file too — same guard applies
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        shutil.copy(FIXTURES_DIR / "ideas.md", content_root / "IDEAS.md")
+
+        config = {'paths': {'ideas_file': 42}}
+        result = scan_ideas(config, content_root)
+        assert len(result['items']) == 4
+
+    def test_non_mapping_database_section_does_not_leak_values(self, caplog):
+        # A dash-list database section carries credentials — the warning
+        # must name the key and type only, never the raw value
+        config = {'database': ['host: db.example.com', 'password: hunter2secret']}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['database']['enabled'] is False
+        assert 'database' in caplog.text
+        assert 'hunter2secret' not in caplog.text
+
+    def test_database_enabled_warning_does_not_leak_value(self, caplog):
+        # Same no-leak rule for scalar values inside the database section
+        config = {'database': {'enabled': 'hunter2secret'}}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['database']['enabled'] is False
+        assert 'hunter2secret' not in caplog.text
+
+    def test_blank_path_keys_silently_default(self, caplog):
+        # `overrides:` / `content_root:` with no value parse to None — that
+        # means "unset" (#376 semantics), so default silently, no warning
+        config = {'paths': {'content_root': None, 'overrides': None}}
+        with caplog.at_level(logging.WARNING):
+            section = build_config_section(config)
+        assert section['content_root'] == str(Path('.').resolve())
+        assert section['overrides_dir'] == str(Path('.').resolve() / 'overrides')
+        assert not any(
+            r.levelno >= logging.WARNING for r in caplog.records
+        )
+
+    def test_blank_ideas_file_silently_defaults(self, tmp_path, caplog):
+        # `ideas_file:` with no value parses to None — unset, not a warning
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        shutil.copy(FIXTURES_DIR / "ideas.md", content_root / "IDEAS.md")
+
+        config = {'paths': {'ideas_file': None}}
+        with caplog.at_level(logging.WARNING):
+            result = scan_ideas(config, content_root)
+        assert len(result['items']) == 4
+        assert 'ideas_file' not in caplog.text
+
+
+@pytest.mark.unit
 class TestReadConfig:
     """Tests for read_config()."""
 
@@ -766,6 +936,35 @@ class TestReadConfig:
         result = read_config()
         assert result == {}
 
+    def test_top_level_list_returns_none_with_error(self, tmp_path, monkeypatch, caplog):
+        # Valid YAML, wrong shape — must not leak a non-dict that crashes
+        # _cfg_section's config.get() during rebuild/update (#389)
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("- foo\n- bar\n")
+
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'CONFIG_FILE', config_path)
+
+        with caplog.at_level(logging.ERROR):
+            result = read_config()
+        assert result is None
+        assert any(
+            str(config_path) in r.message and "list" in r.message
+            for r in caplog.records
+        )
+
+    def test_top_level_scalar_returns_none(self, tmp_path, monkeypatch, caplog):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("just a string\n")
+
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'CONFIG_FILE', config_path)
+
+        with caplog.at_level(logging.ERROR):
+            result = read_config()
+        assert result is None
+        assert "str" in caplog.text
+
 
 @pytest.mark.unit
 class TestReadWriteState:
@@ -813,6 +1012,41 @@ class TestReadWriteState:
 
         result = read_state()
         assert result == {}
+
+    def test_read_json_array_backed_up_returns_empty(self, tmp_path, monkeypatch, caplog):
+        # JSON-valid but not an object — same recovery as corrupted JSON:
+        # warn, back up the file, return empty state
+        _override_indexer_paths(monkeypatch, tmp_path)
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text('["valid", "json", "wrong shape"]')
+
+        with caplog.at_level(logging.ERROR):
+            result = read_state()
+        assert result == {}
+        backups = list(tmp_path.glob("state.*.corrupt"))
+        assert len(backups) == 1
+        assert 'list' in caplog.text
+
+    def test_read_json_string_returns_empty(self, tmp_path, monkeypatch):
+        _override_indexer_paths(monkeypatch, tmp_path)
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text('"just a string"')
+
+        result = read_state()
+        assert result == {}
+        assert len(list(tmp_path.glob("state.*.corrupt"))) == 1
+
+    def test_read_json_number_returns_empty(self, tmp_path, monkeypatch):
+        _override_indexer_paths(monkeypatch, tmp_path)
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text('42')
+
+        result = read_state()
+        assert result == {}
+        assert len(list(tmp_path.glob("state.*.corrupt"))) == 1
 
     def test_write_creates_cache_dir(self, tmp_path, monkeypatch):
         new_cache = tmp_path / "new_cache_dir"
@@ -2191,6 +2425,87 @@ class TestMigrateStateEdgeCases:
         result = migrate_state(state)
         assert result is not None
         assert result['keep'] == 'me'
+
+    def test_float_version_triggers_rebuild(self):
+        # JSON "version": 1.2 parses as a float — non-string => rebuild (#393)
+        state = {'version': 1.2}
+        result = migrate_state(state)
+        assert result is None
+
+    def test_int_version_triggers_rebuild(self):
+        state = {'version': 1}
+        result = migrate_state(state)
+        assert result is None
+
+    def test_null_version_triggers_rebuild(self):
+        # Explicit JSON null — key exists, so .get() default doesn't apply
+        state = {'version': None}
+        result = migrate_state(state)
+        assert result is None
+
+    def test_list_version_triggers_rebuild(self):
+        state = {'version': ['1', '0', '0']}
+        result = migrate_state(state)
+        assert result is None
+
+    def test_list_state_triggers_rebuild(self, caplog):
+        # state.json can be JSON-valid but not an object — .get() would
+        # crash one line above the version guard
+        with caplog.at_level(logging.WARNING):
+            assert migrate_state(['not', 'a', 'dict']) is None
+        assert 'rebuild' in caplog.text.lower()
+
+    def test_string_state_triggers_rebuild(self):
+        assert migrate_state('garbage') is None
+
+    def test_int_state_triggers_rebuild(self):
+        assert migrate_state(42) is None
+
+
+@pytest.mark.unit
+class TestIncrementalUpdateWrongTypedSections:
+    """Wrong-typed state sections trigger a full rebuild, not a crash (#393 family)."""
+
+    def _config_for(self, tmp_path):
+        return {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(tmp_path / "content")},
+        }
+
+    def test_config_section_list_returns_none(self, tmp_path, monkeypatch, caplog):
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 1000.0)
+
+        state = _make_minimal_state(config=['not', 'a', 'mapping'])
+        with caplog.at_level(logging.WARNING):
+            result = incremental_update(state, self._config_for(tmp_path))
+        assert result is None
+        assert 'config' in caplog.text
+
+    def test_config_section_none_returns_none(self, tmp_path, monkeypatch):
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 1000.0)
+
+        state = _make_minimal_state(config=None)
+        assert incremental_update(state, self._config_for(tmp_path)) is None
+
+    def test_albums_section_string_returns_none(self, tmp_path, monkeypatch, caplog):
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 1000.0)
+
+        # Albums dir must exist and config_mtime must match so the
+        # incremental path actually reads the albums map
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "an-album")
+
+        state = _make_minimal_state(albums='x')
+        state['config']['content_root'] = str(content_root)
+        state['config']['config_mtime'] = 1000.0
+
+        with caplog.at_level(logging.WARNING):
+            result = incremental_update(state, self._config_for(tmp_path))
+        assert result is None
+        assert 'albums' in caplog.text
 
 
 @pytest.mark.unit

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -71,6 +71,7 @@ def _make_minimal_state(**overrides):
             'config_mtime': 1000.0,
         },
         'albums': {},
+        'album_collisions': [],
         'ideas': {'counts': {}, 'items': [], 'file_mtime': 0.0},
         'skills': {
             'skills_root': '/tmp/skills',
@@ -442,6 +443,43 @@ class TestValidateState:
         errors = validate_state(state)
         assert errors == []
 
+    def test_album_collisions_valid_entries(self):
+        state = _make_minimal_state(album_collisions=[
+            {
+                'slug': 'midnight',
+                'kept': {'genre': 'jazz', 'path': '/tmp/albums/jazz/midnight'},
+                'shadowed': [
+                    {'genre': 'rock', 'path': '/tmp/albums/rock/midnight'},
+                ],
+            }
+        ])
+        errors = validate_state(state)
+        assert errors == [], f"Unexpected errors: {errors}"
+
+    def test_album_collisions_missing_field_ok(self):
+        """Old states lack album_collisions — not an error (migration adds it)."""
+        state = _make_minimal_state()
+        del state['album_collisions']
+        errors = validate_state(state)
+        assert not any('album_collisions' in e for e in errors)
+
+    def test_album_collisions_not_a_list(self):
+        state = _make_minimal_state(album_collisions="bad")
+        errors = validate_state(state)
+        assert any('album_collisions should be a list' in e for e in errors)
+
+    def test_album_collisions_entry_not_dict(self):
+        state = _make_minimal_state(album_collisions=["bad"])
+        errors = validate_state(state)
+        assert any('album_collisions' in e and 'should be a dict' in e
+                   for e in errors)
+
+    def test_album_collisions_entry_missing_keys(self):
+        state = _make_minimal_state(album_collisions=[{'slug': 'midnight'}])
+        errors = validate_state(state)
+        assert any("missing 'kept'" in e for e in errors)
+        assert any("missing 'shadowed'" in e for e in errors)
+
 
 @pytest.mark.unit
 class TestMigrateState:
@@ -477,7 +515,7 @@ class TestMigrateState:
         assert result is None
 
     def test_same_major_minor_difference_no_rebuild(self):
-        # Same major, migration chain applies 1.0.0 → 1.1.0 → 1.2.0
+        # Same major, migration chain applies 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0
         state = {'version': '1.0.0'}
         result = migrate_state(state)
         assert result is not None
@@ -1031,6 +1069,109 @@ mastering:
         assert "no-mastering-album" in result
         assert result["no-mastering-album"]["mastering"] == {}
 
+    def test_slug_collision_lexicographic_genre_wins(self, tmp_path):
+        """#392: same slug under two genres — lexicographically-first genre
+        wins, the other is recorded as shadowed, never overwritten."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(
+            content_root, "testartist", "rock", "midnight",
+            tracks={"01-rock.md": _make_track_content("Rock Track")})
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        assert list(result.keys()) == ["midnight"]
+        album = result["midnight"]
+        assert album["genre"] == "jazz"
+        assert album["path"] == str(jazz_dir)
+        assert "01-jazz" in album["tracks"]
+        assert "01-rock" not in album["tracks"]
+
+        assert collisions == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }]
+
+    def test_slug_collision_without_out_param_no_overwrite(self, tmp_path):
+        """#392: even without the collisions out-param, the winner is
+        never overwritten by a later genre."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "midnight")
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+
+        result = scan_albums(content_root, "testartist")
+        assert result["midnight"]["genre"] == "jazz"
+        assert result["midnight"]["path"] == str(jazz_dir)
+
+    def test_three_way_collision_accumulates_shadowed(self, tmp_path):
+        """#392: 3-way collision yields one record with two shadowed
+        entries sorted by genre."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+        ambient_dir = _make_album_tree(
+            content_root, "testartist", "ambient", "midnight")
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        assert result["midnight"]["genre"] == "ambient"
+        assert len(collisions) == 1
+        record = collisions[0]
+        assert record['kept'] == {'genre': 'ambient', 'path': str(ambient_dir)}
+        assert record['shadowed'] == [
+            {'genre': 'jazz', 'path': str(jazz_dir)},
+            {'genre': 'rock', 'path': str(rock_dir)},
+        ]
+
+    def test_slug_collision_unreadable_first_twin_records_actual_winner(
+            self, tmp_path):
+        """#392: when the lexicographically-first twin's README is
+        unreadable, the next parseable twin wins AND the collision is
+        still recorded with kept = the twin actually indexed."""
+        content_root = tmp_path / "content"
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        # Invalid UTF-8 makes parse_album_readme fail even when running
+        # as root (unlike chmod-based unreadability).
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+        b_dir = _make_album_tree(
+            content_root, "testartist", "b-genre", "midnight",
+            tracks={"01-b.md": _make_track_content("B Track")})
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        album = result["midnight"]
+        assert album["genre"] == "b-genre"
+        assert album["path"] == str(b_dir)
+        assert "01-b" in album["tracks"]
+        assert collisions == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'b-genre', 'path': str(b_dir)},
+            'shadowed': [{'genre': 'a-genre', 'path': str(a_dir)}],
+        }]
+        # Invariant: the record's kept entry is the entry in the map.
+        assert collisions[0]['kept']['path'] == album['path']
+
+    def test_slug_collision_no_parseable_twin_no_entry_no_record(self, tmp_path):
+        """#392: when NO same-slug candidate parses, there is no album
+        entry and no collision record (parse warnings already fire)."""
+        content_root = tmp_path / "content"
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+        b_dir = _make_album_tree(content_root, "testartist", "b-genre", "midnight")
+        (b_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+
+        collisions = []
+        result = scan_albums(content_root, "testartist", collisions)
+
+        assert result == {}
+        assert collisions == []
+
 
 @pytest.mark.unit
 class TestScanTracks:
@@ -1255,6 +1396,49 @@ class TestBuildState:
         assert state['config']['artist_name'] == 'myartist'
         assert state['config']['content_root'] == str(content_root)
         assert state['config']['config_mtime'] == 42.0
+
+    def test_build_state_album_collisions_empty_when_clean(self, tmp_path, monkeypatch):
+        """#392: album_collisions is always present, [] with no collisions."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "solo-album")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        state = build_state(config)
+        assert state['album_collisions'] == []
+
+    def test_build_state_album_collisions_populated(self, tmp_path, monkeypatch):
+        """#392: on-disk collision surfaces in album_collisions and the
+        winner's tracks stay intact."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(
+            content_root, "testartist", "rock", "midnight",
+            tracks={"01-rock.md": _make_track_content("Rock Track")})
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        state = build_state(config)
+        assert state['album_collisions'] == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }]
+        album = state['albums']['midnight']
+        assert album['genre'] == 'jazz'
+        assert '01-jazz' in album['tracks']
 
 
 @pytest.mark.unit
@@ -1536,6 +1720,234 @@ anchor_track: 3
 
         updated = incremental_update(existing, config)
         assert updated['albums']['my-album']['anchor_track'] == 3
+
+    def test_collision_detected_on_incremental_update(self, tmp_path, monkeypatch):
+        """#392: a cross-genre twin appearing after the initial build is
+        detected and the winner (with its tracks) survives the removal loop."""
+        content_root = tmp_path / "content"
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['album_collisions'] == []
+
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        updated = incremental_update(existing, config)
+        assert updated['album_collisions'] == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }]
+        album = updated['albums']['midnight']
+        assert album['genre'] == 'jazz'
+        assert '01-jazz' in album['tracks']
+
+    def test_collision_winner_deterministic_on_update(self, tmp_path, monkeypatch):
+        """#392: the lexicographically-first genre wins even when the
+        cached entry points at the other genre (deterministic regardless
+        of dict/filesystem order)."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['albums']['midnight']['genre'] == 'rock'
+
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+
+        updated = incremental_update(existing, config)
+        assert 'midnight' in updated['albums']
+        assert updated['albums']['midnight']['genre'] == 'jazz'
+        assert updated['albums']['midnight']['path'] == str(jazz_dir)
+        assert updated['album_collisions'][0]['kept']['genre'] == 'jazz'
+        assert updated['album_collisions'][0]['shadowed'][0]['genre'] == 'rock'
+
+    def test_collision_cleared_when_resolved_on_disk(self, tmp_path, monkeypatch):
+        """#392: removing the shadowed twin clears album_collisions on
+        the next incremental update."""
+        content_root = tmp_path / "content"
+        _make_album_tree(content_root, "testartist", "jazz", "midnight")
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert len(existing['album_collisions']) == 1
+
+        shutil.rmtree(rock_dir)
+
+        updated = incremental_update(existing, config)
+        assert updated['album_collisions'] == []
+        assert updated['albums']['midnight']['genre'] == 'jazz'
+
+    def test_collision_path_mismatch_triggers_reparse(self, tmp_path, monkeypatch):
+        """#392: a cached entry whose path points at the shadowed twin
+        must be fully re-parsed even when README mtimes match — otherwise
+        the twin's data is wrongly reused for the winner."""
+        content_root = tmp_path / "content"
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['albums']['midnight']['path'] == str(rock_dir)
+
+        jazz_readme = """---
+title: "Jazz Midnight"
+genres: ["jazz"]
+explicit: false
+---
+
+# Jazz Midnight
+
+## Album Details
+
+| Attribute | Detail |
+|-----------|--------|
+| **Status** | Concept |
+| **Tracks** | 0 |
+"""
+        jazz_dir = _make_album_tree(
+            content_root, "testartist", "jazz", "midnight",
+            readme_text=jazz_readme,
+            tracks={"01-jazz.md": _make_track_content("Jazz Track")})
+        # Force the winner's README mtime to equal the cached (rock)
+        # mtime so only the path check can trigger the re-parse.
+        cached_mtime = existing['albums']['midnight']['readme_mtime']
+        os.utime(jazz_dir / "README.md", (cached_mtime, cached_mtime))
+
+        updated = incremental_update(existing, config)
+        album = updated['albums']['midnight']
+        assert album['path'] == str(jazz_dir)
+        assert album['genre'] == 'jazz'
+        assert album['title'] == 'Jazz Midnight'
+        assert '01-jazz' in album['tracks']
+
+    def test_collision_unreadable_new_twin_keeps_cached_winner(
+            self, tmp_path, monkeypatch):
+        """#392: cached winner is b-genre; an unreadable a-genre twin
+        appears. The record must report kept = the entry actually in the
+        albums map (b-genre), not claim the unreadable a-genre won."""
+        content_root = tmp_path / "content"
+        b_dir = _make_album_tree(content_root, "testartist", "b-genre", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        assert existing['albums']['midnight']['path'] == str(b_dir)
+
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+
+        updated = incremental_update(existing, config)
+        album = updated['albums']['midnight']
+        assert album['path'] == str(b_dir)
+        assert album['genre'] == 'b-genre'
+        assert updated['album_collisions'] == [{
+            'slug': 'midnight',
+            'kept': {'genre': 'b-genre', 'path': str(b_dir)},
+            'shadowed': [{'genre': 'a-genre', 'path': str(a_dir)}],
+        }]
+        assert updated['album_collisions'][0]['kept']['path'] == album['path']
+
+    def test_collision_unreadable_first_twin_incremental_agrees_with_rebuild(
+            self, tmp_path, monkeypatch):
+        """#392: with the first twin's README unreadable, incremental
+        update picks the SAME winner and emits the SAME collision record
+        as a full rebuild, and kept.path matches the albums map."""
+        content_root = tmp_path / "content"
+        a_dir = _make_album_tree(content_root, "testartist", "a-genre", "midnight")
+        (a_dir / "README.md").write_bytes(b'\xff\xfe\x00garbage')
+        b_dir = _make_album_tree(content_root, "testartist", "b-genre", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        expected_record = {
+            'slug': 'midnight',
+            'kept': {'genre': 'b-genre', 'path': str(b_dir)},
+            'shadowed': [{'genre': 'a-genre', 'path': str(a_dir)}],
+        }
+        assert existing['albums']['midnight']['path'] == str(b_dir)
+        assert existing['album_collisions'] == [expected_record]
+
+        updated = incremental_update(existing, config)
+        album = updated['albums']['midnight']
+        assert album['path'] == str(b_dir)
+        assert album['genre'] == 'b-genre'
+        assert updated['album_collisions'] == [expected_record]
+        assert updated['album_collisions'][0]['kept']['path'] == album['path']
+
+    def test_collision_both_parseable_first_genre_wins_both_paths(
+            self, tmp_path, monkeypatch):
+        """#392: with both READMEs parseable the lexicographically-first
+        genre still wins on both the rebuild and incremental paths."""
+        content_root = tmp_path / "content"
+        jazz_dir = _make_album_tree(content_root, "testartist", "jazz", "midnight")
+        rock_dir = _make_album_tree(content_root, "testartist", "rock", "midnight")
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+        expected_record = {
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': str(jazz_dir)},
+            'shadowed': [{'genre': 'rock', 'path': str(rock_dir)}],
+        }
+        assert existing['albums']['midnight']['path'] == str(jazz_dir)
+        assert existing['album_collisions'] == [expected_record]
+
+        updated = incremental_update(existing, config)
+        assert updated['albums']['midnight']['path'] == str(jazz_dir)
+        assert updated['albums']['midnight']['genre'] == 'jazz'
+        assert updated['album_collisions'] == [expected_record]
 
 
 @pytest.mark.unit
@@ -1997,8 +2409,8 @@ class TestMigrate1_0To1_1:
         }
         result = migrate_state(state)
         assert result is not None
-        # Full chain: 1.0.0 → 1.1.0 → 1.2.0
-        assert result['version'] == '1.2.0'
+        # Full chain: 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0
+        assert result['version'] == '1.3.0'
         assert 'skills' in result
         assert result['skills']['count'] == 0
         assert result['skills']['items'] == {}
@@ -2275,7 +2687,7 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         assert 'plugin_version' in result
         assert result['plugin_version'] is None
 
@@ -2311,8 +2723,77 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         assert result['plugin_version'] == '0.43.0'
+
+
+@pytest.mark.unit
+class TestMigrate1_2To1_3:
+    """Tests for the 1.2.0 → 1.3.0 migration (#392)."""
+
+    def _state_1_2(self, **overrides):
+        state = {
+            'version': '1.2.0',
+            'generated_at': '2026-01-01T00:00:00+00:00',
+            'plugin_version': None,
+            'config': {
+                'content_root': '/tmp/c',
+                'audio_root': '/tmp/a',
+                'documents_root': '/tmp/d',
+                'artist_name': 'test',
+                'config_mtime': 100.0,
+            },
+            'albums': {},
+            'ideas': {'counts': {}, 'items': [], 'file_mtime': 0.0},
+            'skills': {
+                'skills_root': '/tmp/skills',
+                'skills_root_mtime': 0.0,
+                'count': 0,
+                'model_counts': {},
+                'items': {},
+            },
+            'session': {
+                'last_album': None,
+                'last_track': None,
+                'last_phase': None,
+                'pending_actions': [],
+                'updated_at': None,
+            },
+        }
+        state.update(overrides)
+        return state
+
+    def test_migration_adds_album_collisions(self):
+        """State from v1.2.0 gets album_collisions field via migration."""
+        result = migrate_state(self._state_1_2())
+        assert result is not None
+        assert result['version'] == '1.3.0'
+        assert result['album_collisions'] == []
+
+    def test_migration_preserves_existing_album_collisions(self):
+        """If album_collisions already exists, migration preserves it."""
+        collision = {
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': '/tmp/jazz/midnight'},
+            'shadowed': [{'genre': 'rock', 'path': '/tmp/rock/midnight'}],
+        }
+        result = migrate_state(self._state_1_2(album_collisions=[collision]))
+        assert result is not None
+        assert result['version'] == '1.3.0'
+        assert result['album_collisions'] == [collision]
+
+    def test_full_chain_1_0_to_1_3(self):
+        """Existing 1.0 → 1.2 chain still works and now ends at 1.3.0."""
+        state = self._state_1_2()
+        state['version'] = '1.0.0'
+        del state['plugin_version']
+        del state['skills']
+        result = migrate_state(state)
+        assert result is not None
+        assert result['version'] == CURRENT_VERSION == '1.3.0'
+        assert 'skills' in result
+        assert 'plugin_version' in result
+        assert result['album_collisions'] == []
 
 
 @pytest.mark.unit
@@ -2359,7 +2840,7 @@ class TestValidateStatePluginVersion:
 
 @pytest.mark.unit
 class TestFullMigrationChain:
-    """Tests for the complete migration chain 1.0.0 → 1.2.0."""
+    """Tests for the complete migration chain 1.0.0 → 1.3.0."""
 
     def test_1_0_to_1_2_adds_both_skills_and_plugin_version(self):
         """Full chain from 1.0.0 adds skills AND plugin_version."""
@@ -2385,7 +2866,7 @@ class TestFullMigrationChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         # From 1.0→1.1 migration
         assert 'skills' in result
         assert result['skills']['count'] == 0
@@ -2609,7 +3090,7 @@ class TestMigrateStateChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.2.0'
+        assert result['version'] == '1.3.0'
         assert result['plugin_version'] is None
 
     def test_migration_does_not_overwrite_existing_skills(self):
@@ -3057,6 +3538,45 @@ class TestIncrementalUpdateAlbumsDirMissing:
         # Stale album should still be in state since albums_dir doesn't exist
         # (the code only cleans up when albums_dir.exists() is True)
         assert 'albums' in updated
+
+    def test_albums_dir_missing_preserves_collisions(self, tmp_path, monkeypatch):
+        """#392: when albums dir doesn't exist the albums map is
+        deliberately preserved — album_collisions must be preserved with
+        it, not wiped to []."""
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        # Don't create artists/testartist/albums/
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        collision = {
+            'slug': 'midnight',
+            'kept': {'genre': 'jazz', 'path': '/tmp/gone/jazz/midnight'},
+            'shadowed': [{'genre': 'rock', 'path': '/tmp/gone/rock/midnight'}],
+        }
+        existing = _make_minimal_state(album_collisions=[collision])
+        existing['config']['config_mtime'] = 100.0
+        existing['config']['content_root'] = str(content_root)
+        existing['config']['artist_name'] = 'testartist'
+        existing['albums'] = {
+            'midnight': {
+                'path': '/tmp/gone/jazz/midnight',
+                'genre': 'jazz',
+                'title': 'Midnight',
+                'status': 'Concept',
+                'tracks': {},
+                'readme_mtime': 100.0,
+            }
+        }
+
+        updated = incremental_update(existing, config)
+        assert 'midnight' in updated['albums']
+        assert updated['album_collisions'] == [collision]
 
 
 @pytest.mark.unit

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -594,6 +594,57 @@ class TestBuildConfigSection:
         section = build_config_section(config)
         assert section['artist_name'] == ''
 
+    def test_quoted_boolean_strings_do_not_invert(self, monkeypatch):
+        """Quoted "false"/"no" config booleans must not become True (#388)."""
+        config = {
+            'artist': {'name': 'test'},
+            'paths': {'content_root': '/tmp/c'},
+            'database': {'enabled': 'false', 'host': 'db.example', 'name': 'tweets'},
+            'generation': {
+                'require_suno_link_for_final': 'false',
+                'require_source_path_for_documentary': 'no',
+            },
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        section = build_config_section(config)
+        assert section['database']['enabled'] is False
+        # Credentials stay masked when the flag resolves False
+        assert section['database']['host'] == ''
+        assert section['database']['name'] == ''
+        assert section['generation']['require_suno_link_for_final'] is False
+        assert section['generation']['require_source_path_for_documentary'] is False
+
+    def test_quoted_true_boolean_strings_enable(self, monkeypatch):
+        config = {
+            'artist': {'name': 'test'},
+            'paths': {'content_root': '/tmp/c'},
+            'database': {'enabled': 'true', 'host': 'db.example', 'name': 'tweets'},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        section = build_config_section(config)
+        assert section['database']['enabled'] is True
+        assert section['database']['host'] == 'db.example'
+        assert section['database']['name'] == 'tweets'
+
+    def test_garbage_boolean_string_uses_default(self, monkeypatch):
+        """Unparseable boolean strings fall back to the key's default."""
+        config = {
+            'artist': {'name': 'test'},
+            'paths': {'content_root': '/tmp/c'},
+            'database': {'enabled': 'maybe'},
+            'generation': {'require_suno_link_for_final': 'sometimes'},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 0.0)
+
+        section = build_config_section(config)
+        assert section['database']['enabled'] is False  # default False
+        assert section['generation']['require_suno_link_for_final'] is True  # default True
+
     def test_documents_root_derives_from_content_root(self, monkeypatch):
         config = {
             'artist': {'name': 'test'},
@@ -2409,8 +2460,8 @@ class TestMigrate1_0To1_1:
         }
         result = migrate_state(state)
         assert result is not None
-        # Full chain: 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0
-        assert result['version'] == '1.3.0'
+        # Full chain: 1.0.0 → 1.1.0 → 1.2.0 → 1.3.0 → 1.4.0
+        assert result['version'] == '1.4.0'
         assert 'skills' in result
         assert result['skills']['count'] == 0
         assert result['skills']['items'] == {}
@@ -2687,7 +2738,7 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert 'plugin_version' in result
         assert result['plugin_version'] is None
 
@@ -2723,7 +2774,7 @@ class TestMigrate1_1To1_2:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['plugin_version'] == '0.43.0'
 
 
@@ -2767,7 +2818,7 @@ class TestMigrate1_2To1_3:
         """State from v1.2.0 gets album_collisions field via migration."""
         result = migrate_state(self._state_1_2())
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['album_collisions'] == []
 
     def test_migration_preserves_existing_album_collisions(self):
@@ -2779,7 +2830,7 @@ class TestMigrate1_2To1_3:
         }
         result = migrate_state(self._state_1_2(album_collisions=[collision]))
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['album_collisions'] == [collision]
 
     def test_full_chain_1_0_to_1_3(self):
@@ -2790,10 +2841,78 @@ class TestMigrate1_2To1_3:
         del state['skills']
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == CURRENT_VERSION == '1.3.0'
+        assert result['version'] == CURRENT_VERSION == '1.4.0'
         assert 'skills' in result
         assert 'plugin_version' in result
         assert result['album_collisions'] == []
+
+
+@pytest.mark.unit
+class TestMigrate13To14:
+    """Tests for the 1.3.0 → 1.4.0 migration (#388): re-coerce cached
+    explicit values that were stored as truthy strings by the old parsers."""
+
+    def _state_1_3(self, albums):
+        state = {
+            'version': '1.3.0',
+            'generated_at': '2026-01-01T00:00:00+00:00',
+            'plugin_version': None,
+            'config': {
+                'content_root': '/tmp/c',
+                'audio_root': '/tmp/a',
+                'documents_root': '/tmp/d',
+                'artist_name': 'test',
+                'config_mtime': 100.0,
+            },
+            'albums': albums,
+            'album_collisions': [],
+            'ideas': {'counts': {}, 'items': [], 'file_mtime': 0.0},
+            'skills': {
+                'skills_root': '/tmp/skills',
+                'skills_root_mtime': 0.0,
+                'count': 0,
+                'model_counts': {},
+                'items': {},
+            },
+            'session': {
+                'last_album': None,
+                'last_track': None,
+                'last_phase': None,
+                'pending_actions': [],
+                'updated_at': None,
+            },
+        }
+        return state
+
+    def test_recoerces_cached_string_explicit_values(self):
+        albums = {
+            'my-album': {
+                'explicit': 'false',
+                'tracks': {
+                    '01-track': {'explicit': 'false'},
+                    '02-track': {'explicit': 'true'},
+                },
+            },
+        }
+        result = migrate_state(self._state_1_3(albums))
+        assert result is not None
+        assert result['version'] == '1.4.0'
+        assert result['albums']['my-album']['explicit'] is False
+        assert result['albums']['my-album']['tracks']['01-track']['explicit'] is False
+        assert result['albums']['my-album']['tracks']['02-track']['explicit'] is True
+
+    def test_garbage_explicit_defaults_false(self):
+        albums = {'a': {'explicit': 'maybe', 'tracks': {}}}
+        result = migrate_state(self._state_1_3(albums))
+        assert result is not None
+        assert result['albums']['a']['explicit'] is False
+
+    def test_real_bools_untouched(self):
+        albums = {'a': {'explicit': True, 'tracks': {'t': {'explicit': False}}}}
+        result = migrate_state(self._state_1_3(albums))
+        assert result is not None
+        assert result['albums']['a']['explicit'] is True
+        assert result['albums']['a']['tracks']['t']['explicit'] is False
 
 
 @pytest.mark.unit
@@ -2866,7 +2985,7 @@ class TestFullMigrationChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         # From 1.0→1.1 migration
         assert 'skills' in result
         assert result['skills']['count'] == 0
@@ -3090,7 +3209,7 @@ class TestMigrateStateChain:
         }
         result = migrate_state(state)
         assert result is not None
-        assert result['version'] == '1.3.0'
+        assert result['version'] == '1.4.0'
         assert result['plugin_version'] is None
 
     def test_migration_does_not_overwrite_existing_skills(self):

--- a/tests/unit/state/test_migration_tracking.py
+++ b/tests/unit/state/test_migration_tracking.py
@@ -8,6 +8,7 @@ the pure helpers that compute and surface pending migrations.
 """
 
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -179,6 +180,22 @@ class TestCarryMigrationTracking:
         result = carry_migration_tracking(new, existing)
         assert result['last_migrated_version'] is None
 
+    def test_non_string_value_dropped_to_none_with_warning(self, caplog):
+        # A wrong-typed value must not survive rebuilds only to crash
+        # get_pending_migrations' _version_compare later (#393 family).
+        new = {'last_migrated_version': "0.91.0"}
+        existing = {'last_migrated_version': 0.59}
+        with caplog.at_level(logging.WARNING):
+            result = carry_migration_tracking(new, existing)
+        assert result['last_migrated_version'] is None
+        assert 'last_migrated_version' in caplog.text
+
+    def test_list_value_dropped_to_none(self):
+        new = {'last_migrated_version': "0.91.0"}
+        existing = {'last_migrated_version': ['0', '59', '0']}
+        result = carry_migration_tracking(new, existing)
+        assert result['last_migrated_version'] is None
+
 
 # ---------------------------------------------------------------------------
 # parse_migration_file
@@ -263,6 +280,25 @@ class TestGetPendingMigrations:
         assert result['pending'] == []
         assert result['installed_version'] is None
         assert result['reason'] == 'unknown'
+
+    def test_non_string_last_migrated_treated_as_untracked(self, tmp_path, caplog):
+        # A wrong-typed value would crash _version_compare's .split —
+        # treat it like a missing value (same branch as untracked).
+        root = _make_plugin_root(tmp_path, "0.91.0", ["0.44.0", "0.91.0"])
+        with caplog.at_level(logging.WARNING):
+            result = get_pending_migrations({'last_migrated_version': 0.44}, root)
+        assert result['reason'] == 'untracked'
+        assert [m['version'] for m in result['pending']] == ["0.44.0", "0.91.0"]
+        assert result['last_migrated_version'] is None
+        assert 'last_migrated_version' in caplog.text
+
+    def test_list_last_migrated_treated_as_untracked(self, tmp_path):
+        root = _make_plugin_root(tmp_path, "0.91.0", ["0.91.0"])
+        result = get_pending_migrations(
+            {'last_migrated_version': ['0', '44', '0']}, root
+        )
+        assert result['reason'] == 'untracked'
+        assert [m['version'] for m in result['pending']] == ["0.91.0"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/state/test_parsers.py
+++ b/tests/unit/state/test_parsers.py
@@ -85,6 +85,27 @@ class TestParseAlbumReadme:
         assert result['track_count'] == 8
         assert result['release_date'] is None or result['release_date'] == ''
 
+    def test_quoted_explicit_false_frontmatter(self, tmp_path):
+        """Frontmatter explicit: "false" (quoted string) must parse to False, not the truthy string (#388)."""
+        path = tmp_path / "README.md"
+        path.write_text(
+            '---\ntitle: "Quoted Album"\nexplicit: "false"\n---\n\n# Quoted Album\n',
+            encoding='utf-8',
+        )
+        result = parse_album_readme(path)
+        assert '_error' not in result
+        assert result['explicit'] is False
+
+    def test_quoted_explicit_true_frontmatter(self, tmp_path):
+        path = tmp_path / "README.md"
+        path.write_text(
+            '---\ntitle: "Quoted Album"\nexplicit: "true"\n---\n\n# Quoted Album\n',
+            encoding='utf-8',
+        )
+        result = parse_album_readme(path)
+        assert '_error' not in result
+        assert result['explicit'] is True
+
     def test_tracklist_parsing(self):
         path = FIXTURES_DIR / "album-readme.md"
         result = parse_album_readme(path)
@@ -251,6 +272,27 @@ class TestParseTrackFile:
         path = FIXTURES_DIR / "does-not-exist.md"
         result = parse_track_file(path)
         assert '_error' in result
+
+    def test_quoted_explicit_false_frontmatter_fallback(self, tmp_path):
+        """Frontmatter explicit: "false" (quoted string) must not mark explicit (#388)."""
+        path = tmp_path / "01-track.md"
+        path.write_text(
+            '---\ntitle: "Quoted Track"\nexplicit: "false"\n---\n\n# Quoted Track\n',
+            encoding='utf-8',
+        )
+        result = parse_track_file(path)
+        assert '_error' not in result
+        assert result['explicit'] is False
+
+    def test_quoted_explicit_true_frontmatter_fallback(self, tmp_path):
+        path = tmp_path / "01-track.md"
+        path.write_text(
+            '---\ntitle: "Quoted Track"\nexplicit: "true"\n---\n\n# Quoted Track\n',
+            encoding='utf-8',
+        )
+        result = parse_track_file(path)
+        assert '_error' not in result
+        assert result['explicit'] is True
 
 
 class TestParseIdeasFile:

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -216,6 +216,23 @@ def _fresh_state():
     return copy.deepcopy(SAMPLE_STATE)
 
 
+def _state_with_collision(slug="test-album"):
+    """Sample state with an album_collisions record for the given slug (#392)."""
+    state = _fresh_state()
+    state["album_collisions"] = [{
+        "slug": slug,
+        "kept": {
+            "genre": "electronic",
+            "path": f"/tmp/test/artists/test-artist/albums/electronic/{slug}",
+        },
+        "shadowed": [{
+            "genre": "rock",
+            "path": f"/tmp/test/artists/test-artist/albums/rock/{slug}",
+        }],
+    }]
+    return state
+
+
 # ---------------------------------------------------------------------------
 # Re-export completeness — ensure server.py re-exports all registered tools
 # ---------------------------------------------------------------------------
@@ -926,6 +943,46 @@ class TestFindAlbum:
         assert "No albums found" in result["error"]
         assert result.get("rebuilt") is True
 
+    def test_collision_warning_on_collided_slug(self):
+        """Exact match on a collided slug includes a collision_warning."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("test-album")))
+        assert result["found"] is True
+        warning = result["collision_warning"]
+        assert warning["visible"]["genre"] == "electronic"
+        assert warning["shadowed"][0]["genre"] == "rock"
+        assert "rock" in warning["shadowed"][0]["path"]
+        assert "/bitwize-music:rename" in warning["message"]
+        assert "rebuild_state" in warning["message"]
+
+    def test_collision_warning_on_fuzzy_match(self):
+        """Fuzzy-resolved slug also gets the collision warning."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("test")))
+        assert result["found"] is True
+        assert result["slug"] == "test-album"
+        assert "collision_warning" in result
+
+    def test_no_collision_warning_on_clean_slug(self):
+        """A slug absent from album_collisions gets no warning."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("another-album")))
+        assert result["found"] is True
+        assert "collision_warning" not in result
+
+    def test_missing_collisions_field_does_not_crash(self):
+        """Pre-1.3.0 states without album_collisions work unchanged."""
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.find_album("test-album")))
+        assert result["found"] is True
+        assert "collision_warning" not in result
+
 
 # =============================================================================
 # Tests for MCP tool: list_albums
@@ -983,6 +1040,36 @@ class TestListAlbums:
         assert album["status"] == "In Progress"
         assert album["track_count"] == 2
         assert album["tracks_completed"] == 1
+
+    def test_collisions_surfaced_when_present(self):
+        """Non-empty album_collisions is echoed with a warning string."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.list_albums()))
+        assert result["collisions"][0]["slug"] == "test-album"
+        assert "test-album" in result["warning"]
+        assert "/bitwize-music:rename" in result["warning"]
+
+    def test_no_collisions_keys_when_clean(self):
+        """Empty album_collisions adds neither collisions nor warning."""
+        state = _fresh_state()
+        state["album_collisions"] = []
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.list_albums()))
+        assert "collisions" not in result
+        assert "warning" not in result
+
+    def test_missing_collisions_field_does_not_crash(self):
+        """Pre-1.3.0 states without album_collisions work unchanged."""
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.list_albums()))
+        assert result["count"] == 2
+        assert "collisions" not in result
+        assert "warning" not in result
 
 
 # =============================================================================
@@ -1163,6 +1250,38 @@ class TestRebuildStateTool:
             result = json.loads(_run(server.rebuild_state()))
         assert "error" in result
         assert "Config not found" in result["error"]
+
+    def test_collision_count_reported(self):
+        """A rebuild that detects collisions says so immediately."""
+        mock_cache = MockStateCache(_state_with_collision("test-album"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.rebuild_state()))
+        assert result["success"] is True
+        assert result["collision_count"] == 1
+        assert result["collisions"][0]["slug"] == "test-album"
+        assert "/bitwize-music:rename" in result["warning"]
+
+    def test_collision_count_zero_when_clean(self):
+        """Empty album_collisions reports zero without a details list."""
+        state = _fresh_state()
+        state["album_collisions"] = []
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.rebuild_state()))
+        assert result["collision_count"] == 0
+        assert "collisions" not in result
+        assert "warning" not in result
+
+    def test_missing_collisions_field_reports_zero(self):
+        """Rebuild result without album_collisions still reports a count."""
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.rebuild_state()))
+        assert result["success"] is True
+        assert result["collision_count"] == 0
+        assert "collisions" not in result
 
 
 # =============================================================================
@@ -4091,6 +4210,47 @@ class TestCreateAlbumStructure:
             result = json.loads(_run(server.create_album_structure("existing", "rock")))
         assert result["created"] is False
         assert "already exists" in result["error"]
+
+    def test_cross_genre_collision_rejected(self, tmp_path):
+        """Same slug under a DIFFERENT genre blocks creation (#392)."""
+        mock_cache, content = self._make_state_with_tmp(tmp_path)
+        existing = content / "artists" / "test-artist" / "albums" / "rock" / "existing"
+        existing.mkdir(parents=True)
+
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.create_album_structure("existing", "electronic")))
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        assert "rock" in result["error"]
+        assert str(existing) in result["error"]
+        assert "rename" in result["error"].lower()
+        # The colliding twin must NOT be created
+        twin = content / "artists" / "test-artist" / "albums" / "electronic" / "existing"
+        assert not twin.exists()
+
+    def test_glob_metachars_in_slug_do_not_false_collide(self, tmp_path):
+        """The collision sweep is literal — 'alb*m' must not match 'album' (#392)."""
+        mock_cache, content = self._make_state_with_tmp(tmp_path)
+        existing = content / "artists" / "test-artist" / "albums" / "rock" / "album"
+        existing.mkdir(parents=True)
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_shared_mod, "PLUGIN_ROOT", Path(__file__).resolve().parent.parent.parent.parent):
+            result = json.loads(_run(server.create_album_structure("alb*m", "electronic")))
+        # Under fnmatch semantics 'alb*m' matches 'album'; a literal sweep must not.
+        assert "already exists" not in result.get("error", "")
+
+    def test_new_slug_unaffected_by_other_albums(self, tmp_path):
+        """A genuinely new slug still succeeds when other albums exist (regression)."""
+        mock_cache, content = self._make_state_with_tmp(tmp_path)
+        other = content / "artists" / "test-artist" / "albums" / "rock" / "other-album"
+        other.mkdir(parents=True)
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_shared_mod, "PLUGIN_ROOT", Path(__file__).resolve().parent.parent.parent.parent):
+            result = json.loads(_run(server.create_album_structure("fresh-album", "electronic")))
+        assert result["created"] is True
+        assert Path(result["path"]).is_dir()
 
     def test_no_config(self):
         state = {"albums": {}, "ideas": {}, "session": {}}
@@ -7510,15 +7670,18 @@ class TestHealthCheck:
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
              patch("importlib.metadata.version", side_effect=mock_version), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert result["status"] == "ok"
-        assert len(result["checks"]) == 2
+        assert len(result["checks"]) == 3
         assert result["checks"][0]["name"] == "venv"
         assert result["checks"][0]["status"] == "ok"
         assert result["checks"][1]["name"] == "skills"
         assert result["checks"][1]["status"] == "ok"
+        assert result["checks"][2]["name"] == "collisions"
+        assert result["checks"][2]["status"] == "ok"
 
     def test_stale_skills_returns_warn(self, tmp_path):
         """Stale skills with ok venv returns overall warn."""
@@ -7548,7 +7711,8 @@ class TestHealthCheck:
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
              patch("importlib.metadata.version", return_value="2.31.0"), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert result["status"] == "warn"
@@ -7567,7 +7731,8 @@ class TestHealthCheck:
         # No venv
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
-             patch.object(Path, "home", return_value=fakehome):
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert result["status"] == "fail"
@@ -7584,13 +7749,107 @@ class TestHealthCheck:
         (fakehome / ".bitwize-music").mkdir(parents=True)
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
-             patch.object(Path, "home", return_value=fakehome):
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache()):
             result = json.loads(_run(_health_mod.health_check()))
 
         assert "venv" in result
         assert "skills" in result
         assert "status" in result["venv"]
         assert "status" in result["skills"]
+
+    def test_collisions_ok_shape(self, tmp_path):
+        """Empty album_collisions yields the {"status": "ok"} section."""
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "skills").mkdir(parents=True)
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        state = _fresh_state()
+        state["album_collisions"] = []
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["collisions"] == {"status": "ok"}
+        collisions_check = next(
+            c for c in result["checks"] if c["name"] == "collisions")
+        assert collisions_check["status"] == "ok"
+
+    def test_collisions_missing_field_is_ok(self, tmp_path):
+        """Pre-1.3.0 states without album_collisions don't crash health_check."""
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "skills").mkdir(parents=True)
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        state = _fresh_state()
+        assert "album_collisions" not in state
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["collisions"] == {"status": "ok"}
+
+    def test_collisions_detected_shape(self, tmp_path):
+        """Collisions yield status "collision" with details and a fix."""
+        plugin_root = tmp_path / "plugin"
+        (plugin_root / "skills").mkdir(parents=True)
+        fakehome = tmp_path / "fakehome"
+        (fakehome / ".bitwize-music").mkdir(parents=True)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch.object(Path, "home", return_value=fakehome), \
+             patch.object(_shared_mod, "cache",
+                          MockStateCache(_state_with_collision("test-album"))):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["collisions"]["status"] == "collision"
+        assert result["collisions"]["collisions"][0]["slug"] == "test-album"
+        assert "/bitwize-music:rename" in result["collisions"]["fix"]
+        collisions_check = next(
+            c for c in result["checks"] if c["name"] == "collisions")
+        assert collisions_check["status"] == "warn"
+        assert "test-album" in collisions_check["detail"]
+
+    def test_collisions_alone_warn_overall(self, tmp_path):
+        """Venv and skills ok + collisions present → overall warn."""
+        # Set up matching skills (same scaffolding as test_all_ok)
+        plugin_root = tmp_path / "plugin"
+        skill_dir = plugin_root / "skills" / "test-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+
+        cache_dir = (tmp_path / "fakehome" / ".claude" / "plugins" / "cache"
+                     / "bitwize-music" / "bitwize-music" / "1.0.0")
+        cache_skills_dir = cache_dir / "skills" / "test-skill"
+        cache_skills_dir.mkdir(parents=True)
+        (cache_skills_dir / "SKILL.md").write_text("---\nname: test-skill\n---\n")
+        pj = cache_dir / ".claude-plugin"
+        pj.mkdir(parents=True)
+        (pj / "plugin.json").write_text('{"version": "1.0.0"}')
+
+        # Set up venv
+        req = plugin_root / "requirements.txt"
+        req.write_text("requests==2.31.0\n")
+        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
+        venv_dir.mkdir(parents=True)
+        (venv_dir / "python3").touch()
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", plugin_root), \
+             patch("importlib.metadata.version", return_value="2.31.0"), \
+             patch.object(Path, "home", return_value=tmp_path / "fakehome"), \
+             patch.object(_shared_mod, "cache",
+                          MockStateCache(_state_with_collision("test-album"))):
+            result = json.loads(_run(_health_mod.health_check()))
+
+        assert result["status"] == "warn"
+        assert result["checks"][0]["status"] == "ok"
+        assert result["checks"][1]["status"] == "ok"
+        assert result["checks"][2]["name"] == "collisions"
+        assert result["checks"][2]["status"] == "warn"
 
 
 # =============================================================================

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -3530,6 +3530,23 @@ F-B-I came knocking at his door
 | Linux | Lin-ucks | Tech term |
 """
 
+_TRACK_WITH_WORD_SUBSTRING = """\
+# Test Track
+
+## Suno Inputs
+
+### Lyrics Box
+```
+plain lyrics without any phonetic respelling
+```
+
+## Pronunciation Notes
+
+| Word/Phrase | Pronunciation | Reason |
+|-------------|---------------|--------|
+| Wordsworth | WURDZ-wurth | poet name |
+"""
+
 _TRACK_WITH_UNAPPLIED = """\
 # Test Track
 
@@ -3594,6 +3611,24 @@ class TestCheckPronunciationEnforcement:
             result = json.loads(_run(server.check_pronunciation_enforcement("test-album", "05-unapplied")))
         assert result["all_applied"] is False
         assert result["unapplied_count"] == 2  # Both Rah-mohs and F-B-I not in lyrics
+
+    def test_word_substring_rows_are_not_dropped(self, tmp_path):
+        """Rows whose Word cell contains 'Word' must not be skipped (#384)."""
+        track_file = tmp_path / "05-wordsworth.md"
+        track_file.write_text(_TRACK_WITH_WORD_SUBSTRING)
+        state = _fresh_state()
+        state["albums"]["test-album"]["tracks"]["05-wordsworth"] = {
+            "path": str(track_file),
+            "title": "Wordsworth Track",
+            "status": "In Progress",
+        }
+        mock_cache = MockStateCache(state)
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(server.check_pronunciation_enforcement("test-album", "05-wordsworth")))
+        # The phonetic is NOT in the lyrics — a dropped row would false-PASS.
+        assert result["all_applied"] is False
+        assert result["unapplied_count"] == 1
+        assert result["entries"][0]["word"] == "Wordsworth"
 
     def test_empty_pronunciation_table(self, tmp_path):
         track_file = tmp_path / "05-empty-pron.md"
@@ -9325,12 +9360,9 @@ class TestExtractCodeBlockEdgeCases:
 class TestCheckPronunciationEdgeCases:
     """Edge case tests for check_pronunciation_enforcement."""
 
-    def test_word_in_data_row_skipped(self, tmp_path):
-        """Table row containing 'Word' in data is skipped by the header filter.
-
-        Documents that the filter 'if "Word" in line' skips ANY row
-        containing 'Word', including legitimate data rows.
-        """
+    def test_word_in_data_row_parsed(self, tmp_path):
+        """Data rows containing 'Word' are parsed — only the header row is
+        skipped, matched by its first cell (#384)."""
         track_file = tmp_path / "01-test.md"
         track_file.write_text(
             "# Test\n\n"
@@ -9352,10 +9384,11 @@ class TestCheckPronunciationEdgeCases:
                 server.check_pronunciation_enforcement("test-album", "01-test")
             ))
 
-        # The entry with "Word" in the word column is skipped by the header filter
         assert result["found"] is True
-        # "Wordplay" entry is skipped because the line contains "Word"
-        assert len(result["entries"]) == 0
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["word"] == "Wordplay"
+        # The phonetic IS in the lyrics, so the check passes honestly
+        assert result["all_applied"] is True
 
     def test_no_pronunciation_section(self, tmp_path):
         """Track with no Pronunciation Notes section reports all applied."""
@@ -12556,6 +12589,41 @@ class TestGeneratePromoVideos:
         assert "error" in result
         assert "artwork" in result["error"].lower()
 
+    def test_batch_reports_failures_and_ignores_stale_files(self, tmp_path):
+        """Batch mode must report per-track failures, not glob stale files (#382)."""
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        audio_dir.mkdir(parents=True)
+        (audio_dir / "album.png").write_bytes(b"")
+        (audio_dir / "01-track.wav").write_bytes(b"")
+        (audio_dir / "02-track.wav").write_bytes(b"")
+        output_dir = audio_dir / "promo_videos"
+        output_dir.mkdir()
+        (output_dir / "99-stale_promo.mp4").write_bytes(b"old run leftover")
+
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        state["config"]["artist_name"] = "test-artist"
+        mock_cache = MockStateCache(state)
+
+        def fake_batch(**kwargs):
+            return [
+                ("01-track.wav", "01-track_promo.mp4", True),
+                ("02-track.wav", "02-track_promo.mp4", False),
+            ]
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \
+             patch("tools.promotion.generate_promo_video.batch_process_album",
+                   side_effect=fake_batch):
+            result = json.loads(_run(server.generate_promo_videos("test-album")))
+
+        assert result["summary"]["success"] == 1
+        assert result["summary"]["failed"] == 1
+        by_file = {t["filename"]: t["success"] for t in result["tracks"]}
+        assert by_file == {"01-track.wav": True, "02-track.wav": False}
+        # Stale leftovers from previous runs are not reported as new successes
+        assert "99-stale_promo.mp4" not in json.dumps(result)
+
     def test_single_track_not_found(self, tmp_path):
         audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
         audio_dir.mkdir(parents=True)
@@ -13766,6 +13834,10 @@ class TestGeneratePromoVideosComprehensive:
             output_dir.mkdir(exist_ok=True)
             (output_dir / "01-track-1_promo.mp4").write_bytes(b"")
             (output_dir / "02-track-2_promo.mp4").write_bytes(b"")
+            return [
+                ("01-track-1.wav", "01-track-1_promo.mp4", True),
+                ("02-track-2.wav", "02-track-2_promo.mp4", True),
+            ]
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \
@@ -13931,6 +14003,7 @@ class TestGeneratePromoVideosComprehensive:
 
         def mock_batch(**kwargs):
             captured_kwargs.append(kwargs)
+            return []
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \
@@ -14265,6 +14338,10 @@ class TestPromoVideoNewParams:
             output_dir.mkdir(exist_ok=True)
             (output_dir / "01-track-1_promo.mp4").write_bytes(b"")
             (output_dir / "02-track-2_promo.mp4").write_bytes(b"")
+            return [
+                ("01-track-1.wav", "01-track-1_promo.mp4", True),
+                ("02-track-2.wav", "02-track-2_promo.mp4", True),
+            ]
 
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_processing_helpers, "_check_ffmpeg", return_value=None), \

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -15065,6 +15065,37 @@ class TestPublishSheetMusic:
         # Verify retry_upload called for each file
         assert mock_cloud_mod.retry_upload.call_count == 3
 
+    def test_quoted_public_read_false_stays_private(self, tmp_path):
+        """cloud.public_read: "false" (quoted) must not set a public ACL (#388)."""
+        audio_dir = tmp_path / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        singles_dir = audio_dir / "sheet-music" / "singles"
+        singles_dir.mkdir(parents=True)
+        (singles_dir / "01 - Track.pdf").write_bytes(b"pdf1")
+
+        state = _fresh_state()
+        state["config"]["audio_root"] = str(tmp_path)
+        state["config"]["artist_name"] = "test-artist"
+        mock_cache = MockStateCache(state)
+
+        mock_cloud_mod = MagicMock()
+        mock_cloud_mod.retry_upload.return_value = True
+        mock_cloud_mod.get_s3_client.return_value = MagicMock()
+        mock_cloud_mod.get_bucket_name.return_value = "test-bucket"
+
+        mock_config = {
+            "cloud": {"enabled": True, "provider": "r2", "public_read": "false"},
+        }
+
+        with patch.object(_shared_mod, "cache", mock_cache), \
+             patch.object(_processing_helpers, "_check_cloud_enabled", return_value=None), \
+             patch.object(_processing_helpers, "_import_cloud_module", return_value=mock_cloud_mod), \
+             patch("tools.shared.config.load_config", return_value=mock_config):
+            result = json.loads(_run(server.publish_sheet_music("test-album")))
+
+        assert result["summary"]["success"] == 1
+        _, kwargs = mock_cloud_mod.retry_upload.call_args
+        assert kwargs["public_read"] is False
+
     # ------------------------------------------------------------------
     # Frontmatter persistence tests
     # ------------------------------------------------------------------

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -4281,7 +4281,10 @@ class TestCreateAlbumStructure:
         """Album is still created even when templates directory doesn't exist."""
         mock_cache, content = self._make_state_with_tmp(tmp_path)
         fake_plugin = tmp_path / "fake-plugin"
-        fake_plugin.mkdir()
+        # Genre validation scans {PLUGIN_ROOT}/genres — the fake root needs a
+        # valid genre so this test exercises only the missing-templates path.
+        (fake_plugin / "genres" / "rock").mkdir(parents=True)
+        (fake_plugin / "genres" / "rock" / "README.md").write_text("# Rock")
         # No templates/ dir under fake_plugin
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_shared_mod, "PLUGIN_ROOT", fake_plugin):

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -8011,8 +8011,10 @@ class TestCreateIdea:
         mock_cache, content_root = self._make_cache_with_ideas(
             tmp_path, "# Album Ideas\n\n## Ideas\n"
         )
+        from handlers import ideas as ideas_mod
         with patch.object(_shared_mod, "cache", mock_cache), \
-             patch.object(Path, "write_text", side_effect=OSError("permission denied")):
+             patch.object(ideas_mod, "atomic_write_text",
+                          side_effect=OSError("permission denied")):
             result = json.loads(_run(server.create_idea("New Idea")))
         assert "error" in result
 
@@ -8237,15 +8239,13 @@ class TestUpdateIdea:
         mock_cache, content_root = self._make_cache_with_ideas(tmp_path)
         # Make file read-only after first read
         with patch.object(_shared_mod, "cache", mock_cache):
-            # Use patch on Path.write_text to simulate write failure
-            original_write = Path.write_text
+            from handlers import ideas as ideas_mod
 
-            def fail_write(self, *args, **kwargs):
-                if str(self).endswith("IDEAS.md"):
+            def fail_write(path, *args, **kwargs):
+                if str(path).endswith("IDEAS.md"):
                     raise OSError("disk full")
-                return original_write(self, *args, **kwargs)
 
-            with patch.object(Path, "write_text", fail_write):
+            with patch.object(ideas_mod, "atomic_write_text", fail_write):
                 result = json.loads(_run(server.update_idea(
                     "Cyberpunk Dreams", "status", "Complete"
                 )))
@@ -15515,3 +15515,41 @@ class TestDiagnose:
         assert result["status"] == "fail"
         assert result["ok"] + result["warn"] + result["fail"] == result["total"]
 
+
+
+class TestIdeasAtomicWrites:
+    """All IDEAS.md / README.md mutations go through atomic_write_text (#381)."""
+
+    IDEAS = TestUpdateIdea.IDEAS_WITH_ENTRIES
+
+    def _make_cache_with_ideas(self, tmp_path):
+        content_root = tmp_path / "content"
+        content_root.mkdir()
+        (content_root / "IDEAS.md").write_text(self.IDEAS)
+        state = _fresh_state()
+        state["config"]["content_root"] = str(content_root)
+        return MockStateCache(state), content_root
+
+    def _spy(self):
+        from handlers import ideas as ideas_mod
+        return patch.object(
+            ideas_mod, "atomic_write_text", wraps=ideas_mod.atomic_write_text
+        )
+
+    def test_create_idea_writes_atomically(self, tmp_path):
+        mock_cache, content_root = self._make_cache_with_ideas(tmp_path)
+        with patch.object(_shared_mod, "cache", mock_cache), self._spy() as spy:
+            result = json.loads(_run(server.create_idea("Fresh Idea")))
+        assert result["created"] is True
+        assert spy.called
+        assert "### Fresh Idea" in (content_root / "IDEAS.md").read_text()
+
+    def test_update_idea_writes_atomically(self, tmp_path):
+        mock_cache, content_root = self._make_cache_with_ideas(tmp_path)
+        with patch.object(_shared_mod, "cache", mock_cache), self._spy() as spy:
+            result = json.loads(_run(server.update_idea(
+                "Cyberpunk Dreams", field="status", value="Planned"
+            )))
+        assert result["success"] is True
+        assert spy.called
+        assert "**Status**: Planned" in (content_root / "IDEAS.md").read_text()

--- a/tests/unit/state/test_server_integration.py
+++ b/tests/unit/state/test_server_integration.py
@@ -533,7 +533,7 @@ class TestStateRebuildPipeline:
     def test_state_json_has_correct_structure(self, integration_env):
         """state.json built from real files has all expected fields."""
         state = json.loads(integration_env["state_file"].read_text())
-        assert state["version"] == "1.2.0"
+        assert state["version"] == "1.3.0"
         assert "config" in state
         assert "albums" in state
         assert "session" in state

--- a/tests/unit/state/test_server_integration.py
+++ b/tests/unit/state/test_server_integration.py
@@ -533,7 +533,7 @@ class TestStateRebuildPipeline:
     def test_state_json_has_correct_structure(self, integration_env):
         """state.json built from real files has all expected fields."""
         state = json.loads(integration_env["state_file"].read_text())
-        assert state["version"] == "1.3.0"
+        assert state["version"] == "1.4.0"
         assert "config" in state
         assert "albums" in state
         assert "session" in state

--- a/tests/unit/state/test_silent_exceptions.py
+++ b/tests/unit/state/test_silent_exceptions.py
@@ -291,6 +291,30 @@ class TestHelpersCloudConfigWarning:
             "Config load failed" in r.message for r in caplog.records
         ), f"Expected config load warning. Records: {[r.message for r in caplog.records]}"
 
+    def test_quoted_false_reports_not_enabled(self):
+        """cloud.enabled: "false" (quoted) must not pass the gate (#388)."""
+        from handlers.processing import _helpers as helpers_mod
+
+        with patch(
+            "tools.shared.config.load_config",
+            return_value={"cloud": {"enabled": "false"}},
+        ):
+            result = helpers_mod._check_cloud_enabled()
+
+        assert result is not None
+        assert "not enabled" in result
+
+    def test_quoted_true_passes_gate(self):
+        from handlers.processing import _helpers as helpers_mod
+
+        with patch(
+            "tools.shared.config.load_config",
+            return_value={"cloud": {"enabled": "true"}},
+        ):
+            result = helpers_mod._check_cloud_enabled()
+
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # Test 5: _helpers.py — AnthemScore check

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -69,6 +69,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 import logging
 
+from tools.shared.config import coerce_yaml_bool
 from tools.shared.config import load_config as _load_config
 from tools.shared.logging_config import setup_logging
 from tools.shared.progress import ProgressBar
@@ -385,7 +386,9 @@ Examples:
 
     # Check if cloud is enabled
     cloud_config = config.get("cloud", {})
-    if not cloud_config.get("enabled", False):
+    if not coerce_yaml_bool(
+        cloud_config.get("enabled", False), default=False, context="cloud.enabled"
+    ):
         logger.error("Cloud uploads not enabled in config.")
         logger.error("Add 'cloud.enabled: true' to ~/.bitwize-music/config.yaml")
         logger.error("See /reference/cloud/setup-guide.md for setup instructions.")
@@ -393,7 +396,11 @@ Examples:
 
     # Get cloud settings
     provider = cloud_config.get("provider", "r2")
-    public_read = args.public or cloud_config.get("public_read", False)
+    public_read = args.public or coerce_yaml_bool(
+        cloud_config.get("public_read", False),
+        default=False,
+        context="cloud.public_read",
+    )
 
     # Find album
     album_path = find_album_path(config, args.album, args.audio_root)

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -309,6 +309,9 @@ def retry_upload(
     Retries on transient errors (network issues, server errors).
     Does not retry on auth errors (403, 404, missing credentials).
     """
+    # max_retries <= 0 would make the loop body never run — no upload
+    # attempted, silently reported as failure (#385). Always try once.
+    max_retries = max(1, max_retries)
     for attempt in range(1, max_retries + 1):
         result = upload_file(s3_client, bucket, file_path, s3_key, public_read, dry_run)
         if result or dry_run:
@@ -324,6 +327,14 @@ def retry_upload(
         time.sleep(delay)
 
     return False
+
+
+def _positive_int(value: str) -> int:
+    """argparse type: reject values < 1 loudly instead of silently no-op'ing (#385)."""
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {parsed}")
+    return parsed
 
 
 def main() -> None:
@@ -372,9 +383,9 @@ Examples:
     )
     parser.add_argument(
         "--retries",
-        type=int,
+        type=_positive_int,
         default=3,
-        help="Max retry attempts per file on failure (default: 3)",
+        help="Max retry attempts per file on failure (default: 3, minimum: 1)",
     )
 
     args = parser.parse_args()

--- a/tools/database/connection.py
+++ b/tools/database/connection.py
@@ -6,6 +6,8 @@ import logging
 from pathlib import Path
 from typing import Any, cast
 
+from tools.shared.config import coerce_yaml_bool
+
 logger = logging.getLogger(__name__)
 
 CONFIG_PATH = Path.home() / ".bitwize-music" / "config.yaml"
@@ -47,7 +49,9 @@ def get_db_config() -> dict[str, Any] | None:
         return None
 
     db_config = cast(dict[str, Any], config.get("database", {}))
-    if not db_config or not db_config.get("enabled", False):
+    if not db_config or not coerce_yaml_bool(
+        db_config.get("enabled", False), default=False, context="database.enabled"
+    ):
         return None
 
     return db_config

--- a/tools/mastering/codec_preview.py
+++ b/tools/mastering/codec_preview.py
@@ -14,6 +14,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Bound every ffmpeg invocation — a wedged subprocess would otherwise hang
+# master_album's samples stage forever (#387). Mirrors adm_validation.py.
+_FFMPEG_TIMEOUT_SEC = 120
+
 
 class CodecPreviewError(RuntimeError):
     """Raised when the codec preview cannot be produced."""
@@ -63,8 +67,19 @@ def render_aac_preview(
         str(out_path),
     ]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_FFMPEG_TIMEOUT_SEC
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A killed ffmpeg leaves a truncated file that would sit in the
+        # operator-audition folder indistinguishable from a good preview.
+        out_path.unlink(missing_ok=True)
+        raise CodecPreviewError(
+            f"ffmpeg timed out after {_FFMPEG_TIMEOUT_SEC}s encoding {in_path.name}"
+        ) from exc
     if result.returncode != 0 or not out_path.exists():
+        out_path.unlink(missing_ok=True)
         raise CodecPreviewError(
             f"ffmpeg failed encoding {in_path.name}: {result.stderr.strip()}"
         )

--- a/tools/mastering/config.py
+++ b/tools/mastering/config.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from tools.shared.config import load_config
+from tools.shared.config import load_config, parse_yaml_bool
 
 logger = logging.getLogger(__name__)
 
@@ -82,8 +82,9 @@ def load_mastering_config() -> dict[str, Any]:
         expected_type = _KEY_TYPES[key]
         try:
             if expected_type is bool:
-                # YAML already gives us bools; don't coerce arbitrary strings
-                result[key] = bool(value)
+                # bool(value) would turn quoted strings like "false" into
+                # True (#388); parse YAML boolean literals instead.
+                result[key] = parse_yaml_bool(value)
             else:
                 result[key] = expected_type(value)
         except (TypeError, ValueError) as exc:
@@ -98,6 +99,19 @@ def load_mastering_config() -> dict[str, Any]:
     return result
 
 
+def _config_bool(config: dict[str, Any], key: str, default: bool) -> bool:
+    """Bool read tolerant of raw (un-coerced) config dicts passed to the
+    public build_delivery_targets API."""
+    value = config.get(key, default)
+    try:
+        return parse_yaml_bool(value)
+    except ValueError:
+        logger.warning(
+            "Config %s=%r is not a boolean — using %s", key, value, default
+        )
+        return default
+
+
 def _resolve_adm_enabled(album_mastering: dict[str, Any] | None) -> bool:
     """Per-album ADM resolution: frontmatter-required, default OFF.
 
@@ -109,7 +123,18 @@ def _resolve_adm_enabled(album_mastering: dict[str, Any] | None) -> bool:
         return False
     if "adm_validation_enabled" not in album_mastering:
         return False
-    return bool(album_mastering["adm_validation_enabled"])
+    value = album_mastering["adm_validation_enabled"]
+    try:
+        return parse_yaml_bool(value)
+    except ValueError:
+        # Frontmatter is hand-edited; a quoted "false" must not enable ADM
+        # (#388), and garbage stays at the documented default (OFF).
+        logger.warning(
+            "Album frontmatter mastering.adm_validation_enabled=%r is not a "
+            "boolean — ADM validation stays off",
+            value,
+        )
+        return False
 
 
 def build_delivery_targets(
@@ -178,7 +203,7 @@ def build_delivery_targets(
         "ceiling_db": ceiling_db,
         "output_bits": output_bits,
         "output_sample_rate": output_sample_rate,
-        "archival_enabled": bool(config.get("archival_enabled", False)),
+        "archival_enabled": _config_bool(config, "archival_enabled", False),
         "adm_aac_encoder": str(config.get("adm_aac_encoder", "aac")),
         # Per-album opt-in for ADM validation (issue #353). The album's
         # README frontmatter `mastering.adm_validation_enabled: true` is

--- a/tools/promotion/generate_all_promos.py
+++ b/tools/promotion/generate_all_promos.py
@@ -214,9 +214,11 @@ Examples:
 
     if not args.sampler_only:
         promo_dir = album_dir / "promo_videos"
-        promo_count = sum(1 for f in promo_dir.glob("*.mp4")) if promo_dir.exists() else 0
+        # Count only track promos (not the sampler), and say what the number
+        # is — files present in the dir, which may include earlier runs (#382).
+        promo_count = sum(1 for f in promo_dir.glob("*_promo.mp4")) if promo_dir.exists() else 0
         print(f"Track promos: {promo_dir}")
-        print(f"  {promo_count} videos generated")
+        print(f"  {promo_count} promo videos in directory")
 
     if not args.tracks_only:
         sampler = album_dir / "promo_videos" / "album_sampler.mp4"

--- a/tools/promotion/generate_promo_video.py
+++ b/tools/promotion/generate_promo_video.py
@@ -407,8 +407,12 @@ def batch_process_album(
     color_hex: str = "",
     glow: float = 0.6,
     text_color: str = "",
-) -> None:
-    """Process all audio files in an album directory."""
+) -> list[tuple[str, str, bool]]:
+    """Process all audio files in an album directory.
+
+    Returns one (audio_filename, output_filename, success) tuple per track
+    so callers can report real per-track outcomes (#382).
+    """
     audio_extensions = {'.wav', '.mp3', '.flac', '.m4a'}
 
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -420,7 +424,7 @@ def batch_process_album(
 
     if not audio_files:
         logger.warning("No audio files found in %s", album_dir)
-        return
+        return []
 
     logger.info("Found %d tracks", len(audio_files))
     if content_dir:
@@ -470,10 +474,12 @@ def batch_process_album(
     workers = jobs if jobs > 0 else (os.cpu_count() or 1)
     progress = ProgressBar(len(sorted_audio), prefix="Generating")
 
+    results: list[tuple[str, str, bool]] = []
     if workers == 1:
         for audio_file in sorted_audio:
             progress.update(audio_file.name)
-            _, out_name, success = _process_one(audio_file)
+            name, out_name, success = _process_one(audio_file)
+            results.append((name, out_name, success))
             if success:
                 logger.info("  [OK] %s", out_name)
             else:
@@ -485,11 +491,13 @@ def batch_process_album(
             for future in as_completed(futures):
                 af = futures[future]
                 progress.update(af.name)
-                _, out_name, success = future.result()
+                name, out_name, success = future.result()
+                results.append((name, out_name, success))
                 if success:
                     logger.info("  [OK] %s", out_name)
                 else:
                     logger.error("  [FAIL] %s", af.name)
+    return sorted(results)
 
 
 def main() -> None:
@@ -628,7 +636,7 @@ Examples:
 
         output_dir = args.output or args.batch / 'promo_videos'
 
-        batch_process_album(
+        batch_results = batch_process_album(
             album_dir=args.batch,
             artwork_path=artwork,
             output_dir=output_dir,
@@ -642,6 +650,17 @@ Examples:
             glow=args.glow,
             text_color=args.text_color,
         )
+
+        # Per-track failures must surface as a non-zero exit, matching
+        # single-file mode — callers (generate_all_promos.py) key off the
+        # return code (#382).
+        failed = [name for name, _out, ok in batch_results if not ok]
+        if failed:
+            logger.error(
+                "%d of %d tracks failed: %s",
+                len(failed), len(batch_results), ", ".join(failed),
+            )
+            sys.exit(1)
 
     else:
         # Single file mode

--- a/tools/shared/config.py
+++ b/tools/shared/config.py
@@ -31,6 +31,53 @@ OVERRIDE_FILES: dict[str, dict[str, Any]] = {
 }
 
 
+# YAML 1.1 boolean literals. PyYAML converts these to bool when unquoted, so
+# a string here means the user quoted the value in config.yaml/frontmatter.
+_YAML_BOOL_LITERALS: dict[str, bool] = {
+    "true": True, "yes": True, "on": True, "1": True,
+    "false": False, "no": False, "off": False, "0": False,
+}
+
+
+def parse_yaml_bool(value: Any) -> bool:
+    """Coerce a YAML-sourced value to bool, honoring quoted boolean strings.
+
+    ``bool(value)`` treats any non-empty string as True, silently inverting
+    quoted YAML booleans like ``"false"`` or ``"no"`` (#388). Accepts real
+    bools, 0/1 numbers, and YAML 1.1 boolean literals (case-insensitive);
+    raises ValueError for anything else so callers can fall back to their
+    key's default with a warning.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        parsed = _YAML_BOOL_LITERALS.get(value.strip().lower())
+        if parsed is not None:
+            return parsed
+    raise ValueError(f"not a boolean: {value!r}")
+
+
+def coerce_yaml_bool(value: Any, *, default: bool = False, context: str = "") -> bool:
+    """parse_yaml_bool with a warn-and-default fallback for gate sites.
+
+    For boolean config gates where an unparseable value should fall back to
+    the key's documented default rather than raise. ``context`` names the
+    key in the warning (e.g. ``"cloud.enabled"``).
+    """
+    try:
+        return parse_yaml_bool(value)
+    except ValueError:
+        logger.warning(
+            "Cannot interpret %s=%r as a boolean — using default %s",
+            context or "value",
+            value,
+            default,
+        )
+        return default
+
+
 def load_config(
     required: bool = False,
     fallback: dict[str, Any] | None = None

--- a/tools/shared/config.py
+++ b/tools/shared/config.py
@@ -89,7 +89,8 @@ def load_config(
         fallback: Default dict to return when config is missing and not required.
 
     Returns:
-        Parsed config dict, fallback dict, or None if missing/invalid.
+        Parsed config dict ({} for an empty file), or fallback/None when the
+        config is missing, unreadable, unparseable, or not a YAML mapping.
     """
     if not CONFIG_PATH.exists():
         if required:
@@ -105,13 +106,30 @@ def load_config(
 
     try:
         with open(CONFIG_PATH) as f:
-            return yaml.safe_load(f) or {}
+            data = yaml.safe_load(f)
     except (yaml.YAMLError, OSError) as e:
         logger.error("Error reading config: %s", e)
         if required:
             import sys
             sys.exit(1)
         return fallback
+
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        # Valid YAML but wrong shape (e.g. top-level list or scalar) — callers
+        # expect a mapping and would crash on .get() (#389)
+        logger.error(
+            "Config at %s parsed as %s, not a mapping — the file must contain "
+            "top-level `key: value` pairs",
+            CONFIG_PATH,
+            type(data).__name__,
+        )
+        if required:
+            import sys
+            sys.exit(1)
+        return fallback
+    return data
 
 
 def validate_overrides(overrides_dir: Path) -> list[dict[str, str]]:

--- a/tools/shared/logging_config.py
+++ b/tools/shared/logging_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import sys
 from logging.handlers import RotatingFileHandler
@@ -10,6 +11,8 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from tools.shared.colors import Colors
+
+logger = logging.getLogger(__name__)
 
 # Sentinel to track whether file logging has already been configured
 _file_logging_configured = False
@@ -85,6 +88,15 @@ def configure_file_logging(config: dict[str, Any] | None) -> RotatingFileHandler
         return None
 
     log_config = config.get("logging")
+    if log_config is not None and not isinstance(log_config, dict):
+        # A wrong-typed `logging:` section (scalar/list) would crash .get()
+        # on server startup and every CLI — treat it as empty (disabled).
+        logger.warning(
+            "Config section logging is not a mapping (got %s) — "
+            "file logging disabled",
+            type(log_config).__name__,
+        )
+        return None
     if not log_config:
         return None
     # Local import: tools.shared.config logs via this module's setup, so a
@@ -105,7 +117,18 @@ def configure_file_logging(config: dict[str, Any] | None) -> RotatingFileHandler
     log_file = os.path.expanduser(
         log_config.get("file", "~/.bitwize-music/logs/debug.log")
     )
-    max_bytes = log_config.get("max_size_mb", 5) * 1024 * 1024
+    max_size_mb = log_config.get("max_size_mb", 5)
+    if (isinstance(max_size_mb, bool)
+            or not isinstance(max_size_mb, (int, float))
+            or not math.isfinite(max_size_mb)):
+        # bool would silently shrink the cap (True == 1MB); non-numeric
+        # crashes the multiplication; YAML `.inf` overflows int()
+        logger.warning(
+            "Config logging.max_size_mb is not a number (got %s) — using 5",
+            type(max_size_mb).__name__,
+        )
+        max_size_mb = 5
+    max_bytes = int(max_size_mb * 1024 * 1024)
     backup_count = log_config.get("backup_count", 3)
 
     # Auto-create log directory

--- a/tools/shared/logging_config.py
+++ b/tools/shared/logging_config.py
@@ -85,7 +85,14 @@ def configure_file_logging(config: dict[str, Any] | None) -> RotatingFileHandler
         return None
 
     log_config = config.get("logging")
-    if not log_config or not log_config.get("enabled", False):
+    if not log_config:
+        return None
+    # Local import: tools.shared.config logs via this module's setup, so a
+    # top-level import would be circular in spirit even though not in fact.
+    from tools.shared.config import coerce_yaml_bool
+    if not coerce_yaml_bool(
+        log_config.get("enabled", False), default=False, context="logging.enabled"
+    ):
         return None
 
     # Idempotent — don't add duplicate file handlers

--- a/tools/sheet-music/create_songbook.py
+++ b/tools/sheet-music/create_songbook.py
@@ -677,7 +677,12 @@ def main() -> None:
     section_headers = args.section_headers
     if not section_headers and config:
         try:
-            section_headers = config.get('sheet_music', {}).get('section_headers', False)
+            from tools.shared.config import coerce_yaml_bool
+            section_headers = coerce_yaml_bool(
+                config.get('sheet_music', {}).get('section_headers', False),
+                default=False,
+                context='sheet_music.section_headers',
+            )
             if section_headers:
                 logger.info("Using section headers from config: %s", section_headers)
         except (TypeError, AttributeError):

--- a/tools/sheet-music/transcribe.py
+++ b/tools/sheet-music/transcribe.py
@@ -147,13 +147,28 @@ def resolve_album_path(album_name: str) -> Path | None:
         # Expand ~ to home directory
         audio_root = Path(audio_root_str).expanduser()
 
-        # Construct: {audio_root}/artists/{artist}/albums/{genre}/{album}/
-        album_path = audio_root / artist / album_name
+        # Mirrored audio layout: {audio_root}/artists/{artist}/albums/{genre}/{album}/
+        # The genre segment isn't part of the album name, so sweep genre dirs.
+        # iterdir, not glob — album names may contain glob metacharacters.
+        albums_root = audio_root / "artists" / artist / "albums"
+        matches = sorted(
+            genre_dir / album_name
+            for genre_dir in albums_root.iterdir()
+            if genre_dir.is_dir() and (genre_dir / album_name).is_dir()
+        ) if albums_root.is_dir() else []
 
-        if not album_path.exists():
-            logger.warning("Album path not found: %s", album_path)
+        if not matches:
+            logger.warning("Album not found under %s: %s", albums_root, album_name)
             logger.warning("Treating as direct path instead.")
             return None
+        if len(matches) > 1:
+            logger.warning(
+                "Album '%s' exists under multiple genres (%s) — using %s",
+                album_name,
+                ", ".join(m.parent.name for m in matches),
+                matches[0],
+            )
+        album_path = matches[0]
 
         # Validate resolved path stays within audio_root (prevent path traversal)
         try:
@@ -353,7 +368,10 @@ Examples:
                 try:
                     audio_root = Path(config['paths']['audio_root']).expanduser()
                     artist = config['artist']['name']
-                    logger.error("  2. Album path: %s/%s/%s", audio_root, artist, args.source)
+                    logger.error(
+                        "  2. Album path: %s/artists/%s/albums/<genre>/%s",
+                        audio_root, artist, args.source,
+                    )
                 except (KeyError, TypeError):
                     pass
             sys.exit(1)

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -66,7 +66,7 @@ from tools.state.parsers import (
 logger = logging.getLogger(__name__)
 
 # Schema version for state.json
-CURRENT_VERSION = "1.2.0"
+CURRENT_VERSION = "1.3.0"
 
 # Cache location (constant, not configurable)
 CACHE_DIR = Path.home() / ".bitwize-music" / "cache"
@@ -117,11 +117,19 @@ def _migrate_1_1_to_1_2(state: dict[str, Any]) -> dict[str, Any]:
     return state
 
 
+def _migrate_1_2_to_1_3(state: dict[str, Any]) -> dict[str, Any]:
+    """Migrate state from 1.2.0 to 1.3.0: add album_collisions field."""
+    if 'album_collisions' not in state:
+        state['album_collisions'] = []
+    return state
+
+
 # Migration chain for schema upgrades
 # Format: "from_version": (migration_fn, "to_version")
 MIGRATIONS: dict[str, tuple[Any, str]] = {
     "1.0.0": (_migrate_1_0_to_1_1, "1.1.0"),
     "1.1.0": (_migrate_1_1_to_1_2, "1.2.0"),
+    "1.2.0": (_migrate_1_2_to_1_3, "1.3.0"),
 }
 
 
@@ -203,12 +211,18 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def scan_albums(content_root: Path, artist_name: str) -> dict[str, dict[str, Any]]:
+def scan_albums(
+    content_root: Path,
+    artist_name: str,
+    collisions: list[dict[str, Any]] | None = None,
+) -> dict[str, dict[str, Any]]:
     """Scan all album READMEs and their tracks.
 
     Args:
         content_root: Root content directory.
         artist_name: Artist name from config.
+        collisions: Optional out-param; collision records are appended
+            when the same album slug exists under multiple genres (#392).
 
     Returns:
         Dict mapping album slug to album data.
@@ -219,41 +233,77 @@ def scan_albums(content_root: Path, artist_name: str) -> dict[str, dict[str, Any
     if not albums_dir.exists():
         return albums
 
-    # Glob for album READMEs: albums/{genre}/{album}/README.md
+    # Group same-slug dirs structurally first (the sorted glob keeps
+    # genre order deterministic): albums/{genre}/{album}/README.md.
+    # The winner of a collision is the FIRST candidate that actually
+    # indexes — i.e. whose README parses — not merely the first dir, so
+    # an unreadable first twin never silently hands the slug to a later
+    # twin without a collision record (#392).
+    readmes_by_slug: dict[str, list[Path]] = {}
     for readme_path in sorted(albums_dir.glob("*/*/README.md")):
-        album_dir = readme_path.parent
-        album_slug = album_dir.name
-        genre = album_dir.parent.name
+        readmes_by_slug.setdefault(
+            readme_path.parent.name, []).append(readme_path)
 
-        album_data = parse_album_readme(readme_path)
-        if '_error' in album_data:
-            logger.warning("Skipping %s: %s", readme_path, album_data['_error'])
-            continue
+    for album_slug, readme_paths in readmes_by_slug.items():
+        winner_dir: Path | None = None
+        for readme_path in readme_paths:
+            album_dir = readme_path.parent
 
-        # Scan tracks
-        tracks = scan_tracks(album_dir)
+            album_data = parse_album_readme(readme_path)
+            if '_error' in album_data:
+                logger.warning("Skipping %s: %s", readme_path, album_data['_error'])
+                continue  # try the next same-slug candidate, if any
 
-        try:
-            readme_mtime = readme_path.stat().st_mtime
-        except OSError:
-            continue  # File removed between glob and stat
+            # Scan tracks
+            tracks = scan_tracks(album_dir)
 
-        albums[album_slug] = {
-            'path': str(album_dir),
-            'genre': genre,
-            'title': album_data.get('title', album_slug),
-            'status': album_data.get('status', 'Unknown'),
-            'explicit': album_data.get('explicit', False),
-            'anchor_track': album_data.get('anchor_track'),
-            'layout': album_data.get('layout'),
-            'mastering': album_data.get('mastering') or {},
-            'release_date': album_data.get('release_date'),
-            'track_count': album_data.get('track_count', len(tracks)),
-            'tracks_completed': album_data.get('tracks_completed', 0),
-            'streaming_urls': album_data.get('streaming_urls', {}),
-            'readme_mtime': readme_mtime,
-            'tracks': tracks,
-        }
+            try:
+                readme_mtime = readme_path.stat().st_mtime
+            except OSError:
+                continue  # File removed between glob and stat
+
+            albums[album_slug] = {
+                'path': str(album_dir),
+                'genre': album_dir.parent.name,
+                'title': album_data.get('title', album_slug),
+                'status': album_data.get('status', 'Unknown'),
+                'explicit': album_data.get('explicit', False),
+                'anchor_track': album_data.get('anchor_track'),
+                'layout': album_data.get('layout'),
+                'mastering': album_data.get('mastering') or {},
+                'release_date': album_data.get('release_date'),
+                'track_count': album_data.get('track_count', len(tracks)),
+                'tracks_completed': album_data.get('tracks_completed', 0),
+                'streaming_urls': album_data.get('streaming_urls', {}),
+                'readme_mtime': readme_mtime,
+                'tracks': tracks,
+            }
+            winner_dir = album_dir
+            break  # remaining same-slug dirs are shadowed, never parsed
+
+        if len(readme_paths) > 1 and winner_dir is not None:
+            # Emit the record only with kept = the entry actually present
+            # in the albums map. If no candidate indexed, there is no
+            # entry and no record (the parse warnings above already fired).
+            kept = albums[album_slug]
+            shadowed = sorted(
+                ({'genre': p.parent.parent.name, 'path': str(p.parent)}
+                 for p in readme_paths if p.parent != winner_dir),
+                key=lambda s: s['genre'],
+            )
+            logger.warning(
+                "Album slug collision: '%s' — keeping %s, shadowing %s. "
+                "Rename one album (/bitwize-music:rename) or move the "
+                "directory, then rebuild the state cache.",
+                album_slug, kept['path'],
+                ', '.join(s['path'] for s in shadowed),
+            )
+            if collisions is not None:
+                collisions.append({
+                    'slug': album_slug,
+                    'kept': {'genre': kept['genre'], 'path': kept['path']},
+                    'shadowed': shadowed,
+                })
 
     return albums
 
@@ -408,6 +458,8 @@ def build_state(config: dict[str, Any],
     artist_name = config_section['artist_name']
 
     installed_version = _read_plugin_version(plugin_root)
+    album_collisions: list[dict[str, Any]] = []
+    albums = scan_albums(content_root, artist_name, album_collisions)
     return {
         'version': CURRENT_VERSION,
         'generated_at': datetime.now(UTC).isoformat(),
@@ -421,7 +473,8 @@ def build_state(config: dict[str, Any],
         'plugin_version': installed_version,
         'last_migrated_version': installed_version,
         'config': config_section,
-        'albums': scan_albums(content_root, artist_name),
+        'albums': albums,
+        'album_collisions': album_collisions,
         'ideas': scan_ideas(config, content_root),
         'skills': scan_skills(plugin_root),
         'session': {
@@ -475,7 +528,9 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
 
         if path_fields_changed:
             # Content root or artist name changed — full album rescan required
-            state['albums'] = scan_albums(content_root, artist_name)
+            rescan_collisions: list[dict[str, Any]] = []
+            state['albums'] = scan_albums(content_root, artist_name, rescan_collisions)
+            state['album_collisions'] = rescan_collisions
         # else: only non-path config changed (urls, generation, etc.) — keep albums
 
         if ideas_path_changed:
@@ -491,60 +546,124 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
     existing_albums = state.get('albums', {})
 
     if albums_dir.exists():
-        # Find current albums on disk
-        current_album_slugs = set()
-        for readme_path in albums_dir.glob("*/*/README.md"):
-            album_dir = readme_path.parent
-            slug = album_dir.name
-            current_album_slugs.add(slug)
+        collisions: list[dict[str, Any]] = []
+        # Group same-slug dirs structurally first (the sorted glob keeps
+        # genre order deterministic). The winner of a collision is the
+        # FIRST candidate that actually indexes — a cache-valid entry
+        # (path+mtime match) or a successful re-parse — mirroring
+        # scan_albums, so record['kept'] always matches the albums
+        # map (#392).
+        readmes_by_slug: dict[str, list[Path]] = {}
+        for readme_path in sorted(albums_dir.glob("*/*/README.md")):
+            readmes_by_slug.setdefault(
+                readme_path.parent.name, []).append(readme_path)
 
+        current_album_slugs = set()
+        for slug, readme_paths in readmes_by_slug.items():
+            current_album_slugs.add(slug)
             existing_album = existing_albums.get(slug)
 
-            # Check if README changed
-            try:
-                readme_mtime = readme_path.stat().st_mtime
-            except OSError:
-                continue  # File removed between glob and stat
-            if existing_album and existing_album.get('readme_mtime') == readme_mtime:
-                # README unchanged, check individual tracks only
-                _update_tracks_incremental(existing_album, album_dir)
-            else:
-                # README changed or new album — re-parse album-level data
+            winner_dir: Path | None = None
+            for readme_path in readme_paths:
+                album_dir = readme_path.parent
+
+                # Check if README changed
+                try:
+                    readme_mtime = readme_path.stat().st_mtime
+                except OSError:
+                    continue  # File removed between glob and stat
+                # The path must match too — a cross-genre twin's cached
+                # entry must never be reused for the winner (#392).
+                if (existing_album
+                        and existing_album.get('path') == str(album_dir)
+                        and existing_album.get('readme_mtime') == readme_mtime):
+                    # README unchanged — the cache-valid entry counts as
+                    # successfully indexed without re-parsing; check
+                    # individual tracks only. Documented corner: a README
+                    # that becomes unreadable WITHOUT an mtime change keeps
+                    # its cached entry here, while a full rebuild would
+                    # skip it.
+                    _update_tracks_incremental(existing_album, album_dir)
+                    winner_dir = album_dir
+                    break  # remaining same-slug dirs are shadowed
+
+                # README changed, new album, or cached entry points at a
+                # different path — re-parse album-level data
                 album_data = parse_album_readme(readme_path)
-                if '_error' not in album_data:
-                    genre = album_dir.parent.name
+                if '_error' in album_data:
+                    logger.warning(
+                        "Skipping %s: %s", readme_path, album_data['_error'])
+                    continue  # try the next same-slug candidate, if any
 
-                    # Preserve existing tracks and update incrementally
-                    # (README change doesn't mean track files changed)
-                    if existing_album and existing_album.get('tracks'):
-                        tracks = existing_album['tracks']
-                        _update_tracks_incremental(
-                            {'tracks': tracks}, album_dir
-                        )
-                    else:
-                        tracks = scan_tracks(album_dir)
+                genre = album_dir.parent.name
 
-                    existing_albums[slug] = {
-                        'path': str(album_dir),
-                        'genre': genre,
-                        'title': album_data.get('title', slug),
-                        'status': album_data.get('status', 'Unknown'),
-                        'explicit': album_data.get('explicit', False),
-                        'anchor_track': album_data.get('anchor_track'),
-                        'layout': album_data.get('layout'),
-                        'mastering': album_data.get('mastering') or {},
-                        'release_date': album_data.get('release_date'),
-                        'track_count': album_data.get('track_count', len(tracks)),
-                        'tracks_completed': album_data.get('tracks_completed', 0),
-                        'streaming_urls': album_data.get('streaming_urls', {}),
-                        'readme_mtime': readme_mtime,
-                        'tracks': tracks,
-                    }
+                # Preserve existing tracks and update incrementally
+                # (README change doesn't mean track files changed) —
+                # but only when the cached entry is for this same
+                # directory, not a cross-genre twin.
+                if (existing_album
+                        and existing_album.get('path') == str(album_dir)
+                        and existing_album.get('tracks')):
+                    tracks = existing_album['tracks']
+                    _update_tracks_incremental(
+                        {'tracks': tracks}, album_dir
+                    )
+                else:
+                    tracks = scan_tracks(album_dir)
+
+                existing_albums[slug] = {
+                    'path': str(album_dir),
+                    'genre': genre,
+                    'title': album_data.get('title', slug),
+                    'status': album_data.get('status', 'Unknown'),
+                    'explicit': album_data.get('explicit', False),
+                    'anchor_track': album_data.get('anchor_track'),
+                    'layout': album_data.get('layout'),
+                    'mastering': album_data.get('mastering') or {},
+                    'release_date': album_data.get('release_date'),
+                    'track_count': album_data.get('track_count', len(tracks)),
+                    'tracks_completed': album_data.get('tracks_completed', 0),
+                    'streaming_urls': album_data.get('streaming_urls', {}),
+                    'readme_mtime': readme_mtime,
+                    'tracks': tracks,
+                }
+                winner_dir = album_dir
+                break  # remaining same-slug dirs are shadowed
+
+            if len(readme_paths) > 1 and winner_dir is not None:
+                # Emit the record only with kept = the entry actually
+                # present in the albums map. If no candidate indexed,
+                # there is no record (the parse warnings above already
+                # fired).
+                kept = existing_albums[slug]
+                shadowed = sorted(
+                    ({'genre': p.parent.parent.name, 'path': str(p.parent)}
+                     for p in readme_paths if p.parent != winner_dir),
+                    key=lambda s: s['genre'],
+                )
+                collisions.append({
+                    'slug': slug,
+                    'kept': {'genre': kept['genre'], 'path': kept['path']},
+                    'shadowed': shadowed,
+                })
+                logger.warning(
+                    "Album slug collision: '%s' — keeping %s, shadowing %s. "
+                    "Rename one album (/bitwize-music:rename) or move the "
+                    "directory, then rebuild the state cache.",
+                    slug, kept['path'],
+                    ', '.join(s['path'] for s in shadowed),
+                )
 
         # Remove albums that no longer exist on disk
         for slug in list(existing_albums.keys()):
             if slug not in current_album_slugs:
                 del existing_albums[slug]
+
+        # Collisions are recomputed only when the albums dir was actually
+        # scanned — when it's missing, the albums map is deliberately
+        # preserved above, so preserve the matching collision records
+        # too (#392).
+        state['album_collisions'] = collisions
 
     state['albums'] = existing_albums
 
@@ -1018,6 +1137,21 @@ def validate_state(state: dict[str, Any]) -> list[str]:
     else:
         errors.append("albums should be a dict")
 
+    # Album collisions section (added in 1.3.0; absent on older states is
+    # fine — the migration adds it)
+    if 'album_collisions' in state:
+        album_collisions = state['album_collisions']
+        if isinstance(album_collisions, list):
+            for i, entry in enumerate(album_collisions):
+                if not isinstance(entry, dict):
+                    errors.append(f"album_collisions[{i}] should be a dict")
+                    continue
+                for key in ('slug', 'kept', 'shadowed'):
+                    if key not in entry:
+                        errors.append(f"album_collisions[{i}] missing '{key}'")
+        else:
+            errors.append("album_collisions should be a list")
+
     # Ideas section
     ideas = state.get('ideas', {})
     if isinstance(ideas, dict):
@@ -1094,6 +1228,14 @@ def cmd_rebuild(args: argparse.Namespace) -> int:
     print(f"  Tracks: {track_count}")
     print(f"  Ideas: {ideas_count}")
     print(f"  Skills: {skills_count}")
+    collisions = state.get('album_collisions', [])
+    if collisions:
+        print(f"  Collisions: {len(collisions)}")
+        logger.warning(
+            "%d album slug collision(s) detected — run 'show' for details; "
+            "rename with /bitwize-music:rename or move the directory",
+            len(collisions),
+        )
     print(f"  Saved to: {STATE_FILE}")
     return 0
 
@@ -1119,6 +1261,13 @@ def cmd_update(args: argparse.Namespace) -> int:
     state = incremental_update(migrated, config)
     write_state(state)
 
+    collisions = state.get('album_collisions', [])
+    if collisions:
+        logger.warning(
+            "%d album slug collision(s) detected — run 'show' for details; "
+            "rename with /bitwize-music:rename or move the directory",
+            len(collisions),
+        )
     logger.info("State cache updated")
     return 0
 
@@ -1292,6 +1441,18 @@ def cmd_show(args: argparse.Namespace) -> int:
                 suno = ' [suno]' if track.get('has_suno_link') else ''
                 print(f"    {track_slug}: {t_status}{suno}")
     print()
+
+    # Album slug collisions (#392)
+    collisions = state.get('album_collisions', [])
+    if collisions:
+        print(f"{Colors.BOLD}{Colors.YELLOW}Album slug collisions ({len(collisions)}):{Colors.NC}")
+        for collision in collisions:
+            kept = collision.get('kept', {})
+            print(f"  {collision.get('slug', '?')}: keeping {kept.get('genre', '?')} ({kept.get('path', '?')})")
+            for s in collision.get('shadowed', []):
+                print(f"    shadowed: {s.get('genre', '?')} ({s.get('path', '?')})")
+        print("  Fix: rename one album (/bitwize-music:rename) or move the directory, then rebuild.")
+        print()
 
     # Ideas
     ideas = state.get('ideas', {})

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -54,7 +54,7 @@ except ImportError:
     sys.exit(1)
 
 from tools.shared.colors import Colors
-from tools.shared.config import CONFIG_PATH
+from tools.shared.config import CONFIG_PATH, parse_yaml_bool
 from tools.shared.logging_config import setup_logging
 from tools.state.parsers import (
     parse_album_readme,
@@ -66,7 +66,7 @@ from tools.state.parsers import (
 logger = logging.getLogger(__name__)
 
 # Schema version for state.json
-CURRENT_VERSION = "1.3.0"
+CURRENT_VERSION = "1.4.0"
 
 # Cache location (constant, not configurable)
 CACHE_DIR = Path.home() / ".bitwize-music" / "cache"
@@ -124,12 +124,36 @@ def _migrate_1_2_to_1_3(state: dict[str, Any]) -> dict[str, Any]:
     return state
 
 
+def _migrate_1_3_to_1_4(state: dict[str, Any]) -> dict[str, Any]:
+    """Migrate state from 1.3.0 to 1.4.0: re-coerce cached explicit flags.
+
+    The pre-#388 parsers stored quoted frontmatter booleans (e.g.
+    explicit: "false") as raw truthy strings; re-coerce cached values so
+    they don't linger until the source file's mtime changes.
+    """
+    def _fix(entry: dict[str, Any]) -> None:
+        if 'explicit' in entry:
+            try:
+                entry['explicit'] = parse_yaml_bool(entry['explicit'])
+            except ValueError:
+                entry['explicit'] = False
+
+    for album in (state.get('albums') or {}).values():
+        if isinstance(album, dict):
+            _fix(album)
+            for track in (album.get('tracks') or {}).values():
+                if isinstance(track, dict):
+                    _fix(track)
+    return state
+
+
 # Migration chain for schema upgrades
 # Format: "from_version": (migration_fn, "to_version")
 MIGRATIONS: dict[str, tuple[Any, str]] = {
     "1.0.0": (_migrate_1_0_to_1_1, "1.1.0"),
     "1.1.0": (_migrate_1_1_to_1_2, "1.2.0"),
     "1.2.0": (_migrate_1_2_to_1_3, "1.3.0"),
+    "1.3.0": (_migrate_1_3_to_1_4, "1.4.0"),
 }
 
 
@@ -178,12 +202,25 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     overrides_raw = paths.get('overrides', '')
     overrides_dir = str(resolve_path(overrides_raw)) if overrides_raw else str(Path(content_root) / 'overrides')
 
+    def _cfg_bool(section: dict[str, Any], key: str, default: bool) -> bool:
+        # bool() would turn quoted strings like "false" into True (#388);
+        # parse YAML boolean literals, falling back to the key's default.
+        value = section.get(key, default)
+        try:
+            return parse_yaml_bool(value)
+        except ValueError:
+            logger.warning(
+                "Config %s=%r is not a boolean — using %s", key, value, default
+            )
+            return default
+
     # Database config (expose enabled flag, mask credentials)
     db_config = config.get('database') or {}
+    db_enabled = _cfg_bool(db_config, 'enabled', False)
     database_section = {
-        'enabled': bool(db_config.get('enabled', False)),
-        'host': db_config.get('host', '') if db_config.get('enabled') else '',
-        'name': db_config.get('name', '') if db_config.get('enabled') else '',
+        'enabled': db_enabled,
+        'host': db_config.get('host', '') if db_enabled else '',
+        'name': db_config.get('name', '') if db_enabled else '',
     }
 
     # Generation config (service settings and gates)
@@ -191,10 +228,10 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     additional_genres_raw = gen_config.get('additional_genres', [])
     generation_section = {
         'service': gen_config.get('service', 'suno'),
-        'require_suno_link_for_final': bool(gen_config.get('require_suno_link_for_final', True)),
+        'require_suno_link_for_final': _cfg_bool(gen_config, 'require_suno_link_for_final', True),
         'max_lyric_words': int(gen_config.get('max_lyric_words', 800)),
-        'require_source_path_for_documentary': bool(
-            gen_config.get('require_source_path_for_documentary', True)),
+        'require_source_path_for_documentary': _cfg_bool(
+            gen_config, 'require_source_path_for_documentary', True),
         'additional_genres': [str(g).lower().strip() for g in additional_genres_raw]
         if isinstance(additional_genres_raw, list) else [],
     }

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -34,7 +34,7 @@ import tempfile
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 # Lock timeout in seconds (prevents indefinite blocking)
 LOCK_TIMEOUT_SECONDS = 10
@@ -161,16 +161,30 @@ def read_config() -> dict[str, Any] | None:
     """Read ~/.bitwize-music/config.yaml.
 
     Returns:
-        Parsed config dict, or None if missing/invalid.
+        Parsed config dict ({} for an empty file), or None if missing,
+        unreadable, unparseable, or not a YAML mapping.
     """
     if not CONFIG_FILE.exists():
         return None
     try:
         with open(CONFIG_FILE) as f:
-            return yaml.safe_load(f) or {}
+            data = yaml.safe_load(f)
     except (yaml.YAMLError, OSError) as e:
         logger.error("Cannot read config: %s", e)
         return None
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        # Valid YAML but wrong shape (e.g. top-level list or scalar) — callers
+        # expect a mapping and would crash on .get() (#389)
+        logger.error(
+            "Config at %s parsed as %s, not a mapping — the file must contain "
+            "top-level `key: value` pairs",
+            CONFIG_FILE,
+            type(data).__name__,
+        )
+        return None
+    return data
 
 
 def resolve_path(raw: str) -> Path:
@@ -186,22 +200,39 @@ def get_config_mtime() -> float:
         return 0.0
 
 
+def _cfg_section(config: dict[str, Any], key: str) -> dict[str, Any]:
+    """Return a config section as a dict, treating anything else as empty.
+
+    An empty YAML section header (e.g. `paths:` with nothing under it) parses
+    to None, not {}. config.get('paths', {}) returns that None (the key
+    exists), so None must be normalized to {} here — otherwise .get() on None
+    aborts every cache rebuild/update. (#376)
+    A non-mapping value (e.g. `paths: [a, b]`) crashes the same way; the
+    isinstance check runs before normalization so falsy non-mappings
+    (`paths: []`) warn like truthy ones. (#391)
+    """
+    value = config.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        # Log only the key and type, never the value — sections like
+        # `database` may carry credentials that must not leak into logs.
+        logger.warning(
+            "Config section %s is not a mapping (got %s) — using defaults",
+            key, type(value).__name__,
+        )
+        return {}
+    return value
+
+
 def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     """Build the config section of state.json."""
-    # An empty YAML section header (e.g. `paths:` with nothing under it) parses
-    # to None, not {}. config.get('paths', {}) returns that None (the key
-    # exists), so `... or {}` is required to normalize None-valued sections —
-    # otherwise .get() on None aborts every cache rebuild/update. (#376)
-    paths = config.get('paths') or {}
-    artist = config.get('artist') or {}
+    paths = _cfg_section(config, 'paths')
+    artist = _cfg_section(config, 'artist')
 
-    content_root_raw = paths.get('content_root', '.')
-    content_root = str(resolve_path(content_root_raw))
-
-    # Resolve overrides directory (custom path or default to {content_root}/overrides)
-    overrides_raw = paths.get('overrides', '')
-    overrides_dir = str(resolve_path(overrides_raw)) if overrides_raw else str(Path(content_root) / 'overrides')
-
+    # NOTE: these warnings log only the key and type, never the raw value —
+    # some sections (`database`) carry credentials that must not leak
+    # into logs.
     def _cfg_bool(section: dict[str, Any], key: str, default: bool) -> bool:
         # bool() would turn quoted strings like "false" into True (#388);
         # parse YAML boolean literals, falling back to the key's default.
@@ -210,12 +241,56 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
             return parse_yaml_bool(value)
         except ValueError:
             logger.warning(
-                "Config %s=%r is not a boolean — using %s", key, value, default
+                "Config %s is not a boolean (got %s) — using %s",
+                key, type(value).__name__, default,
             )
             return default
 
+    def _cfg_int(section: dict[str, Any], key: str, default: int) -> int:
+        # int(True) == 1 would silently mangle the setting; int() raises
+        # ValueError/TypeError on non-numeric strings and non-scalars (#391)
+        # and OverflowError on YAML `.inf` floats.
+        value = section.get(key, default)
+        if isinstance(value, bool):
+            logger.warning(
+                "Config %s is not an integer (got %s) — using %s",
+                key, type(value).__name__, default,
+            )
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError):
+            logger.warning(
+                "Config %s is not an integer (got %s) — using %s",
+                key, type(value).__name__, default,
+            )
+            return default
+
+    def _cfg_str(section: dict[str, Any], key: str, default: str) -> str:
+        # Non-string path values (e.g. `content_root: 42`) crash resolve_path
+        # and string concatenation (#391). A blank key (`overrides:` with no
+        # value) parses to None and means "unset" — default silently,
+        # mirroring the #376 empty-section semantics.
+        value = section.get(key, default)
+        if value is None:
+            return default
+        if not isinstance(value, str):
+            logger.warning(
+                "Config %s is not a string (got %s) — using %r",
+                key, type(value).__name__, default,
+            )
+            return default
+        return value
+
+    content_root_raw = _cfg_str(paths, 'content_root', '.')
+    content_root = str(resolve_path(content_root_raw))
+
+    # Resolve overrides directory (custom path or default to {content_root}/overrides)
+    overrides_raw = _cfg_str(paths, 'overrides', '')
+    overrides_dir = str(resolve_path(overrides_raw)) if overrides_raw else str(Path(content_root) / 'overrides')
+
     # Database config (expose enabled flag, mask credentials)
-    db_config = config.get('database') or {}
+    db_config = _cfg_section(config, 'database')
     db_enabled = _cfg_bool(db_config, 'enabled', False)
     database_section = {
         'enabled': db_enabled,
@@ -224,12 +299,12 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
     }
 
     # Generation config (service settings and gates)
-    gen_config = config.get('generation') or {}
+    gen_config = _cfg_section(config, 'generation')
     additional_genres_raw = gen_config.get('additional_genres', [])
     generation_section = {
         'service': gen_config.get('service', 'suno'),
         'require_suno_link_for_final': _cfg_bool(gen_config, 'require_suno_link_for_final', True),
-        'max_lyric_words': int(gen_config.get('max_lyric_words', 800)),
+        'max_lyric_words': _cfg_int(gen_config, 'max_lyric_words', 800),
         'require_source_path_for_documentary': _cfg_bool(
             gen_config, 'require_source_path_for_documentary', True),
         'additional_genres': [str(g).lower().strip() for g in additional_genres_raw]
@@ -238,10 +313,10 @@ def build_config_section(config: dict[str, Any]) -> dict[str, Any]:
 
     return {
         'content_root': content_root,
-        'audio_root': str(resolve_path(paths.get('audio_root', content_root_raw + '/audio'))),
-        'documents_root': str(resolve_path(paths.get('documents_root', content_root_raw + '/documents'))),
+        'audio_root': str(resolve_path(_cfg_str(paths, 'audio_root', content_root_raw + '/audio'))),
+        'documents_root': str(resolve_path(_cfg_str(paths, 'documents_root', content_root_raw + '/documents'))),
         'overrides_dir': overrides_dir,
-        'artist_name': artist.get('name', ''),
+        'artist_name': _cfg_str(artist, 'name', ''),
         'config_mtime': get_config_mtime(),
         'database': database_section,
         'generation': generation_section,
@@ -386,6 +461,25 @@ def scan_tracks(album_dir: Path) -> dict[str, dict[str, Any]]:
     return tracks
 
 
+def _ideas_path(config: dict[str, Any], content_root: Path) -> Path:
+    """Resolve the ideas file path (custom paths.ideas_file or default)."""
+    ideas_file_raw = _cfg_section(config, 'paths').get('ideas_file', '')
+    if ideas_file_raw is None:
+        # A blank `ideas_file:` key parses to None and means "unset" —
+        # default silently (#376 semantics)
+        ideas_file_raw = ''
+    elif not isinstance(ideas_file_raw, str):
+        # Non-string values crash resolve_path (#391)
+        logger.warning(
+            "Config ideas_file is not a string (got %s) — using default",
+            type(ideas_file_raw).__name__,
+        )
+        ideas_file_raw = ''
+    if ideas_file_raw:
+        return resolve_path(ideas_file_raw)
+    return content_root / "IDEAS.md"
+
+
 def scan_ideas(config: dict[str, Any], content_root: Path) -> dict[str, Any]:
     """Scan IDEAS.md file.
 
@@ -396,11 +490,7 @@ def scan_ideas(config: dict[str, Any], content_root: Path) -> dict[str, Any]:
     Returns:
         Dict with ideas data, or empty structure.
     """
-    ideas_file_raw = config.get('paths', {}).get('ideas_file', '')
-    if ideas_file_raw:
-        ideas_path = resolve_path(ideas_file_raw)
-    else:
-        ideas_path = content_root / "IDEAS.md"
+    ideas_path = _ideas_path(config, content_root)
 
     if not ideas_path.exists():
         return {
@@ -524,7 +614,9 @@ def build_state(config: dict[str, Any],
     }
 
 
-def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+def incremental_update(
+    existing_state: dict[str, Any], config: dict[str, Any]
+) -> dict[str, Any] | None:
     """Incrementally update state, only re-parsing changed files.
 
     Compares mtime of each file against stored mtime. Only re-parses
@@ -535,8 +627,23 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
         config: Parsed config dict.
 
     Returns:
-        Updated state dict.
+        Updated state dict, or None when a top-level state section is
+        wrong-typed and a full rebuild is required.
     """
+    # Wrong-typed top-level sections (e.g. "config": [] or "albums": "x")
+    # would crash the .get() lookups below — hand back None so the caller
+    # falls back to a full rebuild, the same contract as migrate_state
+    # (#393 family).
+    for section_key in ('config', 'albums'):
+        section_value = existing_state.get(section_key, {})
+        if not isinstance(section_value, dict):
+            logger.warning(
+                "State section %s is not a mapping (got %s) — "
+                "full rebuild required",
+                section_key, type(section_value).__name__,
+            )
+            return None
+
     config_section = build_config_section(config)
     content_root = Path(config_section['content_root'])
     artist_name = config_section['artist_name']
@@ -559,7 +666,7 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
         )
         ideas_path_changed = (
             path_fields_changed or
-            config.get('paths', {}).get('ideas_file') !=
+            _cfg_section(config, 'paths').get('ideas_file') !=
             existing_state.get('_ideas_file_raw')
         )
 
@@ -575,7 +682,7 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
         # else: ideas path unchanged — keep ideas
 
         # Store ideas_file_raw for future comparison
-        state['_ideas_file_raw'] = config.get('paths', {}).get('ideas_file', '')
+        state['_ideas_file_raw'] = _cfg_section(config, 'paths').get('ideas_file', '')
         return state
 
     # Incremental album update
@@ -705,11 +812,7 @@ def incremental_update(existing_state: dict[str, Any], config: dict[str, Any]) -
     state['albums'] = existing_albums
 
     # Incremental ideas update
-    ideas_file_raw = config.get('paths', {}).get('ideas_file', '')
-    if ideas_file_raw:
-        ideas_path = resolve_path(ideas_file_raw)
-    else:
-        ideas_path = content_root / "IDEAS.md"
+    ideas_path = _ideas_path(config, content_root)
 
     old_ideas_mtime = state.get('ideas', {}).get('file_mtime', 0)
     if ideas_path.exists():
@@ -869,32 +972,42 @@ def write_state(state: dict[str, Any]) -> None:
             lock_fd.close()
 
 
+def _quarantine_corrupt_state(reason: str) -> dict[str, Any]:
+    """Back up an unusable state file and return an empty state."""
+    logger.error("%s — backing up and returning empty state", reason)
+    try:
+        import shutil
+
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
+        backup_path = CACHE_DIR / f"state.{timestamp}.corrupt"
+        shutil.copy2(STATE_FILE, backup_path)
+        logger.error("Corrupted state backed up to %s", backup_path)
+    except OSError as backup_err:
+        logger.error("Could not backup corrupted state: %s", backup_err)
+    return {}
+
+
 def read_state() -> dict[str, Any] | None:
     """Read state from cache file.
 
     Returns:
-        Parsed state dict, empty dict if corrupted (after backup), or None if missing.
+        Parsed state dict, empty dict if corrupted or not a JSON object
+        (after backup), or None if missing.
     """
     if not STATE_FILE.exists():
         return None
     try:
         with open(STATE_FILE) as f:
-            return cast(dict[str, Any], json.load(f))
+            data = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
-        # Corrupted — backup the file and return empty state
-        logger.error(
-            "Corrupted state file: %s — backing up and returning empty state", e
+        return _quarantine_corrupt_state(f"Corrupted state file: {e}")
+    if not isinstance(data, dict):
+        # JSON-valid but wrong shape (list/str/number) — same recovery as
+        # corrupted JSON: back it up and start fresh (#393 family)
+        return _quarantine_corrupt_state(
+            f"State file is {type(data).__name__}, not a JSON object"
         )
-        try:
-            import shutil
-
-            timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S")
-            backup_path = CACHE_DIR / f"state.{timestamp}.corrupt"
-            shutil.copy2(STATE_FILE, backup_path)
-            logger.error("Corrupted state backed up to %s", backup_path)
-        except OSError as backup_err:
-            logger.error("Could not backup corrupted state: %s", backup_err)
-        return {}
+    return data
 
 
 def migrate_state(state: dict[str, Any]) -> dict[str, Any] | None:
@@ -904,10 +1017,28 @@ def migrate_state(state: dict[str, Any]) -> dict[str, Any] | None:
         state: Current state dict.
 
     Returns:
-        Migrated state dict. If migration fails or version is
-        unrecognized, returns None to trigger full rebuild.
+        Migrated state dict. If the state is not a dict, migration fails,
+        or the version is unrecognized, returns None to trigger full rebuild.
     """
+    # Defensive: JSON-valid non-object states (list/str/number) reach here
+    # from callers that bypass read_state()'s shape check — .get() below
+    # would crash (#393 family)
+    if not isinstance(state, dict):
+        logger.warning(  # type: ignore[unreachable]
+            "State is %s, not a dict — triggering full rebuild",
+            type(state).__name__,
+        )
+        return None
+
     version = state.get('version', '0.0.0')
+
+    # Non-string version (e.g. JSON "version": 1.2) would crash
+    # _version_compare — treat as unrecognized and rebuild (#393)
+    if not isinstance(version, str):
+        logger.warning(
+            "Non-string state version %r — triggering full rebuild", version
+        )
+        return None
 
     # If version is newer than what we know, rebuild
     if _version_compare(version, CURRENT_VERSION) > 0:
@@ -981,7 +1112,17 @@ def carry_migration_tracking(
     """
     if existing_state is None:
         return new_state
-    new_state['last_migrated_version'] = existing_state.get('last_migrated_version')
+    prior = existing_state.get('last_migrated_version')
+    if prior is not None and not isinstance(prior, str):
+        # A wrong-typed value must not survive rebuilds only to crash
+        # get_pending_migrations' version comparison later — drop it to
+        # None, which keeps pending migrations visible (#393 family).
+        logger.warning(
+            "Non-string last_migrated_version (got %s) — treating as untracked",
+            type(prior).__name__,
+        )
+        prior = None
+    new_state['last_migrated_version'] = prior
     return new_state
 
 
@@ -1055,6 +1196,15 @@ def get_pending_migrations(
         plugin_root = _PROJECT_ROOT
     installed = _read_plugin_version(plugin_root)
     last = state.get('last_migrated_version')
+    if last is not None and not isinstance(last, str):
+        # A wrong-typed value would crash _version_compare's .split() —
+        # treat it as untracked, the same branch as a missing value
+        # (#393 family).
+        logger.warning(
+            "Non-string last_migrated_version (got %s) — treating as untracked",
+            type(last).__name__,
+        )
+        last = None
 
     parsed: list[dict[str, Any]] = []
     migrations_dir = plugin_root / 'migrations'
@@ -1296,6 +1446,9 @@ def cmd_update(args: argparse.Namespace) -> int:
         return cmd_rebuild(args)
 
     state = incremental_update(migrated, config)
+    if state is None:
+        logger.info("State sections invalid, performing full rebuild...")
+        return cmd_rebuild(args)
     write_state(state)
 
     collisions = state.get('album_collisions', [])

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -32,6 +32,18 @@ _RE_IDEAS_SECTION = re.compile(r'^##\s+Ideas\b', re.MULTILINE)
 _RE_IDEAS_SPLIT = re.compile(r'^###\s+', re.MULTILINE)
 
 
+def _frontmatter_bool(value: Any, default: bool = False, context: str = "explicit") -> bool:
+    """Coerce a frontmatter boolean, honoring quoted strings.
+
+    bool() turns quoted YAML booleans like "false" into True (#388);
+    unrecognized values fall back to `default` with a warning rather than
+    aborting the parse — frontmatter is hand-edited and a bad flag
+    shouldn't drop the whole file from the cache.
+    """
+    from tools.shared.config import coerce_yaml_bool
+    return coerce_yaml_bool(value, default=default, context=context)
+
+
 def parse_frontmatter(text: str) -> dict[str, Any]:
     """Parse YAML frontmatter from markdown content.
 
@@ -170,7 +182,7 @@ def parse_album_readme(path: Path) -> dict[str, Any]:
     else:
         result['title'] = _extract_heading(text)
     result['release_date'] = fm.get('release_date') or None
-    result['explicit'] = fm.get('explicit', False)
+    result['explicit'] = _frontmatter_bool(fm.get('explicit', False))
 
     # Optional anchor-track override for album mastering (issue #290 phase 2).
     # Frontmatter uses 1-based track numbers. Non-int / null / missing → None,
@@ -384,7 +396,7 @@ def parse_track_file(path: Path) -> dict[str, Any]:
     if explicit_raw:
         result['explicit'] = explicit_raw.lower().strip() in ('yes', 'true')
     elif 'explicit' in fm:
-        result['explicit'] = bool(fm['explicit'])
+        result['explicit'] = _frontmatter_bool(fm['explicit'])
     else:
         result['explicit'] = False
 


### PR DESCRIPTION
## Release 0.94.0

Bugfix + docs release rolling up everything since 0.93.0 — **14 closed issues** across six PR clusters, every fix TDD'd, adversarially reviewed, and verified against reproductions.

### Fixed
- **Crash-hardening for config/state loading** (#389, #391, #393 — PR #440): `load_config` and the indexer's `read_config` reject non-mapping YAML cleanly; `build_config_section` guards wrong-typed ints/paths/sections with warn-and-default (credential-safe logging); `migrate_state` handles non-string versions, non-object state files, and wrong-typed state sections via the full-rebuild path.
- **Copilot CLI compatibility** (#439 — PR #438, @thejesh23): bracket-form `argument-hint` frontmatter quoted so skills load as strings on every runtime (empirically validated on Copilot CLI 1.0.64/1.0.68).
- **Honest tool reporting** (#382, #384, #385 — PR #437): pronunciation gate parser no longer drops rows containing "Word", batch promo generation reports real per-track results, `--retries` floor prevents silent upload skips.
- **Atomic writes & honest rename recovery** (#381, #383, #398 — PR #435): IDEAS.md and status writes are crash-safe; rename failures rebuild the cache and say so.
- **Path/timeout/boolean fixes** (#375, #387, #388 — PR #434): transcribe album resolution, codec-preview ffmpeg timeout, quoted YAML boolean coercion.
- **Album slug-collision detection** (#392 — PR #433): cross-genre collisions surfaced everywhere instead of silently erasing an album.

### Docs
- Suno vocal-age and generic-vocal troubleshooting guides (PR #436, @markus-michalski).

### Verification
- Full local gate on the release head: ruff + bandit + mypy clean, 4008 tests passing, 85.73% coverage
- Version files in sync: plugin.json + marketplace.json → 0.94.0

⚠️ **Merge with a MERGE COMMIT — never squash** (squashing diverges develop/main permanently; see CLAUDE.md release rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd