### PR TITLE
fix(handlers): validate inputs — return structured errors instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **`create_track` validates `track_number`** (#372). Non-numeric values
+  (`abc`, `1a`, empty), `None`, booleans, and zero/negative numbers now
+  return a structured error naming the invalid value instead of crashing
+  with an unhandled `ValueError` — and `00` no longer silently creates a
+  malformed `00-title.md` track. Integers and numeric strings (`7`, `"03"`)
+  keep working.
+- **`_update_frontmatter_block` honors its error contract** (#378). A track
+  file whose frontmatter parses to a list or scalar now returns
+  `(False, "Frontmatter in <path> is not a mapping (got <type>)")` per the
+  documented contract instead of raising `TypeError` out of the sheet-music
+  publish loop.
+- **`db_sync_album` returns a JSON error on malformed slugs** (#379). Slugs
+  containing path separators, null bytes, or `..` raised an uncaught
+  `ValueError` to the FastMCP layer; the slug lookup is now guarded with the
+  same try/except pattern every sibling `db_*` handler uses.
+- **`db_create_tweet` no longer silently drops the track link** (#380). When
+  `track_number > 0` but no matching track row exists, the tool inserted the
+  tweet with a NULL `track_id` while echoing the requested track number as
+  if it had linked. It now returns an error naming the missing track and
+  album (suggesting `db_sync_album` or `track_number=0`) before any insert.
+- **`analyze_tracks.py` handles WAV-less directories** (#386). Pointing the
+  CLI at a directory with no WAV files crashed with a `ValueError` from an
+  empty-array reduction; it now logs a clear "No tracks to analyze" error
+  and exits nonzero.
+- **Slug validation errors are clean JSON in three more handlers** (#397).
+  `reset_mastering`, `migrate_audio_layout`, and `get_skill` let
+  `_normalize_slug`'s `ValueError` escape as an opaque tool error on inputs
+  like `../other`; all three now catch it and return their module's
+  structured error shape.
+
 ## [0.94.0] - 2026-07-03
 
 ### Fixed

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -212,6 +212,12 @@ def _update_frontmatter_block(
     except yaml.YAMLError as exc:
         return False, f"Cannot parse frontmatter YAML in {file_path}: {exc}"
 
+    if not isinstance(fm, dict):
+        return False, (
+            f"Frontmatter in {file_path} is not a mapping "
+            f"(got {type(fm).__name__})"
+        )
+
     fm[key] = values
 
     new_fm_text = yaml.dump(

--- a/servers/bitwize-music-server/handlers/database.py
+++ b/servers/bitwize-music-server/handlers/database.py
@@ -283,7 +283,9 @@ async def db_create_tweet(
     Args:
         album_slug: Album slug (e.g., "my-album")
         tweet_text: The post text content
-        track_number: Track number to link (0 = album-level post, no track link)
+        track_number: Track number to link (0 = album-level post, no track
+                      link). Returns an error if the track is not found in
+                      the database — no tweet is created.
         platform: Target platform ("twitter", "instagram", "tiktok",
                   "facebook", "youtube"). Default: "twitter"
         content_type: Post type ("promo", "announcement", "engagement",
@@ -327,8 +329,14 @@ async def db_create_tweet(
                 (album_id, track_number),
             )
             track_row = cur.fetchone()
-            if track_row:
-                track_id = track_row["id"]
+            if not track_row:
+                return _safe_json({
+                    "error": f"Track {track_number} not found for album "
+                             f"'{album_slug}' in database. "
+                             "Use db_sync_album to sync tracks first, or pass "
+                             "track_number=0 for an album-level post.",
+                })
+            track_id = track_row["id"]
 
         cur.execute(
             """INSERT INTO tweets
@@ -643,8 +651,14 @@ async def db_sync_album(album_slug: str) -> str:
     if dep_err:
         return _safe_json({"error": dep_err})
 
-    # Get album from plugin state cache
-    slug, album_data, err = _find_album_or_error(album_slug)
+    # Get album from plugin state cache. _find_album_or_error normalizes the
+    # slug, which raises ValueError on path separators, null bytes, or
+    # traversal sequences — convert that into the structured JSON error all
+    # db_* handlers return instead of letting it escape to the MCP layer (#379).
+    try:
+        slug, album_data, err = _find_album_or_error(album_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
     if err:
         return err
     assert album_data is not None

--- a/servers/bitwize-music-server/handlers/maintenance.py
+++ b/servers/bitwize-music-server/handlers/maintenance.py
@@ -57,7 +57,10 @@ async def reset_mastering(
                     "originals/ and stems/ are protected.",
         })
 
-    err, audio_dir = _resolve_audio_dir(album_slug)
+    try:
+        err, audio_dir = _resolve_audio_dir(album_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
     if err:
         return err
     assert audio_dir is not None
@@ -190,7 +193,10 @@ async def migrate_audio_layout(
 
     albums = state.get("albums", {})
     if album_slug:
-        normalized = _normalize_slug(album_slug)
+        try:
+            normalized = _normalize_slug(album_slug)
+        except ValueError as exc:
+            return _safe_json({"error": str(exc)})
         if normalized not in albums:
             return _safe_json({"error": f"Album '{album_slug}' not found in state"})
         album_items = [(normalized, albums[normalized])]

--- a/servers/bitwize-music-server/handlers/skills.py
+++ b/servers/bitwize-music-server/handlers/skills.py
@@ -70,7 +70,10 @@ async def get_skill(name: str) -> str:
             "error": "No skills in state cache. Run rebuild_state first.",
         })
 
-    normalized = _normalize_slug(name)
+    try:
+        normalized = _normalize_slug(name)
+    except ValueError as exc:
+        return _safe_json({"found": False, "error": str(exc)})
 
     # Exact match first
     if normalized in items:

--- a/servers/bitwize-music-server/handlers/status.py
+++ b/servers/bitwize-music-server/handlers/status.py
@@ -425,7 +425,7 @@ async def update_album_status(album_slug: str, status: str, force: bool = False)
 
 async def create_track(
     album_slug: str,
-    track_number: str,
+    track_number: str | int,
     title: str,
     documentary: bool = False,
 ) -> str:
@@ -436,7 +436,8 @@ async def create_track(
 
     Args:
         album_slug: Album slug (e.g., "my-album")
-        track_number: Two-digit track number (e.g., "01", "02")
+        track_number: Positive track number as a numeric string or int
+            (e.g., "01", "2", 7). Anything else returns a structured error.
         title: Track title (e.g., "My New Track")
         documentary: Keep source/quote sections (default: strip them)
 
@@ -456,9 +457,29 @@ async def create_track(
     if not tracks_dir.is_dir():
         return _safe_json({"error": f"tracks/ directory not found in {album_path}"})
 
+    # Validate track_number: must be a positive integer, as an int or a
+    # numeric string (#372). Check bool explicitly — it is an int subclass,
+    # so True would otherwise silently become track 01.
+    invalid_track_number = _safe_json({
+        "error": (
+            f"Invalid track_number {track_number!r}: "
+            'must be a positive integer (e.g., "01", "2")'
+        )
+    })
+    if isinstance(track_number, bool) or not isinstance(track_number, (int, str)):
+        return invalid_track_number
+    if isinstance(track_number, str):
+        try:
+            number = int(track_number.strip())
+        except ValueError:
+            return invalid_track_number
+    else:
+        number = track_number
+    if number < 1:
+        return invalid_track_number
+
     # Normalize track number to zero-padded two digits
-    num = track_number.strip().lstrip("0") or "0"
-    padded = num.zfill(2)
+    padded = str(number).zfill(2)
 
     # Build slug from number and title
     title_slug = _normalize_slug(title)
@@ -492,7 +513,7 @@ async def create_track(
     content = content.replace("[Track's role in the album narrative]", "—")
 
     # Fill frontmatter placeholders
-    content = content.replace("track_number: 0", f"track_number: {int(padded)}")
+    content = content.replace("track_number: 0", f"track_number: {number}")
     content = content.replace(
         "explicit: false",
         f"explicit: {'true' if album.get('explicit', False) else 'false'}",

--- a/tests/unit/mastering/test_analyze_tracks.py
+++ b/tests/unit/mastering/test_analyze_tracks.py
@@ -8,8 +8,10 @@ Usage:
     python -m pytest tools/mastering/tests/test_analyze_tracks.py -v
 """
 
+import logging
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -20,7 +22,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from tools.mastering.analyze_tracks import analyze_track
+from tools.mastering.analyze_tracks import analyze_track, main
 
 
 def _generate_sine(freq=440.0, duration=3.0, rate=44100, amplitude=0.5, stereo=True):
@@ -196,3 +198,74 @@ class TestAnalyzeTrackEdgeCases:
     def test_nonexistent_file_raises(self, tmp_path):
         with pytest.raises(Exception):
             analyze_track(str(tmp_path / "nonexistent.wav"))
+
+
+# ─── Tests: main() empty-directory guard ──────────────────────────────
+
+
+def _fake_analysis(path):
+    """Lightweight stand-in for analyze_track — avoids heavy DSP in main() tests."""
+    return {
+        'filename': Path(path).name,
+        'duration': 3.0,
+        'sample_rate': 44100,
+        'lufs': -14.2,
+        'peak_db': -1.0,
+        'rms_db': -18.0,
+        'dynamic_range': 12.0,
+        'band_energy': {
+            'sub_bass': 5.0, 'bass': 20.0, 'low_mid': 20.0, 'mid': 25.0,
+            'high_mid': 15.0, 'high': 10.0, 'air': 5.0,
+        },
+        'is_dark': False,
+        'tinniness_ratio': 0.3,
+        'max_short_term_lufs': -12.0,
+        'max_momentary_lufs': -10.5,
+        'short_term_range': 4.0,
+        'stl_95': -13.0,
+        'low_rms': -20.0,
+        'vocal_rms': None,
+        'signature_meta': {},
+    }
+
+
+class TestMainNoWavFiles:
+    """main() should exit cleanly (no traceback) when no WAV files are found.
+
+    The error must be reported via the module logger (same convention as the
+    sibling directory-not-found path in main()), not via print to stdout.
+    """
+
+    def test_empty_directory_exits_nonzero_with_message(
+            self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr(sys, 'argv', ['analyze_tracks.py', str(tmp_path)])
+        with caplog.at_level(logging.ERROR, logger='tools.mastering.analyze_tracks'):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+        assert excinfo.value.code == 1
+        assert "No tracks to analyze" in caplog.text
+        assert "no WAV files found" in caplog.text
+
+    def test_directory_with_only_non_wav_files_exits_nonzero(
+            self, tmp_path, monkeypatch, caplog):
+        (tmp_path / "notes.txt").write_text("not audio")
+        (tmp_path / "cover.png").write_bytes(b"\x89PNG")
+        (tmp_path / "song.mp3").write_bytes(b"ID3")
+        monkeypatch.setattr(sys, 'argv', ['analyze_tracks.py', str(tmp_path)])
+        with caplog.at_level(logging.ERROR, logger='tools.mastering.analyze_tracks'):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+        assert excinfo.value.code == 1
+        assert "No tracks to analyze" in caplog.text
+
+    def test_normal_directory_still_analyzes(self, tmp_path, monkeypatch, capsys):
+        """Directories with WAV files must run to completion, unaffected by the guard."""
+        (tmp_path / "track.wav").touch()
+        monkeypatch.setattr(sys, 'argv', ['analyze_tracks.py', str(tmp_path)])
+        with patch('tools.mastering.analyze_tracks.analyze_track',
+                   side_effect=_fake_analysis):
+            main()  # must not raise SystemExit
+        out = capsys.readouterr().out
+        assert "track.wav" in out
+        assert "LUFS range across album" in out
+        assert "No tracks to analyze" not in out

--- a/tests/unit/state/test_create_track_validation.py
+++ b/tests/unit/state/test_create_track_validation.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Unit tests for create_track track_number validation (issue #372).
+
+create_track previously crashed with an unhandled ValueError when
+track_number contained non-digits (e.g. "1a"), and silently created a
+spurious track "00" for empty/whitespace input. It must instead return the
+module's structured ``{"error": ...}`` JSON for any track_number that is not
+a positive integer, and preserve normal behavior for valid ints and numeric
+strings.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_track_validation.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_handlers_rename.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_create_track", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import status as _status_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic filesystem layout + mock cache
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+@pytest.fixture
+def cache_with_album(tmp_path: Path):
+    """Install a mock cache populated with a single album with a tracks/ dir."""
+    content_root = tmp_path / "content"
+    album_dir = (
+        content_root / "artists" / "test-artist" / "albums" / "electronic"
+        / "test-album"
+    )
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+    (album_dir / "README.md").write_text(
+        "# Test Album\n\n## Album Details\n\n| **Title** | Test Album |\n",
+        encoding="utf-8",
+    )
+
+    album_data = {
+        "title": "Test Album",
+        "status": "In Progress",
+        "genre": "electronic",
+        "explicit": False,
+        "path": str(album_dir),
+        "track_count": 0,
+        "tracks_completed": 0,
+        "tracks": {},
+    }
+
+    state = {
+        "version": 2,
+        "config": {
+            "content_root": str(content_root),
+            "artist_name": "test-artist",
+            "generation": {},
+        },
+        "albums": {"test-album": album_data},
+        "session": {},
+    }
+
+    orig_cache = _shared_mod.cache
+    orig_plugin_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.cache = MockStateCache(state)
+    # Real template lives at PROJECT_ROOT/templates/track.md
+    _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+
+    yield state, tracks_dir
+
+    _shared_mod.cache = orig_cache
+    _shared_mod.PLUGIN_ROOT = orig_plugin_root
+
+
+def _create(track_number, title: str = "My New Track") -> dict:
+    return json.loads(_run(
+        _status_mod.create_track("test-album", track_number, title)
+    ))
+
+
+# ===========================================================================
+# Invalid track_number values — structured error, no exception, no file
+# ===========================================================================
+
+
+class TestCreateTrackInvalidNumbers:
+    @pytest.mark.parametrize("bad", ["abc", "1a", "v2", "track1", "", " "])
+    def test_non_numeric_string_returns_structured_error(self, cache_with_album, bad):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(bad)
+
+        assert "error" in result
+        assert "track_number" in result["error"]
+        assert list(tracks_dir.iterdir()) == []
+
+    def test_error_names_the_invalid_value(self, cache_with_album):
+        result = _create("1a")
+
+        assert "error" in result
+        assert "1a" in result["error"]
+
+    def test_none_returns_structured_error(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(None)
+
+        assert "error" in result
+        assert list(tracks_dir.iterdir()) == []
+
+    @pytest.mark.parametrize("bad", [-1, 0])
+    def test_non_positive_int_returns_structured_error(self, cache_with_album, bad):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(bad)
+
+        assert "error" in result
+        assert str(bad) in result["error"]
+        assert list(tracks_dir.iterdir()) == []
+
+    @pytest.mark.parametrize("bad", ["-1", "0", "00"])
+    def test_non_positive_numeric_string_returns_structured_error(
+        self, cache_with_album, bad
+    ):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(bad)
+
+        assert "error" in result
+        assert list(tracks_dir.iterdir()) == []
+
+    def test_bool_true_returns_structured_error(self, cache_with_album):
+        """bool is an int subclass — True must not become track 01."""
+        _state, tracks_dir = cache_with_album
+
+        result = _create(True)
+
+        assert "error" in result
+        assert "True" in result["error"]
+        assert list(tracks_dir.iterdir()) == []
+
+
+# ===========================================================================
+# Valid track_number values — normal behavior preserved
+# ===========================================================================
+
+
+class TestCreateTrackValidNumbers:
+    def test_numeric_string_creates_zero_padded_track(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create("7")
+
+        assert result["created"] is True
+        assert result["filename"] == "07-my-new-track.md"
+        assert result["track_slug"] == "07-my-new-track"
+        track_path = tracks_dir / "07-my-new-track.md"
+        assert track_path.exists()
+        content = track_path.read_text(encoding="utf-8")
+        assert "track_number: 7" in content
+        assert "| **Track #** | 07 |" in content
+
+    def test_plain_int_creates_zero_padded_track(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(7)
+
+        assert result["created"] is True
+        assert result["filename"] == "07-my-new-track.md"
+        assert (tracks_dir / "07-my-new-track.md").exists()
+
+    def test_zero_padded_string_preserved(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create("03")
+
+        assert result["created"] is True
+        assert result["filename"] == "03-my-new-track.md"
+        content = (tracks_dir / "03-my-new-track.md").read_text(encoding="utf-8")
+        assert "track_number: 3" in content
+
+    def test_two_digit_number_not_repadded(self, cache_with_album):
+        _state, _tracks_dir = cache_with_album
+
+        result = _create("12")
+
+        assert result["created"] is True
+        assert result["filename"] == "12-my-new-track.md"
+
+    def test_existing_track_still_reports_duplicate(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+        (tracks_dir / "07-my-new-track.md").write_text("stub", encoding="utf-8")
+
+        result = _create("7")
+
+        assert result["created"] is False
+        assert "error" in result

--- a/tests/unit/state/test_frontmatter_block_validation.py
+++ b/tests/unit/state/test_frontmatter_block_validation.py
@@ -1,0 +1,72 @@
+"""Tests for _update_frontmatter_block non-mapping frontmatter validation (issue #378).
+
+``_update_frontmatter_block`` documents a ``(True, None)`` / ``(False, error)``
+contract, but frontmatter that parses to a YAML list or scalar used to raise
+``TypeError`` at ``fm[key] = values``. These tests pin the contract: non-dict
+frontmatter must return ``(False, error_string)`` and leave the file untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers._shared import _update_frontmatter_block  # noqa: E402
+
+
+class TestNonMappingFrontmatter:
+    """Non-dict frontmatter must return (False, error), never raise."""
+
+    def test_list_frontmatter_returns_false_error(self, tmp_path: Path) -> None:
+        md = tmp_path / "track.md"
+        original = "---\n- a\n- b\n---\n# Body\n"
+        md.write_text(original, encoding="utf-8")
+
+        ok, err = _update_frontmatter_block(md, "sheet_music", {"pdf": "http://x/y.pdf"})
+
+        assert ok is False
+        assert err is not None
+        assert "not a mapping" in err
+        assert str(md) in err
+        assert "list" in err
+        # File must be left untouched on failure.
+        assert md.read_text(encoding="utf-8") == original
+
+    def test_scalar_frontmatter_returns_false_error(self, tmp_path: Path) -> None:
+        md = tmp_path / "track.md"
+        original = "---\njust a string\n---\n# Body\n"
+        md.write_text(original, encoding="utf-8")
+
+        ok, err = _update_frontmatter_block(md, "sheet_music", {"pdf": "http://x/y.pdf"})
+
+        assert ok is False
+        assert err is not None
+        assert "not a mapping" in err
+        assert str(md) in err
+        assert "str" in err
+        assert md.read_text(encoding="utf-8") == original
+
+
+class TestValidMappingFrontmatter:
+    """Regression guard: dict frontmatter keeps working."""
+
+    def test_mapping_frontmatter_updates_successfully(self, tmp_path: Path) -> None:
+        md = tmp_path / "track.md"
+        md.write_text("---\ntitle: Song\n---\n# Body\n", encoding="utf-8")
+
+        ok, err = _update_frontmatter_block(md, "sheet_music", {"pdf": "http://x/y.pdf"})
+
+        assert ok is True
+        assert err is None
+        text = md.read_text(encoding="utf-8")
+        assert "title: Song" in text
+        assert "sheet_music:" in text
+        assert "pdf: http://x/y.pdf" in text
+        assert "# Body" in text

--- a/tests/unit/state/test_handlers_database_validation.py
+++ b/tests/unit/state/test_handlers_database_validation.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Input-validation tests for handlers/database.py MCP tool handlers.
+
+Malformed slugs (path separators, null bytes, traversal sequences) must
+produce a structured JSON error via _safe_json — never an exception that
+escapes the handler to the FastMCP layer.
+
+Structured one class per tool so later issues can append their own classes.
+
+Covers:
+    - issue #379: db_sync_album crashed with an uncaught ValueError on
+      malformed album_slug because _find_album_or_error ran outside the
+      handler's try block.
+    - issue #380: db_create_tweet silently dropped the track link (inserted
+      track_id NULL) and falsely echoed the requested track_number when the
+      track row was not found for the album.
+
+Usage:
+    python -m pytest tests/unit/state/test_handlers_database_validation.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the MCP server source is importable as the `handlers` package
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import database as _database_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(coro: Any) -> str:
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+SAMPLE_STATE: dict[str, Any] = {
+    "albums": {
+        "test-album": {
+            "title": "Test Album",
+            "genre": "electronic",
+            "status": "In Progress",
+            "track_count": 1,
+            "explicit": False,
+            "release_date": None,
+            "streaming_urls": {},
+            "tracks": {
+                "01-first-track": {"title": "First Track"},
+            },
+        },
+    },
+}
+
+
+class MockStateCache:
+    """Minimal StateCache stand-in for _shared.cache."""
+
+    def __init__(self, state: dict[str, Any] | None = None):
+        self._state = state if state is not None else copy.deepcopy(SAMPLE_STATE)
+
+    def get_state(self) -> dict[str, Any]:
+        return self._state
+
+    def get_state_ref(self) -> dict[str, Any]:
+        return self._state
+
+
+class _FakeSyncCursor:
+    """Cursor stand-in for db_sync_album's INSERT ... RETURNING queries."""
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        pass
+
+    def fetchone(self) -> dict[str, Any]:
+        return {"id": 1}
+
+
+class _PatchedDb:
+    """Patch DB deps, connection, and psycopg2 import for handler tests."""
+
+    def __init__(self) -> None:
+        self.conn = MagicMock()
+        self.conn.cursor.return_value = _FakeSyncCursor()
+
+        fake_extras = MagicMock()
+        fake_extras.RealDictCursor = "RealDictCursor"
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.extras = fake_extras
+
+        self._patches = [
+            patch("handlers.database._check_db_deps", return_value=None),
+            patch(
+                "handlers.database._get_db_connection",
+                return_value=(self.conn, None),
+            ),
+            patch.dict(sys.modules, {
+                "psycopg2": fake_psycopg2,
+                "psycopg2.extras": fake_extras,
+            }),
+        ]
+
+    def __enter__(self) -> "_PatchedDb":
+        for p in self._patches:
+            p.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        for p in reversed(self._patches):
+            p.__exit__(*args)
+
+
+# =============================================================================
+# db_sync_album — issue #379
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDbSyncAlbumSlugValidation:
+    """db_sync_album must return a JSON error on malformed album_slug (#379)."""
+
+    def setup_method(self) -> None:
+        self._orig_cache = _shared_mod.cache
+        _shared_mod.cache = MockStateCache()
+
+    def teardown_method(self) -> None:
+        _shared_mod.cache = self._orig_cache
+
+    @pytest.mark.parametrize("bad_slug", [
+        "../etc",
+        "a/b",
+        "a\\b",
+        "nul\0byte",
+    ])
+    def test_malformed_slug_returns_json_error(self, bad_slug: str) -> None:
+        """Malformed slugs return a structured JSON error, not an exception."""
+        with _PatchedDb():
+            result = _run(_database_mod.db_sync_album(bad_slug))
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Invalid" in parsed["error"]
+        assert "synced" not in parsed
+
+    def test_valid_slug_not_found_returns_not_found_error(self) -> None:
+        """Valid but unknown slug still returns the album-not-found JSON."""
+        with _PatchedDb():
+            result = _run(_database_mod.db_sync_album("no-such-album"))
+        parsed = json.loads(result)
+        assert parsed["found"] is False
+        assert "not found" in parsed["error"]
+        assert "available_albums" in parsed
+
+    def test_valid_slug_syncs_album(self) -> None:
+        """Valid existing slug syncs album and tracks (behavior unchanged)."""
+        with _PatchedDb() as db:
+            result = _run(_database_mod.db_sync_album("test-album"))
+        parsed = json.loads(result)
+        assert parsed == {
+            "synced": True,
+            "album_slug": "test-album",
+            "album_id": 1,
+            "tracks_synced": 1,
+        }
+        db.conn.commit.assert_called_once()
+        db.conn.close.assert_called_once()
+
+
+# =============================================================================
+# db_create_tweet — issue #380
+# =============================================================================
+
+
+class _FakeTweetCursor:
+    """Cursor stand-in for db_create_tweet's SELECT/INSERT queries.
+
+    Dispatches fetchone() results based on the last executed SQL so a
+    single cursor can serve the album lookup, the track lookup, and the
+    INSERT ... RETURNING in sequence.
+    """
+
+    def __init__(self, track_exists: bool = True) -> None:
+        self.track_exists = track_exists
+        self.executed: list[str] = []
+        self._last_sql = ""
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self._last_sql = sql
+        self.executed.append(sql)
+
+    def fetchone(self) -> dict[str, Any] | None:
+        if "FROM albums" in self._last_sql:
+            return {"id": 1}
+        if "FROM tracks" in self._last_sql:
+            return {"id": 42} if self.track_exists else None
+        if "INSERT INTO tweets" in self._last_sql:
+            return {
+                "id": 7,
+                "tweet_text": "check out this track",
+                "platform": "twitter",
+                "content_type": "promo",
+                "media_path": None,
+                "posted": False,
+                "enabled": True,
+                "times_posted": 0,
+                "created_at": "2026-01-01T00:00:00",
+            }
+        return None
+
+    @property
+    def inserted(self) -> bool:
+        return any("INSERT INTO tweets" in sql for sql in self.executed)
+
+
+@pytest.mark.unit
+class TestDbCreateTweetTrackLink:
+    """db_create_tweet must not silently drop a requested track link (#380)."""
+
+    def test_missing_track_returns_json_error(self) -> None:
+        """track_number > 0 with no matching track row → structured error."""
+        cursor = _FakeTweetCursor(track_exists=False)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            result = _run(_database_mod.db_create_tweet(
+                "test-album", "check out this track", track_number=5,
+            ))
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "5" in parsed["error"]
+        assert "created" not in parsed
+        assert "track_number" not in parsed.get("tweet", {})
+
+    def test_missing_track_does_not_insert_or_commit(self) -> None:
+        """No tweet row is inserted or committed when the track is missing."""
+        cursor = _FakeTweetCursor(track_exists=False)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            _run(_database_mod.db_create_tweet(
+                "test-album", "check out this track", track_number=5,
+            ))
+        assert not cursor.inserted
+        db.conn.commit.assert_not_called()
+        db.conn.close.assert_called_once()
+
+    def test_track_found_reports_track_number(self) -> None:
+        """Existing track → tweet created with the correct track_number."""
+        cursor = _FakeTweetCursor(track_exists=True)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            result = _run(_database_mod.db_create_tweet(
+                "test-album", "check out this track", track_number=5,
+            ))
+        parsed = json.loads(result)
+        assert parsed["created"] is True
+        assert parsed["tweet"]["track_number"] == 5
+        assert parsed["tweet"]["album_slug"] == "test-album"
+        assert cursor.inserted
+        db.conn.commit.assert_called_once()
+        db.conn.close.assert_called_once()
+
+    def test_album_level_tweet_skips_track_lookup(self) -> None:
+        """track_number=0 → album-level tweet, track_number null (unchanged)."""
+        cursor = _FakeTweetCursor(track_exists=False)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            result = _run(_database_mod.db_create_tweet(
+                "test-album", "album announcement", track_number=0,
+            ))
+        parsed = json.loads(result)
+        assert parsed["created"] is True
+        assert parsed["tweet"]["track_number"] is None
+        assert not any("FROM tracks" in sql for sql in cursor.executed)
+        db.conn.commit.assert_called_once()

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -6532,7 +6532,7 @@ class TestCreateTrack:
         assert "No path" in result["error"]
 
     def test_track_number_all_zeros(self, tmp_path):
-        """Track number '00' produces '00-slug.md'."""
+        """Track number '00' is rejected — track numbers are 1-based (#372)."""
         mock_cache, album_dir, tracks_dir = self._make_cache_with_album(tmp_path)
         template_dir = tmp_path / "templates"
         template_dir.mkdir()
@@ -6540,9 +6540,10 @@ class TestCreateTrack:
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path):
             result = json.loads(_run(server.create_track("test-album", "00", "Intro")))
-        assert result["created"] is True
-        assert result["track_slug"] == "00-intro"
-        assert result["filename"] == "00-intro.md"
+        assert "error" in result
+        assert "track_number" in result["error"]
+        # No spurious 00-intro.md file is created
+        assert list(tracks_dir.iterdir()) == []
 
     def test_special_chars_in_title(self, tmp_path):
         """Special characters in title are handled by slug normalization."""

--- a/tests/unit/state/test_slug_validation_handlers.py
+++ b/tests/unit/state/test_slug_validation_handlers.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Unit tests for slug-validation error handling in MCP handlers (issue #397).
+
+``_normalize_slug`` raises ValueError on path separators, null bytes, and
+traversal sequences. The handler-level call sites in ``handlers/maintenance.py``
+(migrate_audio_layout, reset_mastering via _resolve_audio_dir) and
+``handlers/skills.py`` (get_skill) must catch that ValueError and return the
+module's structured JSON error (``{"error": ...}``) instead of letting the
+exception propagate to the FastMCP layer as an opaque tool error.
+
+Usage:
+    python -m pytest tests/unit/state/test_slug_validation_handlers.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root and server directory are on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import maintenance as _maintenance_mod  # noqa: E402
+from handlers import skills as _skills_mod  # noqa: E402
+
+# Slugs that _normalize_slug rejects with ValueError. The first three hit
+# the separator/null-byte branch via '/' or '\\'; "a\0b" hits the same
+# branch via a null byte alone; "a..b" has no separator, so it reaches and
+# exercises the second ('..' traversal) raise branch.
+BAD_SLUGS = ["../evil", "a/b", "a\\b", "a\0b", "a..b"]
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+class MockStateCache:
+    """In-memory StateCache stand-in (no filesystem I/O)."""
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+
+def _base_state(audio_root: str = "/tmp/test/audio") -> dict:
+    """Minimal state with config, one album, and one skill."""
+    return copy.deepcopy({
+        "config": {
+            "audio_root": audio_root,
+            "artist_name": "test-artist",
+        },
+        "albums": {
+            "test-album": {
+                "genre": "electronic",
+                "title": "Test Album",
+                "status": "In Progress",
+                "tracks": {},
+            },
+        },
+        "skills": {
+            "count": 1,
+            "model_counts": {"opus": 1},
+            "items": {
+                "lyric-writer": {
+                    "description": "Writes or reviews lyrics.",
+                    "model": "claude-opus-4-6",
+                    "model_tier": "opus",
+                    "user_invocable": True,
+                    "argument_hint": None,
+                },
+            },
+        },
+    })
+
+
+# =============================================================================
+# migrate_audio_layout — invalid slugs return structured error JSON
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestMigrateAudioLayoutSlugValidation:
+    """migrate_audio_layout must reject bad slugs with a JSON error, not raise."""
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_slug_returns_structured_error(self, bad_slug):
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout(album_slug=bad_slug, dry_run=True)
+            ))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_slug_behavior_unchanged(self):
+        """A valid slug with no audio dir on disk is skipped, not errored."""
+        mock_cache = MockStateCache(_base_state(audio_root="/nonexistent/audio"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout(album_slug="test-album", dry_run=True)
+            ))
+        assert "error" not in result
+        assert result["summary"]["total_albums"] == 1
+        assert result["albums"][0]["slug"] == "test-album"
+        assert result["albums"][0]["status"] == "skipped"
+        assert result["albums"][0]["skip_reason"] == "no audio dir"
+
+    def test_valid_slug_not_in_state_returns_not_found(self):
+        """A well-formed but unknown slug still gets the not-found error."""
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout(album_slug="no-such-album", dry_run=True)
+            ))
+        assert "error" in result
+        assert "not found" in result["error"]
+
+
+# =============================================================================
+# reset_mastering — invalid slugs return structured error JSON
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestResetMasteringSlugValidation:
+    """reset_mastering must reject bad slugs with a JSON error, not raise."""
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_slug_returns_structured_error(self, bad_slug):
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering(album_slug=bad_slug, dry_run=True)
+            ))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_slug_behavior_unchanged(self, tmp_path):
+        """A valid slug with a real audio dir still runs the dry-run report."""
+        audio_root = tmp_path / "audio"
+        album_dir = (
+            audio_root / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        )
+        mastered = album_dir / "mastered"
+        mastered.mkdir(parents=True)
+        (mastered / "01-track.wav").write_bytes(b"\x00" * 16)
+
+        mock_cache = MockStateCache(_base_state(audio_root=str(audio_root)))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering(album_slug="test-album", dry_run=True)
+            ))
+        assert "error" not in result
+        assert result["dry_run"] is True
+        assert result["results"]["mastered"]["status"] == "would_delete"
+        assert result["results"]["mastered"]["file_count"] == 1
+        # Dry run must not delete anything
+        assert mastered.is_dir()
+
+
+# =============================================================================
+# get_skill — invalid names return structured error JSON
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetSkillSlugValidation:
+    """get_skill must reject bad names with a JSON error, not raise."""
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_name_returns_structured_error(self, bad_slug):
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(_skills_mod.get_skill(name=bad_slug)))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_name_behavior_unchanged(self):
+        """An exact skill name still resolves to found=True."""
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(_skills_mod.get_skill(name="lyric-writer")))
+        assert result["found"] is True
+        assert result["name"] == "lyric-writer"
+
+    def test_valid_name_normalization_unchanged(self):
+        """Names with spaces/case still normalize to the slug and match."""
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(_skills_mod.get_skill(name="Lyric Writer")))
+        assert result["found"] is True
+        assert result["name"] == "lyric-writer"

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -298,6 +298,11 @@ def main() -> None:
     print()
 
     filterable = [f for f in wav_files if 'venv' not in str(f)]
+
+    if not filterable:
+        logger.error("No tracks to analyze (no WAV files found in %s).", wav_dir)
+        sys.exit(1)
+
     workers = args.jobs if args.jobs > 0 else os.cpu_count()
     progress = ProgressBar(len(filterable), prefix="Analyzing")
 


### PR DESCRIPTION
## Description

Handler input-validation cluster — the six remaining reproduced bugs where bad input crashes a tool with an opaque error instead of returning a clean, structured response.

| Issue | Fix |
|---|---|
| #372 | `create_track` validates `track_number`: structured error for non-numeric/bool/≤0 values (incl. the silent `00-title.md` defect); ints and numeric strings keep working |
| #378 | `_update_frontmatter_block` returns `(False, error)` on non-mapping frontmatter per its documented contract |
| #379 | `db_sync_album` catches slug `ValueError` → JSON error, matching every sibling `db_*` handler |
| #380 | `db_create_tweet` errors when the track row is missing instead of silently inserting with a NULL link and echoing a false `track_number` |
| #386 | `analyze_tracks.py` logs a clear error + exits nonzero on WAV-less directories |
| #397 | `reset_mastering` / `migrate_audio_layout` / `get_skill` catch slug `ValueError` → structured JSON |

## Verification

- TDD red-first everywhere: 55 new tests across 4 new dedicated test files + 2 extended ones
- Original triage repros re-run against the fixed tree: all six confirmed fixed
- Per-issue spec review (6 reviewers): all pass; 3 minor findings fixed (stale `00` test reconciled, print→logger consistency, null-byte/traversal slug variants added), 1 minor deliberately skipped as file convention
- Full gate: `ruff` + `bandit` + `mypy` clean; `pytest -n auto` → **4063 passed**, coverage 86.45% (≥75%)

## Type of Change

- [x] fix: Bug fix (patch version bump)

Fixes #372, #378, #379, #380, #386, #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd