### PR TITLE
fix(audio): harden mastering/mixing DSP against edge-case crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Audio/DSP edge-case crashes hardened** across the mastering and mixing
+  pipelines:
+  - **Silent/corrupt tracks no longer poison album LUFS aggregates** (#400).
+    A `-inf` LUFS reading fed `avg_lufs`/`lufs_range` in the verification and
+    ceiling-guard stages, producing `-inf`/`inf` and spurious range failures.
+    A shared `_finite_lufs_aggregates` helper now aggregates finite readings
+    only (returning `None` when all tracks are silent), and downstream
+    rounding/comparisons handle `None`.
+  - **Mix analyzer survives degenerate WAVs** (#401, #402). A zero-length WAV
+    crashed with an empty-array reduction; a sub-10-sample buffer produced a
+    `NaN` noise floor. Both now return a clean per-file result instead.
+  - **`apply_fade_out` no longer raises on sub-sample fades** (#406). A tiny
+    positive duration rounded `fade_samples` to 0 and raised; it is now a
+    no-op fade.
+  - **`original_lufs` reports the source loudness** (#407), measured before
+    processing rather than after.
+  - **Envelope followers no longer divide by zero** (#410). A 0 ms attack or
+    release in `gentle_compress`/`apply_transient_shaper` raised
+    `ZeroDivisionError`; time constants are clamped to a small positive floor.
+  - **`find_mastered_dir` skips non-directory candidates** (#411) instead of
+    crashing with `NotADirectoryError` when a candidate path is a file.
+  - **`find_best_segment` no longer skips the last analysis window** (#412),
+    an off-by-one in the window loop bound.
 - **Malformed slugs return clean JSON across every MCP tool** (#443). The
   shared `_find_album_or_error` / `_resolve_audio_dir` / `_find_track_or_error`
   helpers called `_normalize_slug` raw, and ~13 tool handlers called it

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -201,6 +201,45 @@ def _build_notices(ctx: MasterAlbumCtx) -> None:
             )
 
 
+# ---------------------------------------------------------------------------
+# LUFS aggregation helpers (finite-only)
+# ---------------------------------------------------------------------------
+
+def _finite_lufs_aggregates(
+    results: list[dict[str, Any]],
+) -> tuple[float | None, float | None]:
+    """Return (mean, range) of LUFS across ``results``, over finite values only.
+
+    analyze_track returns -inf LUFS for a silent / corrupt track; feeding that
+    into ``np.mean`` / ``max-min`` poisons the aggregate with non-finite values
+    (avg becomes -inf, range becomes inf). That is the same class of bug as
+    #371 in analyze_audio (and #400 here). Aggregate over the finite LUFS
+    readings only, and return ``(None, None)`` when no track has a finite
+    reading, so no inf/-inf reaches ctx.stages or the result payload.
+    """
+    import math
+
+    import numpy as np
+
+    finite = [
+        r["lufs"] for r in results
+        if isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"])
+    ]
+    if not finite:
+        return None, None
+    return float(np.mean(finite)), float(max(finite) - min(finite))
+
+
+def _round_or_none(value: float | None, ndigits: int) -> float | None:
+    """``round()`` that passes ``None`` through instead of raising TypeError.
+
+    _finite_lufs_aggregates returns None when every track is silent/corrupt;
+    the verification and ceiling-guard stages round those aggregates for
+    reporting, so the None must survive rounding as None.
+    """
+    return round(value, ndigits) if value is not None else None
+
+
 # Injectable for test monkeypatching (tests patch this module-level name).
 _adm_check_fn = _adm_check_fn_default
 _embed_wav_metadata_fn = _embed_wav_metadata_fn_default
@@ -367,7 +406,6 @@ async def _stage_analysis(ctx: MasterAlbumCtx) -> str | None:
     """
     import math
 
-    import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
 
     analysis_results = []
@@ -376,21 +414,17 @@ async def _stage_analysis(ctx: MasterAlbumCtx) -> str | None:
         analysis_results.append(result)
 
     # A silent / near-silent track makes analyze_track return -inf LUFS, which
-    # poisons the np.mean / max-min aggregates with non-finite values (the same
-    # class of bug as #371 in analyze_audio). Aggregate over finite LUFS only,
-    # and surface silent tracks so the operator isn't left with null aggregates
+    # poisons the mean / max-min aggregates with non-finite values (the same
+    # class of bug as #371 in analyze_audio, and #400 below). Aggregate over
+    # finite LUFS only via the shared _finite_lufs_aggregates helper, and
+    # surface silent tracks so the operator isn't left with null aggregates
     # under a "pass" status. (Silent tracks are skipped later in
     # _stage_mastering, so no mastering-side action is needed here.)
-    finite_lufs = [
-        r["lufs"] for r in analysis_results
-        if isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"])
-    ]
     silent_tracks = [
         r["filename"] for r in analysis_results
         if not (isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"]))
     ]
-    avg_lufs = float(np.mean(finite_lufs)) if finite_lufs else None
-    lufs_range = float(max(finite_lufs) - min(finite_lufs)) if finite_lufs else None
+    avg_lufs, lufs_range = _finite_lufs_aggregates(analysis_results)
     tinny_tracks = [r["filename"] for r in analysis_results if r["tinniness_ratio"] > 0.6]
 
     for t in tinny_tracks:
@@ -830,8 +864,8 @@ def _emit_verification_warn_fallback(
     unrecoverable_map: dict[str, dict[str, Any]],
     auto_recovered: list[dict[str, Any]],
     verify_results: list[dict[str, Any]],
-    verify_avg: float,
-    verify_range: float,
+    verify_avg: float | None,
+    verify_range: float | None,
     effective_lufs: float,
 ) -> None:
     """Write VERIFICATION_WARNINGS.md, update stage status to warn,
@@ -876,8 +910,8 @@ def _emit_verification_warn_fallback(
     )
     ctx.stages["verification"] = {
         "status":               "warn",
-        "avg_lufs":             round(verify_avg, 1),
-        "lufs_range":           round(verify_range, 2),
+        "avg_lufs":             _round_or_none(verify_avg, 1),
+        "lufs_range":           _round_or_none(verify_range, 2),
         "all_within_spec":      False,
         "auto_recovered":       auto_recovered,
         "unrecoverable_tracks": sorted(unrecoverable_map.keys()),
@@ -895,7 +929,6 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
     Sets ctx:  verify_results
     Returns: None on pass (all within spec), failure JSON otherwise.
     """
-    import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
     from tools.mastering.fix_dynamic_track import fix_dynamic
 
@@ -906,9 +939,9 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
         result = await ctx.loop.run_in_executor(None, analyze_track, str(wav))
         verify_results.append(result)
 
-    verify_lufs = [r["lufs"] for r in verify_results]
-    verify_avg = float(np.mean(verify_lufs))
-    verify_range = float(max(verify_lufs) - min(verify_lufs))
+    # Aggregate over finite LUFS only — a silent/corrupt mastered WAV reads
+    # -inf and would otherwise poison avg (→ -inf) and range (→ inf); see #400.
+    verify_avg, verify_range = _finite_lufs_aggregates(verify_results)
     effective_lufs = ctx.effective_lufs
     effective_ceiling = ctx.effective_ceiling
 
@@ -926,7 +959,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
         if issues:
             out_of_spec.append({"filename": r["filename"], "issues": issues})
 
-    album_range_fail = verify_range >= 1.0
+    album_range_fail = verify_range is not None and verify_range >= 1.0
     auto_recovered: list[dict[str, Any]] = []
 
     if out_of_spec or album_range_fail:
@@ -1025,9 +1058,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                         None, analyze_track, str(wav),
                     )
                     verify_results.append(result)
-                verify_lufs = [r["lufs"] for r in verify_results]
-                verify_avg = float(np.mean(verify_lufs))
-                verify_range = float(max(verify_lufs) - min(verify_lufs))
+                verify_avg, verify_range = _finite_lufs_aggregates(verify_results)
                 out_of_spec = []
                 for r in verify_results:
                     issues = []
@@ -1045,7 +1076,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                         out_of_spec.append(
                             {"filename": r["filename"], "issues": issues}
                         )
-                album_range_fail = verify_range >= 1.0
+                album_range_fail = verify_range is not None and verify_range >= 1.0
 
         if out_of_spec or album_range_fail:
             # Pure range failure with no individual out-of-spec tracks —
@@ -1053,13 +1084,13 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
             # detail as before.
             if album_range_fail and not out_of_spec:
                 fail_detail: dict[str, Any] = {
-                    "album_lufs_range":  round(verify_range, 2),
+                    "album_lufs_range":  _round_or_none(verify_range, 2),
                     "album_range_limit": 1.0,
                 }
                 ctx.stages["verification"] = {
                     "status":          "fail",
-                    "avg_lufs":        round(verify_avg, 1),
-                    "lufs_range":      round(verify_range, 2),
+                    "avg_lufs":        _round_or_none(verify_avg, 1),
+                    "lufs_range":      _round_or_none(verify_range, 2),
                     "all_within_spec": False,
                 }
                 return _safe_json({
@@ -1097,7 +1128,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                 if halt_eligible_tracks:
                     fail_detail["tracks_out_of_spec"] = halt_eligible_tracks
                 if halt_on_range:
-                    fail_detail["album_lufs_range"] = round(verify_range, 2)
+                    fail_detail["album_lufs_range"] = _round_or_none(verify_range, 2)
                     fail_detail["album_range_limit"] = 1.0
                 if unrecoverable_map:
                     fail_detail["unrecoverable_tracks"] = sorted(
@@ -1105,8 +1136,8 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                     )
                 ctx.stages["verification"] = {
                     "status":          "fail",
-                    "avg_lufs":        round(verify_avg, 1),
-                    "lufs_range":      round(verify_range, 2),
+                    "avg_lufs":        _round_or_none(verify_avg, 1),
+                    "lufs_range":      _round_or_none(verify_range, 2),
                     "all_within_spec": False,
                 }
                 return _safe_json({
@@ -1135,8 +1166,8 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
 
     verification_stage: dict[str, Any] = {
         "status": "pass",
-        "avg_lufs": round(verify_avg, 1),
-        "lufs_range": round(verify_range, 2),
+        "avg_lufs": _round_or_none(verify_avg, 1),
+        "lufs_range": _round_or_none(verify_range, 2),
         "all_within_spec": True,
     }
     if auto_recovered:
@@ -1509,7 +1540,6 @@ async def _stage_ceiling_guard(
         _ceiling_guard_compute_overshoots). Callers that need monkeypatching
         should pass their patched version explicitly.
     """
-    import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
 
     compute_fn = _compute_overshoots if _compute_overshoots is not None else _ceiling_guard_compute_overshoots
@@ -1615,11 +1645,11 @@ async def _stage_ceiling_guard(
             if idx is not None:
                 ctx.verify_results[idx] = fresh
 
-        verify_lufs = [r["lufs"] for r in ctx.verify_results]
-        ctx.stages["verification"]["avg_lufs"] = round(float(np.mean(verify_lufs)), 1)
-        ctx.stages["verification"]["lufs_range"] = round(
-            float(max(verify_lufs) - min(verify_lufs)), 2
-        )
+        # Finite-only recompute — a pulled-down track that reads -inf (silent
+        # or clipped to zero) must not poison the album aggregates (#400).
+        verify_avg, verify_range = _finite_lufs_aggregates(ctx.verify_results)
+        ctx.stages["verification"]["avg_lufs"] = _round_or_none(verify_avg, 1)
+        ctx.stages["verification"]["lufs_range"] = _round_or_none(verify_range, 2)
 
     ctx.stages["ceiling_guard"] = ceiling_stage
     return None

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -342,18 +342,32 @@ def _build_analyzer(
     ) -> dict[str, Any]:
         result: dict[str, Any] = {"filename": filename, "issues": [], "recommendations": {}}
 
+        # #401: zero-length audio has no samples to reduce — np.max / np.mean
+        # over an empty array raises ValueError, which would abort the whole
+        # analyze/polish run with a raw traceback. Return a structured
+        # per-file error so a single malformed WAV is skipped, not fatal.
+        if len(data) == 0:
+            result["issues"].append("empty_audio")
+            result["error"] = "empty audio: WAV has 0 samples"
+            return result
+
         # Overall metrics
         peak = float(np.max(np.abs(data)))
         rms = float(np.sqrt(np.mean(data ** 2)))
         result["peak"] = peak
         result["rms"] = rms
 
-        # Noise floor estimate (quietest 10% of signal)
+        # Noise floor estimate (quietest 10% of signal). #402: buffers
+        # shorter than 10 samples make the //10 slice empty, and np.mean of
+        # an empty slice is NaN (with a RuntimeWarning). Emit None as a
+        # sentinel instead so the value computes cleanly and serializes to
+        # JSON null rather than the invalid token NaN.
         abs_signal = np.abs(data[:, 0])
         sorted_abs = np.sort(abs_signal)
-        noise_floor = float(np.mean(sorted_abs[:len(sorted_abs) // 10]))
+        quietest = sorted_abs[:len(sorted_abs) // 10]
+        noise_floor = float(np.mean(quietest)) if quietest.size else None
         result["noise_floor"] = noise_floor
-        if noise_floor > 0.005:
+        if noise_floor is not None and noise_floor > 0.005:
             result["issues"].append("elevated_noise_floor")
             result["recommendations"]["noise_reduction"] = min(0.8, noise_floor * 100)
 

--- a/tests/unit/mastering/test_finite_lufs_aggregates_dry_400.py
+++ b/tests/unit/mastering/test_finite_lufs_aggregates_dry_400.py
@@ -1,0 +1,83 @@
+"""Contract tests for the shared finite-LUFS aggregation helpers (#400).
+
+``_finite_lufs_aggregates`` / ``_round_or_none`` were added by the #400 fix as
+the single source of truth for "aggregate LUFS over finite readings only" and
+are now consumed by ``_stage_analysis`` (the DRY consolidation of the #371
+inline logic), ``_stage_verification`` and ``_stage_ceiling_guard``.
+
+A silent / corrupt track reads -inf LUFS; feeding that into ``np.mean`` /
+``max - min`` poisons the aggregate (avg -> -inf, range -> inf). These tests
+pin the helper contract directly, so a regression in any one call site — or in
+the helper itself — is caught at the source rather than only through a
+stage-level integration test.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers.processing._album_stages import (  # noqa: E402
+    _finite_lufs_aggregates,
+    _round_or_none,
+)
+
+
+def _rows(*lufs_values: float) -> list[dict]:
+    """Build minimal analyze_track-shaped rows carrying the given LUFS values."""
+    return [{"filename": f"{i:02d}.wav", "lufs": v} for i, v in enumerate(lufs_values)]
+
+
+class TestFiniteLufsAggregates:
+    def test_all_finite_matches_naive_mean_and_range(self):
+        """With no silent tracks the helper equals the plain mean / max-min."""
+        values = [-14.0, -13.2, -15.7, -12.9]
+        avg, rng = _finite_lufs_aggregates(_rows(*values))
+        assert avg == float(np.mean(values))
+        assert rng == float(max(values) - min(values))
+
+    def test_negative_inf_is_ignored(self):
+        """A -inf silent track must not poison avg (-> -inf) or range (-> inf)."""
+        avg, rng = _finite_lufs_aggregates(_rows(-14.0, float("-inf"), -13.0))
+        assert avg == float(np.mean([-14.0, -13.0]))
+        assert rng == pytest.approx(1.0)
+        assert math.isfinite(avg) and math.isfinite(rng)
+
+    def test_nan_is_ignored(self):
+        avg, rng = _finite_lufs_aggregates(_rows(-14.0, float("nan"), -16.0))
+        assert avg == float(np.mean([-14.0, -16.0]))
+        assert rng == pytest.approx(2.0)
+
+    def test_all_non_finite_returns_none_none(self):
+        avg, rng = _finite_lufs_aggregates(_rows(float("-inf"), float("nan")))
+        assert avg is None
+        assert rng is None
+
+    def test_empty_returns_none_none(self):
+        assert _finite_lufs_aggregates([]) == (None, None)
+
+    def test_single_finite_value_has_zero_range(self):
+        avg, rng = _finite_lufs_aggregates(_rows(-14.0))
+        assert avg == -14.0
+        assert rng == 0.0
+
+
+class TestRoundOrNone:
+    def test_none_passes_through(self):
+        assert _round_or_none(None, 1) is None
+        assert _round_or_none(None, 2) is None
+
+    def test_finite_rounds_like_builtin(self):
+        assert _round_or_none(-14.037, 1) == round(-14.037, 1)
+        assert _round_or_none(0.126, 2) == round(0.126, 2)

--- a/tests/unit/mastering/test_master_tracks_406_407.py
+++ b/tests/unit/mastering/test_master_tracks_406_407.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression tests for master_tracks.py bugs #406 and #407.
+
+#406 — apply_fade_out must not raise (nor corrupt audio) when the fade
+       duration is so small it rounds to zero samples.
+#407 — result['original_lufs'] must report the loudness of the SOURCE audio
+       (measured right after read), not the loudness measured after the
+       EQ/compression/fade processing chain.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pyloudnorm as pyln
+import pytest
+import soundfile as sf
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering import master_tracks
+from tools.mastering.master_tracks import apply_fade_out, master_track
+
+
+def _stereo_sine(freq=440.0, duration=3.0, rate=44100, amplitude=0.5):
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    mono = (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float64)
+    return np.column_stack([mono, mono]), rate
+
+
+# ─── #406: sub-sample fade-out must be a safe no-op ───────────────────────
+
+
+class TestFadeOutSubSample:
+    def test_tiny_duration_does_not_raise_stereo(self):
+        """0 < duration < 1/rate => int(rate*duration) == 0 must not crash."""
+        data, rate = _stereo_sine(duration=1.0)
+        # 0.5 sample worth of fade -> int(rate * duration) == 0
+        tiny = 0.5 / rate
+        assert int(rate * tiny) == 0  # precondition that triggered the bug
+        result = apply_fade_out(data, rate, duration=tiny)  # must not raise
+        # A sub-sample fade is effectively nothing: audio stays unchanged.
+        assert np.array_equal(result, data)
+
+    def test_tiny_duration_does_not_raise_mono(self):
+        data, rate = _stereo_sine(duration=1.0)
+        mono = data[:, 0].copy()
+        tiny = 0.5 / rate
+        result = apply_fade_out(mono, rate, duration=tiny)  # must not raise
+        assert np.array_equal(result, mono)
+
+    def test_tiny_duration_linear_curve(self):
+        data, rate = _stereo_sine(duration=1.0)
+        tiny = 0.5 / rate
+        result = apply_fade_out(data, rate, duration=tiny, curve='linear')
+        assert np.array_equal(result, data)
+
+
+# ─── #407: original_lufs must reflect the SOURCE, not processed audio ──────
+
+
+class TestOriginalLufsIsSource:
+    def test_original_lufs_is_source_not_processed(self, tmp_path, monkeypatch):
+        """A processing stage that changes loudness must not leak into
+        the reported 'original_lufs' — it should stay the source value."""
+        data, rate = _stereo_sine(duration=3.0, amplitude=0.5)
+        in_path = tmp_path / "src.wav"
+        out_path = tmp_path / "out.wav"
+        sf.write(str(in_path), data, rate, subtype='PCM_16')
+
+        # Independently measure the true SOURCE loudness the same way the
+        # fix does — read the file back and meter the raw samples.
+        src_data, src_rate = sf.read(str(in_path))
+        src_lufs = pyln.Meter(src_rate).integrated_loudness(src_data)
+        assert np.isfinite(src_lufs)
+
+        # Force a large, deterministic loudness drop *during* processing:
+        # replace the fade stage with a -20 dB (x0.1) attenuation. The old
+        # code measured loudness after this stage and reported it as
+        # 'original_lufs'; the fix measures the source before it.
+        def loudness_dropping_fade(d, r, duration=5.0, curve='exponential'):
+            return d * 0.1
+
+        monkeypatch.setattr(master_tracks, "apply_fade_out",
+                            loudness_dropping_fade)
+
+        result = master_track(str(in_path), str(out_path),
+                              target_lufs=-14.0, fade_out=2.0)
+
+        assert not result.get('skipped', False)
+        # original_lufs must equal the SOURCE loudness...
+        assert result['original_lufs'] == pytest.approx(src_lufs, abs=0.5)
+        # ...and must NOT be the post-processing (~20 dB quieter) value the
+        # buggy code reported.
+        processed_lufs = src_lufs - 20.0
+        assert abs(result['original_lufs'] - processed_lufs) > 10.0

--- a/tests/unit/mastering/test_stage_verification_silent_400.py
+++ b/tests/unit/mastering/test_stage_verification_silent_400.py
@@ -1,0 +1,182 @@
+"""_stage_verification (and the ceiling-guard recompute) must not let a
+silent / corrupt mastered track's -inf LUFS poison its avg_lufs / lufs_range
+aggregates or the album-range control flow.
+
+Regression for issue #400 (residual after #371 fixed _stage_analysis): the
+verification-stage aggregation still used unfiltered ``np.mean`` / ``max-min``
+over LUFS values that can include -inf when a zeroed/corrupt mastered WAV is
+globbed into ``ctx.mastered_files``. That leaves -inf/inf in
+``ctx.stages["verification"]`` (the in-memory payload consumers read directly)
+and makes ``album_range_fail = verify_range >= 1.0`` fire spuriously.
+
+Heavy deps (analyze_track) are mocked — no real audio is read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+for _p in (str(PROJECT_ROOT), str(SERVER_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from handlers.processing import _album_stages
+from handlers.processing._album_stages import MasterAlbumCtx
+
+ANALYZE_TARGET = "tools.mastering.analyze_tracks.analyze_track"
+
+
+def _track(name: str, lufs: float, peak_db: float) -> dict:
+    """A minimally-complete analyze_track result for one mastered file."""
+    return {
+        "filename": name,
+        "lufs": lufs,
+        "peak_db": peak_db,
+        "short_term_range": 6.0,
+        "stl_95": 9.0,
+        "low_rms": -30.0,
+        "vocal_rms": -22.0,
+    }
+
+
+def _make_ctx(tmp_path: Path, names: list[str]) -> MasterAlbumCtx:
+    source_dir = tmp_path / "source"
+    output_dir = tmp_path / "mastered"
+    source_dir.mkdir(exist_ok=True)
+    output_dir.mkdir(exist_ok=True)
+
+    ctx = MasterAlbumCtx(
+        album_slug="test-album",
+        genre="",
+        target_lufs=-14.0,
+        ceiling_db=-1.0,
+        cut_highmid=0.0,
+        cut_highs=0.0,
+        source_subfolder="",
+        freeze_signature=False,
+        new_anchor=False,
+        loop=asyncio.new_event_loop(),
+    )
+    ctx.audio_dir = tmp_path
+    ctx.source_dir = source_dir
+    ctx.output_dir = output_dir
+    # analyze_track is mocked, so these paths need not exist on disk.
+    ctx.mastered_files = [output_dir / n for n in names]
+    ctx.targets = {
+        "output_sample_rate": 48000,
+        "output_bits": 24,
+        "target_lufs": -14.0,
+        "ceiling_db": -1.0,
+    }
+    ctx.settings = {}
+    ctx.effective_lufs = -14.0
+    ctx.effective_ceiling = -1.0
+    ctx.effective_highmid = 0.0
+    ctx.effective_highs = 0.0
+    ctx.effective_compress = 2.5
+    return ctx
+
+
+def _run_verification(ctx: MasterAlbumCtx, fake_analyze) -> str | None:
+    asyncio.set_event_loop(ctx.loop)
+    try:
+        with patch(ANALYZE_TARGET, fake_analyze):
+            return ctx.loop.run_until_complete(
+                _album_stages._stage_verification(ctx),
+            )
+    finally:
+        ctx.loop.close()
+
+
+# ── new helpers ────────────────────────────────────────────────────────────
+
+def test_finite_lufs_aggregates_filters_non_finite() -> None:
+    results = [
+        _track("01-ok.wav", -14.0, -2.0),
+        _track("02-silent.wav", float("-inf"), float("-inf")),
+        _track("03-ok.wav", -13.0, -2.0),
+    ]
+    avg, rng = _album_stages._finite_lufs_aggregates(results)
+    assert avg is not None and math.isfinite(avg)
+    assert rng is not None and math.isfinite(rng)
+    # Aggregated over the two finite tracks only.
+    assert avg == -13.5
+    assert rng == 1.0
+
+
+def test_finite_lufs_aggregates_all_non_finite_returns_none() -> None:
+    results = [
+        _track("01-silent.wav", float("-inf"), float("-inf")),
+        _track("02-silent.wav", float("-inf"), float("-inf")),
+    ]
+    assert _album_stages._finite_lufs_aggregates(results) == (None, None)
+    # Empty input is also None/None (no finite readings at all).
+    assert _album_stages._finite_lufs_aggregates([]) == (None, None)
+
+
+def test_round_or_none_passes_none_through() -> None:
+    assert _album_stages._round_or_none(None, 1) is None
+    assert _album_stages._round_or_none(-13.456, 1) == -13.5
+    assert _album_stages._round_or_none(0.0, 2) == 0.0
+
+
+# ── stage integration ───────────────────────────────────────────────────────
+
+def test_verification_silent_track_keeps_aggregates_finite(tmp_path: Path) -> None:
+    """One in-spec track + one silent (-inf) track. The stage still halts
+    (a silent mastered track is genuinely out of spec), but the reported
+    aggregates must be the finite metrics of the real track, not -inf/inf."""
+    ctx = _make_ctx(tmp_path, ["01-ok.wav", "02-silent.wav"])
+
+    def fake_analyze(path: str) -> dict:
+        name = Path(path).name
+        if "silent" in name:
+            return _track(name, float("-inf"), float("-inf"))
+        return _track(name, -14.0, -2.0)
+
+    result = _run_verification(ctx, fake_analyze)
+
+    stage = ctx.stages["verification"]
+    # Core residual: no -inf/inf may reach the in-memory aggregates.
+    assert stage["avg_lufs"] is not None and math.isfinite(stage["avg_lufs"])
+    assert stage["lufs_range"] is not None and math.isfinite(stage["lufs_range"])
+    # Metrics reflect the one measurable track, not the poisoned union.
+    assert stage["avg_lufs"] == -14.0
+    assert stage["lufs_range"] == 0.0
+
+    # A single silent outlier must not spuriously trip the album-range gate
+    # (range over the finite set is 0.0, well under the 1.0 dB limit).
+    if result is not None:
+        payload = json.loads(result)
+        assert "album_lufs_range" not in payload.get("failure_detail", {})
+        # And nothing serialized as a non-finite JS token.
+        assert "Infinity" not in result and "NaN" not in result
+
+
+def test_verification_all_silent_yields_none_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """Every mastered track silent → no finite readings. Aggregation must
+    yield None (not -inf/nan) and the round() guards must not raise."""
+    ctx = _make_ctx(tmp_path, ["01-silent.wav", "02-silent.wav"])
+
+    def fake_analyze(path: str) -> dict:
+        return _track(Path(path).name, float("-inf"), float("-inf"))
+
+    result = _run_verification(ctx, fake_analyze)
+
+    stage = ctx.stages["verification"]
+    # None is the documented empty sentinel; -inf/nan is the bug.
+    assert stage["avg_lufs"] is None or math.isfinite(stage["avg_lufs"])
+    assert stage["lufs_range"] is None or math.isfinite(stage["lufs_range"])
+    assert stage["avg_lufs"] is None
+    assert stage["lufs_range"] is None
+    if result is not None:
+        assert "Infinity" not in result and "NaN" not in result

--- a/tests/unit/mixing/test_mix_tracks_zerodiv_410.py
+++ b/tests/unit/mixing/test_mix_tracks_zerodiv_410.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Regression tests for issue #410.
+
+gentle_compress / apply_transient_shaper computed time-constant coefficients
+via ``np.exp(-1.0 / (rate * ms / 1000.0))``. When an attack/release time is
+0 ms (reachable through user-override mix presets), the inner
+``rate * ms / 1000.0`` collapses to 0.0 and the Python scalar division
+``-1.0 / 0.0`` raises ZeroDivisionError, aborting the whole polish run.
+
+These tests pin the fix: a 0 ms (or negative) attack/release time must be
+clamped to a tiny positive floor so no exception is raised and output stays
+finite, while a normal positive time still behaves as before.
+
+Usage:
+    python -m pytest tests/unit/mixing/test_mix_tracks_zerodiv_410.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mixing.mix_tracks import (
+    _MIN_TIME_CONSTANT_MS,
+    apply_transient_shaper,
+    gentle_compress,
+)
+
+
+def _signal(rate: int = 44100, seconds: float = 0.1) -> np.ndarray:
+    """A stereo sine with a transient burst so both code paths do real work."""
+    t = np.arange(int(rate * seconds)) / rate
+    tone = 0.8 * np.sin(2 * np.pi * 440 * t)
+    # Add a sharp transient so the transient shaper has something to detect.
+    tone[len(tone) // 2] += 0.15
+    return np.column_stack([tone, tone]).astype(np.float64)
+
+
+class TestGentleCompressZeroTimes:
+    def test_zero_attack_does_not_raise(self):
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, attack_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_zero_release_does_not_raise(self):
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, release_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_both_zero_does_not_raise(self):
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, attack_ms=0, release_ms=0)
+        assert np.all(np.isfinite(result))
+
+    def test_negative_time_clamps_to_floor(self):
+        """A negative attack time must clamp to the floor, not become a
+        coeff>1 runaway envelope. Output byte-identical to the floor-value
+        run pins the clamp; on unfixed code the negative time diverged (it
+        stayed finite on this short signal, so a bare finiteness check did
+        not catch the regression)."""
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, attack_ms=-5.0)
+        clamped = gentle_compress(data, 44100, ratio=4.0,
+                                  attack_ms=_MIN_TIME_CONSTANT_MS)
+        assert np.all(np.isfinite(result))
+        assert np.array_equal(result, clamped)
+
+    def test_normal_attack_still_compresses(self):
+        """A normal positive attack must still reduce peaks above threshold."""
+        data = _signal()
+        result = gentle_compress(data, 44100, threshold_db=-12.0, ratio=4.0,
+                                 attack_ms=10.0, release_ms=100.0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+        assert np.max(np.abs(result)) < np.max(np.abs(data))
+
+
+class TestTransientShaperZeroTimes:
+    def test_zero_fast_attack_does_not_raise(self):
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, attack_gain=6.0,
+                                        fast_attack_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_zero_slow_attack_does_not_raise(self):
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, attack_gain=6.0,
+                                        slow_attack_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_negative_fast_attack_clamps_to_floor(self):
+        """A negative transient fast-attack time must clamp to the floor,
+        producing output byte-identical to the floor-value run (see #410)."""
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, sustain_gain=3.0,
+                                        fast_attack_ms=-1.0)
+        clamped = apply_transient_shaper(data, 44100, sustain_gain=3.0,
+                                         fast_attack_ms=_MIN_TIME_CONSTANT_MS)
+        assert np.all(np.isfinite(result))
+        assert np.array_equal(result, clamped)
+
+    def test_normal_attack_still_shapes(self):
+        """A normal positive attack must still alter the signal."""
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, attack_gain=6.0,
+                                        fast_attack_ms=0.5, slow_attack_ms=20.0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+        assert not np.allclose(result, data)

--- a/tests/unit/promotion/test_find_mastered_dir_411.py
+++ b/tests/unit/promotion/test_find_mastered_dir_411.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #411.
+
+find_mastered_dir must skip candidate paths that exist as regular files
+instead of crashing with NotADirectoryError when it calls iterdir() on them.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the module under test
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from tools.promotion import generate_all_promos as mod
+
+
+@pytest.mark.unit
+class TestFindMasteredDirFileCandidate:
+    """A candidate path that exists as a FILE must not crash the search (#411)."""
+
+    def test_mastered_file_candidate_is_skipped(self, tmp_path):
+        """'mastered' existing as a file must be skipped, not iterdir()'d."""
+        # album_dir itself has no audio, so the loop advances to sub-candidates.
+        (tmp_path / "mastered").write_bytes(b"not a directory")
+
+        # Before the fix this raised NotADirectoryError; now it falls back.
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == tmp_path
+
+    def test_wavs_file_candidate_is_skipped(self, tmp_path):
+        """'wavs' existing as a file must be skipped, not iterdir()'d."""
+        (tmp_path / "wavs").write_bytes(b"not a directory")
+
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == tmp_path
+
+    def test_file_candidate_skipped_and_real_dir_found(self, tmp_path):
+        """A file candidate is skipped while a later real audio dir is still found."""
+        # 'mastered' is a decoy file (probed before 'wavs' in candidate order).
+        (tmp_path / "mastered").write_bytes(b"not a directory")
+        # 'wavs' is a real directory holding audio.
+        wavs = tmp_path / "wavs"
+        wavs.mkdir()
+        (wavs / "01-track.wav").write_bytes(b"audio")
+
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == wavs

--- a/tests/unit/shared/test_find_best_segment_412.py
+++ b/tests/unit/shared/test_find_best_segment_412.py
@@ -1,0 +1,86 @@
+"""Regression tests for find_best_segment window-range off-by-one (issue #412).
+
+find_best_segment scans overlapping ``window_samples``-long windows across the
+RMS energy envelope to locate the most energetic segment. The valid starting
+frame indices span ``0 .. len(rms) - window_samples`` inclusive. A loop of
+``range(len(rms) - window_samples)`` never evaluates that final window, so when
+the peak-energy segment is the last window of the track it is silently skipped;
+in the degenerate ``len(rms) == window_samples`` case the loop never runs at all
+and the start defaults to 0.0.
+
+These tests mock librosa so the RMS / times arrays are fully controlled while
+numpy stays real. find_best_segment wraps its analysis in a broad
+``except Exception`` that falls back to "20% into the track", so each test
+asserts the *exact* expected start time: an off-by-one (wrong window) or a
+swallowed IndexError (fallback value) both produce a different number and fail.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# Ensure project root on sys.path (conftest normally handles this).
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from tools.shared import media_utils as mod
+
+# With duration=15, sr=120 and the internal hop_length=512:
+#   window_samples = int(15 * 120 / 512) = int(3.515625) = 3
+_SR = 120
+_DURATION = 15
+_TOTAL_DURATION = 1000.0  # >> any window time, so the max_start clamp never bites
+# Value returned by the internal fallback path (librosa error / swallowed exc).
+_FALLBACK = min(_TOTAL_DURATION * 0.2, _TOTAL_DURATION - _DURATION)  # 200.0
+
+
+def _run(rms, times):
+    """Invoke find_best_segment with librosa mocked to yield the given arrays."""
+    rms_arr = np.asarray(rms, dtype=float)
+    fake_librosa = MagicMock()
+    fake_librosa.load.return_value = (np.zeros(8, dtype=float), _SR)
+    # librosa.feature.rms(...) returns shape (1, n_frames); the code takes [0].
+    fake_librosa.feature.rms.return_value = np.array([rms_arr])
+    fake_librosa.times_like.return_value = np.asarray(times, dtype=float)
+    with patch.object(mod, "get_audio_duration", return_value=_TOTAL_DURATION), \
+            patch.dict(sys.modules, {"librosa": fake_librosa}):
+        return mod.find_best_segment(Path("/fake.wav"), duration=_DURATION)
+
+
+@pytest.mark.unit
+class TestFindBestSegmentLastWindow:
+    """The final valid analysis window must be considered."""
+
+    def test_selects_last_valid_window(self):
+        # 6 RMS frames, window_samples=3 -> valid start indices 0,1,2,3.
+        # Energy climbs toward the end so the window starting at index 3 (the
+        # LAST valid window) has the highest mean. Buggy range(3) stops at 2.
+        rms = [0.1, 0.1, 0.1, 1.0, 1.0, 1.0]
+        times = [0.0, 10.0, 20.0, 30.0, 40.0, 50.0]
+        # window means: [0:3]=0.1  [1:4]=0.4  [2:5]=0.7  [3:6]=1.0 (max)
+        result = _run(rms, times)
+        assert result == pytest.approx(30.0)  # times[3]; pre-fix -> 20.0
+
+    def test_normal_case_middle_window_unchanged(self):
+        # Peak window sits in the middle (index 1); pre- and post-fix agree,
+        # confirming the range change does not disturb the normal path.
+        rms = [0.1, 0.9, 0.9, 0.9, 0.1, 0.1]
+        times = [0.0, 10.0, 20.0, 30.0, 40.0, 50.0]
+        # window means: [0:3]=0.633  [1:4]=0.9 (max)  [2:5]=0.633  [3:6]=0.367
+        result = _run(rms, times)
+        assert result == pytest.approx(10.0)  # times[1], unchanged by the fix
+
+    def test_boundary_single_window_no_index_error(self):
+        # len(rms) == window_samples (3): exactly one valid window at index 0.
+        # Pre-fix range(0) never runs -> start defaults to 0.0. The fix must
+        # evaluate index 0 and pick times[0] WITHOUT raising IndexError (a raised
+        # IndexError would be swallowed and return the 200.0 fallback instead).
+        rms = [0.2, 0.3, 0.4]
+        times = [5.0, 6.0, 7.0]
+        result = _run(rms, times)
+        assert result != pytest.approx(_FALLBACK)  # no swallowed IndexError
+        assert result == pytest.approx(5.0)  # times[0]; pre-fix -> 0.0

--- a/tests/unit/state/test_mixing_edge_cases_401_402.py
+++ b/tests/unit/state/test_mixing_edge_cases_401_402.py
@@ -1,0 +1,152 @@
+"""Edge-case regression tests for the mix analyzer (#401, #402).
+
+Exercises `_build_analyzer().analyze_one` directly (the callable is split out
+of `analyze_mix_issues` precisely so its logic can be tested without mounting
+an album directory) to cover two degenerate audio buffers:
+
+- #401: a zero-length WAV (0 samples) must not crash the analyze/polish run
+  with a ValueError from reducing an empty array.
+- #402: a sub-10-sample buffer must not produce a NaN noise floor (which
+  serializes to the invalid JSON token ``NaN``) or emit a RuntimeWarning.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def _analyzer():
+    from handlers.processing.mixing import _build_analyzer
+
+    return _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+
+
+# --------------------------------------------------------------------------
+# #401 — zero-length WAV must not crash the reduction path
+# --------------------------------------------------------------------------
+
+def test_zero_length_stereo_returns_structured_error_no_exception():
+    """A (0, 2) buffer returns a structured per-file error, never raises.
+
+    Before the fix, ``np.max(np.abs(data))`` raised ``ValueError: zero-size
+    array to reduction operation maximum which has no identity``.
+    """
+    analyze_one = _analyzer()
+    data = np.zeros((0, 2), dtype=np.float64)
+
+    result = analyze_one(data, 44100, filename="empty.wav")
+
+    assert result["filename"] == "empty.wav"
+    assert "empty_audio" in result["issues"]
+    assert "error" in result
+    assert "0 samples" in result["error"]
+    # No metrics should have been computed from the empty array.
+    assert "peak" not in result
+    assert "noise_floor" not in result
+
+
+def test_zero_length_mono_1d_is_guarded_before_2d_indexing():
+    """A 1-D (0,) buffer is caught by the length guard before ``data[:, 0]``.
+
+    Guards against the guard itself throwing IndexError on a 1-D empty array.
+    """
+    analyze_one = _analyzer()
+    data = np.zeros((0,), dtype=np.float64)
+
+    result = analyze_one(data, 44100, filename="empty-mono.wav")
+
+    assert "empty_audio" in result["issues"]
+    assert "error" in result
+
+
+def test_zero_length_result_serializes_to_valid_json():
+    """The empty-audio error dict round-trips through _safe_json cleanly."""
+    from handlers._shared import _safe_json
+
+    analyze_one = _analyzer()
+    result = analyze_one(np.zeros((0, 2), dtype=np.float64), 44100, filename="empty.wav")
+
+    encoded = _safe_json(result)
+    assert "NaN" not in encoded
+    decoded = json.loads(encoded)
+    assert decoded["issues"] == ["empty_audio"]
+
+
+# --------------------------------------------------------------------------
+# #402 — sub-10-sample buffer must yield a clean noise floor, no NaN/warning
+# --------------------------------------------------------------------------
+
+def test_short_buffer_noise_floor_is_none_and_no_runtime_warning():
+    """A 5-sample buffer yields noise_floor=None with no RuntimeWarning.
+
+    ``len(sorted_abs) // 10 == 0`` makes the quietest-10% slice empty; before
+    the fix ``np.mean([])`` returned NaN and emitted a RuntimeWarning.
+    """
+    analyze_one = _analyzer()
+    mono = np.linspace(0.0, 0.01, 5, dtype=np.float64)
+    data = np.column_stack([mono, mono])
+
+    with warnings.catch_warnings():
+        # Any RuntimeWarning (e.g. "Mean of empty slice") becomes an error.
+        warnings.simplefilter("error", RuntimeWarning)
+        result = analyze_one(data, 44100, filename="short.wav")
+
+    assert result["noise_floor"] is None
+    # Sentinel None means the elevated-noise guard never fires.
+    assert "elevated_noise_floor" not in result["issues"]
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 9])
+def test_sub_10_sample_buffers_never_produce_nan_json(n_samples):
+    """Buffers of 1-9 samples serialize without the invalid ``NaN`` token."""
+    from handlers._shared import _safe_json
+
+    analyze_one = _analyzer()
+    mono = np.linspace(0.0, 0.02, n_samples, dtype=np.float64)
+    data = np.column_stack([mono, mono])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = analyze_one(data, 44100, filename=f"n{n_samples}.wav")
+
+    assert result["noise_floor"] is None
+    encoded = _safe_json(result)
+    assert "NaN" not in encoded
+    assert json.loads(encoded)["noise_floor"] is None
+
+
+# --------------------------------------------------------------------------
+# Regression guard — a normal buffer still analyzes correctly
+# --------------------------------------------------------------------------
+
+def test_normal_buffer_still_computes_finite_noise_floor():
+    """A full-length signal still produces a finite noise floor and metrics."""
+    analyze_one = _analyzer()
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * 100 * t)).astype(np.float64)
+    data = np.column_stack([mono, mono])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = analyze_one(data, rate, filename="normal.wav")
+
+    assert isinstance(result["noise_floor"], float)
+    assert np.isfinite(result["noise_floor"])
+    assert isinstance(result["peak"], float)
+    assert result["peak"] == pytest.approx(0.3, abs=1e-3)
+    assert "error" not in result
+    assert isinstance(result["issues"], list) and result["issues"]

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -569,7 +569,8 @@ def apply_fade_out(data: Any, rate: int, duration: float = 5.0, curve: str = 'ex
         data: Audio data (samples,) for mono or (samples, channels) for stereo
         rate: Sample rate
         duration: Fade duration in seconds (default: 5.0).
-            If <= 0, returns data unchanged (passthrough).
+            If <= 0, or so small it rounds to zero samples, returns data
+            unchanged (passthrough).
             If > audio length, fades the entire track.
         curve: 'exponential' for (1-t)**3, 'linear' for 1-t
 
@@ -581,6 +582,12 @@ def apply_fade_out(data: Any, rate: int, duration: float = 5.0, curve: str = 'ex
 
     total_samples = data.shape[0]
     fade_samples = int(rate * duration)
+
+    # A sub-sample fade (0 < duration < 1/rate) rounds to zero samples.
+    # Return unchanged rather than letting result[-0:] select the whole
+    # array and broadcast against an empty envelope (ValueError).
+    if fade_samples < 1:
+        return data
 
     # If fade is longer than audio, fade the entire track
     if fade_samples > total_samples:
@@ -1058,6 +1065,12 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if was_mono:
         data = np.column_stack([data, data])
 
+    # Measure the SOURCE loudness up-front, before any processing stage
+    # touches the signal, so the reported 'original_lufs' reflects the true
+    # input rather than the post-EQ/compression/fade loudness. Measured on
+    # the (stereo) processing layout to stay comparable with final_lufs.
+    original_lufs = pyln.Meter(rate).integrated_loudness(data)
+
     # DC offset removal (first processing stage)
     dc_freq = p.get('dc_filter_freq', 5.0)
     if dc_freq > 0:
@@ -1191,7 +1204,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if not np.isfinite(current_lufs):
         logger.warning("Audio is silent or near-silent, skipping: %s", input_path)
         return {
-            'original_lufs': float('-inf'),
+            'original_lufs': original_lufs,
             'final_lufs': float('-inf'),
             'gain_applied': 0.0,
             'final_peak': float('-inf'),
@@ -1269,7 +1282,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
             if not np.isfinite(current_lufs):
                 logger.warning("Audio became silent after LRA targeting, skipping: %s", input_path)
                 return {
-                    'original_lufs': float('-inf'),
+                    'original_lufs': original_lufs,
                     'final_lufs': float('-inf'),
                     'gain_applied': 0.0,
                     'final_peak': float('-inf'),
@@ -1356,7 +1369,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
     sf.write(output_path, data, rate, subtype=subtype)
 
     result = {
-        'original_lufs': current_lufs,
+        'original_lufs': original_lufs,
         'final_lufs': final_lufs,
         'gain_applied': gain_db,
         'final_peak': final_peak,

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -426,6 +426,25 @@ else:
     _envelope_follower = _envelope_follower_python
 
 
+# Floor for attack/release times (ms) in envelope-follower time constants.
+# A 0 ms (or negative) time — reachable via user-override mix presets — would
+# make `rate * ms / 1000.0` collapse to 0.0 and raise ZeroDivisionError. This
+# tiny positive floor yields a coefficient of ~0.0 (instantaneous response),
+# which is the correct limit for a "zero" time, without dividing by zero.
+_MIN_TIME_CONSTANT_MS = 1e-3
+
+
+def _time_constant_coeff(rate: int, time_ms: float) -> float:
+    """Smoothing coefficient for an envelope-follower attack/release time.
+
+    Clamps ``time_ms`` to a small positive floor (``_MIN_TIME_CONSTANT_MS``)
+    so a 0 ms or negative time cannot raise ZeroDivisionError; the clamped
+    value produces a coefficient near 0.0 (near-instant tracking).
+    """
+    time_ms = max(float(time_ms), _MIN_TIME_CONSTANT_MS)
+    return float(np.exp(-1.0 / (rate * time_ms / 1000.0)))
+
+
 def gentle_compress(data: Any, rate: int, threshold_db: float = -15.0, ratio: float = 2.5,
                     attack_ms: float = 10.0, release_ms: float = 100.0) -> Any:
     """Apply gentle dynamic compression using envelope following.
@@ -446,9 +465,9 @@ def gentle_compress(data: Any, rate: int, threshold_db: float = -15.0, ratio: fl
 
     threshold_linear = 10 ** (threshold_db / 20)
 
-    # Time constants
-    attack_coeff = np.exp(-1.0 / (rate * attack_ms / 1000.0))
-    release_coeff = np.exp(-1.0 / (rate * release_ms / 1000.0))
+    # Time constants (times clamped to a positive floor to avoid div-by-zero)
+    attack_coeff = _time_constant_coeff(rate, attack_ms)
+    release_coeff = _time_constant_coeff(rate, release_ms)
 
     def _compress_channel(channel: Any) -> Any:
         abs_signal = np.abs(channel)
@@ -852,11 +871,11 @@ def apply_transient_shaper(data: Any, rate: int, attack_gain: float = 0.0,
     if attack_gain == 0 and sustain_gain == 0:
         return data
 
-    # Time constants
-    fast_attack = np.exp(-1.0 / (rate * fast_attack_ms / 1000.0))
-    fast_release = np.exp(-1.0 / (rate * 5.0 / 1000.0))  # 5ms release
-    slow_attack = np.exp(-1.0 / (rate * slow_attack_ms / 1000.0))
-    slow_release = np.exp(-1.0 / (rate * 50.0 / 1000.0))  # 50ms release
+    # Time constants (times clamped to a positive floor to avoid div-by-zero)
+    fast_attack = _time_constant_coeff(rate, fast_attack_ms)
+    fast_release = _time_constant_coeff(rate, 5.0)  # 5ms release
+    slow_attack = _time_constant_coeff(rate, slow_attack_ms)
+    slow_release = _time_constant_coeff(rate, 50.0)  # 50ms release
 
     attack_linear = 10 ** (attack_gain / 20)
     sustain_linear = 10 ** (sustain_gain / 20)

--- a/tools/promotion/generate_all_promos.py
+++ b/tools/promotion/generate_all_promos.py
@@ -39,7 +39,7 @@ def find_mastered_dir(album_dir: Path) -> Path:
     ]
 
     for candidate in candidates:
-        if candidate.exists():
+        if candidate.is_dir():
             # Check if it has audio files
             audio_extensions = {'.wav', '.mp3', '.flac', '.m4a'}
             has_audio = any(f.suffix.lower() in audio_extensions

--- a/tools/shared/media_utils.py
+++ b/tools/shared/media_utils.py
@@ -134,7 +134,7 @@ def find_best_segment(audio_path: Path, duration: int = 15) -> float:
         best_start: float = 0.0
         best_energy: float = 0.0
 
-        for i in range(len(rms) - window_samples):
+        for i in range(len(rms) - window_samples + 1):
             window_energy = np.mean(rms[i:i + window_samples])
             if window_energy > best_energy:
                 best_energy = window_energy


### PR DESCRIPTION
## Description

Clears eight low-severity audio/DSP edge-case bugs where degenerate inputs (silent tracks, zero-length or tiny buffers, 0 ms times, file-vs-dir paths, off-by-one windows) crash or corrupt output. All TDD red-first, each with a dedicated test file.

| Issue | Fix | File |
|---|---|---|
| #400 | Finite-only LUFS aggregation in verification + ceiling-guard stages (shared `_finite_lufs_aggregates`); `-inf` no longer poisons `avg_lufs`/`lufs_range` | `_album_stages.py` |
| #401 | Zero-length WAV → clean per-file error, not empty-array `ValueError` | `processing/mixing.py` |
| #402 | Sub-10-sample buffer → `None` noise floor, not `NaN` + `RuntimeWarning` | `processing/mixing.py` |
| #406 | Sub-sample fade → no-op instead of `ValueError` (`fade_samples` rounds to 0) | `master_tracks.py` |
| #407 | `original_lufs` measured at source (pre-DSP), not post-processing | `master_tracks.py` |
| #410 | `gentle_compress`/`apply_transient_shaper` clamp time constants to a positive floor (no `ZeroDivisionError` at 0 ms) | `mix_tracks.py` |
| #411 | `find_mastered_dir` uses `is_dir()` — file candidate skipped, not `NotADirectoryError` | `generate_all_promos.py` |
| #412 | `find_best_segment` loop bound `+1` so the last window is evaluated | `media_utils.py` |

## Verification

- TDD red-first for every fix (each new test confirmed to fail on the unfixed code); 40 new tests across 7 dedicated files.
- Per-issue spec review (6 reviewers), all repro-confirmed fixed; 3 minor findings addressed (DRY'd `_stage_analysis` onto the #400 helper with a contract test; strengthened #410 negative-time tests; #402 accuracy note).
- Full gate: `ruff` + `bandit` + `mypy` clean; `pytest -n auto` → **4138 passed**, coverage 87.90% (≥75%).

## Type of Change

- [x] fix: Bug fix (patch version bump)

Fixes #400, #401, #402, #406, #407, #410, #411, #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd