### PR TITLE
fix: 6 small independent bugfixes (#412, #411, #406, #394, #399, #344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   the final valid start index (`len(rms) - window_samples`); the
   highest-energy segment near the end of a track (common for
   choruses/outros) could be silently passed over in favor of a weaker one.
+- **`find_mastered_dir` no longer crashes when a candidate path is a file**
+  (#411). Each candidate was checked with `.exists()` (true for regular
+  files too) then immediately handed to `.iterdir()`, raising
+  `NotADirectoryError` if e.g. a stray `wavs` file sat next to the expected
+  `wavs/` directory. Now checked with `.is_dir()`.
 
 ## [0.94.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **`test_config_load_failure_logs_warning` scopes `caplog` to the wrong
+  logger** (#344). The warning under test is logged by
+  `handlers.processing.sheet_music`, not `handlers.processing._helpers`;
+  the test now scopes `caplog.at_level(...)` to the correct logger name.
 - **Malformed slugs return clean JSON across every MCP tool** (#443). The
   shared `_find_album_or_error` / `_resolve_audio_dir` / `_find_track_or_error`
   helpers called `_normalize_slug` raw, and ~13 tool handlers called it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   files too) then immediately handed to `.iterdir()`, raising
   `NotADirectoryError` if e.g. a stray `wavs` file sat next to the expected
   `wavs/` directory. Now checked with `.is_dir()`.
+- **`apply_fade_out` raises on a tiny positive duration** (#406). When
+  `0 < duration < 1/rate`, `fade_samples = int(rate * duration)` rounds to
+  `0`; the early return only guarded `duration <= 0`, so `result[-0:]`
+  (the *whole* array, not an empty slice) was multiplied against an
+  empty envelope, raising a broadcast `ValueError`. Now guarded on
+  `fade_samples <= 0` as well.
 
 ## [0.94.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   `UnicodeDecodeError` that raises on invalid bytes. Both files are now
   opened with `encoding="utf-8"` and the except clause also catches
   `UnicodeDecodeError`.
+- **`_stage_layout` crashes on a non-UTF-8 prior `LAYOUT.md`** (#399). The
+  stage's docstring guarantees "write errors go to warnings, never halt",
+  but the read of an existing `LAYOUT.md` sat outside the `try`/`except`
+  block; a file with invalid UTF-8 bytes raised `UnicodeDecodeError`
+  straight through the stage, halting the whole `master_album` pipeline.
+  The read is now guarded — an unreadable prior file is discarded (with a
+  warning) and a fresh `LAYOUT.md` is still written.
 
 ## [0.94.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   `_normalize_slug`'s `ValueError` escape as an opaque tool error on inputs
   like `../other`; all three now catch it and return their module's
   structured error shape.
+- **`find_best_segment` no longer skips its last analysis window** (#412).
+  The energy-window loop ran `range(len(rms) - window_samples)`, excluding
+  the final valid start index (`len(rms) - window_samples`); the
+  highest-energy segment near the end of a track (common for
+  choruses/outros) could be silently passed over in favor of a weaker one.
 
 ## [0.94.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   (the *whole* array, not an empty slice) was multiplied against an
   empty envelope, raising a broadcast `ValueError`. Now guarded on
   `fade_samples <= 0` as well.
+- **`check_version_sync` hook crashes on non-UTF-8 manifest files** (#394).
+  `plugin.json`/`marketplace.json` were opened without an explicit
+  encoding, decoding with the platform default; the surrounding
+  `except (json.JSONDecodeError, OSError)` didn't cover the
+  `UnicodeDecodeError` that raises on invalid bytes. Both files are now
+  opened with `encoding="utf-8"` and the except clause also catches
+  `UnicodeDecodeError`.
 
 ## [0.94.0] - 2026-07-03
 

--- a/hooks/check_version_sync.py
+++ b/hooks/check_version_sync.py
@@ -31,11 +31,11 @@ def check_sync(data: dict) -> list[str]:
         return []
 
     try:
-        with open(plugin_path) as f:
+        with open(plugin_path, encoding="utf-8") as f:
             plugin_data = json.load(f)
-        with open(marketplace_path) as f:
+        with open(marketplace_path, encoding="utf-8") as f:
             marketplace_data = json.load(f)
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return []
 
     plugin_version = plugin_data.get("version", "")

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2006,9 +2006,14 @@ async def _stage_layout(ctx: MasterAlbumCtx) -> str | None:
     prior_transitions: list[dict[str, Any]] | None = None
     layout_path = ctx.audio_dir / "LAYOUT.md"
     if layout_path.is_file():
-        prior_transitions = _parse_layout_yaml(
-            layout_path.read_text(encoding="utf-8")
-        )
+        try:
+            prior_transitions = _parse_layout_yaml(
+                layout_path.read_text(encoding="utf-8")
+            )
+        except (OSError, UnicodeDecodeError) as _layout_read_exc:
+            ctx.warnings.append(
+                f"Layout: could not read prior {layout_path} — {_layout_read_exc}."
+            )
 
     layout_stage: dict[str, Any] = {
         "status": "pass",

--- a/tests/unit/hooks/test_check_version_sync.py
+++ b/tests/unit/hooks/test_check_version_sync.py
@@ -1,0 +1,55 @@
+"""Tests for hooks/check_version_sync.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+_MODULE_PATH = _PROJECT_ROOT / "hooks" / "check_version_sync.py"
+_spec = importlib.util.spec_from_file_location("check_version_sync", _MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+@pytest.mark.unit
+class TestCheckSyncEncoding:
+    """#394: manifest files must be read as UTF-8, and decode failures must
+    not raise past check_sync (only JSONDecodeError/OSError were caught)."""
+
+    def _plugin_dir(self, tmp_path):
+        plugin_dir = tmp_path / ".claude-plugin"
+        plugin_dir.mkdir()
+        return plugin_dir
+
+    def test_utf8_manifest_content_is_read_correctly(self, tmp_path):
+        """A non-ASCII (but valid UTF-8) version string must not be mangled
+        by falling back to a platform default encoding."""
+        plugin_dir = self._plugin_dir(tmp_path)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps({"version": "1.0.0-café"}), encoding="utf-8"
+        )
+        (plugin_dir / "marketplace.json").write_text(
+            json.dumps({"plugins": [{"version": "1.0.0-café"}]}), encoding="utf-8"
+        )
+        data = {"tool_input": {"file_path": str(plugin_dir / "plugin.json")}}
+        assert mod.check_sync(data) == []
+
+    def test_non_utf8_manifest_does_not_raise(self, tmp_path):
+        """A manifest file with bytes invalid in UTF-8 must be treated as
+        unreadable (empty issue list), not raise UnicodeDecodeError."""
+        plugin_dir = self._plugin_dir(tmp_path)
+        # 0xff is not valid UTF-8 anywhere in a byte stream.
+        (plugin_dir / "plugin.json").write_bytes(b'{"version": "1.0.0-\xff"}')
+        (plugin_dir / "marketplace.json").write_text(
+            json.dumps({"plugins": [{"version": "1.0.0"}]}), encoding="utf-8"
+        )
+        data = {"tool_input": {"file_path": str(plugin_dir / "plugin.json")}}
+        assert mod.check_sync(data) == []

--- a/tests/unit/mastering/test_master_album_layout_flow.py
+++ b/tests/unit/mastering/test_master_album_layout_flow.py
@@ -165,3 +165,26 @@ def test_layout_never_halts_pipeline_on_write_failure(
     assert result.get("failed_stage") is None
     assert result["stages"]["layout"]["status"] == "warn"
     assert any("layout" in str(w).lower() for w in result["warnings"])
+
+
+def test_layout_never_halts_pipeline_on_unreadable_prior_file(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#399: a pre-existing LAYOUT.md with non-UTF-8 bytes must not crash
+    the pipeline. The read happened outside any try/except, so
+    UnicodeDecodeError propagated straight out of _stage_layout."""
+    _write_sine_wav(tmp_path / "01-a.wav")
+    _write_sine_wav(tmp_path / "02-b.wav", freq=330.0)
+    _install_album(monkeypatch, tmp_path, "layout-album")
+
+    # 0xff is not valid UTF-8 anywhere in a byte stream.
+    (tmp_path / "LAYOUT.md").write_bytes(b"transitions:\n  - mode: \xff\n")
+
+    result = _run(tmp_path, "layout-album")
+    assert result.get("failed_stage") is None, result.get("failure_detail")
+    assert any("layout" in str(w).lower() for w in result["warnings"])
+    # Prior (unreadable) transitions are discarded; a fresh LAYOUT.md is
+    # still written using the default transition mode.
+    assert result["stages"]["layout"]["status"] == "pass"
+    parsed = _extract_yaml((tmp_path / "LAYOUT.md").read_text(encoding="utf-8"))
+    assert len(parsed["transitions"]) == 1

--- a/tests/unit/mastering/test_master_tracks.py
+++ b/tests/unit/mastering/test_master_tracks.py
@@ -792,6 +792,18 @@ class TestApplyFadeOut:
         apply_fade_out(data, rate, duration=1.0)
         assert np.array_equal(data, original)
 
+    def test_tiny_positive_duration_passthrough(self):
+        """#406: 0 < duration < 1/rate rounds fade_samples to 0.
+
+        np.linspace(0, 1, 0) previously fed an empty envelope into
+        result[-0:] *= envelope, which raised a ValueError from the
+        broadcast shape mismatch (result[-0:] is the *whole* array,
+        not an empty slice).
+        """
+        data, rate = _generate_sine(duration=1.0)
+        result = apply_fade_out(data, rate, duration=1e-6)
+        assert np.array_equal(result, data)
+
 
 # ─── Tests: Process One Track ─────────────────────────────────────────
 

--- a/tests/unit/promotion/test_generate_all_promos.py
+++ b/tests/unit/promotion/test_generate_all_promos.py
@@ -67,6 +67,13 @@ class TestFindMasteredDir:
         result = mod.find_mastered_dir(tmp_path)
         assert result == tmp_path
 
+    def test_candidate_that_is_a_file_does_not_crash(self, tmp_path):
+        """#411: a candidate path that exists as a *file* must be skipped,
+        not handed to iterdir() (which raises NotADirectoryError)."""
+        (tmp_path / "wavs").write_bytes(b"not a directory")
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == tmp_path
+
 
 # ---------------------------------------------------------------------------
 # find_artwork

--- a/tests/unit/shared/test_media_utils.py
+++ b/tests/unit/shared/test_media_utils.py
@@ -149,3 +149,25 @@ class TestFindBestSegment:
             result = mod.find_best_segment(Path("/fake.wav"), duration=15)
             # Fallback: min(120 * 0.2, 120 - 15) = min(24, 105) = 24
             assert result == pytest.approx(24.0)
+
+    @patch.object(mod, "get_audio_duration", return_value=20.0)
+    def test_last_window_is_considered(self, _mock_dur):
+        """#412: the highest-energy window at the very end must not be skipped.
+
+        window_samples=2 over a 5-sample rms track: valid start indices are
+        0..3 inclusive (range(5 - 2 + 1)). The off-by-one bug stopped at
+        range(5 - 2) = range(3), silently excluding the last (highest-energy)
+        window and returning a worse start time.
+        """
+        import numpy as np
+
+        fake_librosa = MagicMock()
+        fake_librosa.load.return_value = (np.zeros(10), 512)  # y, sr=512
+        fake_librosa.feature.rms.return_value = np.array([[0, 0, 0, 10, 10]])
+        fake_librosa.times_like.return_value = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+
+        with patch.dict(sys.modules, {"librosa": fake_librosa}):
+            # duration=2, hop_length=512 (hardcoded) -> window_samples = int(2*512/512) = 2
+            result = mod.find_best_segment(Path("/fake.wav"), duration=2)
+
+        assert result == pytest.approx(3.0)

--- a/tests/unit/state/test_silent_exceptions.py
+++ b/tests/unit/state/test_silent_exceptions.py
@@ -245,7 +245,7 @@ class TestSheetMusicConfigWarning:
                 "sys.modules",
                 {"tools.shared.config": types.ModuleType("tools.shared.config")},
             ),
-            caplog.at_level("WARNING", logger="handlers.processing._helpers"),
+            caplog.at_level("WARNING", logger="handlers.processing.sheet_music"),
         ):
             stub = sys.modules["tools.shared.config"]
             stub.load_config = MagicMock(side_effect=ImportError("no module"))

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -582,6 +582,10 @@ def apply_fade_out(data: Any, rate: int, duration: float = 5.0, curve: str = 'ex
     total_samples = data.shape[0]
     fade_samples = int(rate * duration)
 
+    # Duration too small to produce even one sample of fade — passthrough.
+    if fade_samples <= 0:
+        return data
+
     # If fade is longer than audio, fade the entire track
     if fade_samples > total_samples:
         fade_samples = total_samples

--- a/tools/promotion/generate_all_promos.py
+++ b/tools/promotion/generate_all_promos.py
@@ -39,7 +39,7 @@ def find_mastered_dir(album_dir: Path) -> Path:
     ]
 
     for candidate in candidates:
-        if candidate.exists():
+        if candidate.is_dir():
             # Check if it has audio files
             audio_extensions = {'.wav', '.mp3', '.flac', '.m4a'}
             has_audio = any(f.suffix.lower() in audio_extensions

--- a/tools/shared/media_utils.py
+++ b/tools/shared/media_utils.py
@@ -134,7 +134,7 @@ def find_best_segment(audio_path: Path, duration: int = 15) -> float:
         best_start: float = 0.0
         best_energy: float = 0.0
 
-        for i in range(len(rms) - window_samples):
+        for i in range(len(rms) - window_samples + 1):
             window_energy = np.mean(rms[i:i + window_samples])
             if window_energy > best_energy:
                 best_energy = window_energy


### PR DESCRIPTION
## Summary

Six small, independent bugfixes, each closing one filed issue with its own regression test. All commits are separate on purpose (not squashed) so any subset can be cherry-picked independently:

- `#412` — `find_best_segment`'s energy-window loop excluded the last valid start index (off-by-one), so the highest-energy segment near a track's chorus/outro could be silently skipped by the promo-video picker.
- `#411` — `find_mastered_dir` checked `.exists()` (true for files too) before `.iterdir()`, crashing with `NotADirectoryError` if a stray file sat where a directory was expected.
- `#406` — `apply_fade_out` raised a broadcast `ValueError` when `0 < duration < 1/rate` rounded `fade_samples` to `0`; now guarded alongside the existing `duration <= 0` check.
- `#394` — `check_version_sync`'s hook opened manifest files without an explicit encoding and didn't catch `UnicodeDecodeError`, crashing on non-UTF-8 bytes.
- `#399` — `_stage_layout`'s read of a prior `LAYOUT.md` sat outside its `try`/`except`, so a non-UTF-8 file halted the whole `master_album` pipeline despite the stage's own "never halt" contract.
- `#344` — a test (`test_config_load_failure_logs_warning`) scoped `caplog.at_level(...)` to the wrong logger.

Note: this branch originally also included a fix for #443, but `develop` already had a broader fix for it (`9385ef2`, merged same day) by the time this PR was prepared — dropped to avoid duplicating that work.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [x] Test-only change (#344)

## Testing performed
- Each fix has a new regression test that was manually verified to fail against the pre-fix code and pass with the fix.
- `make check` (ruff + bandit + mypy + pytest) passes locally: 4104 passed, 87.87% coverage.
- No new dependencies, no config/schema changes, no migration note needed (all verified against CONTRIBUTING.md's migration-note criteria).

## Related issues
Fixes #412, #411, #406, #394, #399, #344

## Reviewer checklist
- [ ] Confirm CHANGELOG.md entries read correctly with the rest of `[Unreleased]`
- [ ] Spot-check that dropping #443 from this branch (already fixed on `develop`) is correct