### PR TITLE
fix(handlers): handler & CLI correctness — YAML escaping, encoding, validation ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Handler & CLI correctness fixes**:
+  - **`check_version_sync` no longer crashes on non-UTF-8 manifests** (#394).
+    Manifests are read as UTF-8 and `UnicodeDecodeError` is handled, so the
+    hook degrades cleanly instead of tracebacking on a non-UTF-8 locale.
+  - **Idea duplicate detection is case-insensitive** (#395), matching the
+    case-insensitive readers — `"cyberpunk dreams"` is now rejected as a
+    duplicate of `"Cyberpunk Dreams"` instead of creating a second entry.
+  - **Rhyme-scheme analyzer groups clear rhymes correctly** (#396). The
+    spelling-based tail extraction split rhyming pairs (`eyes`/`cries`,
+    `times`/`rhymes`); the nucleus is now capped and vowel `y`/`i` folded so
+    they share a rhyme group, without merging genuinely distinct words.
+  - **`_stage_layout` survives a corrupt `LAYOUT.md`** (#399). A non-UTF-8
+    layout file raised `UnicodeDecodeError` outside the stage's guard,
+    aborting the master pipeline; the read is now guarded and the stage
+    regenerates from defaults per its non-halting contract.
+  - **`create_track` writes valid YAML for quoted titles** (#403). A title
+    containing a double-quote produced malformed frontmatter (silently
+    dropping fields); the frontmatter scalar is now YAML-escaped.
+  - **`update_streaming_url` escapes URLs in frontmatter** (#404). A URL with
+    a double-quote or backslash produced malformed YAML on the in-place edit
+    path, silently dropping the URL from the state cache; it is now escaped.
+  - **`find_album_path` validates before globbing** (#405). An `album_name`
+    with glob metacharacters was expanded as a pattern before the guard ran;
+    validation now precedes all glob use.
+  - **`qc_tracks` no longer aborts the batch on one bad file** (#408). A
+    corrupt WAV now yields a per-track FAIL row and the batch continues,
+    instead of tearing down the run.
+  - **`reference_master` batch mode excludes the reference reliably** (#409).
+    The reference WAV is matched by resolved path, so an absolute `--reference`
+    is no longer re-mastered as its own target.
 - **Audio/DSP edge-case crashes hardened** across the mastering and mixing
   pipelines:
   - **Silent/corrupt tracks no longer poison album LUFS aggregates** (#400).

--- a/hooks/check_version_sync.py
+++ b/hooks/check_version_sync.py
@@ -31,11 +31,11 @@ def check_sync(data: dict) -> list[str]:
         return []
 
     try:
-        with open(plugin_path) as f:
+        with open(plugin_path, encoding="utf-8") as f:
             plugin_data = json.load(f)
-        with open(marketplace_path) as f:
+        with open(marketplace_path, encoding="utf-8") as f:
             marketplace_data = json.load(f)
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return []
 
     plugin_version = plugin_data.get("version", "")

--- a/servers/bitwize-music-server/handlers/ideas.py
+++ b/servers/bitwize-music-server/handlers/ideas.py
@@ -185,8 +185,17 @@ async def create_idea(
     else:
         text = "# Album Ideas\n\n---\n\n## Ideas\n"
 
-    # Check for duplicate title
-    if f"### {title.strip()}\n" in text:
+    # Check for duplicate title (case-insensitive, matching the readers in
+    # _find_idea_in_state / get_ideas / promote_idea which compare on
+    # ``title.strip().lower()``). Scan every "### <title>" header rather than
+    # doing an exact-case substring match, so "cyberpunk dreams" is rejected
+    # when "Cyberpunk Dreams" already exists (#395).
+    needle = title.strip().lower()
+    existing_titles = {
+        header.strip().lower()
+        for header in re.findall(r'^###\s+(.+?)\s*$', text, re.MULTILINE)
+    }
+    if needle in existing_titles:
         return _safe_json({
             "created": False,
             "error": f"Idea '{title.strip()}' already exists in IDEAS.md",

--- a/servers/bitwize-music-server/handlers/lyrics_analysis.py
+++ b/servers/bitwize-music-server/handlers/lyrics_analysis.py
@@ -322,10 +322,23 @@ def _count_syllables_word(word: str) -> int:
 
 
 def _get_rhyme_tail(word: str) -> str:
-    """Extract rhyme tail from last vowel cluster to end of word.
+    """Derive a spelling-based rhyme key: last vowel nucleus plus coda.
 
-    Strips trailing 's' for plural tolerance before extracting.
-    Examples: "night" -> "ight", "away" -> "ay", "desire" -> "ire"
+    Pure spelling can't recover pronunciation, but the key normalizes the
+    common orthographic variants of a single rhyme sound so that clearly
+    rhyming end words land in the same group (#396):
+
+    - A trailing plural / 3rd-person 's' is dropped ("eye"/"eyes",
+      "cry"/"cries") so inflection doesn't split a rhyme.
+    - The vowel nucleus is capped at two letters (a vowel plus an optional
+      glide). Without this an irregular three-vowel spelling like "eye"
+      keeps its whole "eye" cluster while "cries" yields only "ie"; capping
+      reduces both to the same "ie".
+    - Vowel 'y' is folded to 'i' in the returned tail, so "rhyme"/"rhymes"
+      ("yme") matches "time"/"times" ("ime").
+
+    Examples: "night" -> "ight", "away" -> "ai", "desire" -> "ire",
+    "eyes" -> "ie", "cries" -> "ie", "times" -> "ime", "rhymes" -> "ime".
     """
     if not word:
         return ""
@@ -345,22 +358,23 @@ def _get_rhyme_tail(word: str) -> str:
     if len(word) > 2 and word.endswith("e") and word[-2] not in vowels:
         scan_word = word[:-1]
 
-    # Find last vowel cluster start in scan_word
+    # Find the last vowel cluster, capping the nucleus at two letters (a
+    # vowel plus an optional glide) so irregular multi-vowel spellings such
+    # as "eye" normalize to the same nucleus as a regular "-ie".
     last_vowel_pos = -1
     for i in range(len(scan_word) - 1, -1, -1):
         if scan_word[i] in vowels:
             last_vowel_pos = i
-            # Walk back through consecutive vowels
-            while i > 0 and scan_word[i - 1] in vowels:
-                i -= 1
-                last_vowel_pos = i
+            if i > 0 and scan_word[i - 1] in vowels:
+                last_vowel_pos = i - 1
             break
 
     if last_vowel_pos < 0:
         return word  # No vowels — return whole word
 
-    # Return from vowel position to end of ORIGINAL word
-    return word[last_vowel_pos:]
+    # Return from the nucleus to the end of the (plural-stripped) word,
+    # folding vowel 'y' to 'i' so equivalent spellings share a key.
+    return word[last_vowel_pos:].replace("y", "i")
 
 
 async def count_syllables(text: str) -> str:

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2036,9 +2036,20 @@ async def _stage_layout(ctx: MasterAlbumCtx) -> str | None:
     prior_transitions: list[dict[str, Any]] | None = None
     layout_path = ctx.audio_dir / "LAYOUT.md"
     if layout_path.is_file():
-        prior_transitions = _parse_layout_yaml(
-            layout_path.read_text(encoding="utf-8")
-        )
+        # A corrupt/binary LAYOUT.md (e.g. invalid UTF-8) must not halt the
+        # pipeline: read_text raises UnicodeDecodeError (a ValueError, NOT an
+        # OSError) which would escape the emitter try/except below. Guard the
+        # read separately so a bad prior layout degrades to "no prior
+        # transitions" and is surfaced via warnings, per the stage contract.
+        try:
+            prior_transitions = _parse_layout_yaml(
+                layout_path.read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            ctx.warnings.append(
+                f"Layout emitter: could not read prior LAYOUT.md ({exc}); "
+                "regenerating from defaults."
+            )
 
     layout_stage: dict[str, Any] = {
         "status": "pass",

--- a/servers/bitwize-music-server/handlers/status.py
+++ b/servers/bitwize-music-server/handlers/status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from pathlib import Path
@@ -506,7 +507,17 @@ async def create_track(
 
     # Fill in placeholders
     album_title = album.get("title", normalized)
-    content = template.replace("[Track Title]", title)
+    # The frontmatter title is a quoted YAML scalar (title: "[Track Title]"),
+    # so it must receive a properly escaped value — a raw replace of a title
+    # containing a double quote would break the YAML and silently drop every
+    # frontmatter field on parse (#403). json.dumps() emits a valid YAML
+    # double-quoted scalar (escapes quotes/backslashes); ensure_ascii=False
+    # keeps non-ASCII readable so the scalar matches the human-readable body
+    # (H1, details table), which still take the raw title.
+    content = template.replace(
+        'title: "[Track Title]"', f"title: {json.dumps(title, ensure_ascii=False)}"
+    )
+    content = content.replace("[Track Title]", title)
     content = content.replace("| **Track #** | XX |", f"| **Track #** | {padded} |")
     content = content.replace("[Album Name](../README.md)", f"[{album_title}](../README.md)")
     content = content.replace("[Character/Perspective]", "—")

--- a/servers/bitwize-music-server/handlers/streaming.py
+++ b/servers/bitwize-music-server/handlers/streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -157,12 +158,15 @@ async def update_streaming_url(album_slug: str, platform: str, url: str) -> str:
         # Match lines like "  soundcloud: ..." or "  apple_music: ..."
         stripped = fm_line.lstrip()
         if stripped.startswith(f"{canonical_platform}:"):
-            # Replace the value, preserving indent
+            # Replace the value, preserving indent. json.dumps emits a valid
+            # YAML double-quoted scalar (quotes included) with any embedded
+            # quotes/backslashes escaped, so a URL containing " or \ can't
+            # corrupt the frontmatter. ensure_ascii=False preserves any raw
+            # non-ASCII char (matching the yaml.dump fallback's allow_unicode)
+            # so it round-trips exactly instead of via a lossy surrogate pair.
+            # json.dumps("") -> '""' handles clearing.
             indent = fm_line[:len(fm_line) - len(stripped)]
-            if url:
-                fm_lines[idx] = f'{indent}{canonical_platform}: "{url}"'
-            else:
-                fm_lines[idx] = f"{indent}{canonical_platform}: \"\""
+            fm_lines[idx] = f"{indent}{canonical_platform}: {json.dumps(url, ensure_ascii=False)}"
             updated = True
             break
 

--- a/tests/unit/cloud/test_find_album_path_glob_405.py
+++ b/tests/unit/cloud/test_find_album_path_glob_405.py
@@ -1,0 +1,75 @@
+"""Regression tests for find_album_path glob-injection guard ordering (#405).
+
+The glob-metacharacter / path-separator validation must run BEFORE any
+glob expansion. Previously the mirrored-structure branch interpolated
+``album_name`` into a glob pattern (``albums/*/{album_name}``) and could
+silently resolve a wildcard to an unintended in-tree album directory
+before the explicit rejection ever executed.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Import the module under test
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Force-mock boto3 before importing the module so tests behave consistently
+# regardless of whether boto3 is installed on this machine. Save originals and
+# restore after import to prevent MagicMock pollution leaking into later tests.
+_MOCK_DEPS = ["boto3", "botocore", "botocore.exceptions"]
+_SAVED_DEPS = {dep: sys.modules.get(dep) for dep in _MOCK_DEPS}
+for dep in _MOCK_DEPS:
+    sys.modules[dep] = MagicMock()
+
+from tools.cloud import upload_to_cloud as mod
+
+# Restore original modules to avoid polluting later tests
+for dep, original in _SAVED_DEPS.items():
+    if original is None:
+        sys.modules.pop(dep, None)
+    else:
+        sys.modules[dep] = original
+
+
+@pytest.mark.unit
+class TestFindAlbumPathGlobInjection:
+    """album_name with glob metacharacters is rejected before glob expansion (#405)."""
+
+    def _make_config(self, tmp_path):
+        return {
+            "paths": {"audio_root": str(tmp_path)},
+            "artist": {"name": "testartist"},
+        }
+
+    def test_star_rejected_even_when_a_dir_matches(self, tmp_path):
+        # A real album dir exists that the pattern albums/*/* would match.
+        album_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "my-album"
+        album_dir.mkdir(parents=True)
+        # album_name "*" must be rejected outright, NOT resolved to album_dir.
+        with pytest.raises(SystemExit):
+            mod.find_album_path(self._make_config(tmp_path), "*")
+
+    def test_question_mark_rejected_even_when_a_dir_matches(self, tmp_path):
+        # "a?b" would glob-match this dir via albums/*/a?b if the guard is bypassed.
+        matching_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "aXb"
+        matching_dir.mkdir(parents=True)
+        with pytest.raises(SystemExit):
+            mod.find_album_path(self._make_config(tmp_path), "a?b")
+
+    def test_bracket_rejected_even_when_a_dir_matches(self, tmp_path):
+        # "[abc]" would glob-match a single-char dir via albums/*/[abc].
+        matching_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "b"
+        matching_dir.mkdir(parents=True)
+        with pytest.raises(SystemExit):
+            mod.find_album_path(self._make_config(tmp_path), "[abc]")
+
+    def test_normal_album_name_still_resolves(self, tmp_path):
+        album_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "my-album"
+        album_dir.mkdir(parents=True)
+        result = mod.find_album_path(self._make_config(tmp_path), "my-album")
+        assert result == album_dir

--- a/tests/unit/hooks/test_check_version_sync_394.py
+++ b/tests/unit/hooks/test_check_version_sync_394.py
@@ -1,0 +1,140 @@
+"""Regression tests for issue #394.
+
+``check_version_sync`` opened ``plugin.json`` / ``marketplace.json`` with a bare
+``open()`` (the platform-default text encoding) and only caught
+``(json.JSONDecodeError, OSError)``. A ``UnicodeDecodeError`` — a ``ValueError``
+subclass, not an ``OSError`` or ``JSONDecodeError`` — raised while decoding a
+manifest that is not valid in the active encoding therefore escaped
+``check_sync()`` and, since ``main()`` does not wrap it, crashed the hook with a
+traceback. These tests lock in graceful degradation: an undecodable manifest
+degrades to ``[]`` and valid manifests (including valid UTF-8 with accents)
+still parse.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Import the standalone hook module via importlib (hooks/ is not a package).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+_MODULE_PATH = _PROJECT_ROOT / "hooks" / "check_version_sync.py"
+_spec = importlib.util.spec_from_file_location("check_version_sync_394", _MODULE_PATH)
+check_version_sync = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_version_sync)
+
+
+# A lone 0xE9 byte is cp1252 'é' but an invalid UTF-8 sequence (bare lead byte),
+# i.e. exactly the "author name with an accent saved in a non-UTF-8 encoding"
+# scenario from the issue.
+_NON_UTF8_PLUGIN = b'{"version": "0.94.0", "author": "Jos\xe9"}'
+_NON_UTF8_MARKETPLACE = b'{"plugins": [{"version": "0.94.0", "name": "Jos\xe9"}]}'
+
+
+def _manifest_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".claude-plugin"
+    d.mkdir()
+    return d
+
+
+def _event(file_path: Path) -> dict:
+    return {"tool_input": {"file_path": str(file_path)}}
+
+
+def _write_plugin(d: Path, version: str) -> Path:
+    p = d / "plugin.json"
+    p.write_text(json.dumps({"version": version}), encoding="utf-8")
+    return p
+
+
+def _write_marketplace(d: Path, version: str) -> Path:
+    p = d / "marketplace.json"
+    p.write_text(json.dumps({"plugins": [{"version": version}]}), encoding="utf-8")
+    return p
+
+
+def test_non_utf8_plugin_manifest_returns_cleanly(tmp_path):
+    """A non-UTF-8 plugin.json must degrade to [] instead of raising."""
+    d = _manifest_dir(tmp_path)
+    plugin = d / "plugin.json"
+    plugin.write_bytes(_NON_UTF8_PLUGIN)
+    _write_marketplace(d, "0.94.0")
+
+    # Under the bug this raised UnicodeDecodeError out of check_sync().
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_non_utf8_marketplace_manifest_returns_cleanly(tmp_path):
+    """The second open() (marketplace.json) must degrade cleanly too."""
+    d = _manifest_dir(tmp_path)
+    plugin = _write_plugin(d, "0.94.0")
+    (d / "marketplace.json").write_bytes(_NON_UTF8_MARKETPLACE)
+
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_valid_matching_versions_returns_empty(tmp_path):
+    """Valid, in-sync manifests still parse and report no issues."""
+    d = _manifest_dir(tmp_path)
+    plugin = _write_plugin(d, "0.94.0")
+    _write_marketplace(d, "0.94.0")
+
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_valid_utf8_accented_author_parses(tmp_path):
+    """Valid UTF-8 content with an accent must parse regardless of locale."""
+    d = _manifest_dir(tmp_path)
+    plugin = d / "plugin.json"
+    plugin.write_text(
+        json.dumps({"version": "0.94.0", "author": "José"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_marketplace(d, "0.94.0")
+
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_valid_mismatched_versions_reports(tmp_path, monkeypatch):
+    """A genuine version mismatch is still detected after the fix."""
+    d = _manifest_dir(tmp_path)
+    plugin = _write_plugin(d, "0.94.0")
+    _write_marketplace(d, "0.93.0")
+
+    # Deterministically take the "other file not mid-edit" branch: pretend the
+    # working tree has no other pending manifest edit.
+    def _fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(check_version_sync.subprocess, "run", _fake_run)
+
+    issues = check_version_sync.check_sync(_event(plugin))
+    assert len(issues) == 1
+    assert "0.94.0" in issues[0]
+    assert "0.93.0" in issues[0]
+
+
+def test_hook_main_does_not_crash_on_non_utf8_manifest(tmp_path):
+    """End-to-end: the hook process exits 0 with no traceback, not a crash."""
+    d = _manifest_dir(tmp_path)
+    plugin = d / "plugin.json"
+    plugin.write_bytes(_NON_UTF8_PLUGIN)
+    _write_marketplace(d, "0.94.0")
+
+    payload = json.dumps({"tool_input": {"file_path": str(plugin)}})
+    result = subprocess.run(
+        [sys.executable, str(_MODULE_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert "Traceback" not in result.stderr, result.stderr
+    assert result.returncode == 0, (result.returncode, result.stderr)

--- a/tests/unit/mastering/test_qc_tracks_batch_408.py
+++ b/tests/unit/mastering/test_qc_tracks_batch_408.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Regression tests for #408 — qc_tracks batch resilience to a bad file.
+
+Both the serial and parallel QC batch paths in ``qc_tracks.main`` used to call
+``qc_track`` / ``future.result()`` with no per-file guard, so a single corrupt
+or unreadable WAV tore down the whole run: in serial mode the remaining files
+were skipped, and in parallel mode the exception re-raised out of
+``future.result()`` and aborted the pool after partial work.
+
+The fix wraps each per-file call in a try/except that emits a per-track FAIL
+row (matching qc_track's result shape) and keeps going, while still signalling
+the failure through a non-zero exit.
+
+Usage:
+    python -m pytest tests/unit/mastering/test_qc_tracks_batch_408.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.qc_tracks import ALL_CHECKS
+from tools.mastering.qc_tracks import main as qc_main
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+
+def _pass_result(name: str) -> dict:
+    """A well-formed all-PASS qc_track result for a good file."""
+    return {
+        "filename": name,
+        "checks": {
+            c: {"status": "PASS", "value": "ok", "detail": "ok"} for c in ALL_CHECKS
+        },
+        "verdict": "PASS",
+    }
+
+
+def _write_valid_wav(path: Path, rate: int = 44100, seconds: float = 0.2) -> None:
+    """Write a small, well-formed stereo PCM_16 WAV that passes the format check."""
+    n = int(rate * seconds)
+    t = np.linspace(0, seconds, n, endpoint=False)
+    mono = (0.2 * np.sin(2 * np.pi * 220 * t)).astype(np.float64)
+    data = np.column_stack([mono, mono])
+    sf.write(str(path), data, rate, subtype="PCM_16")
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_serial_batch_continues_past_unreadable_file(tmp_path, monkeypatch, capsys):
+    """Serial path: one file whose qc_track raises must not abort the batch.
+
+    The good files on either side of the bad one still get results, the bad
+    file gets a FAIL row surfacing the read error, and the run signals failure
+    via a non-zero exit instead of dumping a traceback.
+    """
+    good1 = tmp_path / "01-good.wav"
+    bad = tmp_path / "02-bad.wav"
+    good2 = tmp_path / "03-good.wav"
+    for p in (good1, bad, good2):
+        p.touch()  # qc_track is mocked, so contents are irrelevant
+
+    def mock_qc(filepath, checks=None, genre=None):
+        if "bad" in Path(filepath).name:
+            raise RuntimeError("corrupt WAV: could not read frames")
+        return _pass_result(Path(filepath).name)
+
+    monkeypatch.setattr("tools.mastering.qc_tracks.qc_track", mock_qc)
+    monkeypatch.setattr(sys, "argv", ["qc_tracks", str(tmp_path), "-j", "1"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        qc_main()
+
+    assert excinfo.value.code == 1  # failure is signalled
+
+    out = capsys.readouterr().out
+    # Partial progress preserved — every file, including ones AFTER the bad one.
+    assert "01-good.wav" in out
+    assert "02-bad.wav" in out
+    assert "03-good.wav" in out
+    # The bad file renders as a FAIL row; good files as PASS.
+    assert "3 tracks" in out
+    assert "2 PASS" in out
+    assert "1 FAIL" in out
+    assert any("02-bad.wav" in line and "FAIL" in line for line in out.splitlines())
+    # The read error is surfaced (not a raw traceback).
+    assert "Could not read" in out
+
+
+def test_parallel_batch_continues_past_corrupt_file(tmp_path, monkeypatch, capsys):
+    """Parallel path: a genuinely corrupt WAV must not tear down the pool.
+
+    Uses real files with -j 2 so ``future.result()`` re-raises soundfile's
+    read error from the worker; the fix catches it per-future and keeps the
+    other tracks' results.
+    """
+    _write_valid_wav(tmp_path / "01-good.wav")
+    _write_valid_wav(tmp_path / "03-good.wav")
+    # Garbage bytes with a .wav extension — libsndfile cannot parse it.
+    (tmp_path / "02-bad.wav").write_bytes(b"this is definitely not audio \x00\xff" * 4)
+
+    monkeypatch.setattr(
+        sys, "argv", ["qc_tracks", str(tmp_path), "-j", "2", "--checks", "format"]
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        qc_main()
+
+    assert excinfo.value.code == 1
+
+    out = capsys.readouterr().out
+    assert "01-good.wav" in out
+    assert "02-bad.wav" in out
+    assert "03-good.wav" in out
+    assert "3 tracks" in out
+    assert "2 PASS" in out
+    assert "1 FAIL" in out
+    assert any("02-bad.wav" in line and "FAIL" in line for line in out.splitlines())
+
+
+def test_all_good_serial_completes_without_error_exit(tmp_path, monkeypatch, capsys):
+    """Guard: when every file reads cleanly the run must NOT exit non-zero.
+
+    Protects against the failure signal firing spuriously on a healthy batch.
+    """
+    for name in ("01-a.wav", "02-b.wav", "03-c.wav"):
+        (tmp_path / name).touch()
+
+    def mock_qc(filepath, checks=None, genre=None):
+        return _pass_result(Path(filepath).name)
+
+    monkeypatch.setattr("tools.mastering.qc_tracks.qc_track", mock_qc)
+    monkeypatch.setattr(sys, "argv", ["qc_tracks", str(tmp_path), "-j", "1"])
+
+    qc_main()  # must return normally — no SystemExit
+
+    out = capsys.readouterr().out
+    assert "3 tracks" in out
+    assert "3 PASS" in out
+    assert "1 FAIL" not in out

--- a/tests/unit/mastering/test_reference_master_exclude_409.py
+++ b/tests/unit/mastering/test_reference_master_exclude_409.py
@@ -1,0 +1,119 @@
+"""Regression tests for issue #409.
+
+Batch mode must exclude the ``--reference`` WAV from the target list
+regardless of how the reference path is supplied (absolute, ``./``-prefixed,
+or a bare relative name). The original code compared the glob output
+(always relative, e.g. ``PosixPath('ref.wav')``) against ``Path(args.reference)``
+with a lexical ``f != reference_path``; an absolute ``--reference`` never
+compared equal, so the professionally-mastered reference was re-mastered as
+its own target and written into the delivery set.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the module under test
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Force-mock matchering before importing the module so tests behave
+# consistently regardless of whether matchering is installed.
+_MOCK_DEPS = ["matchering"]
+_SAVED_DEPS = {dep: sys.modules.get(dep) for dep in _MOCK_DEPS}
+for dep in _MOCK_DEPS:
+    sys.modules[dep] = MagicMock()
+
+from tools.mastering import reference_master as mod
+
+# Restore original modules to avoid polluting later tests
+for dep, original in _SAVED_DEPS.items():
+    if original is None:
+        sys.modules.pop(dep, None)
+    else:
+        sys.modules[dep] = original
+
+
+def _target_names(mock_master) -> list[str]:
+    """Filenames passed as the *target* (first positional arg) to each call."""
+    return [c.args[0].name for c in mock_master.call_args_list]
+
+
+@pytest.mark.unit
+class TestReferenceExcludedFromBatch:
+    """The reference WAV living inside the batch dir must never be a target."""
+
+    @patch.object(mod, "master_with_reference")
+    def test_absolute_reference_is_excluded(self, mock_master, tmp_path, monkeypatch):
+        # Reference sits *inside* the working dir alongside the tracks.
+        work_dir = tmp_path / "tracks"
+        work_dir.mkdir()
+        (work_dir / "reference.wav").write_bytes(b"ref")
+        (work_dir / "track1.wav").write_bytes(b"t1")
+        (work_dir / "track2.wav").write_bytes(b"t2")
+        monkeypatch.chdir(work_dir)
+
+        # --reference supplied as an ABSOLUTE path (the real #409 trigger).
+        abs_ref = (work_dir / "reference.wav").resolve()
+        assert abs_ref.is_absolute()
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["reference_master.py", "--reference", str(abs_ref),
+             "--output-dir", str(tmp_path / "mastered")],
+        )
+        mod.main()
+
+        targets = _target_names(mock_master)
+        # The reference must NOT be re-mastered as its own target.
+        assert "reference.wav" not in targets, (
+            f"reference re-mastered as a target: {targets}"
+        )
+        assert set(targets) == {"track1.wav", "track2.wav"}
+        assert mock_master.call_count == 2
+
+    @patch.object(mod, "master_with_reference")
+    def test_relative_reference_still_excluded(self, mock_master, tmp_path, monkeypatch):
+        # Regression guard: the bare-relative form must keep working.
+        work_dir = tmp_path / "tracks"
+        work_dir.mkdir()
+        (work_dir / "reference.wav").write_bytes(b"ref")
+        (work_dir / "track1.wav").write_bytes(b"t1")
+        (work_dir / "track2.wav").write_bytes(b"t2")
+        monkeypatch.chdir(work_dir)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["reference_master.py", "--reference", "reference.wav",
+             "--output-dir", str(tmp_path / "mastered")],
+        )
+        mod.main()
+
+        targets = _target_names(mock_master)
+        assert "reference.wav" not in targets
+        assert set(targets) == {"track1.wav", "track2.wav"}
+        assert mock_master.call_count == 2
+
+    @patch.object(mod, "master_with_reference")
+    def test_dot_prefixed_reference_is_excluded(self, mock_master, tmp_path, monkeypatch):
+        # ``./ref.wav`` is normalized by pathlib, but assert it explicitly.
+        work_dir = tmp_path / "tracks"
+        work_dir.mkdir()
+        (work_dir / "reference.wav").write_bytes(b"ref")
+        (work_dir / "track1.wav").write_bytes(b"t1")
+        monkeypatch.chdir(work_dir)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["reference_master.py", "--reference", "./reference.wav",
+             "--output-dir", str(tmp_path / "mastered")],
+        )
+        mod.main()
+
+        targets = _target_names(mock_master)
+        assert "reference.wav" not in targets
+        assert set(targets) == {"track1.wav"}
+        assert mock_master.call_count == 1

--- a/tests/unit/mastering/test_stage_layout_unicode_399.py
+++ b/tests/unit/mastering/test_stage_layout_unicode_399.py
@@ -1,0 +1,97 @@
+"""_stage_layout must honor its 'Returns: None always, never halt' contract
+even when a pre-existing LAYOUT.md contains invalid UTF-8 bytes.
+
+Regression for issue #399: the read of a prior LAYOUT.md
+(``layout_path.read_text(encoding="utf-8")``) ran OUTSIDE the stage's
+protective try/except, which only caught ``(LayoutError, OSError)``. A corrupt
+or binary LAYOUT.md raises ``UnicodeDecodeError`` (a ``ValueError`` subclass,
+NOT an ``OSError``), so it escaped the guard and aborted the master_album
+pipeline. A corrupt prior layout must instead be logged to warnings while the
+stage degrades gracefully and still writes a fresh LAYOUT.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def _run_layout_stage(audio_dir: Path, mastered_names: list[str]):
+    from handlers.processing._album_stages import MasterAlbumCtx, _stage_layout
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    ctx = MasterAlbumCtx(
+        album_slug="test", genre="pop", target_lufs=-14.0, ceiling_db=-1.0,
+        cut_highmid=0.0, cut_highs=0.0, source_subfolder="",
+        freeze_signature=False, new_anchor=False, loop=loop,
+        audio_dir=audio_dir,
+        mastered_files=[Path(name) for name in mastered_names],
+    )
+    try:
+        result = loop.run_until_complete(_stage_layout(ctx))
+    finally:
+        loop.close()
+    return ctx, result
+
+
+def test_non_utf8_prior_layout_does_not_halt(tmp_path: Path) -> None:
+    """A LAYOUT.md with invalid UTF-8 bytes must not raise out of the stage."""
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    # 0xFF/0xFE/0xC3-0x28 are invalid UTF-8 sequences → read_text(utf-8) raises
+    # UnicodeDecodeError, which is a ValueError (not an OSError).
+    (audio_dir / "LAYOUT.md").write_bytes(b"\xff\xfe\x00\x80 not utf-8 \xc3\x28")
+
+    ctx, result = _run_layout_stage(audio_dir, ["01-a.wav", "02-b.wav"])
+
+    # Contract: the stage returns None and never halts the pipeline.
+    assert result is None
+    # The corrupt prior LAYOUT.md is surfaced to the operator via warnings.
+    assert any("LAYOUT" in str(w) for w in ctx.warnings)
+    # A layout stage result is still recorded (structured result not discarded).
+    assert "layout" in ctx.stages
+
+
+def test_valid_prior_layout_still_parses(tmp_path: Path) -> None:
+    """A well-formed prior LAYOUT.md is read and its hand-edits are preserved."""
+    from tools.mastering.layout import (
+        parse_layout_yaml,
+        render_layout_markdown,
+    )
+
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    prior = [
+        {
+            "from": "01-a.wav",
+            "to": "02-b.wav",
+            "mode": "gapless",
+            "gap_ms": 0,
+            "tail_fade_ms": 0,
+            "head_fade_ms": 0,
+        },
+    ]
+    (audio_dir / "LAYOUT.md").write_text(
+        render_layout_markdown("test", prior), encoding="utf-8"
+    )
+
+    ctx, result = _run_layout_stage(audio_dir, ["01-a.wav", "02-b.wav"])
+
+    assert result is None
+    # No warnings for a clean, valid prior layout.
+    assert not any("LAYOUT" in str(w) for w in ctx.warnings)
+    # The hand-edited gapless transition survived the parse → compute → render
+    # round-trip, proving the prior file was read and fed into the emitter.
+    rewritten = parse_layout_yaml(
+        (audio_dir / "LAYOUT.md").read_text(encoding="utf-8")
+    )
+    assert rewritten[0]["mode"] == "gapless"

--- a/tests/unit/state/test_create_idea_dup_395.py
+++ b/tests/unit/state/test_create_idea_dup_395.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Regression tests for handlers/ideas.py — create_idea duplicate guard (#395).
+
+create_idea's duplicate check must be case-insensitive to match the readers
+(_find_idea_in_state / get_ideas / promote_idea), which compare titles via
+``title.strip().lower()``. Before the fix the guard did an exact-case
+substring match (``f"### {title.strip()}\n" in text``), so "cyberpunk dreams"
+could be created alongside an existing "Cyberpunk Dreams", producing two
+entries the readers then treat as the same idea.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_idea_dup_395.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# Mock the MCP SDK if not installed
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_dup395", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import ideas as _ideas_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    """In-memory state cache; rebuild() is a no-op that records calls."""
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+        self.rebuild_called = 0
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self):
+        self.rebuild_called += 1
+        return self._state
+
+
+def _make_state(content_root: Path) -> dict:
+    return {
+        "version": 2,
+        "config": {"content_root": str(content_root), "artist_name": "test-artist"},
+        "albums": {},
+        "ideas": {"counts": {}, "items": [], "total": 0},
+        "session": {},
+    }
+
+
+def _count_headers(text: str) -> int:
+    """Count '### <title>' idea headers in IDEAS.md text."""
+    return len(re.findall(r'^###\s+', text, re.MULTILINE))
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir(parents=True)
+    return root
+
+
+@pytest.fixture
+def use_cache(content_root: Path):
+    """Install a MockStateCache pointing at content_root; restore afterward."""
+    orig_cache = _shared_mod.cache
+    cache = MockStateCache(_make_state(content_root))
+    _shared_mod.cache = cache
+    yield cache
+    _shared_mod.cache = orig_cache
+
+
+def _write_ideas_md(content_root: Path, body: str) -> Path:
+    ideas_path = content_root / "IDEAS.md"
+    ideas_path.write_text(body, encoding="utf-8")
+    return ideas_path
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive duplicate guard (#395)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIdeaCaseInsensitiveDuplicate:
+    def test_lowercase_dup_of_titlecase_rejected(self, content_root, use_cache):
+        """"cyberpunk dreams" is a duplicate of an existing "Cyberpunk Dreams"."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n"
+            "**Genre**: electronic\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("cyberpunk dreams")))
+
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        # No second section was written.
+        text = ideas_path.read_text(encoding="utf-8")
+        assert _count_headers(text) == 1
+        assert "### cyberpunk dreams" not in text
+
+    def test_uppercase_dup_of_titlecase_rejected(self, content_root, use_cache):
+        """Uppercasing an existing title is still a duplicate."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("CYBERPUNK DREAMS")))
+
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        assert _count_headers(ideas_path.read_text(encoding="utf-8")) == 1
+
+    def test_exact_case_dup_still_rejected(self, content_root, use_cache):
+        """Existing exact-case behavior is preserved."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("Cyberpunk Dreams")))
+
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        assert _count_headers(ideas_path.read_text(encoding="utf-8")) == 1
+
+
+class TestCreateIdeaGenuinelyNew:
+    def test_new_distinct_title_still_created(self, content_root, use_cache):
+        """A title that isn't a case-variant of any existing idea is created."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("Synthwave Nights")))
+
+        assert result["created"] is True
+        assert result["title"] == "Synthwave Nights"
+        text = ideas_path.read_text(encoding="utf-8")
+        # Both the original and the new idea are present.
+        assert "### Cyberpunk Dreams" in text
+        assert "### Synthwave Nights" in text
+        assert _count_headers(text) == 2
+
+    def test_new_title_created_into_empty_ideas(self, content_root, use_cache):
+        """Sanity: a first idea into a fresh file is created."""
+        ideas_path = _write_ideas_md(content_root, "# Album Ideas\n\n## Ideas\n")
+
+        result = json.loads(_run(_ideas_mod.create_idea("Cyberpunk Dreams")))
+
+        assert result["created"] is True
+        assert _count_headers(ideas_path.read_text(encoding="utf-8")) == 1

--- a/tests/unit/state/test_create_track_title_unicode_403.py
+++ b/tests/unit/state/test_create_track_title_unicode_403.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Unit tests for create_track frontmatter non-ASCII readability (issue #403 polish).
+
+The #403 fix writes the frontmatter title via ``json.dumps(title)``. With the
+default ``ensure_ascii=True`` a non-ASCII title is emitted as ``\\uXXXX``
+escapes inside the quoted scalar (e.g. ``title: "caf\\u00e9"`` for ``café``).
+It round-trips (YAML decodes the escape back to ``café``), but the on-disk
+frontmatter no longer matches the human-readable body (H1/table keep the raw
+``café``). Passing ``ensure_ascii=False`` keeps quotes/backslashes escaped
+while preserving readable unicode, aligning the frontmatter with the body.
+
+These tests pin the readable-frontmatter behavior; they FAIL on the
+``ensure_ascii=True`` output and PASS once ``ensure_ascii=False`` is used.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_track_title_unicode_403.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_create_track_validation.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_track_unicode", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import status as _status_mod  # noqa: E402
+from tools.state.parsers import parse_frontmatter  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic filesystem layout + mock cache (mirrors
+# test_create_track_title_yaml_403.py)
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+@pytest.fixture
+def cache_with_album(tmp_path: Path):
+    """Install a mock cache populated with a single album with a tracks/ dir."""
+    content_root = tmp_path / "content"
+    album_dir = (
+        content_root / "artists" / "test-artist" / "albums" / "electronic"
+        / "test-album"
+    )
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+    (album_dir / "README.md").write_text(
+        "# Test Album\n\n## Album Details\n\n| **Title** | Test Album |\n",
+        encoding="utf-8",
+    )
+
+    album_data = {
+        "title": "Test Album",
+        "status": "In Progress",
+        "genre": "electronic",
+        "explicit": False,
+        "path": str(album_dir),
+        "track_count": 0,
+        "tracks_completed": 0,
+        "tracks": {},
+    }
+
+    state = {
+        "version": 2,
+        "config": {
+            "content_root": str(content_root),
+            "artist_name": "test-artist",
+            "generation": {},
+        },
+        "albums": {"test-album": album_data},
+        "session": {},
+    }
+
+    orig_cache = _shared_mod.cache
+    orig_plugin_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.cache = MockStateCache(state)
+    # Real template lives at PROJECT_ROOT/templates/track.md
+    _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+
+    yield state, tracks_dir
+
+    _shared_mod.cache = orig_cache
+    _shared_mod.PLUGIN_ROOT = orig_plugin_root
+
+
+def _create(title: str, track_number="1") -> dict:
+    return json.loads(_run(
+        _status_mod.create_track("test-album", track_number, title)
+    ))
+
+
+def _written_content(tracks_dir: Path) -> str:
+    files = list(tracks_dir.iterdir())
+    assert len(files) == 1, f"expected exactly one track file, got {files}"
+    return files[0].read_text(encoding="utf-8")
+
+
+# ===========================================================================
+# Non-ASCII titles stay human-readable in the frontmatter scalar
+# ===========================================================================
+
+
+class TestFrontmatterTitleUnicodeReadable:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "café",
+            "naïve",
+            "Björk",
+            "Résumé",
+            "日本語",
+        ],
+    )
+    def test_non_ascii_title_written_readable(self, cache_with_album, title):
+        """The frontmatter scalar keeps readable unicode, not \\uXXXX escapes."""
+        _state, tracks_dir = cache_with_album
+
+        result = _create(title)
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+
+        # The readable, unescaped title appears verbatim in the quoted scalar
+        # (this is what ensure_ascii=False produces; ensure_ascii=True would
+        # instead emit \uXXXX escapes and this line would be absent).
+        assert f'title: "{title}"' in content
+
+        # Frontmatter still parses cleanly and the title round-trips exactly.
+        fm = parse_frontmatter(content)
+        assert "_error" not in fm, fm.get("_error")
+        assert fm.get("title") == title
+
+    def test_frontmatter_matches_readable_body(self, cache_with_album):
+        """Frontmatter title reads the same as the H1/table body (no escapes)."""
+        _state, tracks_dir = cache_with_album
+
+        _create("café")
+        content = _written_content(tracks_dir)
+
+        # Body keeps the raw unicode ...
+        assert "# café" in content
+        assert "| **Title** | café |" in content
+        # ... and the frontmatter now matches it, with no \uXXXX artifact.
+        assert 'title: "café"' in content
+        assert "caf\\u00e9" not in content
+
+
+# ===========================================================================
+# A double quote must still be escaped (the original #403 correctness fix) —
+# ensure_ascii=False must not regress quote/backslash escaping.
+# ===========================================================================
+
+
+class TestSpecialCharsStillEscaped:
+    def test_double_quote_title_still_valid_yaml(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create('Say "Goodbye"')
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+        fm = parse_frontmatter(content)
+        assert "_error" not in fm
+        assert fm.get("title") == 'Say "Goodbye"'
+        # The raw unescaped quotes must never leak into the scalar.
+        assert 'title: "Say "Goodbye""' not in content
+
+    def test_ascii_title_byte_identical_scalar(self, cache_with_album):
+        """A plain ASCII title is unaffected by ensure_ascii=False."""
+        _state, tracks_dir = cache_with_album
+
+        _create("My New Track")
+        content = _written_content(tracks_dir)
+        assert 'title: "My New Track"' in content

--- a/tests/unit/state/test_create_track_title_yaml_403.py
+++ b/tests/unit/state/test_create_track_title_yaml_403.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Unit tests for create_track frontmatter YAML escaping (issue #403).
+
+create_track filled the template with a blanket
+``template.replace("[Track Title]", title)``. Because the template
+frontmatter carries the title as a quoted scalar (``title: "[Track Title]"``),
+a title containing a double quote (e.g. ``Say "Goodbye"``) produced
+``title: "Say "Goodbye""`` — invalid YAML. parse_frontmatter() then failed and
+every frontmatter field (title, track_number, explicit) was silently dropped.
+
+The frontmatter title must receive a properly escaped YAML double-quoted
+scalar (json.dumps output is valid YAML) so the whole frontmatter block still
+parses and the title round-trips exactly, while the human-readable body (H1,
+details table) keeps the raw title.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_track_title_yaml_403.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_create_track_validation.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_track_yaml", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import status as _status_mod  # noqa: E402
+from tools.state.parsers import parse_frontmatter  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic filesystem layout + mock cache (mirrors
+# test_create_track_validation.py)
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+@pytest.fixture
+def cache_with_album(tmp_path: Path):
+    """Install a mock cache populated with a single album with a tracks/ dir."""
+    content_root = tmp_path / "content"
+    album_dir = (
+        content_root / "artists" / "test-artist" / "albums" / "electronic"
+        / "test-album"
+    )
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+    (album_dir / "README.md").write_text(
+        "# Test Album\n\n## Album Details\n\n| **Title** | Test Album |\n",
+        encoding="utf-8",
+    )
+
+    album_data = {
+        "title": "Test Album",
+        "status": "In Progress",
+        "genre": "electronic",
+        "explicit": False,
+        "path": str(album_dir),
+        "track_count": 0,
+        "tracks_completed": 0,
+        "tracks": {},
+    }
+
+    state = {
+        "version": 2,
+        "config": {
+            "content_root": str(content_root),
+            "artist_name": "test-artist",
+            "generation": {},
+        },
+        "albums": {"test-album": album_data},
+        "session": {},
+    }
+
+    orig_cache = _shared_mod.cache
+    orig_plugin_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.cache = MockStateCache(state)
+    # Real template lives at PROJECT_ROOT/templates/track.md
+    _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+
+    yield state, tracks_dir
+
+    _shared_mod.cache = orig_cache
+    _shared_mod.PLUGIN_ROOT = orig_plugin_root
+
+
+def _create(title: str, track_number="1") -> dict:
+    return json.loads(_run(
+        _status_mod.create_track("test-album", track_number, title)
+    ))
+
+
+def _written_content(tracks_dir: Path) -> str:
+    files = list(tracks_dir.iterdir())
+    assert len(files) == 1, f"expected exactly one track file, got {files}"
+    return files[0].read_text(encoding="utf-8")
+
+
+# ===========================================================================
+# Frontmatter must stay valid YAML and the title must round-trip exactly
+# ===========================================================================
+
+
+class TestFrontmatterTitleEscaping:
+    # NOTE: titles containing a backslash are rejected earlier by
+    # _normalize_slug (path-separator guard) and never reach the frontmatter
+    # fill, so they are out of scope here. #403 is specifically about a
+    # double quote breaking the quoted YAML scalar. json.dumps still escapes
+    # backslashes correctly for any title that does reach the fill.
+    @pytest.mark.parametrize(
+        "title",
+        [
+            'Say "Goodbye"',
+            'Quote "Test" Song',
+            '"Leading quote',
+            'Trailing quote"',
+            "It's a \"trap\"",
+        ],
+    )
+    def test_special_char_title_frontmatter_round_trips(
+        self, cache_with_album, title
+    ):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(title)
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+        fm = parse_frontmatter(content)
+
+        # Frontmatter must parse cleanly (no degraded _error) ...
+        assert "_error" not in fm, fm.get("_error")
+        # ... and the title must survive verbatim.
+        assert fm.get("title") == title
+
+    def test_double_quote_title_preserves_sibling_frontmatter_fields(
+        self, cache_with_album
+    ):
+        """The bug dropped *all* frontmatter fields, not just the title."""
+        _state, tracks_dir = cache_with_album
+
+        result = _create('Say "Goodbye"', track_number="4")
+        assert result["created"] is True
+
+        fm = parse_frontmatter(_written_content(tracks_dir))
+        assert "_error" not in fm
+        assert fm.get("track_number") == 4
+        assert fm.get("explicit") is False
+        assert fm.get("instrumental") is False
+
+    def test_double_quote_title_kept_readable_in_body(self, cache_with_album):
+        """Human-readable body (H1 + details table) keeps the raw title."""
+        _state, tracks_dir = cache_with_album
+
+        _create('Say "Goodbye"')
+        content = _written_content(tracks_dir)
+
+        assert '# Say "Goodbye"' in content
+        assert '| **Title** | Say "Goodbye" |' in content
+        # The unescaped raw title must never leak into the frontmatter scalar.
+        assert 'title: "Say "Goodbye""' not in content
+
+
+# ===========================================================================
+# Normal titles keep working
+# ===========================================================================
+
+
+class TestNormalTitleUnaffected:
+    def test_plain_title_round_trips(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create("My New Track")
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+        fm = parse_frontmatter(content)
+        assert "_error" not in fm
+        assert fm.get("title") == "My New Track"
+        assert fm.get("track_number") == 1
+        assert "# My New Track" in content
+        assert "| **Title** | My New Track |" in content

--- a/tests/unit/state/test_rhyme_tail_396.py
+++ b/tests/unit/state/test_rhyme_tail_396.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #396 — rhyme-tail spelling normalization.
+
+_get_rhyme_tail derived a rhyme key from spelling, but the plural-strip
+(dropping a trailing 's') ran before the vowel-cluster logic, so clearly
+rhyming end-word pairs landed in different tails:
+
+    "eyes"  -> "eye"  vs "cries" -> "ie"    (no match)
+    "times" -> "ime"  vs "rhymes" -> "yme"  (no match)
+
+These tests pin the fix: rhyming pairs must share a tail (and a rhyme
+group), while genuinely non-rhyming pairs must stay distinct.
+
+Usage:
+    python -m pytest tests/unit/state/test_rhyme_tail_396.py -v
+"""
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Import server module from hyphenated directory via importlib. Executing the
+# server puts ``servers/bitwize-music-server`` on sys.path so ``handlers`` is
+# importable. Mirror the mcp mock used by the other lyrics tests so this file
+# runs even when the real ``mcp`` package is not installed.
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_rhyme396", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_server = _import_server()
+from handlers import lyrics_analysis as _lyrics_analysis_mod
+
+_get_rhyme_tail = _lyrics_analysis_mod._get_rhyme_tail
+analyze_rhyme_scheme = _lyrics_analysis_mod.analyze_rhyme_scheme
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestRhymeTailNormalization396:
+    """_get_rhyme_tail must fold spelling variants of the same rhyme sound."""
+
+    def test_eyes_cries_share_tail(self):
+        # Both /aɪz/ — the plural-strip must not split "eye" from "ie".
+        assert _get_rhyme_tail("eyes") == _get_rhyme_tail("cries")
+
+    def test_times_rhymes_share_tail(self):
+        # Both /aɪmz/ — the y/i spelling difference must not split them.
+        assert _get_rhyme_tail("times") == _get_rhyme_tail("rhymes")
+
+    def test_non_rhyme_pair_stays_distinct(self):
+        # "eyes" and "cat" do not rhyme — the fix must not over-broaden.
+        assert _get_rhyme_tail("eyes") != _get_rhyme_tail("cat")
+
+    def test_tails_have_groupable_length(self):
+        # analyze_rhyme_scheme only groups tails of length >= 2, so the
+        # normalized tails for these pairs must clear that bar.
+        assert len(_get_rhyme_tail("eyes")) >= 2
+        assert len(_get_rhyme_tail("times")) >= 2
+
+
+class TestAnalyzeRhymeScheme396:
+    """analyze_rhyme_scheme must report the corrected scheme for #396 pairs."""
+
+    STANZA = (
+        "[Verse]\n"
+        "I cannot hide behind my eyes\n"
+        "The lonely stranger softly cries\n"
+        "I've heard this melody a thousand times\n"
+        "The quiet poet speaks in rhymes\n"
+    )
+
+    def test_scheme_is_aabb(self):
+        result = json.loads(_run(analyze_rhyme_scheme(self.STANZA)))
+        section = result["sections"][0]
+        assert section["scheme"] == "AABB"
+
+    def test_rhyming_pairs_grouped(self):
+        result = json.loads(_run(analyze_rhyme_scheme(self.STANZA)))
+        lines = result["sections"][0]["lines"]
+        # eyes/cries share a group; times/rhymes share a group...
+        assert lines[0]["rhyme_group"] == lines[1]["rhyme_group"]
+        assert lines[2]["rhyme_group"] == lines[3]["rhyme_group"]
+        # ...and the two pairs are distinct groups.
+        assert lines[0]["rhyme_group"] != lines[2]["rhyme_group"]
+
+    def test_end_words_captured(self):
+        result = json.loads(_run(analyze_rhyme_scheme(self.STANZA)))
+        end_words = [ld["end_word"] for ld in result["sections"][0]["lines"]]
+        assert end_words == ["eyes", "cries", "times", "rhymes"]

--- a/tests/unit/state/test_update_streaming_url_unicode_404.py
+++ b/tests/unit/state/test_update_streaming_url_unicode_404.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Regression tests for update_streaming_url unicode round-trip (issue #404 polish).
+
+The #404 fix writes the URL into the in-place frontmatter scalar via
+``json.dumps(url)``. With the default ``ensure_ascii=True`` a
+supplementary-plane character (e.g. an emoji, U+1F3B5) is emitted as a
+UTF-16 surrogate pair (``\\ud83c\\udfb5``). PyYAML parses that back as two
+lone surrogates, not the original character — a lossy round-trip — even
+though the YAML stays valid (so #404's malformed-YAML/silent-drop failure
+does not recur). This is inconsistent with the same function's yaml.dump
+fallback, which uses ``allow_unicode=True`` and preserves the character.
+
+Passing ``ensure_ascii=False`` keeps quotes/backslashes escaped while
+preserving the raw character, so every URL round-trips exactly. These tests
+FAIL on the ``ensure_ascii=True`` output (astral char lost) and PASS once
+``ensure_ascii=False`` is used, while a BMP-unicode case and the existing
+special-char guards keep passing.
+
+Usage:
+    python -m pytest tests/unit/state/test_update_streaming_url_unicode_404.py -v
+"""
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (mirrors test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location(
+        "state_server_streaming_unicode_404", SERVER_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import streaming as _streaming_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+    def rebuild(self):
+        return self._state
+
+
+def _state_for(album_path: str) -> dict:
+    return {
+        "version": 2,
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "status": "Released",
+                "genre": "electronic",
+                "path": album_path,
+                "streaming_urls": {
+                    "spotify": "https://old-url.com",
+                },
+                "tracks": {},
+            },
+        },
+    }
+
+
+# Existing streaming block so the in-place edit path (the one under test) is
+# taken instead of the yaml.dump fallback.
+_README_TEMPLATE = """\
+---
+title: Test Album
+streaming:
+  spotify: "https://old-url.com"
+---
+
+# Test Album
+
+| **Status** | Released |
+"""
+
+
+def _write_readme(tmp_path: Path) -> Path:
+    readme = tmp_path / "README.md"
+    readme.write_text(_README_TEMPLATE, encoding="utf-8")
+    return readme
+
+
+def _do_update(tmp_path: Path, platform: str, url: str) -> dict:
+    """Run update_streaming_url against a real README, real parser.
+
+    write_state and the DB sync are stubbed out; everything else (file I/O,
+    parse_album_readme) is exercised for real so the round-trip is genuine.
+    """
+    readme = _write_readme(tmp_path)
+    state = _state_for(str(tmp_path))
+    orig_cache = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    try:
+        with patch("tools.state.indexer.write_state"), \
+             patch("handlers.database._check_db_deps",
+                   side_effect=ImportError("no db")):
+            result = json.loads(
+                _run(_streaming_mod.update_streaming_url("test-album", platform, url))
+            )
+    finally:
+        _shared_mod.cache = orig_cache
+    result["_readme_text"] = readme.read_text(encoding="utf-8")
+    result["_state_streaming"] = copy.deepcopy(
+        state["albums"]["test-album"]["streaming_urls"]
+    )
+    return result
+
+
+def _reparse_streaming(readme_text: str) -> dict:
+    """Parse the streaming block back out of the written README frontmatter."""
+    lines = readme_text.split("\n")
+    end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
+    fm = yaml.safe_load("\n".join(lines[1:end])) or {}
+    return fm.get("streaming", {}) or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStreamingUrlUnicodeRoundTrip:
+    """Issue #404: the written URL must round-trip every character exactly."""
+
+    def test_supplementary_plane_char_round_trips(self, tmp_path):
+        """An astral char (emoji) must survive the YAML round-trip, not become
+        two lone surrogates (the ensure_ascii=True failure mode)."""
+        url = "https://example.com/track?n=\U0001f3b5"  # U+1F3B5 musical note
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert result["url"] == url
+
+        # Frontmatter stays valid YAML and round-trips the exact URL ...
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        # ... and the state-cache re-parse kept the exact URL (not a lossy
+        # surrogate-pair variant).
+        assert result["_state_streaming"].get("spotify") == url
+        # The raw character is present on disk (readable), not escaped.
+        assert url in result["_readme_text"]
+        assert "\\ud83c" not in result["_readme_text"]
+
+    def test_bmp_unicode_url_round_trips(self, tmp_path):
+        """A BMP accented URL round-trips under both settings; guard it stays so."""
+        url = "https://exämple.com/café"
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+
+class TestSpecialCharsStillEscaped:
+    """ensure_ascii=False must not regress the original #404 quote/backslash fix."""
+
+    def test_url_with_double_quote_stays_valid_yaml(self, tmp_path):
+        url = 'https://example.com/track?ref="promo"&id=5'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_url_with_backslash_stays_valid_yaml(self, tmp_path):
+        url = 'https://example.com/track\\weird?q="x"'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_plain_ascii_url_scalar_unaffected(self, tmp_path):
+        """An ASCII URL needing no escaping is written byte-identically."""
+        url = "https://open.spotify.com/album/abc123"
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert f'spotify: "{url}"' in result["_readme_text"]
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/unit/state/test_update_streaming_url_yaml_404.py
+++ b/tests/unit/state/test_update_streaming_url_yaml_404.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Regression tests for issue #404 — update_streaming_url YAML escaping.
+
+The in-place frontmatter edit path in update_streaming_url must YAML-escape
+the URL before writing it into a double-quoted scalar. A URL containing a
+double-quote or backslash previously produced malformed YAML, which the
+immediate re-parse then dropped (silently losing the URL from the state
+cache while leaving the README file corrupt).
+
+These tests drive a real README.md through the handler and the real
+parse_album_readme parser to prove the written frontmatter stays valid and
+the URL round-trips.
+
+Usage:
+    python -m pytest tests/unit/state/test_update_streaming_url_yaml_404.py -v
+"""
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (mirrors test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_streaming_404", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import streaming as _streaming_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+    def rebuild(self):
+        return self._state
+
+
+def _state_for(album_path: str) -> dict:
+    return {
+        "version": 2,
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "status": "Released",
+                "genre": "electronic",
+                "path": album_path,
+                "streaming_urls": {
+                    "spotify": "https://old-url.com",
+                },
+                "tracks": {},
+            },
+        },
+    }
+
+
+# Existing streaming block so the in-place edit path (the buggy one) is taken
+# instead of the yaml.dump fallback.
+_README_TEMPLATE = """\
+---
+title: Test Album
+streaming:
+  spotify: "https://old-url.com"
+---
+
+# Test Album
+
+| **Status** | Released |
+"""
+
+
+def _write_readme(tmp_path: Path) -> Path:
+    readme = tmp_path / "README.md"
+    readme.write_text(_README_TEMPLATE, encoding="utf-8")
+    return readme
+
+
+def _do_update(tmp_path: Path, platform: str, url: str) -> dict:
+    """Run update_streaming_url against a real README, real parser.
+
+    write_state and the DB sync are stubbed out; everything else (file I/O,
+    parse_album_readme) is exercised for real so the round-trip is genuine.
+    """
+    readme = _write_readme(tmp_path)
+    state = _state_for(str(tmp_path))
+    orig_cache = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    try:
+        with patch("tools.state.indexer.write_state"), \
+             patch("handlers.database._check_db_deps",
+                   side_effect=ImportError("no db")):
+            result = json.loads(
+                _run(_streaming_mod.update_streaming_url("test-album", platform, url))
+            )
+    finally:
+        _shared_mod.cache = orig_cache
+    result["_readme_text"] = readme.read_text(encoding="utf-8")
+    result["_state_streaming"] = copy.deepcopy(
+        state["albums"]["test-album"]["streaming_urls"]
+    )
+    return result
+
+
+def _reparse_streaming(readme_text: str) -> dict:
+    """Parse the streaming block back out of the written README frontmatter.
+
+    Raises yaml.YAMLError if the frontmatter is malformed — which is exactly
+    the failure mode issue #404 describes.
+    """
+    lines = readme_text.split("\n")
+    end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
+    fm = yaml.safe_load("\n".join(lines[1:end])) or {}
+    return fm.get("streaming", {}) or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStreamingUrlYamlEscaping:
+    """Issue #404: in-place frontmatter edit must YAML-escape the URL."""
+
+    def test_url_with_double_quote_stays_valid_yaml(self, tmp_path):
+        """A URL containing a double-quote must not corrupt the frontmatter."""
+        url = 'https://example.com/track?ref="promo"&id=5'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert result["url"] == url
+
+        # Frontmatter must still be valid YAML and round-trip the exact URL.
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+
+        # And the state cache re-parse must have kept the URL (not silently
+        # dropped it because the frontmatter went malformed).
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_url_with_backslash_stays_valid_yaml(self, tmp_path):
+        """A URL containing a backslash must not corrupt the frontmatter."""
+        url = 'https://example.com/track\\weird?q="x"'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_normal_url_still_round_trips(self, tmp_path):
+        """Regression guard: an ordinary URL keeps working after the fix."""
+        url = "https://open.spotify.com/album/abc123"
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert result["url"] == url
+
+        # Written frontmatter should not contain JSON-escape artifacts for a
+        # URL that needs no escaping.
+        assert f'spotify: "{url}"' in result["_readme_text"]
+
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -174,6 +174,13 @@ def find_album_path(config: dict[str, Any], album_name: str, audio_root_override
     artist: str = config["artist"]["name"]
     checked: list[str] = []
 
+    # Validate album_name before ANY glob use (prevent path traversal and glob
+    # injection). Must run before the mirrored-structure branch below, which
+    # interpolates album_name into a glob pattern (#405).
+    if os.sep in album_name or '/' in album_name or any(c in album_name for c in '*?[]'):
+        logger.error("Album name '%s' contains invalid characters (path separators or glob patterns)", album_name)
+        sys.exit(1)
+
     # Try mirrored structure: {audio_root}/artists/{artist}/albums/{genre}/{album}
     genre_glob = audio_root / "artists" / artist / "albums" / "*" / album_name
     genre_matches = sorted(genre_glob.parent.parent.glob(f"*/{album_name}"))
@@ -187,11 +194,6 @@ def find_album_path(config: dict[str, Any], album_name: str, audio_root_override
     checked.append(str(album_path_direct))
     if album_path_direct.exists() and _is_within(album_path_direct, audio_root):
         return album_path_direct
-
-    # Validate album_name before glob search (prevent path traversal and glob injection)
-    if os.sep in album_name or '/' in album_name or any(c in album_name for c in '*?[]'):
-        logger.error("Album name '%s' contains invalid characters (path separators or glob patterns)", album_name)
-        sys.exit(1)
 
     # Glob search as fallback (handles genre folders, mirrored structures)
     matches = sorted(audio_root.rglob(album_name))

--- a/tools/mastering/qc_tracks.py
+++ b/tools/mastering/qc_tracks.py
@@ -556,6 +556,28 @@ def qc_track(
     }
 
 
+def _error_result(filepath: Path | str, exc: Exception) -> dict[str, Any]:
+    """Build a QC result row for a file that could not be read or processed.
+
+    Mirrors the shape returned by :func:`qc_track` (``filename`` / ``checks`` /
+    ``verdict``) so a corrupt or unreadable file renders as an ordinary
+    per-track FAIL row in the table, summary count, and ISSUES section instead
+    of tearing down the whole batch with a traceback (#408). The read failure
+    is surfaced through a single synthetic ``read`` check.
+    """
+    return {
+        "filename": os.path.basename(str(filepath)),
+        "checks": {
+            "read": {
+                "status": "FAIL",
+                "value": "unreadable",
+                "detail": f"Could not read/QC file: {exc}",
+            }
+        },
+        "verdict": "FAIL",
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Technical audio QC checks.")
     parser.add_argument(
@@ -622,11 +644,20 @@ def main() -> None:
     workers = args.jobs if args.jobs > 0 else os.cpu_count()
     progress = ProgressBar(len(filterable), prefix="QC scanning")
 
+    # A single corrupt/unreadable file must not abort the batch — catch its
+    # failure, emit a per-track FAIL row, and keep scanning the rest (#408).
+    had_read_error = False
+
     if workers == 1:
         results = []
         for wav_file in filterable:
             progress.update(wav_file.name)
-            result = qc_track(str(wav_file), checks=active_checks, genre=genre)
+            try:
+                result = qc_track(str(wav_file), checks=active_checks, genre=genre)
+            except Exception as exc:
+                logger.warning("QC failed for %s: %s", wav_file.name, exc)
+                result = _error_result(wav_file, exc)
+                had_read_error = True
             results.append(result)
     else:
         logger.info("Using %d parallel workers", workers)
@@ -639,7 +670,12 @@ def main() -> None:
             for future in as_completed(futures):
                 idx = futures[future]
                 progress.update(filterable[idx].name)
-                ordered[idx] = future.result()
+                try:
+                    ordered[idx] = future.result()
+                except Exception as exc:
+                    logger.warning("QC failed for %s: %s", filterable[idx].name, exc)
+                    ordered[idx] = _error_result(filterable[idx], exc)
+                    had_read_error = True
         results = [ordered[i] for i in sorted(ordered)]
 
     # Determine which checks were run
@@ -697,6 +733,11 @@ def main() -> None:
                 print(f"    [{info['status']}] {check}: {info['detail']}")
 
     print()
+
+    # Signal partial failure to callers/CI when any file could not be QC'd —
+    # every other track's result has already been printed above (#408).
+    if had_read_error:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/mastering/reference_master.py
+++ b/tools/mastering/reference_master.py
@@ -110,9 +110,14 @@ Examples:
         master_with_reference(target_path, reference_path, output_path)
     else:
         # Batch mode - process all WAVs in current directory
+        # Compare resolved paths so the reference is excluded regardless of
+        # how --reference was supplied (absolute, './'-prefixed, or relative);
+        # glob output is always relative to '.', so a lexical compare misses
+        # an absolute --reference and re-masters it as its own target (#409).
+        reference_resolved = reference_path.resolve()
         wav_files = sorted([f for f in Path('.').glob('*.wav')
                            if 'venv' not in str(f)
-                           and f != reference_path])
+                           and f.resolve() != reference_resolved])
 
         if not wav_files:
             logger.error("No WAV files found in current directory")


### PR DESCRIPTION
## Description

Clears nine handler/CLI correctness bugs — YAML-escaping, text encoding, case-sensitivity, validation ordering, and batch robustness. All TDD red-first, each with a dedicated test file.

| Issue | Fix | File |
|---|---|---|
| #394 | Read manifests as UTF-8 + handle `UnicodeDecodeError` | `hooks/check_version_sync.py` |
| #395 | Case-insensitive idea duplicate guard (matches readers) | `ideas.py` |
| #396 | Rhyme tail: cap nucleus + fold `y`/`i` so `eyes`/`cries`, `times`/`rhymes` group | `lyrics_analysis.py` |
| #399 | Guard the `LAYOUT.md` read so a corrupt file doesn't abort the master pipeline | `_album_stages.py` |
| #403 | YAML-escape the title frontmatter scalar (`json.dumps`, `ensure_ascii=False`) | `status.py` |
| #404 | YAML-escape the URL on the in-place frontmatter edit | `streaming.py` |
| #405 | Validate `album_name` before any glob expansion | `upload_to_cloud.py` |
| #408 | Per-track FAIL row + continue when a QC file can't be read | `qc_tracks.py` |
| #409 | Exclude the reference by resolved path in batch mode | `reference_master.py` |

## Verification

- TDD red-first for every fix (each new test confirmed to fail on unfixed code); 54 new tests across dedicated files.
- Per-issue spec review (9 reviewers), all repro-confirmed fixed; 3 minor findings addressed (`ensure_ascii=False` so non-ASCII titles/URLs round-trip on #403/#404).
- Full gate: `ruff` + `bandit` + `mypy` clean; `pytest -n auto` → **4192 passed**, coverage 87.91% (≥75%).

## Type of Change

- [x] fix: Bug fix (patch version bump)

Fixes #394, #395, #396, #399, #403, #404, #405, #408, #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd