### PR TITLE
fix(sheet-music): record real title-page fact in singles manifest (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Songbook no longer drops the first music page of every track** (#390).
+  `create_songbook` inferred `singles_have_title_pages = (manifest is not
+  None)` and unconditionally skipped page 0 of each single. But
+  `prepare_singles` writes `.manifest.json` even when it silently skips the
+  title page (pypdf/reportlab missing, or the step raised) — so singles with
+  no title page but a manifest lost their real first page (the whole track
+  for a 1-page transcription) and the TOC miscounted. `prepare_singles` now
+  records the actual per-track `title_page` fact in the manifest, and
+  `create_songbook` trusts that flag (falling back to the prior filename
+  heuristic for legacy manifests), so only genuine title pages are skipped.
 - **`create_track` validates `track_number`** (#372). Non-numeric values
   (`abc`, `1a`, empty), `None`, booleans, and zero/negative numbers now
   return a structured error naming the invalid value instead of crashing

--- a/tests/unit/sheet_music/test_prepare_singles.py
+++ b/tests/unit/sheet_music/test_prepare_singles.py
@@ -220,6 +220,7 @@ class TestPrepareSinglesLegacy:
 
     @patch.object(mod, "_add_title_page_and_footer")
     def test_processes_xml_and_pdf(self, mock_title_page, tmp_path):
+        mock_title_page.return_value = True  # -> bool contract (#390)
         source = self._make_source(tmp_path, [
             "01-first-pour.xml",
             "01-first-pour.pdf",
@@ -234,6 +235,7 @@ class TestPrepareSinglesLegacy:
 
     @patch.object(mod, "_add_title_page_and_footer")
     def test_processes_multiple_tracks(self, mock_title_page, tmp_path):
+        mock_title_page.return_value = True  # -> bool contract (#390)
         source = self._make_source(tmp_path, [
             "01-first.xml", "01-first.pdf",
             "02-second.xml", "02-second.pdf",
@@ -312,6 +314,7 @@ class TestPrepareSinglesManifest:
 
     @patch.object(mod, "_add_title_page_and_footer")
     def test_manifest_flow_uses_titles(self, mock_title_page, tmp_path):
+        mock_title_page.return_value = True  # -> bool contract (#390)
         source = tmp_path / "source"
         source.mkdir()
 

--- a/tests/unit/sheet_music/test_songbook_title_page_390.py
+++ b/tests/unit/sheet_music/test_songbook_title_page_390.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Regression tests for songbook title-page handling (issue #390).
+
+create_songbook used to infer ``singles_have_title_pages = manifest is not
+None`` and unconditionally skip page 0 of every single. But prepare_singles
+writes ``.manifest.json`` unconditionally while silently skipping the title
+page when pypdf/reportlab are unavailable (or the title-page step raises). In
+that case the singles have NO title page yet the manifest exists, so the
+songbook dropped the real first music page of every track (the entire track
+for a 1-page transcription) and miscounted the TOC.
+
+The fix records the actual per-track title-page fact in the manifest
+(``"title_page": true|false``) and makes the songbook trust that flag.
+
+These tests use real pypdf/reportlab so the actual page slicing is exercised.
+
+Usage:
+    python -m pytest tests/unit/sheet_music/test_songbook_title_page_390.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("pypdf")
+pytest.importorskip("reportlab")
+
+from pypdf import PdfReader, PdfWriter  # noqa: E402
+from reportlab.lib.pagesizes import letter  # noqa: E402
+from reportlab.pdfgen import canvas  # noqa: E402
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def _load(module_name: str, rel_path: str):
+    """Load a hyphenated tools module with REAL deps (no mocking)."""
+    path = _PROJECT_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+songbook = _load("create_songbook_real", "tools/sheet-music/create_songbook.py")
+prepare = _load("prepare_singles_real", "tools/sheet-music/prepare_singles.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build real PDFs with identifiable per-page text
+# ---------------------------------------------------------------------------
+
+
+def _write_pdf(path: Path, page_labels: list[str]) -> None:
+    """Write a PDF with one page per label, each stamped with that label."""
+    c = canvas.Canvas(str(path), pagesize=letter)
+    for label in page_labels:
+        c.drawString(72, 720, label)
+        c.showPage()
+    c.save()
+
+
+def _page_texts(path: Path) -> list[str]:
+    return [(p.extract_text() or "") for p in PdfReader(str(path)).pages]
+
+
+def _make_single(source_dir: Path, filename: str, music_pages: int,
+                 *, title_page: bool) -> str:
+    """Create a single PDF and return the unique marker on its first music page.
+
+    The marker is stamped on the first *music* page so a test can assert the
+    songbook did not drop it. When ``title_page`` is True, a title page is
+    prepended (as prepare_singles would), so the music pages start at index 1.
+    """
+    marker = f"MUSIC::{filename}::p1"
+    labels: list[str] = []
+    if title_page:
+        labels.append(f"TITLEPAGE::{filename}")
+    labels.append(marker)
+    labels.extend(f"MUSIC::{filename}::p{n}" for n in range(2, music_pages + 1))
+    _write_pdf(source_dir / f"{filename}.pdf", labels)
+    return marker
+
+
+def _write_manifest(source_dir: Path, entries: list[dict]) -> None:
+    (source_dir / ".manifest.json").write_text(
+        json.dumps({"tracks": entries}, indent=2), encoding="utf-8"
+    )
+
+
+# ===========================================================================
+# Consumer: create_songbook must not drop music pages (#390 core)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestSongbookHonorsTitlePageFlag:
+    def test_single_without_title_page_keeps_its_only_music_page(self, tmp_path):
+        """A 1-page single with title_page=false must survive intact (#390).
+
+        This is the reported worst case: without the flag the songbook skipped
+        page 0 and dropped the entire track.
+        """
+        src = tmp_path / "singles"
+        src.mkdir()
+        marker = _make_single(src, "01 - Lonely Track", music_pages=1,
+                              title_page=False)
+        _write_manifest(src, [{
+            "number": 1, "title": "Lonely Track",
+            "filename": "01 - Lonely Track", "title_page": False,
+        }])
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        # Front matter (title, copyright, TOC) + the one music page = 4.
+        assert len(texts) == 4
+        assert any(marker in t for t in texts), "the only music page was dropped"
+
+    def test_single_with_title_page_skips_only_the_title_page(self, tmp_path):
+        """title_page=true → the prepended title page is skipped, music kept."""
+        src = tmp_path / "singles"
+        src.mkdir()
+        marker = _make_single(src, "01 - Real Title", music_pages=2,
+                              title_page=True)
+        _write_manifest(src, [{
+            "number": 1, "title": "Real Title",
+            "filename": "01 - Real Title", "title_page": True,
+        }])
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        # 3 front matter + 2 music pages (title page dropped) = 5.
+        assert len(texts) == 5
+        assert any(marker in t for t in texts)
+        assert not any("TITLEPAGE" in t for t in texts), "title page leaked in"
+
+    def test_mixed_flags_across_tracks(self, tmp_path):
+        """Per-track flags are honored independently (one true, one false)."""
+        src = tmp_path / "singles"
+        src.mkdir()
+        m_no = _make_single(src, "01 - No Title", music_pages=1, title_page=False)
+        m_yes = _make_single(src, "02 - Has Title", music_pages=1, title_page=True)
+        _write_manifest(src, [
+            {"number": 1, "title": "No Title",
+             "filename": "01 - No Title", "title_page": False},
+            {"number": 2, "title": "Has Title",
+             "filename": "02 - Has Title", "title_page": True},
+        ])
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        # 3 front matter + 1 (no-title single) + 1 (has-title single, minus its
+        # title page) = 5.
+        assert len(texts) == 5
+        assert any(m_no in t for t in texts)
+        assert any(m_yes in t for t in texts)
+        assert not any("TITLEPAGE" in t for t in texts)
+
+    def test_legacy_manifest_without_flag_unchanged(self, tmp_path):
+        """A manifest lacking the flag keeps the prior assume-title-page path.
+
+        Backward-compat: existing correct singles (title pages present, old
+        manifests) must not regress.
+        """
+        src = tmp_path / "singles"
+        src.mkdir()
+        marker = _make_single(src, "01 - Legacy", music_pages=1, title_page=True)
+        _write_manifest(src, [{
+            "number": 1, "title": "Legacy", "filename": "01 - Legacy",
+        }])  # no "title_page" key
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        assert len(texts) == 4  # title page skipped as before
+        assert any(marker in t for t in texts)
+
+
+# ===========================================================================
+# Producer: prepare_singles records the real title-page fact
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestAddTitlePageReturnsFact:
+    def test_returns_true_and_prepends_page_on_success(self, tmp_path):
+        pdf = tmp_path / "track.pdf"
+        _write_pdf(pdf, ["MUSIC::only-page"])
+        assert PdfReader(str(pdf)).pages.__len__() == 1
+
+        added = prepare._add_title_page_and_footer(
+            pdf, "My Track", "Artist", None, None, "letter"
+        )
+
+        assert added is True
+        # Title page prepended: now 2 pages, page 0 is the title page.
+        pages = _page_texts(pdf)
+        assert len(pages) == 2
+        assert "MUSIC::only-page" in pages[1]
+
+    def test_returns_false_when_title_page_cannot_be_added(self, tmp_path):
+        """A read/parse failure hits the broad except → returns False.
+
+        This is the silent-skip path that must be recorded as title_page=false
+        so the songbook does not later skip a non-existent title page.
+        """
+        missing = tmp_path / "does-not-exist.pdf"
+
+        added = prepare._add_title_page_and_footer(
+            missing, "My Track", "Artist", None, None, "letter"
+        )
+
+        assert added is False
+
+
+@pytest.mark.unit
+class TestPrepareSinglesRecordsTitlePageFact:
+    """prepare_singles must write the real title-page fact into the manifest."""
+
+    def _make_source(self, tmp_path: Path) -> Path:
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "First Pour.xml").write_text(
+            "<score><work-title>First Pour</work-title></score>"
+        )
+        (source / "First Pour.pdf").write_text("pdf content")
+        (source / ".manifest.json").write_text(json.dumps({
+            "tracks": [
+                {"number": 1, "source_slug": "01-first-pour", "title": "First Pour"}
+            ]
+        }))
+        return source
+
+    def test_manifest_records_title_page_true_when_added(self, tmp_path):
+        source = self._make_source(tmp_path)
+        with patch.object(prepare, "_add_title_page_and_footer", return_value=True):
+            result = prepare.prepare_singles(source, tmp_path / "singles")
+        entry = result["manifest"]["tracks"][0]
+        assert entry["title_page"] is True
+
+    def test_manifest_records_title_page_false_when_skipped(self, tmp_path):
+        """The bug's trigger: deps missing → title page skipped → flag False."""
+        source = self._make_source(tmp_path)
+        with patch.object(prepare, "_add_title_page_and_footer", return_value=False):
+            result = prepare.prepare_singles(source, tmp_path / "singles")
+        entry = result["manifest"]["tracks"][0]
+        assert entry["title_page"] is False
+
+        # And the persisted manifest on disk carries the same fact.
+        written = json.loads(
+            (tmp_path / "singles" / ".manifest.json").read_text(encoding="utf-8")
+        )
+        assert written["tracks"][0]["title_page"] is False

--- a/tools/sheet-music/create_songbook.py
+++ b/tools/sheet-music/create_songbook.py
@@ -497,9 +497,26 @@ def create_songbook(
             if entry_title:
                 manifest_title_lookup[entry_title] = entry_title
 
-    # When manifest is present, all singles from prepare_singles have title pages.
-    # Without manifest, only non-numbered files (clean-titled) have title pages.
-    singles_have_title_pages = manifest is not None
+    # Whether each single actually has a prepended title page. prepare_singles
+    # records this per track in the manifest ("title_page"), because it silently
+    # skips the title page when pypdf/reportlab are unavailable — so a manifest
+    # merely existing does NOT imply a title page is present (#390). Trust the
+    # recorded flag when it is there; fall back (legacy manifests, or no
+    # manifest) to the filename heuristic: numbered files have no title page.
+    manifest_title_page_lookup = {}
+    if manifest:
+        for entry in manifest.get("tracks", []):
+            filename = entry.get("filename", "")
+            if filename and "title_page" in entry:
+                manifest_title_page_lookup[filename] = bool(entry["title_page"])
+
+    def _has_title_page(pdf_file: Path) -> bool:
+        if pdf_file.stem in manifest_title_page_lookup:
+            return manifest_title_page_lookup[pdf_file.stem]
+        if manifest is not None:
+            # Legacy manifest without the per-track flag: preserve prior behavior.
+            return True
+        return not re.match(r'^\d+', pdf_file.stem)
 
     # Get page counts for TOC
     tracks = []
@@ -512,12 +529,8 @@ def create_songbook(
         else:
             track_name = pdf_file.stem
         page_count = get_pdf_page_count(pdf_file)
-        # Singles have a prepended title page — don't count it for the songbook
-        if singles_have_title_pages:
-            has_title_page = True
-        else:
-            has_title_page = not re.match(r'^\d+', pdf_file.stem)
-        if has_title_page:
+        # A prepended title page is not counted in the songbook TOC (#390).
+        if _has_title_page(pdf_file):
             page_count -= 1
         if include_section_headers:
             page_count += 1  # Add section header page
@@ -551,11 +564,7 @@ def create_songbook(
         # Singles have a prepended title page — skip it in the songbook
         # (the songbook has its own front matter and optional section headers)
         reader = PdfReader(pdf_file)
-        if singles_have_title_pages:
-            has_title_page = True
-        else:
-            has_title_page = not re.match(r'^\d+', pdf_file.stem)
-        start_page = 1 if has_title_page else 0
+        start_page = 1 if _has_title_page(pdf_file) else 0
         for page in reader.pages[start_page:]:
             writer.add_page(page)
 

--- a/tools/sheet-music/prepare_singles.py
+++ b/tools/sheet-music/prepare_singles.py
@@ -194,11 +194,16 @@ def prepare_xml(source_xml: Path, singles_dir: Path, title: str, dry_run: bool =
     return out_path
 
 
-def _add_title_page_and_footer(pdf_path: Path, title: str, artist: str | None, cover_image: str | None, footer_url: str | None, page_size_name: str) -> None:
+def _add_title_page_and_footer(pdf_path: Path, title: str, artist: str | None, cover_image: str | None, footer_url: str | None, page_size_name: str) -> bool:
     """Prepend a title page and add footer URL to every page of a single PDF.
 
     Uses shared helpers from create_songbook module. Gracefully skips
     if pypdf/reportlab are not available (they're optional deps).
+
+    Returns:
+        True if a title page was actually prepended, False if the step was
+        skipped (missing deps) or failed. Callers record this in the manifest
+        so create_songbook knows whether page 0 is a title page (#390).
     """
     try:
         # Late import — songbook module needs pypdf/reportlab
@@ -237,10 +242,13 @@ def _add_title_page_and_footer(pdf_path: Path, title: str, artist: str | None, c
             writer.write(f)
 
         logger.info("  Added title page + footer to %s", pdf_path.name)
+        return True
     except ImportError:
         logger.warning("  pypdf/reportlab not installed — skipping title page and footer for %s", pdf_path.name)
+        return False
     except Exception as e:
         logger.warning("  Could not add title page to %s: %s", pdf_path.name, e)
+        return False
 
 
 def resolve_source_dir(given_path: str | Path) -> tuple[Path, Path]:
@@ -405,12 +413,18 @@ def prepare_singles(source_dir: str | Path, singles_dir: str | Path, musescore: 
 
         print(f"\n  [{lookup_key}] -> \"{singles_name}\"")
 
-        manifest_tracks.append({
+        # `title_page` records whether a title page was actually prepended to
+        # this single (updated after _add_title_page_and_footer runs). It
+        # stays False when no PDF is produced or the title-page step is
+        # skipped, so create_songbook never skips a page that isn't there (#390).
+        manifest_entry: dict[str, Any] = {
             "number": track_num,
             "source_slug": source_slug,
             "title": title,
             "filename": singles_name,
-        })
+            "title_page": False,
+        }
+        manifest_tracks.append(manifest_entry)
 
         track_result: dict[str, Any] = {"source": source_slug, "title": title, "filename": singles_name, "files": []}
 
@@ -453,7 +467,7 @@ def prepare_singles(source_dir: str | Path, singles_dir: str | Path, musescore: 
 
             # Add title page and footer to the PDF
             if pdf_written and not dry_run:
-                _add_title_page_and_footer(
+                manifest_entry["title_page"] = _add_title_page_and_footer(
                     pdf_dst, title, artist, cover_image, footer_url, page_size_name
                 )
                 track_result["files"].append(pdf_dst.name)


### PR DESCRIPTION
## Description

Fixes #390 — the songbook dropped the first music page of every track (the entire track for single-page transcriptions) and miscounted the TOC.

### Root cause
`create_songbook` inferred `singles_have_title_pages = (manifest is not None)` and unconditionally skipped page 0 of each single. But `prepare_singles` writes `.manifest.json` **unconditionally**, while `_add_title_page_and_footer` silently skips the title page when pypdf/reportlab are missing (ImportError) or the step raises. Result: singles with no title page but a manifest present → the songbook skipped the real first music page.

### Fix
Record ground truth instead of inferring it:
- **`prepare_singles.py`**: `_add_title_page_and_footer` now returns `bool` (True only when a title page was actually prepended; False on ImportError/other failure). Each manifest track entry records this as `"title_page"`.
- **`create_songbook.py`**: a single `_has_title_page(pdf_file)` helper trusts the per-track manifest flag when present. For **legacy manifests** (no flag) and the **no-manifest** case it falls back to the prior behavior, so existing correct songbooks don't regress. Both the TOC page-count and the page-slicing now use this one helper (removing the duplicated inference).

### Verification
- TDD red-first using **real pypdf/reportlab** (so actual page slicing is exercised): a 1-page single with `title_page=false` now survives intact; `title_page=true` still skips only the title page; mixed per-track flags honored; legacy-manifest path unchanged. Plus producer tests that `prepare_singles` writes the correct `title_page` into the manifest.
- Backward-compatible: 3 existing `prepare_singles` tests updated only to give their `_add_title_page_and_footer` mock a bool return (the new contract) — no assertion weakened.
- Full gate: `ruff` + `bandit` + `mypy` clean; `pytest -n auto` → **4071 passed**, coverage 87.79% (≥75%).

## Type of Change

- [x] fix: Bug fix (patch version bump)

## Migration

`.manifest.json` gains an additive `title_page` field. Old manifests without it keep working via the fallback. No action required; re-running `prepare_singles` regenerates the manifest with the accurate flag.

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd