### PR TITLE
fix(handlers): JSON error boundary for slug ValueError across all MCP tools (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Malformed slugs return clean JSON across every MCP tool** (#443). The
+  shared `_find_album_or_error` / `_resolve_audio_dir` / `_find_track_or_error`
+  helpers called `_normalize_slug` raw, and ~13 tool handlers called it
+  directly, so a slug with a path separator, null byte, or `..` traversal
+  raised an uncaught `ValueError` to the MCP layer — the same class #397/#442
+  fixed in a handful of handlers. The three helpers now convert that
+  `ValueError` into their structured error, and a single error boundary
+  installed at tool registration wraps every handler so any leaked
+  `ValueError` becomes a `{"error": ...}` response. Only `ValueError` is
+  caught, so genuine bugs still surface; the boundary preserves each tool's
+  FastMCP schema (it wraps via `functools.wraps`).
 - **Songbook no longer drops the first music page of every track** (#390).
   `create_songbook` inferred `singles_have_title_pages = (manifest is not
   None)` and unconditionally skipped page 0 of each single. But

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -6,6 +6,8 @@ module's ``register()`` function is called.
 
 from __future__ import annotations
 
+import functools
+import inspect
 import json
 import math
 import re
@@ -167,6 +169,59 @@ def _safe_json(data: Any) -> str:
         # circular reference trips it here rather than as the ValueError that
         # json.dumps would otherwise raise. Catch it to keep the no-crash contract.
         return json.dumps({"error": f"JSON serialization failed: {e}"})
+
+
+def _json_error_boundary(fn: Any) -> Any:
+    """Wrap an MCP tool handler so a ValueError becomes a structured JSON error.
+
+    Many handlers normalize a user-supplied slug via _normalize_slug, which
+    raises ValueError on path separators / null bytes / traversal. Handlers
+    that call it directly (rather than through the guarded _find_album_or_error
+    / _resolve_audio_dir / _find_track_or_error helpers) would otherwise let
+    that ValueError escape to the MCP layer as an opaque tool error. This
+    boundary, installed once at registration, guarantees every tool — current
+    and future — returns clean JSON instead (#443).
+
+    Only ValueError is caught: it is the documented slug-validation signal.
+    Unexpected exceptions still propagate so real bugs are not masked.
+    """
+    if inspect.iscoroutinefunction(fn):
+        @functools.wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await fn(*args, **kwargs)
+            except ValueError as exc:
+                return _safe_json({"error": str(exc)})
+        return async_wrapper
+
+    @functools.wraps(fn)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except ValueError as exc:
+            return _safe_json({"error": str(exc)})
+    return sync_wrapper
+
+
+def install_error_boundary(mcp: Any) -> None:
+    """Wrap ``mcp.tool`` so every registered handler gets _json_error_boundary.
+
+    Call once BEFORE the per-module ``register(mcp)`` calls. FastMCP builds
+    each tool's input schema from the handler signature via
+    ``inspect.signature``, which follows ``functools.wraps``' ``__wrapped__``,
+    so the boundary leaves the generated tool schema unchanged (#443).
+    """
+    original_tool = mcp.tool
+
+    def tool(*args: Any, **kwargs: Any) -> Any:
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapping_decorator(fn: Any) -> Any:
+            return decorator(_json_error_boundary(fn))
+
+        return wrapping_decorator
+
+    mcp.tool = tool
 
 
 def _update_frontmatter_block(
@@ -353,10 +408,17 @@ def _find_album_or_error(album_slug: str) -> tuple[str, dict[str, Any] | None, s
 
     If album found: (slug, data, None)
     If not found: (slug, None, error_json_string)
+    If the slug is malformed: (raw_slug, None, error_json_string) — the
+    ValueError _normalize_slug raises on path separators / null bytes /
+    traversal is converted to a structured error so callers never leak it to
+    the MCP layer (#443).
     """
     state = cache.get_state()
     albums = state.get("albums", {})
-    normalized = _normalize_slug(album_slug)
+    try:
+        normalized = _normalize_slug(album_slug)
+    except ValueError as exc:
+        return album_slug, None, _safe_json({"found": False, "error": str(exc)})
     album = albums.get(normalized)
 
     if not album:
@@ -414,8 +476,13 @@ def _find_track_or_error(tracks: dict[str, Any], track_slug: str, album_slug: st
 
     If track found: (matched_slug, track_data, None)
     If not found: (slug, None, error_json_string)
+    If the slug is malformed: (raw_slug, None, error_json_string) — the
+    _normalize_slug ValueError is converted to a structured error (#443).
     """
-    normalized = _normalize_slug(track_slug)
+    try:
+        normalized = _normalize_slug(track_slug)
+    except ValueError as exc:
+        return track_slug, None, _safe_json({"found": False, "error": str(exc)})
     track_data = tracks.get(normalized)
     if track_data:
         return normalized, track_data, None
@@ -450,7 +517,10 @@ def _resolve_audio_dir(album_slug: str, subfolder: str = "") -> tuple[str | None
     artist = config.get("artist_name", "")
     if not audio_root or not artist:
         return _safe_json({"error": "audio_root or artist_name not configured"}), None
-    normalized = _normalize_slug(album_slug)
+    try:
+        normalized = _normalize_slug(album_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)}), None
     albums = state.get("albums", {})
     album_data = albums.get(normalized, {})
     genre = album_data.get("genre", "")

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -379,6 +379,11 @@ from handlers import (
     text_analysis,
 )
 
+# Wrap mcp.tool so every handler returns a structured JSON error instead of
+# leaking a slug-validation ValueError to the MCP layer (#443). Must run before
+# the per-module register() calls below.
+_shared.install_error_boundary(mcp)
+
 core.register(mcp)
 content.register(mcp)
 text_analysis.register(mcp)

--- a/tests/unit/state/test_slug_validation_boundary_443.py
+++ b/tests/unit/state/test_slug_validation_boundary_443.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tests for the MCP-wide slug-validation error boundary (issue #443).
+
+#397/#442 caught the slug-``ValueError`` leak in three handlers at the call
+site. #443 addresses the whole class: the shared helpers
+``_find_album_or_error`` / ``_resolve_audio_dir`` / ``_find_track_or_error``
+call ``_normalize_slug`` (which raises on path separators / null bytes /
+traversal), and ~13 tool handlers call it directly. The fix:
+
+  * the three shared helpers now convert the ValueError to their structured
+    error tuple, and
+  * ``install_error_boundary`` wraps every registered tool so any leaked
+    ValueError becomes a ``{"error": ...}`` JSON response instead of an
+    opaque MCP-layer crash.
+
+Usage:
+    python -m pytest tests/unit/state/test_slug_validation_boundary_443.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import core as _core_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+BAD_SLUGS = ["../evil", "a/b", "a\\b", "a\0b", "a..b"]
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+def _base_state() -> dict:
+    return copy.deepcopy({
+        "config": {"audio_root": "/tmp/audio", "artist_name": "test-artist"},
+        "albums": {
+            "test-album": {
+                "genre": "electronic", "title": "Test Album",
+                "status": "In Progress", "tracks": {"01-a": {"title": "A"}},
+            },
+        },
+    })
+
+
+# ===========================================================================
+# _json_error_boundary — unit behavior
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestJsonErrorBoundary:
+    def test_value_error_becomes_json(self):
+        async def handler(slug: str) -> str:
+            raise ValueError("Invalid name: bad")
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        result = json.loads(_run(wrapped("../x")))
+        assert result["error"] == "Invalid name: bad"
+
+    def test_normal_return_passes_through(self):
+        async def handler(slug: str) -> str:
+            return json.dumps({"ok": slug})
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        assert json.loads(_run(wrapped("fine")))["ok"] == "fine"
+
+    def test_non_value_error_still_propagates(self):
+        """Only ValueError is caught — real bugs must not be masked."""
+        async def handler(slug: str) -> str:
+            raise KeyError("genuine bug")
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        with pytest.raises(KeyError):
+            _run(wrapped("x"))
+
+    def test_wrapped_handler_stays_a_coroutine_function(self):
+        """FastMCP must still see an async tool (schema/dispatch depend on it)."""
+        import inspect
+
+        async def handler(slug: str) -> str:
+            return "ok"
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        assert inspect.iscoroutinefunction(wrapped)
+        # functools.wraps preserves the signature FastMCP introspects.
+        assert list(inspect.signature(wrapped).parameters) == ["slug"]
+        assert wrapped.__name__ == "handler"
+
+
+# ===========================================================================
+# End-to-end: a previously-unguarded direct-call handler via the boundary
+# ===========================================================================
+
+
+class _FakeMCP:
+    """Minimal FastMCP stand-in that stores registered tools by name."""
+
+    def __init__(self) -> None:
+        self._tools: dict = {}
+
+    def tool(self):
+        def decorator(fn):
+            self._tools[fn.__name__] = fn
+            return fn
+        return decorator
+
+
+@pytest.mark.unit
+class TestBoundaryProtectsDirectCallHandlers:
+    """find_album calls _normalize_slug directly — before #443 it raised.
+
+    The boundary installed at registration must turn that into JSON.
+    """
+
+    def setup_method(self) -> None:
+        self._orig = _shared_mod.cache
+        _shared_mod.cache = MockStateCache(_base_state())
+
+    def teardown_method(self) -> None:
+        _shared_mod.cache = self._orig
+
+    def _registered_find_album(self):
+        mcp = _FakeMCP()
+        _shared_mod.install_error_boundary(mcp)
+        _core_mod.register(mcp)
+        return mcp._tools["find_album"]
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_slug_returns_json_not_raise(self, bad_slug):
+        find_album = self._registered_find_album()
+        result = json.loads(_run(find_album(bad_slug)))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_name_unchanged_through_boundary(self):
+        find_album = self._registered_find_album()
+        result = json.loads(_run(find_album("test-album")))
+        assert result.get("found") is True
+
+    def test_direct_unwrapped_call_still_raises(self):
+        """Sanity: the module-level fn is unguarded; the boundary is the fix."""
+        with pytest.raises(ValueError):
+            _run(_core_mod.find_album("../evil"))
+
+
+# ===========================================================================
+# Shared helpers convert the ValueError in-flow (contract-shaped errors)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestHelpersHardened:
+    def setup_method(self) -> None:
+        self._orig = _shared_mod.cache
+        _shared_mod.cache = MockStateCache(_base_state())
+
+    def teardown_method(self) -> None:
+        _shared_mod.cache = self._orig
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_find_album_or_error_returns_error_tuple(self, bad_slug):
+        slug, album, err = _shared_mod._find_album_or_error(bad_slug)
+        assert album is None
+        assert err is not None
+        assert "Invalid name" in json.loads(err)["error"]
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_resolve_audio_dir_returns_error(self, bad_slug):
+        err, path = _shared_mod._resolve_audio_dir(bad_slug)
+        assert path is None
+        assert err is not None
+        assert "Invalid name" in json.loads(err)["error"]
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_find_track_or_error_returns_error_tuple(self, bad_slug):
+        tracks = {"01-a": {"title": "A"}}
+        slug, data, err = _shared_mod._find_track_or_error(tracks, bad_slug)
+        assert data is None
+        assert err is not None
+        assert "Invalid name" in json.loads(err)["error"]
+
+    def test_valid_album_still_resolves(self):
+        slug, album, err = _shared_mod._find_album_or_error("test-album")
+        assert err is None
+        assert album is not None


### PR DESCRIPTION
## Description

Fixes #443 — completes the slug-validation hardening started in #397/#442. `_normalize_slug` raises `ValueError` on path separators, null bytes, and `..` traversal. It is reached two ways, and both leaked the exception to the MCP layer as an opaque tool error:

1. **Through the shared helpers** `_find_album_or_error` / `_resolve_audio_dir` / `_find_track_or_error` (~35 handlers) — they called `_normalize_slug` raw.
2. **Directly** in ~13 tool entry points (`find_album`, `get_track`, `list_tracks`, `resolve_path`, `master_audio`, `generate_promo_videos`, …).

A static AST sweep of the handlers found all the direct-call sites; empirically `get_streaming_urls('../evil')` and `find_album('../evil')` raised straight to the MCP layer before this change.

## Fix — two complementary layers

- **Helpers convert in-flow**: the three shared helpers now catch the `ValueError` and return their structured error tuple, so helper-based handlers return contract-shaped JSON as part of their normal `if error: return error` flow.
- **Registration boundary catches the rest**: `install_error_boundary(mcp)` wraps `mcp.tool` once (before the per-module `register()` calls) so every registered handler — current and future, including the ~13 direct-call ones — returns `{"error": ...}` if a `ValueError` escapes. **Only `ValueError` is caught**, so genuine bugs (KeyError/TypeError/…) still surface rather than being masked. The wrapper uses `functools.wraps`, so FastMCP's schema introspection (`inspect.signature`) is unchanged — verified against real FastMCP that tool name, parameters, and required fields are intact.

The redundant call-site guards from #397/#442 are left in place as harmless defense-in-depth.

## Verification

- TDD red-first: boundary unit tests (ValueError→JSON, normal pass-through, **non-ValueError still propagates**, wrapper stays a coroutine function with the original signature); an end-to-end test that a previously-unguarded handler (`find_album`) returns JSON through the registered boundary **while the raw module-level fn still raises** (proving the boundary is load-bearing); and the three hardened helpers across separator/null-byte/traversal inputs.
- Verified every `_find_album_or_error` caller checks the error before using the (now raw-slug) first tuple element — no regression.
- Full gate: `ruff` + `bandit` + `mypy` clean; `pytest -n auto` → **4098 passed**, coverage 87.74% (≥75%). All server-integration tests pass, confirming registration/schemas are intact.

## Type of Change

- [x] fix: Bug fix (patch version bump)

Fixes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd