### PR TITLE
feat(suno-engineer): expand Suno metatag reference coverage and prompt workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Expanded Suno metatag reference coverage and suno-engineer prompt-building workflow**.
+  Metatags were mentioned in the plugin but scattered and thin — `structure-tags.md` had
+  only 6 delivery/mood bracket tags and was missing `[Post-Chorus]`/`[Fade In]`/`[Hook]`,
+  `v5-best-practices.md`'s Sound Effects list had only 6 examples, and the Duet pattern
+  existed only inside `suno-engineer/SKILL.md` with no canonical reference. More
+  importantly, `suno-engineer`'s own workflow never instructed pulling mood/voice/SFX
+  vocabulary from the reference docs it already links, so real generations only ever
+  got bare structure tags. Added a terminology explainer (structure tags vs.
+  delivery/mood bracket tags vs. Style Box descriptors vs. inline lyrical metatags) to
+  `reference/suno/README.md` and `structure-tags.md`; expanded mood tags, sound effects,
+  and added a Duet/Call-and-Response + Production/Vocal FX section to `voice-tags.md`;
+  and updated `suno-engineer/SKILL.md`'s workflow to explicitly pull concrete
+  descriptors from these references when building vocals, instruments, and Style Box
+  prompts. Deliberately did not adopt invented `[Mood: X]`/`[Energy: X]` bracket syntax
+  or bracket-style instrument tags from third-party guides — those contradict this
+  plugin's field-tested anti-"tag soup" guidance.
+
 ### Fixed
 - **Audio/DSP edge-case crashes hardened** across the mastering and mixing
   pipelines:

--- a/reference/suno/README.md
+++ b/reference/suno/README.md
@@ -31,6 +31,19 @@ Reference guides for Suno AI music generation.
 
 > **Related skill**: `/bitwize-music:suno-engineer` provides interactive guidance using these references.
 
+## Suno Tag/Metatag Terminology
+
+"Metatag" is often used loosely for all bracketed Suno keywords. This plugin distinguishes four categories, each with its own home doc:
+
+| Category | Example | Lives in |
+|----------|---------|----------|
+| Structure tags | `[Verse]`, `[Chorus]`, `[Post-Chorus]` | [structure-tags.md](structure-tags.md) |
+| Delivery/mood bracket tags | `[Whispered]`, `[Aggressive]` | [structure-tags.md](structure-tags.md) — "Custom Mood/Style Tags" |
+| Style Box descriptors (prose, not brackets) | `gravelly, belting, Southern rock vocal` | [voice-tags.md](voice-tags.md), [instrumental-tags.md](instrumental-tags.md) |
+| Inline lyrical metatags | `[Verse 1: Raspy older female vocal, husky contralto]` | [tips-and-tricks.md](tips-and-tricks.md#vocal-sounds-too-young-despite-maturedeep-descriptors) — escalation technique, not default |
+
+Structure tags are mandatory in every section; the other three are optional accents — see each doc's usage guidance to avoid "tag soup"/prompt fatigue.
+
 ## Quick Links
 
 - [Suno Website](https://suno.com)

--- a/reference/suno/structure-tags.md
+++ b/reference/suno/structure-tags.md
@@ -2,6 +2,14 @@
 
 Complete reference for song structure tags in Suno lyrics.
 
+> **Suno tag/metatag terminology**: "metatag" gets used loosely — here's the actual taxonomy across this plugin's reference docs:
+> - **Structure tags** (this file) — `[Verse]`, `[Chorus]`, etc. Define song sections. Go in the Lyrics Box.
+> - **Delivery/mood bracket tags** (this file, "Custom Mood/Style Tags" below) — `[Whispered]`, `[Shout]`, etc. Short, standalone Lyrics Box tags that color delivery without defining a section.
+> - **Style Box descriptors** ([voice-tags.md](voice-tags.md), [instrumental-tags.md](instrumental-tags.md)) — comma-separated prose in the Style Box (`gravelly, belting, Southern rock vocal`), not bracket tags. This is how Suno V5 actually wants mood/energy/instrumentation — see the "Keep It Simple" guidance in [v5-best-practices.md](v5-best-practices.md).
+> - **Inline lyrical metatags** ([tips-and-tricks.md](tips-and-tricks.md#vocal-sounds-too-young-despite-maturedeep-descriptors)) — a per-section descriptor prefixed inside the section tag itself, e.g. `[Verse 1: Raspy older female vocal, husky contralto]`. An escalation technique for stubborn vocal-identity issues, not a default pattern.
+>
+> Rule of thumb: structure tags are mandatory every section; delivery bracket tags and inline metatags are optional accents (1-3 max per section — see "Performance Cues" below); mood/energy/instrumentation belongs in Style Box prose, not bracket tags.
+
 ## Basic Structure Tags
 
 ### Intro
@@ -26,12 +34,14 @@ Complete reference for song structure tags in Suno lyrics.
 ```
 [Chorus]
 [Catchy Hook]
+[Hook]
 ```
 
 ### Bridge
 ```
 [Bridge]
 [Pre-Chorus]
+[Post-Chorus]
 ```
 
 ### Instrumental Sections
@@ -47,6 +57,7 @@ Complete reference for song structure tags in Suno lyrics.
 ```
 [Outro]
 [End]
+[Fade In]
 [Fade Out]
 [Fade to End]
 [Big Finish]
@@ -55,7 +66,7 @@ Complete reference for song structure tags in Suno lyrics.
 
 ## Custom Mood/Style Tags
 
-These descriptive tags influence delivery:
+These descriptive tags influence delivery. Use 1-3 per section, same discipline as Performance Cues below — stacking many at once causes the "prompt fatigue" described in [v5-best-practices.md](v5-best-practices.md):
 
 ```
 [Shout]          - Aggressive, shouted delivery
@@ -64,6 +75,12 @@ These descriptive tags influence delivery:
 [Spoken]         - Spoken word, not sung
 [Whispered]      - Quiet, intimate
 [Energetic]      - High energy delivery
+[Aggressive]     - Intense, confrontational delivery
+[Intimate]       - Personal, close, hushed tone
+[Playful]        - Lighthearted, fun energy
+[Triumphant]     - Victorious, anthemic delivery
+[Vulnerable]     - Raw, exposed emotion
+[Haunting]       - Eerie, unsettled mood
 ```
 
 ## Example Song Structure
@@ -195,6 +212,7 @@ V5 improved tag reliability significantly over V4/V4.5. Tags that were inconsist
 
 ### Less Reliable
 - `[Intro]` - Use descriptive alternatives
+- `[Post-Chorus]`, `[Fade In]` - Less field-tested than their established counterparts (`[Pre-Chorus]`, `[Fade Out]`) — test before relying on them
 - Custom tags - Results vary
 
 ## Tips
@@ -226,7 +244,8 @@ V5 improved tag reliability significantly over V4/V4.5. Tags that were inconsist
 
 ## See Also
 
-- **`/reference/suno/v5-best-practices.md`** - Complete Suno V5 prompting guide, style box construction
+- **`/reference/suno/v5-best-practices.md`** - Complete Suno V5 prompting guide, style box construction, Sound Effects/Atmospheric tags
 - **`/reference/suno/pronunciation-guide.md`** - Phonetic spelling and pronunciation fixes for lyrics
-- **`/reference/suno/voice-tags.md`** - Vocal style descriptors and manipulation tags
+- **`/reference/suno/voice-tags.md`** - Vocal style descriptors, Duet pattern, Production/Vocal FX descriptors
+- **`/reference/suno/tips-and-tricks.md`** - Inline lyrical metatags for stubborn vocal-identity issues
 - **`/skills/lyric-writer/SKILL.md`** - Complete lyric writing workflow and standards

--- a/reference/suno/v5-best-practices.md
+++ b/reference/suno/v5-best-practices.md
@@ -287,12 +287,25 @@ Then suddenly [laughter] breaks the silence
 ```
 
 **Common Effects**:
+
+**Human:**
 - `[laughter]` - Natural laughing
 - `[screaming]` - Vocal scream
 - `[whisper]` - Whispered delivery
-- `[echo]` - Echo/reverb effect
+- `[sigh]` - Breathing out, reflective
+- `[gasp]` - Sharp intake of breath
+- `[cough]` - Clearing throat, realistic aside
+
+**Crowd:**
 - `[crowd]` - Crowd noise
 - `[applause]` - Clapping/applause
+- `[cheering]` - Crowd excitement
+
+**Mechanical/transition:**
+- `[echo]` - Echo/reverb effect
+- `[phone ringing]` - Telephone sound, narrative device
+- `[static]` - Radio noise, transition
+- `[record scratch]` - DJ/hip-hop transition marker
 
 **Note**: Effects work best when placed mid-line, not as standalone lines
 

--- a/reference/suno/voice-tags.md
+++ b/reference/suno/voice-tags.md
@@ -60,6 +60,36 @@ Control how the voice interacts with the mix:
 | `Liquid-like` | Flowing, fluid |
 | `Breathy exhale` | Airy, exhaled quality |
 
+## Production/Vocal FX Descriptors
+
+Style Box prose describing how the vocal is processed (not bracket tags — comma-separate with other descriptors, same as Vocal Style/Texture tags above):
+
+| Descriptor | Effect |
+|-----------|--------|
+| `Reverb` / `spacious reverb` | Echoing, roomy sound — ballads, ambient |
+| `Delay` / `slapback delay` | Repeated echoes — dub, experimental |
+| `Auto-tuned` | Pitch-corrected, modern pop/trap effect |
+| `No autotune` / `natural pitch` | Organic, unprocessed vocal — see [Negative Prompting](v5-best-practices.md#negative-prompting) |
+| `Vocoded` / `vocoder` | Robotic, electronic processing |
+| `Distorted vocals` | Gritty, overdriven — rock, industrial |
+| `Filtered` / `telephone effect` | Narrow-band, lo-fi/vintage transition sound |
+
+**Note**: To exclude one of these instead, use the Style Box's negative-prompting pattern (`no autotune`, `no heavy reverb`) rather than a separate field — see [v5-best-practices.md § Negative Prompting](v5-best-practices.md#negative-prompting).
+
+## Duet / Call-and-Response
+
+For two-character dialogue, duets, or call-and-response sections, alternate section tags per character in the Lyrics Box:
+
+```
+[Verse - Character A]
+First character's lyrics
+
+[Verse - Character B]
+Second character's lyrics
+```
+
+Mention the arrangement explicitly in the Style Box so Suno knows to generate two distinct voices: `Dual vocalists, male and female, trading verses`. For a chorus where both characters sing together, describe it directly in the Style Box rather than inventing a bracket tag: `duet chorus, blended male/female harmony`.
+
 ## Regional Vocal Styles
 
 Add geographic/cultural flavor:

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -64,9 +64,10 @@ Unlike V4, V5 follows instructions exactly. Don't overthink it.
 
 ### Section Tags are Critical
 Structure your songs with explicit section markers:
-- `[Intro]`, `[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]`
+- `[Intro]`, `[Verse]`, `[Chorus]`, `[Pre-Chorus]`, `[Bridge]`, `[Outro]`, `[End]` — see `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` for the full set (including `[Post-Chorus]`, `[Break]`, `[Interlude]`, `[Fade In]`/`[Fade Out]`)
 - V5 uses these to shape arrangement
 - Without tags, structure can be unpredictable
+- **Optional accent**: one delivery/mood bracket tag per section (`[Whispered]`, `[Aggressive]`, etc.) can color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly (1 per section); this is not a substitute for Style Box mood/energy prose.
 
 ### Vocals First
 In Style Prompt, put vocal description FIRST:
@@ -274,15 +275,7 @@ Use descriptive section tags only (no parentheticals — Suno will sing them as 
 ```
 
 ### Voice Switching
-For dialogue or duets:
-```
-[Verse - Character A]
-First character's lyrics
-
-[Verse - Character B]
-Second character's lyrics
-```
-Mention in style prompt: "Dual vocalists, male and female, trading verses"
+For dialogue or duets, alternate section tags per character and mention the arrangement in the Style Box (e.g. "Dual vocalists, male and female, trading verses"). Full pattern and Style Box phrasing: `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` § Duet / Call-and-Response
 
 ---
 
@@ -309,12 +302,13 @@ As the Suno engineer, you:
 2. **Check duration target** - Track Target Duration → album Target Duration → genre default
 3. **Check artist persona** - Review saved voice profile (if applicable)
 4. **Select genre** - Choose appropriate genre tags
-5. **Define vocals** - Specify voice type, delivery, energy
-6. **Choose instruments** - Select key instruments and sonic texture
-7. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed
-8. **Generate in Suno** - Create track with assembled inputs
-9. **Iterate if needed** - Refine based on output quality
-10. **Log results** - Document in Generation Log with rating
+5. **Define vocals** - Specify voice type, delivery, energy. Pull a concrete texture/style descriptor from `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` (Vocal Style Tags, Vocal Texture Tags, Production/Vocal FX Descriptors) instead of a generic "male vocal, rock" — e.g. "gravelly, belting" beats "powerful"
+6. **Choose instruments** - Select key instruments and sonic texture. Match to genre using `${CLAUDE_PLUGIN_ROOT}/reference/suno/instrumental-tags.md` § Genre-Specific Instruments (2-4 key instruments, not a full list)
+7. **Check for sound effects/atmosphere** - If the lyrics reference rain, footsteps, crowds, laughter, or similar, add matching tags per `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Sound Effects / Atmospheric Effects (mention in both Lyrics Box and Style Prompt for atmospheric/environmental sounds)
+8. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed
+9. **Generate in Suno** - Create track with assembled inputs
+10. **Iterate if needed** - Refine based on output quality
+11. **Log results** - Document in Generation Log with rating
 
 ---
 


### PR DESCRIPTION
## Summary

Every Suno generation only ever got bare structure tags (`[Intro]`, `[Verse]`, `[Chorus]`...) — never mood, voice-delivery, SFX, or richer structure tags — despite "metatags" being nominally mentioned in the plugin. Investigation found two compounding gaps:

- **Docs gap**: `structure-tags.md` had only 6 delivery/mood bracket tags and was missing `[Post-Chorus]`/`[Fade In]`/`[Hook]`; `v5-best-practices.md`'s Sound Effects list had only 6 examples; the Duet pattern existed only inside `suno-engineer/SKILL.md` with no canonical reference doc.
- **Workflow gap (the actual root cause)**: `suno-engineer/SKILL.md` — the skill that builds the Style Box / Lyrics Box — never instructed pulling mood/voice/SFX vocabulary from the reference docs it already links. That's why real generations never got more than bare structure: the skill never asked for more.

This PR:
- Adds a terminology explainer (structure tags vs. delivery/mood bracket tags vs. Style Box descriptors vs. inline lyrical metatags) to `reference/suno/README.md` and `structure-tags.md`, so the taxonomy is discoverable in one place instead of scattered across 6 loosely-related mentions.
- Expands `structure-tags.md` (`[Post-Chorus]`, `[Fade In]`, `[Hook]`, mood tags 6→12).
- Expands `v5-best-practices.md`'s Sound Effects taxonomy (6→14, grouped Human/Crowd/Mechanical).
- Adds a Duet/Call-and-Response section and a Production/Vocal FX Descriptors table to `voice-tags.md`.
- Updates `suno-engineer/SKILL.md`'s workflow (steps 5-7) to explicitly pull concrete descriptors from these references when defining vocals, instruments, and checking for sound effects — this is the change that should actually show up in future generations.

**Deliberately NOT included** (see CHANGELOG for rationale): invented `[Mood: X]`/`[Energy: X]` bracket syntax and bracket-style instrument tags, both sourced from a third-party marketing blog used as a reference point during research. Both contradict this plugin's own field-tested anti-"tag soup"/prompt-fatigue guidance (`v5-best-practices.md` "Keep It Simple", `instrumental-tags.md` "Producer's Prompt Approach"). Also did not touch `pre-generation-check`'s Gate 5 — the bare `[Verse]`/`[Chorus]` requirement stays a hard gate; mood/voice/SFX tags remain optional accents, not mandatory.

## Type of change
- [x] Documentation
- [x] Skill behavior enhancement (non-breaking)
- [ ] Bug fix
- [ ] Breaking change

## Testing performed
- `make check` (ruff + bandit + mypy + pytest): 4098 passed, 87.73% coverage, exit 0
- Targeted re-run after review fixes and after rebase onto latest `develop`: `tests/plugin/test_skills.py test_references.py test_terminology.py test_consistency.py` — 56 passed, 2 xpassed (pre-existing, unrelated plugin-cache xfails), 0 failures
- Manually verified every new cross-reference link/anchor resolves
- Self-review caught and fixed: an invalid `6.5.` Markdown list marker in `SKILL.md`'s workflow (now a clean integer sequence 1-11), category-label bold styling, an imprecise README anchor, and softened a casually-introduced `[Duet]` bracket-tag mention to stay consistent with the anti-tag-soup stance

## Deployment notes
Pure documentation + skill-instruction content — no code, no dependencies, no config/schema changes, no migration file needed (confirmed against `migrations/README.md`'s own exclusion criteria for docs-only changes). Existing track files and albums need zero migration.

## Related issues
None filed — arose from direct investigation of generation quality.

## Reviewer checklist
- [ ] Terminology explainer in `reference/suno/README.md` reads clearly and doesn't duplicate content elsewhere
- [ ] Agree with the decision to reject `[Mood: X]`/`[Energy: X]` bracket syntax and instrument bracket tags
- [ ] `suno-engineer/SKILL.md` workflow changes (steps 5-7) read naturally in context
