### PR TITLE
chore: release 0.95.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.95.0-dev",
+      "version": "0.95.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.94.0",
+      "version": "0.95.0-dev",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.95.0-dev",
+  "version": "0.95.0",
   "author": {
     "name": "bitwize-music"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.94.0",
+  "version": "0.95.0-dev",
   "author": {
     "name": "bitwize-music"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,6 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
-### Fixed
-- **`suno-engineer` now requires checking the Style Box descriptor ceiling and defaults to
-  per-section Performance Cues** (follow-up to #449). #449 documented concrete vocal/instrument/SFX
-  descriptors and mentioned `v5-best-practices.md`'s "4-7 descriptor sweet spot" and
-  `structure-tags.md`'s Performance Cues technique, but never wired either into the
-  `suno-engineer` workflow or its Quality Standards checklist as something to actually check
-  before finalizing a prompt. In real album production this produced Style Boxes with 20+
-  comma-separated descriptors (mostly synonym-piles like "imperious, commanding, regal, grand,
-  theatrical, explosive") and Lyrics Boxes with bare `[Verse]`/`[Chorus]` tags carrying no
-  delivery variation — output that repeatedly came back sounding flat and generic across
-  multiple tracks on an album. Added an explicit workflow step + Quality Standards checks
-  requiring: (1) Style Box trimmed to the 4-7 descriptor sweet spot before generating, and
-  (2) 1-3 Performance Cues appended to every structure tag (`[Verse 1 - cold, regal]`) by
-  default, moving the song's emotional arc out of the Style Box prose and into the Lyrics Box
-  where it belongs. Rewriting one in-progress track's Style Box (20+ descriptors → 6) and
-  adding Performance Cues to all 12 of its section tags produced a subjectively much more
-  dynamic, less generic-sounding generation — the before/after difference is what prompted
-  this fix.
-- **`suno-engineer` guidance-consistency follow-ups** (#454, follow-up to #453). Trimmed the
-  Style Prompt example to the 4-7 sweet spot (it modeled 9 descriptors); reconciled the
-  emotional-arc location between `suno-engineer/SKILL.md` and `voice-tags.md` § Emotion Arc
-  Mapping (baseline mood in Style Box prose, per-section variation in Performance Cues,
-  cross-referenced both ways); updated `templates/track.md` to model per-section Performance
-  Cues instead of bare section tags and to stop redirecting delivery notes to the Style Box;
-  and clarified that Performance Cues plus the optional standalone accent share one
-  ≤3-per-section budget.
-
 ## [0.95.0] - 2026-07-04
 
 ### Added
@@ -184,6 +157,32 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   `_normalize_slug`'s `ValueError` escape as an opaque tool error on inputs
   like `../other`; all three now catch it and return their module's
   structured error shape.
+
+- **`suno-engineer` now requires checking the Style Box descriptor ceiling and defaults to
+  per-section Performance Cues** (follow-up to #449). #449 documented concrete vocal/instrument/SFX
+  descriptors and mentioned `v5-best-practices.md`'s "4-7 descriptor sweet spot" and
+  `structure-tags.md`'s Performance Cues technique, but never wired either into the
+  `suno-engineer` workflow or its Quality Standards checklist as something to actually check
+  before finalizing a prompt. In real album production this produced Style Boxes with 20+
+  comma-separated descriptors (mostly synonym-piles like "imperious, commanding, regal, grand,
+  theatrical, explosive") and Lyrics Boxes with bare `[Verse]`/`[Chorus]` tags carrying no
+  delivery variation — output that repeatedly came back sounding flat and generic across
+  multiple tracks on an album. Added an explicit workflow step + Quality Standards checks
+  requiring: (1) Style Box trimmed to the 4-7 descriptor sweet spot before generating, and
+  (2) 1-3 Performance Cues appended to every structure tag (`[Verse 1 - cold, regal]`) by
+  default, moving the song's emotional arc out of the Style Box prose and into the Lyrics Box
+  where it belongs. Rewriting one in-progress track's Style Box (20+ descriptors → 6) and
+  adding Performance Cues to all 12 of its section tags produced a subjectively much more
+  dynamic, less generic-sounding generation — the before/after difference is what prompted
+  this fix.
+- **`suno-engineer` guidance-consistency follow-ups** (#454, follow-up to #453). Trimmed the
+  Style Prompt example to the 4-7 sweet spot (it modeled 9 descriptors); reconciled the
+  emotional-arc location between `suno-engineer/SKILL.md` and `voice-tags.md` § Emotion Arc
+  Mapping (baseline mood in Style Box prose, per-section variation in Performance Cues,
+  cross-referenced both ways); updated `templates/track.md` to model per-section Performance
+  Cues instead of bare section tags and to stop redirecting delivery notes to the Style Box;
+  and clarified that Performance Cues plus the optional standalone accent share one
+  ≤3-per-section budget.
 
 ## [0.94.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Handler & CLI correctness fixes**:
+  - **`check_version_sync` no longer crashes on non-UTF-8 manifests** (#394).
+    Manifests are read as UTF-8 and `UnicodeDecodeError` is handled, so the
+    hook degrades cleanly instead of tracebacking on a non-UTF-8 locale.
+  - **Idea duplicate detection is case-insensitive** (#395), matching the
+    case-insensitive readers — `"cyberpunk dreams"` is now rejected as a
+    duplicate of `"Cyberpunk Dreams"` instead of creating a second entry.
+  - **Rhyme-scheme analyzer groups clear rhymes correctly** (#396). The
+    spelling-based tail extraction split rhyming pairs (`eyes`/`cries`,
+    `times`/`rhymes`); the nucleus is now capped and vowel `y`/`i` folded so
+    they share a rhyme group, without merging genuinely distinct words.
+  - **`_stage_layout` survives a corrupt `LAYOUT.md`** (#399). A non-UTF-8
+    layout file raised `UnicodeDecodeError` outside the stage's guard,
+    aborting the master pipeline; the read is now guarded and the stage
+    regenerates from defaults per its non-halting contract.
+  - **`create_track` writes valid YAML for quoted titles** (#403). A title
+    containing a double-quote produced malformed frontmatter (silently
+    dropping fields); the frontmatter scalar is now YAML-escaped.
+  - **`update_streaming_url` escapes URLs in frontmatter** (#404). A URL with
+    a double-quote or backslash produced malformed YAML on the in-place edit
+    path, silently dropping the URL from the state cache; it is now escaped.
+  - **`find_album_path` validates before globbing** (#405). An `album_name`
+    with glob metacharacters was expanded as a pattern before the guard ran;
+    validation now precedes all glob use.
+  - **`qc_tracks` no longer aborts the batch on one bad file** (#408). A
+    corrupt WAV now yields a per-track FAIL row and the batch continues,
+    instead of tearing down the run.
+  - **`reference_master` batch mode excludes the reference reliably** (#409).
+    The reference WAV is matched by resolved path, so an absolute `--reference`
+    is no longer re-mastered as its own target.
 - **Audio/DSP edge-case crashes hardened** across the mastering and mixing
   pipelines:
   - **Silent/corrupt tracks no longer poison album LUFS aggregates** (#400).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.95.0] - 2026-07-04
+
 ### Added
 - **Expanded Suno metatag reference coverage and suno-engineer prompt-building workflow**.
   Metatags were mentioned in the plugin but scattered and thin — `structure-tags.md` had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **`suno-engineer` now requires checking the Style Box descriptor ceiling and defaults to
+  per-section Performance Cues** (follow-up to #449). #449 documented concrete vocal/instrument/SFX
+  descriptors and mentioned `v5-best-practices.md`'s "4-7 descriptor sweet spot" and
+  `structure-tags.md`'s Performance Cues technique, but never wired either into the
+  `suno-engineer` workflow or its Quality Standards checklist as something to actually check
+  before finalizing a prompt. In real album production this produced Style Boxes with 20+
+  comma-separated descriptors (mostly synonym-piles like "imperious, commanding, regal, grand,
+  theatrical, explosive") and Lyrics Boxes with bare `[Verse]`/`[Chorus]` tags carrying no
+  delivery variation — output that repeatedly came back sounding flat and generic across
+  multiple tracks on an album. Added an explicit workflow step + Quality Standards checks
+  requiring: (1) Style Box trimmed to the 4-7 descriptor sweet spot before generating, and
+  (2) 1-3 Performance Cues appended to every structure tag (`[Verse 1 - cold, regal]`) by
+  default, moving the song's emotional arc out of the Style Box prose and into the Lyrics Box
+  where it belongs. Rewriting one in-progress track's Style Box (20+ descriptors → 6) and
+  adding Performance Cues to all 12 of its section tags produced a subjectively much more
+  dynamic, less generic-sounding generation — the before/after difference is what prompted
+  this fix.
+
 ## [0.95.0] - 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Songbook no longer drops the first music page of every track** (#390).
+  `create_songbook` inferred `singles_have_title_pages = (manifest is not
+  None)` and unconditionally skipped page 0 of each single. But
+  `prepare_singles` writes `.manifest.json` even when it silently skips the
+  title page (pypdf/reportlab missing, or the step raised) — so singles with
+  no title page but a manifest lost their real first page (the whole track
+  for a 1-page transcription) and the TOC miscounted. `prepare_singles` now
+  records the actual per-track `title_page` fact in the manifest, and
+  `create_songbook` trusts that flag (falling back to the prior filename
+  heuristic for legacy manifests), so only genuine title pages are skipped.
 - **`create_track` validates `track_number`** (#372). Non-numeric values
   (`abc`, `1a`, empty), `None`, booleans, and zero/negative numbers now
   return a structured error naming the invalid value instead of crashing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Expanded Suno metatag reference coverage and suno-engineer prompt-building workflow**.
+  Metatags were mentioned in the plugin but scattered and thin — `structure-tags.md` had
+  only 6 delivery/mood bracket tags and was missing `[Post-Chorus]`/`[Fade In]`/`[Hook]`,
+  `v5-best-practices.md`'s Sound Effects list had only 6 examples, and the Duet pattern
+  existed only inside `suno-engineer/SKILL.md` with no canonical reference. More
+  importantly, `suno-engineer`'s own workflow never instructed pulling mood/voice/SFX
+  vocabulary from the reference docs it already links, so real generations only ever
+  got bare structure tags. Added a terminology explainer (structure tags vs.
+  delivery/mood bracket tags vs. Style Box descriptors vs. inline lyrical metatags) to
+  `reference/suno/README.md` and `structure-tags.md`; expanded mood tags, sound effects,
+  and added a Duet/Call-and-Response + Production/Vocal FX section to `voice-tags.md`;
+  and updated `suno-engineer/SKILL.md`'s workflow to explicitly pull concrete
+  descriptors from these references when building vocals, instruments, and Style Box
+  prompts. Deliberately did not adopt invented `[Mood: X]`/`[Energy: X]` bracket syntax
+  or bracket-style instrument tags from third-party guides — those contradict this
+  plugin's field-tested anti-"tag soup" guidance.
+
 ### Performance
 - **ADM validation runs per-track checks in parallel** (#345). The mastering
   pipeline's inter-sample clip check encodes+decodes each track via two ffmpeg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   adding Performance Cues to all 12 of its section tags produced a subjectively much more
   dynamic, less generic-sounding generation — the before/after difference is what prompted
   this fix.
+- **`suno-engineer` guidance-consistency follow-ups** (#454, follow-up to #453). Trimmed the
+  Style Prompt example to the 4-7 sweet spot (it modeled 9 descriptors); reconciled the
+  emotional-arc location between `suno-engineer/SKILL.md` and `voice-tags.md` § Emotion Arc
+  Mapping (baseline mood in Style Box prose, per-section variation in Performance Cues,
+  cross-referenced both ways); updated `templates/track.md` to model per-section Performance
+  Cues instead of bare section tags and to stop redirecting delivery notes to the Style Box;
+  and clarified that Performance Cues plus the optional standalone accent share one
+  ≤3-per-section budget.
 
 ## [0.95.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Performance
+- **ADM validation runs per-track checks in parallel** (#345). The mastering
+  pipeline's inter-sample clip check encodes+decodes each track via two ffmpeg
+  subprocesses; running them serially dominated wall-clock time (and tripled on
+  retry). The checks now run concurrently, bounded to CPU count, with identical
+  results, ordering, error handling, and clip-halt behavior.
+
 ### Docs
 - **Suno Song Editor workflow guide** (#237) — `reference/workflows/song-editor.md`:
   when to use section-level edits vs. regeneration vs. mix-engineer polish, each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Malformed slugs return clean JSON across every MCP tool** (#443). The
+  shared `_find_album_or_error` / `_resolve_audio_dir` / `_find_track_or_error`
+  helpers called `_normalize_slug` raw, and ~13 tool handlers called it
+  directly, so a slug with a path separator, null byte, or `..` traversal
+  raised an uncaught `ValueError` to the MCP layer — the same class #397/#442
+  fixed in a handful of handlers. The three helpers now convert that
+  `ValueError` into their structured error, and a single error boundary
+  installed at tool registration wraps every handler so any leaked
+  `ValueError` becomes a `{"error": ...}` response. Only `ValueError` is
+  caught, so genuine bugs still surface; the boundary preserves each tool's
+  FastMCP schema (it wraps via `functools.wraps`).
 - **Songbook no longer drops the first music page of every track** (#390).
   `create_songbook` inferred `singles_have_title_pages = (manifest is not
   None)` and unconditionally skipped page 0 of each single. But

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 ## [Unreleased]
 
 ### Fixed
+- **Audio/DSP edge-case crashes hardened** across the mastering and mixing
+  pipelines:
+  - **Silent/corrupt tracks no longer poison album LUFS aggregates** (#400).
+    A `-inf` LUFS reading fed `avg_lufs`/`lufs_range` in the verification and
+    ceiling-guard stages, producing `-inf`/`inf` and spurious range failures.
+    A shared `_finite_lufs_aggregates` helper now aggregates finite readings
+    only (returning `None` when all tracks are silent), and downstream
+    rounding/comparisons handle `None`.
+  - **Mix analyzer survives degenerate WAVs** (#401, #402). A zero-length WAV
+    crashed with an empty-array reduction; a sub-10-sample buffer produced a
+    `NaN` noise floor. Both now return a clean per-file result instead.
+  - **`apply_fade_out` no longer raises on sub-sample fades** (#406). A tiny
+    positive duration rounded `fade_samples` to 0 and raised; it is now a
+    no-op fade.
+  - **`original_lufs` reports the source loudness** (#407), measured before
+    processing rather than after.
+  - **Envelope followers no longer divide by zero** (#410). A 0 ms attack or
+    release in `gentle_compress`/`apply_transient_shaper` raised
+    `ZeroDivisionError`; time constants are clamped to a small positive floor.
+  - **`find_mastered_dir` skips non-directory candidates** (#411) instead of
+    crashing with `NotADirectoryError` when a candidate path is a file.
+  - **`find_best_segment` no longer skips the last analysis window** (#412),
+    an off-by-one in the window loop bound.
 - **Malformed slugs return clean JSON across every MCP tool** (#443). The
   shared `_find_album_or_error` / `_resolve_audio_dir` / `_find_track_or_error`
   helpers called `_normalize_slug` raw, and ~13 tool handlers called it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **`create_track` validates `track_number`** (#372). Non-numeric values
+  (`abc`, `1a`, empty), `None`, booleans, and zero/negative numbers now
+  return a structured error naming the invalid value instead of crashing
+  with an unhandled `ValueError` — and `00` no longer silently creates a
+  malformed `00-title.md` track. Integers and numeric strings (`7`, `"03"`)
+  keep working.
+- **`_update_frontmatter_block` honors its error contract** (#378). A track
+  file whose frontmatter parses to a list or scalar now returns
+  `(False, "Frontmatter in <path> is not a mapping (got <type>)")` per the
+  documented contract instead of raising `TypeError` out of the sheet-music
+  publish loop.
+- **`db_sync_album` returns a JSON error on malformed slugs** (#379). Slugs
+  containing path separators, null bytes, or `..` raised an uncaught
+  `ValueError` to the FastMCP layer; the slug lookup is now guarded with the
+  same try/except pattern every sibling `db_*` handler uses.
+- **`db_create_tweet` no longer silently drops the track link** (#380). When
+  `track_number > 0` but no matching track row exists, the tool inserted the
+  tweet with a NULL `track_id` while echoing the requested track number as
+  if it had linked. It now returns an error naming the missing track and
+  album (suggesting `db_sync_album` or `track_number=0`) before any insert.
+- **`analyze_tracks.py` handles WAV-less directories** (#386). Pointing the
+  CLI at a directory with no WAV files crashed with a `ValueError` from an
+  empty-array reduction; it now logs a clear "No tracks to analyze" error
+  and exits nonzero.
+- **Slug validation errors are clean JSON in three more handlers** (#397).
+  `reset_mastering`, `migrate_audio_layout`, and `get_skill` let
+  `_normalize_slug`'s `ValueError` escape as an opaque tool error on inputs
+  like `../other`; all three now catch it and return their module's
+  structured error shape.
+
 ## [0.94.0] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Docs
+- **Suno Song Editor workflow guide** (#237) — `reference/workflows/song-editor.md`:
+  when to use section-level edits vs. regeneration vs. mix-engineer polish, each
+  operation with use cases, and mastering-pipeline interaction.
+- **Creative Sliders reference** (#238) — `reference/suno/creative-sliders.md`:
+  per-slider behavior, genre starting ranges, interaction effects, and
+  slider-vs-prompt guidance; linked from the Suno reference index.
+- **Covers & Personas workflow guide** (#239) — `reference/workflows/covers-and-personas.md`
+  plus optional cover-track sections in `templates/track.md`.
+- **Expanded error-recovery guide** (#240) — added recovery procedures for state
+  cache corruption, mastering mid-failure cleanup, malformed markdown, batch
+  partial failures, config path resolution, and plugin/MCP corruption.
+
+### Tests
+- **Dedicated handler test coverage** (#236) — new `test_handlers_content.py`,
+  `test_handlers_promo.py`, and `test_handlers_maintenance.py` (the last closing
+  the `migrate_audio_layout` coverage gap).
+- **Corrected logger scoping** (#344) in `test_config_load_failure_logs_warning`
+  so it pins the actual emitting module.
+
 ### Fixed
 - **Handler & CLI correctness fixes**:
   - **`check_version_sync` no longer crashes on non-UTF-8 manifests** (#394).

--- a/hooks/check_version_sync.py
+++ b/hooks/check_version_sync.py
@@ -31,11 +31,11 @@ def check_sync(data: dict) -> list[str]:
         return []
 
     try:
-        with open(plugin_path) as f:
+        with open(plugin_path, encoding="utf-8") as f:
             plugin_data = json.load(f)
-        with open(marketplace_path) as f:
+        with open(marketplace_path, encoding="utf-8") as f:
             marketplace_data = json.load(f)
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return []
 
     plugin_version = plugin_data.get("version", "")

--- a/reference/suno/README.md
+++ b/reference/suno/README.md
@@ -7,6 +7,7 @@ Reference guides for Suno AI music generation.
 | Guide | Description |
 |-------|-------------|
 | [V5 Best Practices](v5-best-practices.md) | Comprehensive prompting guide for V5 |
+| [Creative Sliders](creative-sliders.md) | Weirdness, Style Influence, Audio Influence — deep dive |
 | [Pronunciation Guide](pronunciation-guide.md) | Homographs, tech terms, fixes |
 | [Tips & Tricks](tips-and-tricks.md) | Troubleshooting and operational techniques |
 | [Structure Tags](structure-tags.md) | Song section tags reference |

--- a/reference/suno/README.md
+++ b/reference/suno/README.md
@@ -32,6 +32,19 @@ Reference guides for Suno AI music generation.
 
 > **Related skill**: `/bitwize-music:suno-engineer` provides interactive guidance using these references.
 
+## Suno Tag/Metatag Terminology
+
+"Metatag" is often used loosely for all bracketed Suno keywords. This plugin distinguishes four categories, each with its own home doc:
+
+| Category | Example | Lives in |
+|----------|---------|----------|
+| Structure tags | `[Verse]`, `[Chorus]`, `[Post-Chorus]` | [structure-tags.md](structure-tags.md) |
+| Delivery/mood bracket tags | `[Whispered]`, `[Aggressive]` | [structure-tags.md](structure-tags.md) — "Custom Mood/Style Tags" |
+| Style Box descriptors (prose, not brackets) | `gravelly, belting, Southern rock vocal` | [voice-tags.md](voice-tags.md), [instrumental-tags.md](instrumental-tags.md) |
+| Inline lyrical metatags | `[Verse 1: Raspy older female vocal, husky contralto]` | [tips-and-tricks.md](tips-and-tricks.md#vocal-sounds-too-young-despite-maturedeep-descriptors) — escalation technique, not default |
+
+Structure tags are mandatory in every section; the other three are optional accents — see each doc's usage guidance to avoid "tag soup"/prompt fatigue.
+
 ## Quick Links
 
 - [Suno Website](https://suno.com)

--- a/reference/suno/creative-sliders.md
+++ b/reference/suno/creative-sliders.md
@@ -1,0 +1,161 @@
+# Suno Creative Sliders Reference
+
+Deep-dive guide to Suno V5's three Creative Sliders — **Weirdness**, **Style Influence**, and **Audio Influence** — including per-slider behavior, genre starting points, interaction effects, and when to reach for a slider vs. rewrite the style prompt.
+
+> **Related skills**: `/bitwize-music:suno-engineer` (constructs prompts and picks slider settings)
+> **Related docs**: [v5-best-practices.md](v5-best-practices.md#creative-sliders) (this file expands the brief Creative Sliders table there), [tips-and-tricks.md](tips-and-tricks.md), [genre-list.md](genre-list.md)
+
+---
+
+## What the Sliders Do
+
+The sliders live in the V5 generation interface and sit *on top of* your style prompt. They don't change **what** Suno makes — the prompt does that. They change **how hard Suno commits to the prompt** and **how far it's allowed to wander**.
+
+- **Weirdness** — how experimental vs. predictable the result is.
+- **Style Influence** — how tightly the output hugs your style prompt.
+- **Audio Influence** — how much a piece of uploaded reference audio shapes the output (only appears when you provide reference audio).
+
+Throughout this guide, slider positions are given on a **0.00–1.00 scale** — the same range the API exposes for `styleWeight` and `weirdnessConstraint` (see the [README API table](README.md#api-parameters)). If your interface shows a 0–100 scale instead, read `0.70` as `70`. **These bands are starting-point recommendations from this guide, not Suno-official defaults** — start at the defaults, generate once, then dial them in by ear.
+
+---
+
+## Weirdness
+
+Controls how experimental and unexpected Suno's choices are — melody, harmony, arrangement quirks, structural surprises.
+
+| Position | Behavior |
+|----------|----------|
+| **Low** (`0.00–0.30`) | Predictable, hooky, familiar. Strong, singable choices; conventional song shapes. The safe zone for radio-style results. |
+| **Mid** (`0.30–0.55`) | Balanced. Mostly conventional with occasional pleasant surprises. |
+| **High** (`0.55–1.00`) | Experimental and unexpected. Odd chord moves, unusual textures, less predictable structure. Rewarding for exploration, but drift and misfires increase. |
+
+**Raise it** when the output is too safe or generic and you want the AI to surprise you. **Lower it** when you need a dependable hook and clean, conventional structure.
+
+**Note**: High Weirdness increases variance between generations — expect to generate more takes and cherry-pick.
+
+---
+
+## Style Influence
+
+Controls how tightly the output adheres to your style prompt — genre hallmarks, named instruments, mood words.
+
+| Position | Behavior |
+|----------|----------|
+| **Low** (`0.00–0.40`) | Loose. Suno treats the prompt as a suggestion, blends influences freely, fills gaps its own way. Good for fusions and happy accidents. |
+| **Mid** (`0.40–0.60`) | Balanced adherence. Honors the prompt while leaving room to breathe. |
+| **High** (`0.60–1.00`) | Tight. Strong genre purity; the prompt's tags are enforced hard. Best when the genre must be unmistakable. |
+
+**Raise it** for genre purity — when the result is drifting off-genre or ignoring your tags. **Lower it** when you want the AI to surprise you, blend styles, or when a dominant Persona is over-processing the mix (per [tips-and-tricks.md](tips-and-tricks.md#personas-for-vocal-consistency), lowering Style Influence can rebalance an overpowering Persona).
+
+**Caution**: Very high Style Influence on a thin or contradictory prompt can produce a rigid, wooden result — the engine is enforcing tags that fight each other. If that happens, fix the prompt before pushing the slider higher (see [Sliders vs. Style Prompt](#sliders-vs-style-prompt)).
+
+---
+
+## Audio Influence
+
+Controls how much a piece of **uploaded reference audio** shapes the output. This slider **appears only when audio is uploaded** — via Cover, Upload Audio, or Sample to Song. With no reference audio, it isn't shown.
+
+| Position | Behavior |
+|----------|----------|
+| **Low** (`0.00–0.40`) | The upload is a loose seed. Your prompt and style lead; the reference just nudges. |
+| **Mid** (`0.40–0.65`) | Balanced — the output carries the reference's character while following the prompt. |
+| **High** (`0.65–1.00`) | The output hews closely to the uploaded audio's melody, feel, and arrangement. Safest for faithful covers and cross-track consistency. |
+
+**Raise it** when a cover or reworked upload isn't resembling the source enough. **Lower it** when you want more transformation and less of the original bleeding through.
+
+---
+
+## Recommended Starting Ranges by Genre
+
+Starting points only — generate, listen, then adjust. Weirdness and Style Influence are always available; Audio Influence applies only to upload/cover workflows. See [Genre-Specific Tips](v5-best-practices.md#genre-specific-tips) for the matching prompt guidance.
+
+| Genre category | Weirdness | Style Influence | Why |
+|----------------|-----------|-----------------|-----|
+| Pop / radio pop | `0.10–0.30` | `0.60–0.80` | Familiar hooks and clean structure win; keep it on-genre. |
+| Hip-Hop / Rap | `0.20–0.40` | `0.50–0.70` | Protect the pocket and flow; a little room for beat character. |
+| Rock / Punk | `0.20–0.45` | `0.55–0.75` | Genre hallmarks matter; punk stays tight and fast. |
+| Folk / Acoustic | `0.10–0.30` | `0.60–0.80` | Intimacy and coherence over surprise. |
+| Electronic / EDM | `0.30–0.55` | `0.45–0.65` | Sound design rewards some experimentation. |
+| K-Pop | `0.20–0.40` | `0.65–0.85` | Maximalist but genre-precise — switch-ups come from the prompt, not the slider. |
+| Cinematic / Orchestral | `0.15–0.40` | `0.55–0.75` | Mood and coherence carry the piece. |
+| Jazz / Improv | `0.40–0.65` | `0.40–0.60` | An improvisational feel benefits from deviation. |
+| Ambient / Experimental / IDM | `0.55–0.85` | `0.25–0.50` | The unexpected is the point; loosen the leash. |
+| Metal / Heavy | `0.10–0.30` | `0.65–0.85` | Suno struggles with heavy genres — lock hard on-genre and minimize deviation (see [Known V5 Limitations](v5-best-practices.md#known-v5-limitations); consider testing V4.5). |
+| Documentary / narrative | `0.10–0.30` | `0.55–0.75` | The story carries the track — favor clear vocals and predictable structure so the lyric lands. |
+
+---
+
+## Interaction Effects
+
+The two always-on sliders combine into four broad regions:
+
+| | **Low Style Influence** | **High Style Influence** |
+|---|---|---|
+| **High Weirdness** | **Wild card** — maximum surprise, genre may dissolve. Great for idea-mining; expect drift and many regenerations. | **Adventurous within the lane** — unexpected choices that still read as the genre. The sweet spot for keeping a familiar genre fresh (pair with a specific genre tag). |
+| **Low Weirdness** | **Loose & smooth** — Suno fills gaps its own way but stays tame. Good for gentle fusions. | **Safe & on-genre** — faithful, predictable, release-ready. The default for pop, folk, and narrative work; the risk is a generic result. |
+
+**Key takeaways:**
+- **High Weirdness + a specific genre tag** is the reliable "interesting but not chaotic" combo — the genre tag anchors the surprises.
+- **Low Style Influence when you want the AI to surprise you** — it's the fastest lever for happy accidents.
+- Push **both sliders to their extremes** only deliberately: high Weirdness + low Style Influence is a genuine wild card, not a fine-tuning move.
+
+**Audio Influence interactions** (upload/cover flows):
+
+- **High Audio Influence + Low Weirdness** — output tracks the reference closely. Safest for faithful covers and consistency.
+- **High Audio Influence + High Weirdness** — a tug-of-war: the upload pulls toward the source while Weirdness pushes away. This can yield striking reinterpretations, but also incoherent or muddy results. Move one slider at a time and audition carefully.
+- **High Audio Influence + High Style Influence** — two "adherence" pulls competing. If the reference audio and the style prompt describe *different* things, they fight — decide which is your source of truth and relax the other.
+
+---
+
+## Sliders vs. Style Prompt
+
+The single most useful habit: diagnose whether a bad result is a **prompt problem** or a **slider problem** before you touch anything.
+
+- The **style prompt** decides *what* the track is — genre, instruments, mood, tempo, vocal identity. A slider can't add a banjo, fix a mispronunciation, or change the tempo.
+- The **sliders** decide *how strictly* Suno commits to that prompt and *how far* it may wander. They're fine-tuning, not a rescue for a vague or wrong prompt.
+
+**Change the prompt when** the output has the wrong genre, wrong instruments, wrong mood or tempo, a missing element, or the vocal character is off. No slider fixes content. (Keep the prompt to 4–7 descriptors — a bloated prompt won't be rescued by sliders either; see [Keep It Simple](v5-best-practices.md#prompt-construction).)
+
+**Adjust a slider when** the prompt is already right but the *interpretation* is off:
+
+| Symptom | First move |
+|---------|-----------|
+| Output is generic / too safe | Raise Weirdness a little, **or** lower Style Influence a little (one at a time) |
+| Output drifts off-genre / ignores tags | Raise Style Influence; if still off, sharpen the genre tag in the prompt |
+| Output is chaotic / incoherent | Lower Weirdness; keep Style Influence mid–high |
+| Result feels rigid / wooden | Lower Style Influence slightly, **or** simplify the prompt |
+| Wrong instruments, mood, or tempo | Change the prompt — not a slider issue |
+| Mispronunciation / wrong words | Fix lyrics + pronunciation — not a slider issue |
+| Cover doesn't resemble the source | Raise Audio Influence |
+| Cover too close, want more transformation | Lower Audio Influence and/or raise Weirdness |
+
+**Golden rule — change one thing at a time.** Adjusting a slider *and* rewriting the prompt in the same pass makes it impossible to know which move helped (this mirrors the "adjust one element at a time" advice in [Iteration Tips](v5-best-practices.md#iteration-tips)).
+
+---
+
+## Quick Workflow
+
+1. **Write a clear prompt first** — 4–7 descriptors, genre + instruments + mood + vocal.
+2. **Generate at the default slider positions.** Don't pre-adjust blind.
+3. **Listen, then diagnose** — is this a prompt problem or a slider problem? (Use the table above.)
+4. **If it's a slider problem, move ONE slider a small step** and regenerate.
+5. **Log every attempt** — note the slider value and what changed, so you can reproduce the keeper.
+
+---
+
+## Related Skills
+
+- **`/bitwize-music:suno-engineer`** — Technical Suno V5 prompting expert
+  - Chooses slider settings alongside the style prompt
+  - Diagnoses prompt-vs-slider issues on regeneration
+  - Uses this guide as reference
+
+- **`/bitwize-music:lyric-reviewer`** — Pre-generation QC gate
+  - Confirms the prompt is ready before slider tuning matters
+
+## See Also
+
+- **`/reference/suno/v5-best-practices.md`** — Full V5 prompting guide; the [Creative Sliders](v5-best-practices.md#creative-sliders) section this file expands, plus [Genre-Specific Tips](v5-best-practices.md#genre-specific-tips) and [Known V5 Limitations](v5-best-practices.md#known-v5-limitations)
+- **`/reference/suno/tips-and-tricks.md`** — Operational troubleshooting; Personas and Style Influence interaction
+- **`/reference/suno/genre-list.md`** — 500+ genre tags to pin down the genre before tuning sliders
+- **`/reference/suno/README.md`** — API parameter table (`styleWeight`, `weirdnessConstraint`)

--- a/reference/suno/structure-tags.md
+++ b/reference/suno/structure-tags.md
@@ -2,6 +2,14 @@
 
 Complete reference for song structure tags in Suno lyrics.
 
+> **Suno tag/metatag terminology**: "metatag" gets used loosely — here's the actual taxonomy across this plugin's reference docs:
+> - **Structure tags** (this file) — `[Verse]`, `[Chorus]`, etc. Define song sections. Go in the Lyrics Box.
+> - **Delivery/mood bracket tags** (this file, "Custom Mood/Style Tags" below) — `[Whispered]`, `[Shout]`, etc. Short, standalone Lyrics Box tags that color delivery without defining a section.
+> - **Style Box descriptors** ([voice-tags.md](voice-tags.md), [instrumental-tags.md](instrumental-tags.md)) — comma-separated prose in the Style Box (`gravelly, belting, Southern rock vocal`), not bracket tags. This is how Suno V5 actually wants mood/energy/instrumentation — see the "Keep It Simple" guidance in [v5-best-practices.md](v5-best-practices.md).
+> - **Inline lyrical metatags** ([tips-and-tricks.md](tips-and-tricks.md#vocal-sounds-too-young-despite-maturedeep-descriptors)) — a per-section descriptor prefixed inside the section tag itself, e.g. `[Verse 1: Raspy older female vocal, husky contralto]`. An escalation technique for stubborn vocal-identity issues, not a default pattern.
+>
+> Rule of thumb: structure tags are mandatory every section; delivery bracket tags and inline metatags are optional accents (1-3 max per section — see "Performance Cues" below); mood/energy/instrumentation belongs in Style Box prose, not bracket tags.
+
 ## Basic Structure Tags
 
 ### Intro
@@ -26,12 +34,14 @@ Complete reference for song structure tags in Suno lyrics.
 ```
 [Chorus]
 [Catchy Hook]
+[Hook]
 ```
 
 ### Bridge
 ```
 [Bridge]
 [Pre-Chorus]
+[Post-Chorus]
 ```
 
 ### Instrumental Sections
@@ -47,6 +57,7 @@ Complete reference for song structure tags in Suno lyrics.
 ```
 [Outro]
 [End]
+[Fade In]
 [Fade Out]
 [Fade to End]
 [Big Finish]
@@ -55,7 +66,7 @@ Complete reference for song structure tags in Suno lyrics.
 
 ## Custom Mood/Style Tags
 
-These descriptive tags influence delivery:
+These descriptive tags influence delivery. Use 1-3 per section, same discipline as Performance Cues below — stacking many at once causes the "prompt fatigue" described in [v5-best-practices.md](v5-best-practices.md):
 
 ```
 [Shout]          - Aggressive, shouted delivery
@@ -64,6 +75,12 @@ These descriptive tags influence delivery:
 [Spoken]         - Spoken word, not sung
 [Whispered]      - Quiet, intimate
 [Energetic]      - High energy delivery
+[Aggressive]     - Intense, confrontational delivery
+[Intimate]       - Personal, close, hushed tone
+[Playful]        - Lighthearted, fun energy
+[Triumphant]     - Victorious, anthemic delivery
+[Vulnerable]     - Raw, exposed emotion
+[Haunting]       - Eerie, unsettled mood
 ```
 
 ## Example Song Structure
@@ -195,6 +212,7 @@ V5 improved tag reliability significantly over V4/V4.5. Tags that were inconsist
 
 ### Less Reliable
 - `[Intro]` - Use descriptive alternatives
+- `[Post-Chorus]`, `[Fade In]` - Less field-tested than their established counterparts (`[Pre-Chorus]`, `[Fade Out]`) — test before relying on them
 - Custom tags - Results vary
 
 ## Tips
@@ -226,7 +244,8 @@ V5 improved tag reliability significantly over V4/V4.5. Tags that were inconsist
 
 ## See Also
 
-- **`/reference/suno/v5-best-practices.md`** - Complete Suno V5 prompting guide, style box construction
+- **`/reference/suno/v5-best-practices.md`** - Complete Suno V5 prompting guide, style box construction, Sound Effects/Atmospheric tags
 - **`/reference/suno/pronunciation-guide.md`** - Phonetic spelling and pronunciation fixes for lyrics
-- **`/reference/suno/voice-tags.md`** - Vocal style descriptors and manipulation tags
+- **`/reference/suno/voice-tags.md`** - Vocal style descriptors, Duet pattern, Production/Vocal FX descriptors
+- **`/reference/suno/tips-and-tricks.md`** - Inline lyrical metatags for stubborn vocal-identity issues
 - **`/skills/lyric-writer/SKILL.md`** - Complete lyric writing workflow and standards

--- a/reference/suno/v5-best-practices.md
+++ b/reference/suno/v5-best-practices.md
@@ -287,12 +287,25 @@ Then suddenly [laughter] breaks the silence
 ```
 
 **Common Effects**:
+
+**Human:**
 - `[laughter]` - Natural laughing
 - `[screaming]` - Vocal scream
 - `[whisper]` - Whispered delivery
-- `[echo]` - Echo/reverb effect
+- `[sigh]` - Breathing out, reflective
+- `[gasp]` - Sharp intake of breath
+- `[cough]` - Clearing throat, realistic aside
+
+**Crowd:**
 - `[crowd]` - Crowd noise
 - `[applause]` - Clapping/applause
+- `[cheering]` - Crowd excitement
+
+**Mechanical/transition:**
+- `[echo]` - Echo/reverb effect
+- `[phone ringing]` - Telephone sound, narrative device
+- `[static]` - Radio noise, transition
+- `[record scratch]` - DJ/hip-hop transition marker
 
 **Note**: Effects work best when placed mid-line, not as standalone lines
 

--- a/reference/suno/v5-best-practices.md
+++ b/reference/suno/v5-best-practices.md
@@ -392,6 +392,8 @@ V5 includes sliders in the generation interface that affect output:
 - High Weirdness + specific genre tag = interesting results within a genre
 - Low Style Influence is useful when you want the AI to surprise you
 
+> **Deep dive**: [creative-sliders.md](creative-sliders.md) — per-slider behavior, genre starting ranges, interaction effects, and when to move a slider vs. rewrite the prompt.
+
 ---
 
 ## Voices & Custom Models
@@ -658,6 +660,7 @@ crisp, warm, bright, deep, spacious
 
 ## See Also
 
+- **`/reference/suno/creative-sliders.md`** - Weirdness / Style Influence / Audio Influence deep dive: genre starting ranges, interaction effects, slider-vs-prompt
 - **`/reference/suno/pronunciation-guide.md`** - Phonetic spelling, homographs, pronunciation fixes
 - **`/reference/suno/structure-tags.md`** - Complete list of section tags ([Verse], [Chorus], etc.)
 - **`/reference/suno/genre-list.md`** - 500+ genre tags for style prompts

--- a/reference/suno/voice-tags.md
+++ b/reference/suno/voice-tags.md
@@ -163,7 +163,7 @@ chorus slightly wider and warmer with gentle vibrato on sustained notes;
 bridge raw and exposed, single-take feel.
 ```
 
-This lets you create an **emotional arc** across the song rather than a flat vocal performance throughout.
+This lets you create an **emotional arc** across the song rather than a flat vocal performance throughout. This Style-Box "Performance:" method and per-section **Performance Cues** in the Lyrics Box ([structure-tags.md](structure-tags.md) § Performance Cues, e.g. `[Verse 1 - quiet, intimate]`) are two routes to the same arc — pick one per track rather than splitting it across both.
 
 ## Advanced Vocal Workflow
 

--- a/reference/suno/voice-tags.md
+++ b/reference/suno/voice-tags.md
@@ -60,6 +60,36 @@ Control how the voice interacts with the mix:
 | `Liquid-like` | Flowing, fluid |
 | `Breathy exhale` | Airy, exhaled quality |
 
+## Production/Vocal FX Descriptors
+
+Style Box prose describing how the vocal is processed (not bracket tags — comma-separate with other descriptors, same as Vocal Style/Texture tags above):
+
+| Descriptor | Effect |
+|-----------|--------|
+| `Reverb` / `spacious reverb` | Echoing, roomy sound — ballads, ambient |
+| `Delay` / `slapback delay` | Repeated echoes — dub, experimental |
+| `Auto-tuned` | Pitch-corrected, modern pop/trap effect |
+| `No autotune` / `natural pitch` | Organic, unprocessed vocal — see [Negative Prompting](v5-best-practices.md#negative-prompting) |
+| `Vocoded` / `vocoder` | Robotic, electronic processing |
+| `Distorted vocals` | Gritty, overdriven — rock, industrial |
+| `Filtered` / `telephone effect` | Narrow-band, lo-fi/vintage transition sound |
+
+**Note**: To exclude one of these instead, use the Style Box's negative-prompting pattern (`no autotune`, `no heavy reverb`) rather than a separate field — see [v5-best-practices.md § Negative Prompting](v5-best-practices.md#negative-prompting).
+
+## Duet / Call-and-Response
+
+For two-character dialogue, duets, or call-and-response sections, alternate section tags per character in the Lyrics Box:
+
+```
+[Verse - Character A]
+First character's lyrics
+
+[Verse - Character B]
+Second character's lyrics
+```
+
+Mention the arrangement explicitly in the Style Box so Suno knows to generate two distinct voices: `Dual vocalists, male and female, trading verses`. For a chorus where both characters sing together, describe it directly in the Style Box rather than inventing a bracket tag: `duet chorus, blended male/female harmony`.
+
 ## Regional Vocal Styles
 
 Add geographic/cultural flavor:

--- a/reference/workflows/covers-and-personas.md
+++ b/reference/workflows/covers-and-personas.md
@@ -1,0 +1,138 @@
+# Covers and Personas
+
+Two Suno features let you carry work forward instead of starting every track from a blank prompt:
+
+- **Personas** save a generated song's vocal identity so the *same singer* can appear across many different songs.
+- **Covers** reimagine an *existing* song or sample in a new style or genre, keeping the underlying song while changing the production.
+
+This is the workflow companion. For the underlying feature reference — creation steps, best practices, and limits — see [Personas](../suno/v5-best-practices.md#personas) and [Personas for Vocal Consistency](../suno/tips-and-tricks.md#personas-for-vocal-consistency); this guide points to that material rather than repeating it.
+
+> **Plan note**: Personas and Voices are **Pro/Premier** features. Covers are the **Cover** action in the Suno editor, applied to uploaded audio or a prior generation.
+
+---
+
+## When to Use What
+
+| You want to… | Reach for | Notes |
+|--------------|-----------|-------|
+| Write a brand-new song from lyrics + a style prompt | **Original generation** | The default for most album tracks. |
+| Keep the *same singer* across several different songs | **Persona** | Save one good vocal, reuse it. Pro/Premier. |
+| Reinterpret an *existing* song or sample in a new style/genre | **Cover** | Keeps the song, changes the production. |
+| Sing a track in *your own real voice* | **Voices** (voice cloning) | V5.5, Pro/Premier. An alternative to a Persona — pick one, not both (see [Voices & Custom Models](../suno/v5-best-practices.md#voices--custom-models)). |
+| A consistent voice *and* genre variety across the album | **Persona + Cover** | The Persona holds the voice; the Cover shifts the genre. |
+
+---
+
+## Personas: A Reusable Vocal Identity
+
+A Persona is the most reliable way to keep one voice consistent across an album. Full reference: [Personas](../suno/v5-best-practices.md#personas).
+
+### Creating a Persona
+
+1. Generate a song until the vocal is one you'd happily hear again on other tracks.
+2. From the song's menu, save its vocal identity as a Persona.
+3. Apply the Persona when generating new songs — it carries the vocal character.
+4. Keep the Style Box simple (one or two genres) when a Persona is active; the Persona handles the voice, so you don't re-describe it.
+
+### Using a Persona Across an Album
+
+- A Persona locks a specific AI singer **independent of musical style** — you can move it across genres (the same singer doing a folk track and an electronic track).
+- Personas run **dominant** in the mix. If the Style Box fights the Persona, the Persona usually wins — work with it, not against it.
+- **Limits**: 200 songs with Personas are included per billing cycle, then 10 credits per song.
+- The December 2025 update made Personas more dominant. If a result sounds overprocessed, simplify the Style Box or lower Style Influence.
+
+### Persona (feature) vs the README "persona" field
+
+This project also records an album's voice as a plain-text **persona** description in the album README — e.g. `Male baritone, gravelly, introspective, folk storyteller` (see [terminology.md](../terminology.md)). That description is the *plan*; a Suno Persona is the *saved artifact* that enforces it. Write the description first, generate a track that matches it, then save that track as the Suno Persona so every later track inherits the same voice.
+
+---
+
+## Covers: Reimagining an Existing Song
+
+A Cover reinterprets an existing track in a different style or genre (see [terminology.md](../terminology.md)) — for example, covering a folk song as electronic.
+
+### What a Cover Keeps and Changes
+
+- **Keeps** the underlying song — its topline melody and structure.
+- **Changes** the production: genre, instrumentation, tempo feel, era.
+- To change the *words*, use **Extend** or a fresh generation instead — a Cover restyles, it doesn't rewrite. See [Working with Splice Samples](../suno/tips-and-tricks.md#working-with-splice-samples) for the Extend-vs-Cover split.
+
+### When to Reach for a Cover
+
+- You have an acoustic demo or a [Splice](../suno/tips-and-tricks.md#working-with-splice-samples) sample you want rendered as a full production.
+- You want a second version of a track in a contrasting genre (an album cut plus, say, an electronic remix).
+- You're genre-bending — layering new styles onto a song you already like.
+
+### Setting Up a Cover Track
+
+**From an uploaded sample:**
+
+1. Upload the sample (e.g. from Splice).
+2. Choose the **Cover** action to reinterpret it in a new style. (Choose **Extend** instead if you want to add or replace lyrics.)
+3. Set the destination genre/mood in the Style Box — describe the *new* target style, not the original.
+4. Adjust **Audio Influence** — higher lets the uploaded audio shape the output more (closer to the source), lower gives Suno more freedom. The slider appears only when audio is uploaded (see [Creative Sliders](../suno/v5-best-practices.md#creative-sliders)).
+5. Optionally pull stems afterward and drop unwanted parts.
+
+**From a prior generation:**
+
+1. Open a song you already generated.
+2. Choose **Cover** and set the new target genre/style in the Style Box.
+3. Generate and pick the best take.
+
+**Rights note**: Covering your own generations or cleared samples is clean. Covering someone else's copyrighted recording is a rights question like any release — keep to material you have the rights to.
+
+---
+
+## Covers + Personas: Genre-Bending with One Voice
+
+Combining the two is a powerful remixing technique — full notes at [Combining Personas with Covers](../suno/tips-and-tricks.md#combining-personas-with-covers).
+
+1. Generate a song with a Persona applied.
+2. Use **Cover** to transform it into a different genre.
+3. The Persona's vocal identity carries through the genre shift.
+4. Layer multiple Covers for complex genre-bending results.
+
+**Caveat**: Because the December 2025 update made Personas more dominant, a Cover built on a Persona can come back overprocessed. If it does, simplify the Style Box or lower Style Influence.
+
+---
+
+## Covers vs Original Generation: Choosing
+
+- **Start from original generation** whenever the song doesn't exist yet. It gives Suno the most room and is the cleanest path to a strong first take — the default for album tracks.
+- **Switch to a Cover** only when you already have audio (a sample or a prior generation) whose *song* you want to keep but whose *style* you want to change. If you'd end up rewriting the lyrics or melody anyway, a fresh generation is usually faster than fighting a Cover.
+- **Reach for a Persona** (with or without a Cover) when the thing you need to hold constant is the *voice*, not the song.
+
+---
+
+## Track File Setup
+
+The track template has an optional **Cover / Persona Setup** block (in `templates/track.md`) for recording the original-song reference, the Persona in use, and cover-specific style notes. Fill it in for cover or persona tracks; delete the block for standard original-generation tracks — it does not affect the normal writing flow.
+
+---
+
+## Checklists
+
+**Before saving a Persona:**
+
+- [ ] The source generation's vocal is one you'd happily hear across the album
+- [ ] The Style Box was simple enough that you're capturing the voice, not the arrangement
+
+**Before generating a Cover:**
+
+- [ ] The source audio is something you have the rights to (your own generation or a cleared sample)
+- [ ] The Style Box describes the NEW target style, not the original
+- [ ] Audio Influence is set intentionally (higher hews closer to the source)
+- [ ] If a Persona is also applied, the Style Box is kept simple so the Persona isn't fighting the prompt
+
+---
+
+## See Also
+
+- [Personas — v5-best-practices.md](../suno/v5-best-practices.md#personas) — feature reference, best practices, limits
+- [Personas for Vocal Consistency — tips-and-tricks.md](../suno/tips-and-tricks.md#personas-for-vocal-consistency) — quick workflow and the Covers combo
+- [Combining Personas with Covers — tips-and-tricks.md](../suno/tips-and-tricks.md#combining-personas-with-covers)
+- [Working with Splice Samples — tips-and-tricks.md](../suno/tips-and-tricks.md#working-with-splice-samples) — Cover vs Extend on uploads
+- [Voices & Custom Models — v5-best-practices.md](../suno/v5-best-practices.md#voices--custom-models) — voice cloning, the alternative to a Persona
+- [Creative Sliders — v5-best-practices.md](../suno/v5-best-practices.md#creative-sliders) — Audio Influence and Style Influence
+- [terminology.md](../terminology.md) — Cover, Persona, Voice Tags definitions
+- [Importing Audio Files](importing-audio.md) — moving finished WAVs into the album

--- a/reference/workflows/error-recovery.md
+++ b/reference/workflows/error-recovery.md
@@ -223,6 +223,109 @@ This document covers edge cases and recovery procedures for common workflow issu
 
 ---
 
+## 13. State Cache Corrupted or Stale
+
+**Symptoms**: Albums missing from `list_albums`/`find_album`, wrong statuses or titles after a manual file edit, MCP tools return "Run rebuild_state first", `diagnose` reports state_cache "Cannot parse state.json", or `album_collisions` looks stale.
+
+**Prevention**: Prefer MCP tools (which write the cache atomically) over hand-editing files. Never edit `~/.bitwize-music/cache/state.json` directly — it's a derived cache, not source data. The cache auto-reloads when `state.json` or `config.yaml` mtime changes and auto-rebuilds on a schema-version bump.
+
+**Recovery Steps**:
+1. Run `diagnose` (or `health_check`) and read the `state_cache` check to confirm the cache is the problem
+2. Run the `rebuild_state` MCP tool to regenerate `state.json` from the markdown files on disk
+3. If the rebuild reports `collision_count` > 0, resolve the slug collision (rename one album with `/bitwize-music:rename` or move its directory), then `rebuild_state` again
+4. If `state.json` is unparseable and rebuild still fails, delete `~/.bitwize-music/cache/state.json` and run `rebuild_state` (it recreates the file from scratch)
+5. Verify with `list_albums` that albums and statuses match reality
+
+**Note on auto-recovery (#383/#381/#398)**: When a `rename`/move operation returns `cache_rebuilt: true`, the server already detected a cache divergence and rebuilt from disk for you — no action needed. If it instead returns a `warning` telling you to run `rebuild_state`, the automatic recovery failed and you must run it manually before trusting album lookups.
+
+**When to Delete vs Revert**: `state.json` is a rebuildable cache — always safe to delete and rebuild. Never delete the markdown files it's built from.
+
+---
+
+## 14. Mastering Pipeline Failed Mid-Run
+
+**Symptoms**: Mastering crashed or was interrupted partway. `mastered/` (or `polished/`, `mastering_samples/`) holds partial, zero-byte, or wrong-count WAVs. Some tracks mastered, others not.
+
+**Prevention**: Always run the mastering dry-run/preview first (see [mastering-workflow.md](../mastering/mastering-workflow.md)). Never master over `originals/` — the pipeline reads from originals and writes to `mastered/`.
+
+**Recovery Steps**:
+1. Run `reset_mastering` with `dry_run=True` (the default) to see exactly what's in `mastered/` and how much would be removed
+2. Once the report looks right, re-run with `dry_run=False` to delete the partial output. Add `subfolders: ["mastered", "polished", "mastering_samples"]` if the polish or sample folders are also partial
+3. `originals/` and `stems/` are protected — `reset_mastering` refuses to touch them, so your source audio is safe
+4. Confirm `originals/` still holds the unmastered WAVs, then re-run mastering from a clean slate
+5. If only a few tracks failed, re-master just those instead of resetting the whole folder
+
+**When to Delete vs Revert**: Delete partial mastered output via `reset_mastering`, never by hand (hand-deletion risks the protected `originals/`/`stems/`). Keep originals always.
+
+---
+
+## 15. Malformed Track or Album Markdown
+
+**Symptoms**: A track or album is missing from `list_albums`/`get_track`, shows blank or wrong fields, or `rebuild_state` skips it. Frontmatter YAML won't parse (unquoted colon, bad indentation, missing closing `---`), or required sections/fields are absent.
+
+**Prevention**: Edit track/album files through the skills (`/bitwize-music:import-track`, status via `update_track_field`) rather than hand-editing frontmatter. Keep both `---` fences and start from the templates in `{plugin_root}/templates/`.
+
+**Recovery Steps**:
+1. Run `/bitwize-music:validate-album <album-name>` to pinpoint the broken file and the missing or invalid fields
+2. Open the flagged markdown and fix the structure: matching `---` frontmatter fences top and bottom, valid YAML (quote any value containing `:`), and a valid `title`. Note the parser reads `Status` from the **Track Details** table, *not* frontmatter, and derives the track number from the file's zero-padded name prefix (`01-`, `02-`) rather than any field — repair a wrong status in that table (or via `update_track_field`) and fix ordering by renaming the file, not by editing frontmatter
+3. Compare against a healthy sibling track or the template if unsure of the schema
+4. Run `rebuild_state` so the corrected file is re-indexed
+5. Confirm with `get_track`/`list_albums` that the fields now read correctly
+
+**When to Delete vs Revert**: Never delete the file — fix the frontmatter in place. If a file is hopelessly corrupted, restore it from git (`git checkout HEAD -- path/to/track.md`) rather than recreating it by hand.
+
+---
+
+## 16. Batch Operation Partially Completed
+
+**Symptoms**: A batch action (approving all Generated tracks → Final, or a bulk status update) stopped partway. Some tracks advanced, others still show the old status; the album status didn't advance because one track lagged.
+
+**Prevention**: Batch status changes apply one track at a time — each `update_track_field` call is its own atomic write, so no single file is ever left half-written. Note which tracks you intend to change before starting.
+
+**Recovery Steps**:
+1. Run `list_albums`/`get_track` (or `/bitwize-music:album-dashboard`) to see which tracks were and weren't updated
+2. Re-run the operation only on the tracks that were missed — each write is atomic and idempotent, so re-applying a field that's already set is harmless
+3. If the cache looks out of sync with the files after the partial run, run `rebuild_state`
+4. Confirm the album status advanced once all tracks reached the target level (all `Final` → album `Complete`)
+
+**When to Delete vs Revert**: Nothing to delete — re-apply the remaining updates. Atomic per-track writes mean already-changed tracks are safe; only the un-changed ones need action.
+
+---
+
+## 17. Config Path Resolution Fails (Missing Directories, Broken Symlinks)
+
+**Symptoms**: Skills error that a root path doesn't exist; `diagnose` reports config "does not exist: <path>" or "Missing required config field"; a `content_root`/`audio_root`/`documents_root` points at a deleted directory or a broken symlink; content "vanishes" because its root moved. (Distinct from Scenario 10, where config is correct but files landed in the wrong place.)
+
+**Prevention**: Keep `~/.bitwize-music/config.yaml` pointing at real, existing directories. After moving a content/audio/documents root, update config the same session.
+
+**Recovery Steps**:
+1. Run `diagnose` and read the `config` check — it lists every missing field and every root path that doesn't resolve
+2. If a directory was moved or deleted, recreate/restore it or update the path in `~/.bitwize-music/config.yaml` (use `/bitwize-music:configure` for a guided edit)
+3. For a broken symlink, repoint it at the real target (`ln -sfn <target> <link>`) or replace it with a real directory
+4. Editing `config.yaml` changes its mtime, so the cache reloads automatically; if paths still look wrong, run `rebuild_state`
+5. Re-run `diagnose` to confirm all paths resolve
+
+**When to Delete vs Revert**: Fix or restore directories — don't delete content. Only the config path values change; the album files stay put.
+
+---
+
+## 18. Plugin Corrupted or MCP Server Broken
+
+**Symptoms**: MCP tools unavailable or erroring at session start; `health_check` reports missing or ghost skills; skills you expect don't appear; the `bitwize-music-mcp` server fails to start (import errors, missing venv).
+
+**Prevention**: Install and upgrade via the marketplace (`claude plugin update bitwize-music`) rather than editing the cached plugin. Keep the venv in sync (session-start venv check / `check_venv_health`).
+
+**Recovery Steps**:
+1. If MCP tools are entirely unavailable, the server didn't start — run `/bitwize-music:setup` (or `/bitwize-music:setup mcp`) to detect the Python environment and reinstall dependencies. Quick check: `~/.bitwize-music/venv/bin/python3 -c "import mcp"`
+2. If the server runs but skills are missing/ghost, `health_check` will say so — run `claude plugin update bitwize-music` to refresh the plugin cache, then restart the session
+3. If `health_check` reports skills `no_cache`, the plugin isn't installed via the marketplace — reinstall it (or use `--plugin-dir` for local development)
+4. If the venv is stale or missing (`check_venv_health` → `stale`/`no_venv`), run the reported `pip install -r requirements.txt` fix, or `/bitwize-music:setup` to rebuild the venv
+5. Once tools respond, run `rebuild_state` and `diagnose` to confirm a clean baseline
+
+**When to Delete vs Revert**: Reinstall or refresh the plugin and venv rather than hand-patching cached skill files. Your content lives under the config roots, not in the plugin cache, so a plugin reinstall never touches your albums.
+
+---
+
 ## Emergency Recovery
 
 For major disasters (data loss, corrupted files, accidental mass deletion):

--- a/reference/workflows/song-editor.md
+++ b/reference/workflows/song-editor.md
@@ -1,0 +1,153 @@
+# Suno Song Editor Workflow
+
+The Song Editor lets you fix a generated track section by section — remake, rewrite, extend, reorder, or delete individual parts — without throwing away the whole take. This guide covers *when* to reach for it (versus full regeneration or the mix-engineer polish pass), what each operation is good for, and how section edits fit the download → polish → master pipeline.
+
+> **Related docs**: [v5-best-practices.md#song-editor](../suno/v5-best-practices.md#song-editor) (capability table), [error-recovery.md](error-recovery.md), [importing-audio.md](importing-audio.md), [mastering-workflow.md](../mastering/mastering-workflow.md)
+
+*This guide intentionally does not repeat the operation-by-operation capability table — see [v5-best-practices.md#song-editor](../suno/v5-best-practices.md#song-editor) for that. Here we cover when and why.*
+
+---
+
+## Where Song Editor Lives in the Workflow
+
+Song Editor runs **inside Suno, before you download.** It edits the generation in place. Everything after download — stem extraction, mix polish, mastering — operates on a fixed WAV:
+
+```
+Generate → [Song Editor: remake / rewrite / extend / reorder / delete] → download WAV/stems
+         → import-audio → mix-engineer (polish) → mastering-engineer → release
+```
+
+The single most important rule: **lock the arrangement in Song Editor before you download.** (See [Clip Extension & the Mastering Pipeline](#clip-extension--the-mastering-pipeline) below for why.)
+
+---
+
+## Decision Matrix: Song Editor vs Regeneration vs Polish
+
+When a take isn't right, first ask **what kind of wrong it is** — the answer picks the tool.
+
+| Symptom | Scope | Tool | Why |
+|---------|-------|------|-----|
+| One section off (cracked chorus note, rushed bridge); rest is a keeper | Section | **Song Editor — Remake** | Re-rolls only the bad section; approved sections stay untouched |
+| Wrong words/melody in a section (factual error, weak line, pronunciation) | Section | **Song Editor — Rewrite** | Changes content, keeps the section's role and the rest of the take |
+| Section order or length wrong (bridge should precede final chorus; song runs long) | Arrangement | **Song Editor — Reorder / Delete / Extend** | Restructures without re-rolling performances you like |
+| Whole track wrong: genre, tempo, mood, overall vibe | Whole track | **Full regeneration** | A global problem needs a new take; per-section edits can't fix the foundation |
+| You changed the Style Box or rewrote most of the lyrics | Whole track | **Full regeneration** | The generation no longer matches its inputs |
+| Performance & words are right, but audio is noisy / muddy / harsh / clicky | Audio quality | **mix-engineer polish** | Not a content problem — clean the stems; no Suno credits, no re-roll |
+
+Two rules of thumb:
+
+- **Localized problem, keeper take → Song Editor.** It preserves everything you've already approved and re-rolls only what you point at. Reach for it *before* full regeneration whenever the rest of the take is worth keeping — full regeneration is non-deterministic and can lose the good parts.
+- **Audio-quality-only problem → polish, not regeneration.** If the notes and words are right and only the *sound* is off, Song Editor and regeneration are the wrong tools — they re-roll the performance and spend credits. Use the [mix-engineer](../../skills/mix-engineer/SKILL.md) pass instead: it processes stems, changes no content, and costs no Suno credits.
+
+---
+
+## Section Operations & When to Use Them
+
+Definitions live in the [capability table](../suno/v5-best-practices.md#song-editor). Below is *when each operation earns its place* and what to watch for.
+
+### Remake — same prompt, new take of one section
+
+**Use it when** a single section is the only weak spot in an otherwise-keeper take: a chorus vocal cracked, one verse drifted off-genre, the bridge felt rushed. Remake rolls the dice on just that region and locks the rest.
+
+**Watch for**: the remade section can land at a slightly different timbre or level than its neighbors. Audition the seams. Mastering's whole-track normalization blends minor differences later, but an obvious tonal jump is better fixed with another remake *before* download.
+
+### Rewrite — new lyrics/melody, same role
+
+**Use it when** the content of a section is wrong but its slot in the arrangement is right: a factual error in a documentary verse, a weak line you tightened with [lyric-writer](../../skills/lyric-writer/SKILL.md), a hook that isn't landing, or a pronunciation fix that needs fresh audio for just that section.
+
+**Do first**: run the fix through lyric-writer and the pronunciation-specialist so you rewrite once, not three times.
+
+**Watch for**: keep the section's structural role. Rewriting a pre-chorus into a second verse breaks the song's shape — that's a job for full regeneration, not a section rewrite. And **update the track file** (see [Keep the Track File in Sync](#keep-the-track-file-in-sync)).
+
+### Extend — append bars at a section's tail
+
+**Use it when** a section ends too abruptly or a transition needs room: 1–2 bars into or out of a chorus for a smoother hand-off, an outro that needs to breathe, a longer intro runway.
+
+**Watch for**: the documented **2–3 extensions max per song** ceiling — over-extending causes uneven lyrics, weaker vocals, and quality drops. Extension also changes total track length, which has pipeline consequences (see below).
+
+### Reorder — move sections in the arrangement
+
+**Use it when** the running order plays better rearranged: the bridge lands harder right before the final chorus, or two verses swap for a stronger narrative order. As with Delete, the engine bridges the newly-adjacent sections.
+
+**Watch for**: continuity. On documentary/story albums, reordering can scramble chronology or break a callback set up earlier. Re-read the full lyric flow after reordering, and sync the track file's lyric order to match.
+
+### Delete — remove a weak section
+
+**Use it when** the song is stronger without a part: a redundant "twin verse," a dead instrumental stretch, a second bridge that adds nothing, or trimming length (Suno quality [degrades past ~6–7 minutes](../suno/v5-best-practices.md#known-v5-limitations)). The engine smooths the transition.
+
+**Watch for**: two things. Deleting can pull the track under its **Target Duration** — check against the album/track duration target. And on documentary tracks, deleting a verse may drop a *sourced* fact — make sure nothing load-bearing (or cited) leaves with it.
+
+### Keep the Track File in Sync
+
+Song Editor changes the **audio**, not the **markdown.** After any Rewrite, Reorder, or Delete, update the track file's lyrics (and their order) and add a Generation Log row noting the edit. A track file whose lyrics don't match the audio is the same hazard [error-recovery.md](error-recovery.md#5-lyrics-mistake-after-generation) warns about — and on source-based albums it breaks the audit trail between lyrics and verified sources.
+
+---
+
+## Clip Extension & the Mastering Pipeline
+
+Everything downstream of Suno — stem extraction, [mix polish](../../skills/mix-engineer/SKILL.md), and [mastering](../mastering/mastering-workflow.md) — runs on the **downloaded WAV.** Song Editor runs *upstream* of that. So:
+
+**Finalize every Song Editor edit before you download, extract stems, polish, or master.**
+
+Why it matters:
+
+- **Any section edit changes the source audio.** Extend appends bars (longer track, new tail); Rewrite and Remake replace audio inside a section; Reorder and Delete change what's where. Once you've downloaded and started polishing or mastering, going back into Song Editor produces a *new* WAV — the stems you extracted are stale, and the polish/master you ran no longer applies. You re-run the whole downstream pipeline for that track.
+- **Master the finished track as one unit — never section by section.** Mastering normalizes the full track to **-14 LUFS / -1.0 dBTP** with under 1 dB of variation across the album (see [mastering-workflow.md](../mastering/mastering-workflow.md)). A remade or extended section is still raw Suno output at Suno's [pre-mastering loudness](../suno/v5-best-practices.md#suno-output-loudness-pre-mastering) (e.g., pop/EDM around -9 to -7 LUFS) — it is *not* mastered just because the surrounding track was. Send the whole, arrangement-locked track through mastering once so loudness and limiting stay consistent across the seams.
+- **Fix gross seams in Suno, not in the master.** The mix-engineer's per-stem processing and mastering's whole-track normalization blend *minor* level/timbre differences between an edited section and its neighbors. A jarring mismatch, though, should be re-rolled with another Remake before download — mastering evens loudness, it doesn't rebuild a performance.
+
+Practical gate: a track isn't ready for `import-audio` until its arrangement is locked. Add **"all Song Editor edits final?"** to your pre-download check alongside the "Before Mastering" list in [error-recovery.md](error-recovery.md#prevention-checklist).
+
+---
+
+## Integration with the Regeneration Workflow
+
+CLAUDE.md's [Regeneration Workflow](../../CLAUDE.md#regeneration-workflow) is the spine for handling a rejected `Generated` track. Song Editor slots into it as a lower-risk fourth path — usually the right first move when the problem is *localized.*
+
+The four steps are unchanged; Song Editor mainly expands **Step 2 (decide the fix path):**
+
+| Rejection reason | Fix path |
+|------------------|----------|
+| Whole track wrong (genre, tempo, mood) | Revise Style Box via suno-engineer → **full regenerate** |
+| Wrong words / pronunciation in one or a few sections | Fix via lyric-writer + pronunciation-specialist → **Song Editor Rewrite** on those sections |
+| One flubbed section, take otherwise a keeper (Suno non-determinism) | **Song Editor Remake** on that section |
+| Order or length wrong | **Song Editor Reorder / Delete / Extend** |
+| Words & performance right, only the audio quality is off | **mix-engineer polish** (not a regeneration) |
+
+The rest of the workflow carries over exactly:
+
+- **Step 1 — Log the rejection.** A Song Editor edit is still an attempt: note the reason, then log which section and operation you used.
+- **Step 3 — Regenerate / log the new attempt.** Add a Generation Log row for the edit the same way you would for a full regeneration.
+- **Step 4 — When satisfied.** Mark the keeper with ✓ in the Rating column and advance Status to `Final`.
+- **Status stays `Generated`.** Section edits never move status backward, exactly like full regeneration. A track is `Final` only once it has a ✓. (See [status-tracking.md](status-tracking.md).)
+
+**Rule of thumb**: when the rest of the take is a keeper, reach for Song Editor before full regeneration. Full regeneration discards approved sections and re-rolls the dice; Song Editor keeps what works and re-rolls only what you point at.
+
+---
+
+## Quick Checklist
+
+Before a Song Editor pass:
+
+- [ ] Confirm the problem is *localized* (section-level), not global — global → full regenerate
+- [ ] Confirm it's a *content/performance* problem, not audio quality — audio-only → mix-engineer polish
+- [ ] For Rewrite: run lyric-writer + pronunciation-specialist first
+
+After a Song Editor pass:
+
+- [ ] Audition the seams between edited and untouched sections
+- [ ] Update the track file's lyrics/order to match the new audio (Rewrite/Reorder/Delete)
+- [ ] Add a Generation Log row noting the section + operation
+- [ ] Confirm total extensions stay within the 2–3 ceiling
+- [ ] Arrangement locked before download → import-audio → polish → master
+
+---
+
+## See Also
+
+- [v5-best-practices.md#song-editor](../suno/v5-best-practices.md#song-editor) — capability table (Remake / Rewrite / Extend / Reorder / Delete)
+- [tips-and-tricks.md#song-editor-v5](../suno/tips-and-tricks.md#song-editor-v5) — quick-reference tips
+- [CLAUDE.md#regeneration-workflow](../../CLAUDE.md#regeneration-workflow) — rejected-track decision spine
+- [mix-engineer skill](../../skills/mix-engineer/SKILL.md) — stem polish (the audio-quality path)
+- [mastering-workflow.md](../mastering/mastering-workflow.md) — loudness normalization and limiting
+- [importing-audio.md](importing-audio.md) — moving the downloaded WAV into place
+- [error-recovery.md](error-recovery.md) — recovery procedures for lyric/audio mismatches

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -6,6 +6,8 @@ module's ``register()`` function is called.
 
 from __future__ import annotations
 
+import functools
+import inspect
 import json
 import math
 import re
@@ -167,6 +169,59 @@ def _safe_json(data: Any) -> str:
         # circular reference trips it here rather than as the ValueError that
         # json.dumps would otherwise raise. Catch it to keep the no-crash contract.
         return json.dumps({"error": f"JSON serialization failed: {e}"})
+
+
+def _json_error_boundary(fn: Any) -> Any:
+    """Wrap an MCP tool handler so a ValueError becomes a structured JSON error.
+
+    Many handlers normalize a user-supplied slug via _normalize_slug, which
+    raises ValueError on path separators / null bytes / traversal. Handlers
+    that call it directly (rather than through the guarded _find_album_or_error
+    / _resolve_audio_dir / _find_track_or_error helpers) would otherwise let
+    that ValueError escape to the MCP layer as an opaque tool error. This
+    boundary, installed once at registration, guarantees every tool — current
+    and future — returns clean JSON instead (#443).
+
+    Only ValueError is caught: it is the documented slug-validation signal.
+    Unexpected exceptions still propagate so real bugs are not masked.
+    """
+    if inspect.iscoroutinefunction(fn):
+        @functools.wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await fn(*args, **kwargs)
+            except ValueError as exc:
+                return _safe_json({"error": str(exc)})
+        return async_wrapper
+
+    @functools.wraps(fn)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except ValueError as exc:
+            return _safe_json({"error": str(exc)})
+    return sync_wrapper
+
+
+def install_error_boundary(mcp: Any) -> None:
+    """Wrap ``mcp.tool`` so every registered handler gets _json_error_boundary.
+
+    Call once BEFORE the per-module ``register(mcp)`` calls. FastMCP builds
+    each tool's input schema from the handler signature via
+    ``inspect.signature``, which follows ``functools.wraps``' ``__wrapped__``,
+    so the boundary leaves the generated tool schema unchanged (#443).
+    """
+    original_tool = mcp.tool
+
+    def tool(*args: Any, **kwargs: Any) -> Any:
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapping_decorator(fn: Any) -> Any:
+            return decorator(_json_error_boundary(fn))
+
+        return wrapping_decorator
+
+    mcp.tool = tool
 
 
 def _update_frontmatter_block(
@@ -353,10 +408,17 @@ def _find_album_or_error(album_slug: str) -> tuple[str, dict[str, Any] | None, s
 
     If album found: (slug, data, None)
     If not found: (slug, None, error_json_string)
+    If the slug is malformed: (raw_slug, None, error_json_string) — the
+    ValueError _normalize_slug raises on path separators / null bytes /
+    traversal is converted to a structured error so callers never leak it to
+    the MCP layer (#443).
     """
     state = cache.get_state()
     albums = state.get("albums", {})
-    normalized = _normalize_slug(album_slug)
+    try:
+        normalized = _normalize_slug(album_slug)
+    except ValueError as exc:
+        return album_slug, None, _safe_json({"found": False, "error": str(exc)})
     album = albums.get(normalized)
 
     if not album:
@@ -414,8 +476,13 @@ def _find_track_or_error(tracks: dict[str, Any], track_slug: str, album_slug: st
 
     If track found: (matched_slug, track_data, None)
     If not found: (slug, None, error_json_string)
+    If the slug is malformed: (raw_slug, None, error_json_string) — the
+    _normalize_slug ValueError is converted to a structured error (#443).
     """
-    normalized = _normalize_slug(track_slug)
+    try:
+        normalized = _normalize_slug(track_slug)
+    except ValueError as exc:
+        return track_slug, None, _safe_json({"found": False, "error": str(exc)})
     track_data = tracks.get(normalized)
     if track_data:
         return normalized, track_data, None
@@ -450,7 +517,10 @@ def _resolve_audio_dir(album_slug: str, subfolder: str = "") -> tuple[str | None
     artist = config.get("artist_name", "")
     if not audio_root or not artist:
         return _safe_json({"error": "audio_root or artist_name not configured"}), None
-    normalized = _normalize_slug(album_slug)
+    try:
+        normalized = _normalize_slug(album_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)}), None
     albums = state.get("albums", {})
     album_data = albums.get(normalized, {})
     genre = album_data.get("genre", "")

--- a/servers/bitwize-music-server/handlers/_shared.py
+++ b/servers/bitwize-music-server/handlers/_shared.py
@@ -212,6 +212,12 @@ def _update_frontmatter_block(
     except yaml.YAMLError as exc:
         return False, f"Cannot parse frontmatter YAML in {file_path}: {exc}"
 
+    if not isinstance(fm, dict):
+        return False, (
+            f"Frontmatter in {file_path} is not a mapping "
+            f"(got {type(fm).__name__})"
+        )
+
     fm[key] = values
 
     new_fm_text = yaml.dump(

--- a/servers/bitwize-music-server/handlers/database.py
+++ b/servers/bitwize-music-server/handlers/database.py
@@ -283,7 +283,9 @@ async def db_create_tweet(
     Args:
         album_slug: Album slug (e.g., "my-album")
         tweet_text: The post text content
-        track_number: Track number to link (0 = album-level post, no track link)
+        track_number: Track number to link (0 = album-level post, no track
+                      link). Returns an error if the track is not found in
+                      the database — no tweet is created.
         platform: Target platform ("twitter", "instagram", "tiktok",
                   "facebook", "youtube"). Default: "twitter"
         content_type: Post type ("promo", "announcement", "engagement",
@@ -327,8 +329,14 @@ async def db_create_tweet(
                 (album_id, track_number),
             )
             track_row = cur.fetchone()
-            if track_row:
-                track_id = track_row["id"]
+            if not track_row:
+                return _safe_json({
+                    "error": f"Track {track_number} not found for album "
+                             f"'{album_slug}' in database. "
+                             "Use db_sync_album to sync tracks first, or pass "
+                             "track_number=0 for an album-level post.",
+                })
+            track_id = track_row["id"]
 
         cur.execute(
             """INSERT INTO tweets
@@ -643,8 +651,14 @@ async def db_sync_album(album_slug: str) -> str:
     if dep_err:
         return _safe_json({"error": dep_err})
 
-    # Get album from plugin state cache
-    slug, album_data, err = _find_album_or_error(album_slug)
+    # Get album from plugin state cache. _find_album_or_error normalizes the
+    # slug, which raises ValueError on path separators, null bytes, or
+    # traversal sequences — convert that into the structured JSON error all
+    # db_* handlers return instead of letting it escape to the MCP layer (#379).
+    try:
+        slug, album_data, err = _find_album_or_error(album_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
     if err:
         return err
     assert album_data is not None

--- a/servers/bitwize-music-server/handlers/ideas.py
+++ b/servers/bitwize-music-server/handlers/ideas.py
@@ -185,8 +185,17 @@ async def create_idea(
     else:
         text = "# Album Ideas\n\n---\n\n## Ideas\n"
 
-    # Check for duplicate title
-    if f"### {title.strip()}\n" in text:
+    # Check for duplicate title (case-insensitive, matching the readers in
+    # _find_idea_in_state / get_ideas / promote_idea which compare on
+    # ``title.strip().lower()``). Scan every "### <title>" header rather than
+    # doing an exact-case substring match, so "cyberpunk dreams" is rejected
+    # when "Cyberpunk Dreams" already exists (#395).
+    needle = title.strip().lower()
+    existing_titles = {
+        header.strip().lower()
+        for header in re.findall(r'^###\s+(.+?)\s*$', text, re.MULTILINE)
+    }
+    if needle in existing_titles:
         return _safe_json({
             "created": False,
             "error": f"Idea '{title.strip()}' already exists in IDEAS.md",

--- a/servers/bitwize-music-server/handlers/lyrics_analysis.py
+++ b/servers/bitwize-music-server/handlers/lyrics_analysis.py
@@ -322,10 +322,23 @@ def _count_syllables_word(word: str) -> int:
 
 
 def _get_rhyme_tail(word: str) -> str:
-    """Extract rhyme tail from last vowel cluster to end of word.
+    """Derive a spelling-based rhyme key: last vowel nucleus plus coda.
 
-    Strips trailing 's' for plural tolerance before extracting.
-    Examples: "night" -> "ight", "away" -> "ay", "desire" -> "ire"
+    Pure spelling can't recover pronunciation, but the key normalizes the
+    common orthographic variants of a single rhyme sound so that clearly
+    rhyming end words land in the same group (#396):
+
+    - A trailing plural / 3rd-person 's' is dropped ("eye"/"eyes",
+      "cry"/"cries") so inflection doesn't split a rhyme.
+    - The vowel nucleus is capped at two letters (a vowel plus an optional
+      glide). Without this an irregular three-vowel spelling like "eye"
+      keeps its whole "eye" cluster while "cries" yields only "ie"; capping
+      reduces both to the same "ie".
+    - Vowel 'y' is folded to 'i' in the returned tail, so "rhyme"/"rhymes"
+      ("yme") matches "time"/"times" ("ime").
+
+    Examples: "night" -> "ight", "away" -> "ai", "desire" -> "ire",
+    "eyes" -> "ie", "cries" -> "ie", "times" -> "ime", "rhymes" -> "ime".
     """
     if not word:
         return ""
@@ -345,22 +358,23 @@ def _get_rhyme_tail(word: str) -> str:
     if len(word) > 2 and word.endswith("e") and word[-2] not in vowels:
         scan_word = word[:-1]
 
-    # Find last vowel cluster start in scan_word
+    # Find the last vowel cluster, capping the nucleus at two letters (a
+    # vowel plus an optional glide) so irregular multi-vowel spellings such
+    # as "eye" normalize to the same nucleus as a regular "-ie".
     last_vowel_pos = -1
     for i in range(len(scan_word) - 1, -1, -1):
         if scan_word[i] in vowels:
             last_vowel_pos = i
-            # Walk back through consecutive vowels
-            while i > 0 and scan_word[i - 1] in vowels:
-                i -= 1
-                last_vowel_pos = i
+            if i > 0 and scan_word[i - 1] in vowels:
+                last_vowel_pos = i - 1
             break
 
     if last_vowel_pos < 0:
         return word  # No vowels — return whole word
 
-    # Return from vowel position to end of ORIGINAL word
-    return word[last_vowel_pos:]
+    # Return from the nucleus to the end of the (plural-stripped) word,
+    # folding vowel 'y' to 'i' so equivalent spellings share a key.
+    return word[last_vowel_pos:].replace("y", "i")
 
 
 async def count_syllables(text: str) -> str:

--- a/servers/bitwize-music-server/handlers/maintenance.py
+++ b/servers/bitwize-music-server/handlers/maintenance.py
@@ -57,7 +57,10 @@ async def reset_mastering(
                     "originals/ and stems/ are protected.",
         })
 
-    err, audio_dir = _resolve_audio_dir(album_slug)
+    try:
+        err, audio_dir = _resolve_audio_dir(album_slug)
+    except ValueError as exc:
+        return _safe_json({"error": str(exc)})
     if err:
         return err
     assert audio_dir is not None
@@ -190,7 +193,10 @@ async def migrate_audio_layout(
 
     albums = state.get("albums", {})
     if album_slug:
-        normalized = _normalize_slug(album_slug)
+        try:
+            normalized = _normalize_slug(album_slug)
+        except ValueError as exc:
+            return _safe_json({"error": str(exc)})
         if normalized not in albums:
             return _safe_json({"error": f"Album '{album_slug}' not found in state"})
         album_items = [(normalized, albums[normalized])]

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2036,9 +2036,20 @@ async def _stage_layout(ctx: MasterAlbumCtx) -> str | None:
     prior_transitions: list[dict[str, Any]] | None = None
     layout_path = ctx.audio_dir / "LAYOUT.md"
     if layout_path.is_file():
-        prior_transitions = _parse_layout_yaml(
-            layout_path.read_text(encoding="utf-8")
-        )
+        # A corrupt/binary LAYOUT.md (e.g. invalid UTF-8) must not halt the
+        # pipeline: read_text raises UnicodeDecodeError (a ValueError, NOT an
+        # OSError) which would escape the emitter try/except below. Guard the
+        # read separately so a bad prior layout degrades to "no prior
+        # transitions" and is surfaced via warnings, per the stage contract.
+        try:
+            prior_transitions = _parse_layout_yaml(
+                layout_path.read_text(encoding="utf-8")
+            )
+        except (OSError, ValueError) as exc:
+            ctx.warnings.append(
+                f"Layout emitter: could not read prior LAYOUT.md ({exc}); "
+                "regenerating from defaults."
+            )
 
     layout_stage: dict[str, Any] = {
         "status": "pass",

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -2378,18 +2378,38 @@ async def _stage_adm_validation(ctx: MasterAlbumCtx) -> str | None:
     results: list[dict[str, Any]] = []
     encoder_errors: list[str] = []
 
-    for wav in ctx.mastered_files:
-        try:
-            r = await ctx.loop.run_in_executor(
-                None,
-                functools.partial(
-                    _adm_check_fn, wav,
-                    encoder=encoder, ceiling_db=ceiling_db, bitrate_kbps=256,
-                ),
-            )
-            results.append(r)
-        except ADMValidationError as exc:
-            encoder_errors.append(f"{wav.name}: {exc}")
+    # Each track's ADM check spawns two ffmpeg subprocesses (AAC encode + decode)
+    # with a tempdir round-trip; running them serially dominates mastering
+    # wall-clock time, and worsens on retry (#345). Run the per-track checks
+    # concurrently, bounded to CPU count so the CPU-bound ffmpeg encodes don't
+    # oversubscribe the machine. Order is preserved so `results` still lines up
+    # with ctx.mastered_files (encoder_used / markdown depend on it). Only
+    # ADMValidationError is handled here — as in the serial version, any other
+    # exception propagates out of the stage.
+    adm_semaphore = asyncio.Semaphore(max(1, os.cpu_count() or 1))
+
+    async def _check_one(wav: Path) -> tuple[dict[str, Any] | None, str | None]:
+        async with adm_semaphore:
+            try:
+                r = await ctx.loop.run_in_executor(
+                    None,
+                    functools.partial(
+                        _adm_check_fn, wav,
+                        encoder=encoder, ceiling_db=ceiling_db, bitrate_kbps=256,
+                    ),
+                )
+                return r, None
+            except ADMValidationError as exc:
+                return None, f"{wav.name}: {exc}"
+
+    outcomes = await asyncio.gather(
+        *(_check_one(wav) for wav in ctx.mastered_files)
+    )
+    for result, error in outcomes:
+        if error is not None:
+            encoder_errors.append(error)
+        elif result is not None:
+            results.append(result)
 
     ctx.adm_validation_results = results
 

--- a/servers/bitwize-music-server/handlers/processing/_album_stages.py
+++ b/servers/bitwize-music-server/handlers/processing/_album_stages.py
@@ -201,6 +201,45 @@ def _build_notices(ctx: MasterAlbumCtx) -> None:
             )
 
 
+# ---------------------------------------------------------------------------
+# LUFS aggregation helpers (finite-only)
+# ---------------------------------------------------------------------------
+
+def _finite_lufs_aggregates(
+    results: list[dict[str, Any]],
+) -> tuple[float | None, float | None]:
+    """Return (mean, range) of LUFS across ``results``, over finite values only.
+
+    analyze_track returns -inf LUFS for a silent / corrupt track; feeding that
+    into ``np.mean`` / ``max-min`` poisons the aggregate with non-finite values
+    (avg becomes -inf, range becomes inf). That is the same class of bug as
+    #371 in analyze_audio (and #400 here). Aggregate over the finite LUFS
+    readings only, and return ``(None, None)`` when no track has a finite
+    reading, so no inf/-inf reaches ctx.stages or the result payload.
+    """
+    import math
+
+    import numpy as np
+
+    finite = [
+        r["lufs"] for r in results
+        if isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"])
+    ]
+    if not finite:
+        return None, None
+    return float(np.mean(finite)), float(max(finite) - min(finite))
+
+
+def _round_or_none(value: float | None, ndigits: int) -> float | None:
+    """``round()`` that passes ``None`` through instead of raising TypeError.
+
+    _finite_lufs_aggregates returns None when every track is silent/corrupt;
+    the verification and ceiling-guard stages round those aggregates for
+    reporting, so the None must survive rounding as None.
+    """
+    return round(value, ndigits) if value is not None else None
+
+
 # Injectable for test monkeypatching (tests patch this module-level name).
 _adm_check_fn = _adm_check_fn_default
 _embed_wav_metadata_fn = _embed_wav_metadata_fn_default
@@ -367,7 +406,6 @@ async def _stage_analysis(ctx: MasterAlbumCtx) -> str | None:
     """
     import math
 
-    import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
 
     analysis_results = []
@@ -376,21 +414,17 @@ async def _stage_analysis(ctx: MasterAlbumCtx) -> str | None:
         analysis_results.append(result)
 
     # A silent / near-silent track makes analyze_track return -inf LUFS, which
-    # poisons the np.mean / max-min aggregates with non-finite values (the same
-    # class of bug as #371 in analyze_audio). Aggregate over finite LUFS only,
-    # and surface silent tracks so the operator isn't left with null aggregates
+    # poisons the mean / max-min aggregates with non-finite values (the same
+    # class of bug as #371 in analyze_audio, and #400 below). Aggregate over
+    # finite LUFS only via the shared _finite_lufs_aggregates helper, and
+    # surface silent tracks so the operator isn't left with null aggregates
     # under a "pass" status. (Silent tracks are skipped later in
     # _stage_mastering, so no mastering-side action is needed here.)
-    finite_lufs = [
-        r["lufs"] for r in analysis_results
-        if isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"])
-    ]
     silent_tracks = [
         r["filename"] for r in analysis_results
         if not (isinstance(r["lufs"], (int, float)) and math.isfinite(r["lufs"]))
     ]
-    avg_lufs = float(np.mean(finite_lufs)) if finite_lufs else None
-    lufs_range = float(max(finite_lufs) - min(finite_lufs)) if finite_lufs else None
+    avg_lufs, lufs_range = _finite_lufs_aggregates(analysis_results)
     tinny_tracks = [r["filename"] for r in analysis_results if r["tinniness_ratio"] > 0.6]
 
     for t in tinny_tracks:
@@ -830,8 +864,8 @@ def _emit_verification_warn_fallback(
     unrecoverable_map: dict[str, dict[str, Any]],
     auto_recovered: list[dict[str, Any]],
     verify_results: list[dict[str, Any]],
-    verify_avg: float,
-    verify_range: float,
+    verify_avg: float | None,
+    verify_range: float | None,
     effective_lufs: float,
 ) -> None:
     """Write VERIFICATION_WARNINGS.md, update stage status to warn,
@@ -876,8 +910,8 @@ def _emit_verification_warn_fallback(
     )
     ctx.stages["verification"] = {
         "status":               "warn",
-        "avg_lufs":             round(verify_avg, 1),
-        "lufs_range":           round(verify_range, 2),
+        "avg_lufs":             _round_or_none(verify_avg, 1),
+        "lufs_range":           _round_or_none(verify_range, 2),
         "all_within_spec":      False,
         "auto_recovered":       auto_recovered,
         "unrecoverable_tracks": sorted(unrecoverable_map.keys()),
@@ -895,7 +929,6 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
     Sets ctx:  verify_results
     Returns: None on pass (all within spec), failure JSON otherwise.
     """
-    import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
     from tools.mastering.fix_dynamic_track import fix_dynamic
 
@@ -906,9 +939,9 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
         result = await ctx.loop.run_in_executor(None, analyze_track, str(wav))
         verify_results.append(result)
 
-    verify_lufs = [r["lufs"] for r in verify_results]
-    verify_avg = float(np.mean(verify_lufs))
-    verify_range = float(max(verify_lufs) - min(verify_lufs))
+    # Aggregate over finite LUFS only — a silent/corrupt mastered WAV reads
+    # -inf and would otherwise poison avg (→ -inf) and range (→ inf); see #400.
+    verify_avg, verify_range = _finite_lufs_aggregates(verify_results)
     effective_lufs = ctx.effective_lufs
     effective_ceiling = ctx.effective_ceiling
 
@@ -926,7 +959,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
         if issues:
             out_of_spec.append({"filename": r["filename"], "issues": issues})
 
-    album_range_fail = verify_range >= 1.0
+    album_range_fail = verify_range is not None and verify_range >= 1.0
     auto_recovered: list[dict[str, Any]] = []
 
     if out_of_spec or album_range_fail:
@@ -1025,9 +1058,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                         None, analyze_track, str(wav),
                     )
                     verify_results.append(result)
-                verify_lufs = [r["lufs"] for r in verify_results]
-                verify_avg = float(np.mean(verify_lufs))
-                verify_range = float(max(verify_lufs) - min(verify_lufs))
+                verify_avg, verify_range = _finite_lufs_aggregates(verify_results)
                 out_of_spec = []
                 for r in verify_results:
                     issues = []
@@ -1045,7 +1076,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                         out_of_spec.append(
                             {"filename": r["filename"], "issues": issues}
                         )
-                album_range_fail = verify_range >= 1.0
+                album_range_fail = verify_range is not None and verify_range >= 1.0
 
         if out_of_spec or album_range_fail:
             # Pure range failure with no individual out-of-spec tracks —
@@ -1053,13 +1084,13 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
             # detail as before.
             if album_range_fail and not out_of_spec:
                 fail_detail: dict[str, Any] = {
-                    "album_lufs_range":  round(verify_range, 2),
+                    "album_lufs_range":  _round_or_none(verify_range, 2),
                     "album_range_limit": 1.0,
                 }
                 ctx.stages["verification"] = {
                     "status":          "fail",
-                    "avg_lufs":        round(verify_avg, 1),
-                    "lufs_range":      round(verify_range, 2),
+                    "avg_lufs":        _round_or_none(verify_avg, 1),
+                    "lufs_range":      _round_or_none(verify_range, 2),
                     "all_within_spec": False,
                 }
                 return _safe_json({
@@ -1097,7 +1128,7 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                 if halt_eligible_tracks:
                     fail_detail["tracks_out_of_spec"] = halt_eligible_tracks
                 if halt_on_range:
-                    fail_detail["album_lufs_range"] = round(verify_range, 2)
+                    fail_detail["album_lufs_range"] = _round_or_none(verify_range, 2)
                     fail_detail["album_range_limit"] = 1.0
                 if unrecoverable_map:
                     fail_detail["unrecoverable_tracks"] = sorted(
@@ -1105,8 +1136,8 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
                     )
                 ctx.stages["verification"] = {
                     "status":          "fail",
-                    "avg_lufs":        round(verify_avg, 1),
-                    "lufs_range":      round(verify_range, 2),
+                    "avg_lufs":        _round_or_none(verify_avg, 1),
+                    "lufs_range":      _round_or_none(verify_range, 2),
                     "all_within_spec": False,
                 }
                 return _safe_json({
@@ -1135,8 +1166,8 @@ async def _stage_verification(ctx: MasterAlbumCtx) -> str | None:
 
     verification_stage: dict[str, Any] = {
         "status": "pass",
-        "avg_lufs": round(verify_avg, 1),
-        "lufs_range": round(verify_range, 2),
+        "avg_lufs": _round_or_none(verify_avg, 1),
+        "lufs_range": _round_or_none(verify_range, 2),
         "all_within_spec": True,
     }
     if auto_recovered:
@@ -1509,7 +1540,6 @@ async def _stage_ceiling_guard(
         _ceiling_guard_compute_overshoots). Callers that need monkeypatching
         should pass their patched version explicitly.
     """
-    import numpy as np
     from tools.mastering.analyze_tracks import analyze_track
 
     compute_fn = _compute_overshoots if _compute_overshoots is not None else _ceiling_guard_compute_overshoots
@@ -1615,11 +1645,11 @@ async def _stage_ceiling_guard(
             if idx is not None:
                 ctx.verify_results[idx] = fresh
 
-        verify_lufs = [r["lufs"] for r in ctx.verify_results]
-        ctx.stages["verification"]["avg_lufs"] = round(float(np.mean(verify_lufs)), 1)
-        ctx.stages["verification"]["lufs_range"] = round(
-            float(max(verify_lufs) - min(verify_lufs)), 2
-        )
+        # Finite-only recompute — a pulled-down track that reads -inf (silent
+        # or clipped to zero) must not poison the album aggregates (#400).
+        verify_avg, verify_range = _finite_lufs_aggregates(ctx.verify_results)
+        ctx.stages["verification"]["avg_lufs"] = _round_or_none(verify_avg, 1)
+        ctx.stages["verification"]["lufs_range"] = _round_or_none(verify_range, 2)
 
     ctx.stages["ceiling_guard"] = ceiling_stage
     return None

--- a/servers/bitwize-music-server/handlers/processing/mixing.py
+++ b/servers/bitwize-music-server/handlers/processing/mixing.py
@@ -342,18 +342,32 @@ def _build_analyzer(
     ) -> dict[str, Any]:
         result: dict[str, Any] = {"filename": filename, "issues": [], "recommendations": {}}
 
+        # #401: zero-length audio has no samples to reduce — np.max / np.mean
+        # over an empty array raises ValueError, which would abort the whole
+        # analyze/polish run with a raw traceback. Return a structured
+        # per-file error so a single malformed WAV is skipped, not fatal.
+        if len(data) == 0:
+            result["issues"].append("empty_audio")
+            result["error"] = "empty audio: WAV has 0 samples"
+            return result
+
         # Overall metrics
         peak = float(np.max(np.abs(data)))
         rms = float(np.sqrt(np.mean(data ** 2)))
         result["peak"] = peak
         result["rms"] = rms
 
-        # Noise floor estimate (quietest 10% of signal)
+        # Noise floor estimate (quietest 10% of signal). #402: buffers
+        # shorter than 10 samples make the //10 slice empty, and np.mean of
+        # an empty slice is NaN (with a RuntimeWarning). Emit None as a
+        # sentinel instead so the value computes cleanly and serializes to
+        # JSON null rather than the invalid token NaN.
         abs_signal = np.abs(data[:, 0])
         sorted_abs = np.sort(abs_signal)
-        noise_floor = float(np.mean(sorted_abs[:len(sorted_abs) // 10]))
+        quietest = sorted_abs[:len(sorted_abs) // 10]
+        noise_floor = float(np.mean(quietest)) if quietest.size else None
         result["noise_floor"] = noise_floor
-        if noise_floor > 0.005:
+        if noise_floor is not None and noise_floor > 0.005:
             result["issues"].append("elevated_noise_floor")
             result["recommendations"]["noise_reduction"] = min(0.8, noise_floor * 100)
 

--- a/servers/bitwize-music-server/handlers/skills.py
+++ b/servers/bitwize-music-server/handlers/skills.py
@@ -70,7 +70,10 @@ async def get_skill(name: str) -> str:
             "error": "No skills in state cache. Run rebuild_state first.",
         })
 
-    normalized = _normalize_slug(name)
+    try:
+        normalized = _normalize_slug(name)
+    except ValueError as exc:
+        return _safe_json({"found": False, "error": str(exc)})
 
     # Exact match first
     if normalized in items:

--- a/servers/bitwize-music-server/handlers/status.py
+++ b/servers/bitwize-music-server/handlers/status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from pathlib import Path
@@ -506,7 +507,17 @@ async def create_track(
 
     # Fill in placeholders
     album_title = album.get("title", normalized)
-    content = template.replace("[Track Title]", title)
+    # The frontmatter title is a quoted YAML scalar (title: "[Track Title]"),
+    # so it must receive a properly escaped value — a raw replace of a title
+    # containing a double quote would break the YAML and silently drop every
+    # frontmatter field on parse (#403). json.dumps() emits a valid YAML
+    # double-quoted scalar (escapes quotes/backslashes); ensure_ascii=False
+    # keeps non-ASCII readable so the scalar matches the human-readable body
+    # (H1, details table), which still take the raw title.
+    content = template.replace(
+        'title: "[Track Title]"', f"title: {json.dumps(title, ensure_ascii=False)}"
+    )
+    content = content.replace("[Track Title]", title)
     content = content.replace("| **Track #** | XX |", f"| **Track #** | {padded} |")
     content = content.replace("[Album Name](../README.md)", f"[{album_title}](../README.md)")
     content = content.replace("[Character/Perspective]", "—")

--- a/servers/bitwize-music-server/handlers/status.py
+++ b/servers/bitwize-music-server/handlers/status.py
@@ -425,7 +425,7 @@ async def update_album_status(album_slug: str, status: str, force: bool = False)
 
 async def create_track(
     album_slug: str,
-    track_number: str,
+    track_number: str | int,
     title: str,
     documentary: bool = False,
 ) -> str:
@@ -436,7 +436,8 @@ async def create_track(
 
     Args:
         album_slug: Album slug (e.g., "my-album")
-        track_number: Two-digit track number (e.g., "01", "02")
+        track_number: Positive track number as a numeric string or int
+            (e.g., "01", "2", 7). Anything else returns a structured error.
         title: Track title (e.g., "My New Track")
         documentary: Keep source/quote sections (default: strip them)
 
@@ -456,9 +457,29 @@ async def create_track(
     if not tracks_dir.is_dir():
         return _safe_json({"error": f"tracks/ directory not found in {album_path}"})
 
+    # Validate track_number: must be a positive integer, as an int or a
+    # numeric string (#372). Check bool explicitly — it is an int subclass,
+    # so True would otherwise silently become track 01.
+    invalid_track_number = _safe_json({
+        "error": (
+            f"Invalid track_number {track_number!r}: "
+            'must be a positive integer (e.g., "01", "2")'
+        )
+    })
+    if isinstance(track_number, bool) or not isinstance(track_number, (int, str)):
+        return invalid_track_number
+    if isinstance(track_number, str):
+        try:
+            number = int(track_number.strip())
+        except ValueError:
+            return invalid_track_number
+    else:
+        number = track_number
+    if number < 1:
+        return invalid_track_number
+
     # Normalize track number to zero-padded two digits
-    num = track_number.strip().lstrip("0") or "0"
-    padded = num.zfill(2)
+    padded = str(number).zfill(2)
 
     # Build slug from number and title
     title_slug = _normalize_slug(title)
@@ -492,7 +513,7 @@ async def create_track(
     content = content.replace("[Track's role in the album narrative]", "—")
 
     # Fill frontmatter placeholders
-    content = content.replace("track_number: 0", f"track_number: {int(padded)}")
+    content = content.replace("track_number: 0", f"track_number: {number}")
     content = content.replace(
         "explicit: false",
         f"explicit: {'true' if album.get('explicit', False) else 'false'}",

--- a/servers/bitwize-music-server/handlers/streaming.py
+++ b/servers/bitwize-music-server/handlers/streaming.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from pathlib import Path
 from typing import Any
@@ -157,12 +158,15 @@ async def update_streaming_url(album_slug: str, platform: str, url: str) -> str:
         # Match lines like "  soundcloud: ..." or "  apple_music: ..."
         stripped = fm_line.lstrip()
         if stripped.startswith(f"{canonical_platform}:"):
-            # Replace the value, preserving indent
+            # Replace the value, preserving indent. json.dumps emits a valid
+            # YAML double-quoted scalar (quotes included) with any embedded
+            # quotes/backslashes escaped, so a URL containing " or \ can't
+            # corrupt the frontmatter. ensure_ascii=False preserves any raw
+            # non-ASCII char (matching the yaml.dump fallback's allow_unicode)
+            # so it round-trips exactly instead of via a lossy surrogate pair.
+            # json.dumps("") -> '""' handles clearing.
             indent = fm_line[:len(fm_line) - len(stripped)]
-            if url:
-                fm_lines[idx] = f'{indent}{canonical_platform}: "{url}"'
-            else:
-                fm_lines[idx] = f"{indent}{canonical_platform}: \"\""
+            fm_lines[idx] = f"{indent}{canonical_platform}: {json.dumps(url, ensure_ascii=False)}"
             updated = True
             break
 

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -379,6 +379,11 @@ from handlers import (
     text_analysis,
 )
 
+# Wrap mcp.tool so every handler returns a structured JSON error instead of
+# leaking a slug-validation ValueError to the MCP layer (#443). Must run before
+# the per-module register() calls below.
+_shared.install_error_boundary(mcp)
+
 core.register(mcp)
 content.register(mcp)
 text_analysis.register(mcp)

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -67,7 +67,8 @@ Structure your songs with explicit section markers:
 - `[Intro]`, `[Verse]`, `[Chorus]`, `[Pre-Chorus]`, `[Bridge]`, `[Outro]`, `[End]` — see `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` for the full set (including `[Post-Chorus]`, `[Break]`, `[Interlude]`, `[Fade In]`/`[Fade Out]`)
 - V5 uses these to shape arrangement
 - Without tags, structure can be unpredictable
-- **Optional accent**: one delivery/mood bracket tag per section (`[Whispered]`, `[Aggressive]`, etc.) can color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly (1 per section); this is not a substitute for Style Box mood/energy prose.
+- **Default, not optional — Performance Cues**: append 1-3 delivery cues directly to each structure tag (`[Verse 1 - cold, regal, controlled]`, `[Bridge - raw, breaking, desperate]`) — see the same reference's "Performance Cues" section. This is how an emotional arc is carried across a song. Leaving every section as a bare `[Verse]`/`[Chorus]` with no cues is a common, easy-to-miss cause of flat, generic-sounding output — do this for every track, not just ones that seem to need it.
+- **Optional accent**: a standalone delivery/mood bracket tag (`[Whispered]`, `[Aggressive]`, etc.) can additionally color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly (1 per section); this is not a substitute for Style Box mood/energy prose.
 
 ### Vocals First
 In Style Prompt, put vocal description FIRST:
@@ -171,6 +172,8 @@ Chorus lyrics here
 Male baritone, passionate delivery, storytelling vocal. Alternative rock,
 clean electric guitar, driving bassline, tight drums. Modern production, dynamic range.
 ```
+
+**Before finalizing, count every descriptor across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`), so counting commas alone undercounts. V5's sweet spot is 4-7 total; 8+ causes "prompt fatigue" where V5 dilutes or ignores tags (see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Watch for synonym-piles — stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse to 1-2 words per concept (vocal identity, genre, tempo, 2-3 instruments, 1 production note) to keep the total within 4-7. Move section-by-section emotional variation into Performance Cues in the Lyrics Box instead of adding more adjectives here — that is the correct place for an arc, not the Style Box.
 
 ### Exclude Styles (Negative Prompting)
 
@@ -303,12 +306,13 @@ As the Suno engineer, you:
 3. **Check artist persona** - Review saved voice profile (if applicable)
 4. **Select genre** - Choose appropriate genre tags
 5. **Define vocals** - Specify voice type, delivery, energy. Pull a concrete texture/style descriptor from `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` (Vocal Style Tags, Vocal Texture Tags, Production/Vocal FX Descriptors) instead of a generic "male vocal, rock" — e.g. "gravelly, belting" beats "powerful"
-6. **Choose instruments** - Select key instruments and sonic texture. Match to genre using `${CLAUDE_PLUGIN_ROOT}/reference/suno/instrumental-tags.md` § Genre-Specific Instruments (2-4 key instruments, not a full list)
+6. **Choose instruments** - Select key instruments and sonic texture. Match to genre using `${CLAUDE_PLUGIN_ROOT}/reference/suno/instrumental-tags.md` § Genre-Specific Instruments (2-3 key instruments, not a full list — keeps the Style Box total within 4-7)
 7. **Check for sound effects/atmosphere** - If the lyrics reference rain, footsteps, crowds, laughter, or similar, add matching tags per `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Sound Effects / Atmospheric Effects (mention in both Lyrics Box and Style Prompt for atmospheric/environmental sounds)
-8. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed
-9. **Generate in Suno** - Create track with assembled inputs
-10. **Iterate if needed** - Refine based on output quality
-11. **Log results** - Document in Generation Log with rating
+8. **Add Performance Cues** - Append 1-3 delivery cues to each structure tag in the Lyrics Box (`[Verse 1 - cold, regal]`, `[Bridge - raw, breaking]`) so the emotional arc plays out section-by-section, per `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` § Performance Cues — do this by default, not only when a track "seems to need it"
+9. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed, then count comma-separated descriptors and trim to the 4-7 sweet spot (collapse synonym-piles; see § Style Prompt above)
+10. **Generate in Suno** - Create track with assembled inputs
+11. **Iterate if needed** - Refine based on output quality
+12. **Log results** - Document in Generation Log with rating
 
 ---
 
@@ -322,6 +326,10 @@ Only mark track as "Generated" when output meets:
 - [ ] Structure follows tags
 - [ ] No awkward cuts or loops
 - [ ] No unwanted instruments/elements present (verify exclusions were effective)
+
+Before generating, also verify the prompt itself is built for reliable output, not just the resulting audio:
+- [ ] Style Box stays within the 4-7 descriptor sweet spot (no synonym-stacking)
+- [ ] Structure tags carry Performance Cues on every section by default (not left as bare `[Verse]`/`[Chorus]`), with the sharpest variation where the emotional arc shifts
 
 ---
 
@@ -357,5 +365,6 @@ When you discover new Suno behavior or techniques, **update the reference docume
 4. **Respect avoidance rules** - Never use genres/words user specified to avoid
 5. **Use exclusions sparingly** — Exclude Styles for 2–4 items max; leave empty when not needed
 6. **Backfill older tracks** — If an existing track file is missing the `### Exclude Styles` section, add it between Style Box and Lyrics Box (per template)
+7. **Fight prompt fatigue by default** — Style Box: 4-7 descriptors, not 20 synonym-stacked ones. Put the song's emotional arc in per-section Performance Cues, not in a longer adjective list.
 
 Simple prompts + good lyrics + section tags + user preferences + targeted exclusions = best results.

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -64,9 +64,10 @@ Unlike V4, V5 follows instructions exactly. Don't overthink it.
 
 ### Section Tags are Critical
 Structure your songs with explicit section markers:
-- `[Intro]`, `[Verse]`, `[Chorus]`, `[Bridge]`, `[Outro]`
+- `[Intro]`, `[Verse]`, `[Chorus]`, `[Pre-Chorus]`, `[Bridge]`, `[Outro]`, `[End]` — see `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` for the full set (including `[Post-Chorus]`, `[Break]`, `[Interlude]`, `[Fade In]`/`[Fade Out]`)
 - V5 uses these to shape arrangement
 - Without tags, structure can be unpredictable
+- **Optional accent**: one delivery/mood bracket tag per section (`[Whispered]`, `[Aggressive]`, etc.) can color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly (1 per section); this is not a substitute for Style Box mood/energy prose.
 
 ### Vocals First
 In Style Prompt, put vocal description FIRST:
@@ -274,15 +275,7 @@ Use descriptive section tags only (no parentheticals — Suno will sing them as 
 ```
 
 ### Voice Switching
-For dialogue or duets:
-```
-[Verse - Character A]
-First character's lyrics
-
-[Verse - Character B]
-Second character's lyrics
-```
-Mention in style prompt: "Dual vocalists, male and female, trading verses"
+For dialogue or duets, alternate section tags per character and mention the arrangement in the Style Box (e.g. "Dual vocalists, male and female, trading verses"). Full pattern and Style Box phrasing: `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` § Duet / Call-and-Response
 
 ---
 
@@ -309,12 +302,13 @@ As the Suno engineer, you:
 2. **Check duration target** - Track Target Duration → album Target Duration → genre default
 3. **Check artist persona** - Review saved voice profile (if applicable)
 4. **Select genre** - Choose appropriate genre tags
-5. **Define vocals** - Specify voice type, delivery, energy
-6. **Choose instruments** - Select key instruments and sonic texture
-7. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed
-8. **Generate in Suno** - Create track with assembled inputs
-9. **Iterate if needed** - Refine based on output quality
-10. **Log results** - Document in Generation Log with rating
+5. **Define vocals** - Specify voice type, delivery, energy. Pull a concrete texture/style descriptor from `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` (Vocal Style Tags, Vocal Texture Tags, Production/Vocal FX Descriptors) instead of a generic "male vocal, rock" — e.g. "gravelly, belting" beats "powerful"
+6. **Choose instruments** - Select key instruments and sonic texture. Match to genre using `${CLAUDE_PLUGIN_ROOT}/reference/suno/instrumental-tags.md` § Genre-Specific Instruments (2-4 key instruments, not a full list)
+7. **Check for sound effects/atmosphere** - If the lyrics reference rain, footsteps, crowds, laughter, or similar, add matching tags per `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Sound Effects / Atmospheric Effects (mention in both Lyrics Box and Style Prompt for atmospheric/environmental sounds)
+8. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed
+9. **Generate in Suno** - Create track with assembled inputs
+10. **Iterate if needed** - Refine based on output quality
+11. **Log results** - Document in Generation Log with rating
 
 ---
 

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -68,7 +68,7 @@ Structure your songs with explicit section markers:
 - V5 uses these to shape arrangement
 - Without tags, structure can be unpredictable
 - **Default, not optional — Performance Cues**: append 1-3 delivery cues directly to each structure tag (`[Verse 1 - cold, regal, controlled]`, `[Bridge - raw, breaking, desperate]`) — see the same reference's "Performance Cues" section. This is how an emotional arc is carried across a song. Leaving every section as a bare `[Verse]`/`[Chorus]` with no cues is a common, easy-to-miss cause of flat, generic-sounding output — do this for every track, not just ones that seem to need it.
-- **Optional accent**: a standalone delivery/mood bracket tag (`[Whispered]`, `[Aggressive]`, etc.) can additionally color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly (1 per section); this is not a substitute for Style Box mood/energy prose.
+- **Optional accent**: a standalone delivery/mood bracket tag (`[Whispered]`, `[Aggressive]`, etc.) can additionally color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly, and count it against the **same ≤3-per-section budget** as the Performance Cues above (cues + accent ≤ 3 bracketed descriptors per section — more than 3 causes noise). This is not a substitute for Style Box mood/energy prose.
 
 ### Vocals First
 In Style Prompt, put vocal description FIRST:
@@ -169,11 +169,11 @@ Chorus lyrics here
 
 **Example**:
 ```
-Male baritone, passionate delivery, storytelling vocal. Alternative rock,
-clean electric guitar, driving bassline, tight drums. Modern production, dynamic range.
+Male baritone, storytelling delivery. Alternative rock, clean electric guitar,
+driving bass, tight drums. Modern production.
 ```
 
-**Before finalizing, count every descriptor across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`), so counting commas alone undercounts. V5's sweet spot is 4-7 total; 8+ causes "prompt fatigue" where V5 dilutes or ignores tags (see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Watch for synonym-piles — stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse to 1-2 words per concept (vocal identity, genre, tempo, 2-3 instruments, 1 production note) to keep the total within 4-7. Move section-by-section emotional variation into Performance Cues in the Lyrics Box instead of adding more adjectives here — that is the correct place for an arc, not the Style Box.
+**Before finalizing, count every descriptor across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`), so counting commas alone undercounts. V5's sweet spot is 4-7 total; 8+ causes "prompt fatigue" where V5 dilutes or ignores tags (see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Watch for synonym-piles — stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse to 1-2 words per concept (vocal identity, genre, tempo, 2-3 instruments, 1 production note) to keep the total within 4-7. Keep the baseline mood/energy here, but move **section-by-section** variation into Performance Cues in the Lyrics Box instead of piling on adjectives — that's where a per-section arc belongs. (An alternative arc technique — mapping sections in Style-Box "Performance:" prose — lives in `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` § Emotion Arc Mapping; use one approach per track, not both.)
 
 ### Exclude Styles (Negative Prompting)
 

--- a/templates/track.md
+++ b/templates/track.md
@@ -216,22 +216,23 @@ Suno Inputs below with the destination genre/mood, then note here what to preser
 
 <!-- VOCAL TRACKS: WARNING: Suno sings EVERYTHING literally including parenthetical directions.
      NEVER use (whispered), (softly), (screaming), (spoken), (laughing), etc.
-     Use metatags like [Whispered] or put delivery notes in the Style Box instead. -->
+     Use standalone metatags like [Whispered], or append per-section Performance Cues to the
+     section tag (e.g. [Verse 1 - cold, regal]) — never parentheticals. -->
 
 ```
-[Verse 1]
+[Verse 1 - calm, reflective]
 [Lyrics here...]
 
-[Chorus]
+[Chorus - big, anthemic]
 [Lyrics here...]
 
-[Verse 2]
+[Verse 2 - restless, driving]
 [Lyrics here...]
 
-[Bridge]
+[Bridge - stripped, intimate]
 [Lyrics here...]
 
-[Outro]
+[Outro - resolved, fading]
 [Lyrics here...]
 ```
 <!-- /SERVICE: suno -->

--- a/templates/track.md
+++ b/templates/track.md
@@ -144,6 +144,53 @@ Space is not a constraint. Thoroughness is the priority.]
 - **Instrumentation**: [Key instruments/sounds]
 
 <!-- SERVICE: suno -->
+<!-- COVER TRACKS: Include this block ONLY if this track is a Suno Cover (reimagines an existing
+     song or uploaded audio in a new style) and/or is built on a saved Persona (Pro/Premier).
+     Delete the entire block for standard original-generation tracks — it is optional and does
+     not affect the normal writing flow. Full workflow and decision guidance:
+     reference/workflows/covers-and-personas.md -->
+
+## Cover / Persona Setup
+
+### Original Song Reference
+
+*What this cover reworks. Delete this subsection if the track is not a Cover.*
+
+| Attribute | Detail |
+|-----------|--------|
+| **Cover of** | [Original song, or the prior generation this reworks] |
+| **Source audio** | [Uploaded sample e.g. Splice / earlier Suno generation / — ] |
+| **Keeps** | [What carries over: topline melody, structure] |
+| **Reimagines** | [The new target genre/style the Cover shifts it into] |
+| **Audio Influence** | [Slider setting — higher hews closer to the source; shown only when audio is uploaded] |
+
+### Persona Selection
+
+*The saved vocal identity applied to this track. Delete this subsection if no Persona is used.*
+
+| Attribute | Detail |
+|-----------|--------|
+| **Persona** | [Saved Persona name, or —] |
+| **Vocal identity** | [What it locks in, e.g. male baritone, gravelly, folk storyteller] |
+| **Saved from** | [The generation this Persona was captured from] |
+
+When a Persona is applied, keep the Style Box below simple (one or two genres) and drop detailed
+vocal descriptors — the Persona carries the voice. Personas run dominant in the mix; if the result
+sounds overprocessed, simplify the Style Box or lower Style Influence.
+
+### Cover-Specific Style Guidance
+
+The Style Box for a Cover describes the NEW target style, not the original. Fill the Style Box under
+Suno Inputs below with the destination genre/mood, then note here what to preserve versus transform:
+
+- **Preserve**: [elements of the original to keep — e.g. topline melody, song structure]
+- **Transform**: [what the Cover changes — genre, instrumentation, tempo feel, production era]
+- **Layering**: [if stacking multiple Covers for genre-bending, note the order — see workflow guide]
+
+<!-- END COVER SECTIONS -->
+<!-- /SERVICE: suno -->
+
+<!-- SERVICE: suno -->
 ## Suno Inputs
 
 ### Style Box

--- a/tests/unit/cloud/test_find_album_path_glob_405.py
+++ b/tests/unit/cloud/test_find_album_path_glob_405.py
@@ -1,0 +1,75 @@
+"""Regression tests for find_album_path glob-injection guard ordering (#405).
+
+The glob-metacharacter / path-separator validation must run BEFORE any
+glob expansion. Previously the mirrored-structure branch interpolated
+``album_name`` into a glob pattern (``albums/*/{album_name}``) and could
+silently resolve a wildcard to an unintended in-tree album directory
+before the explicit rejection ever executed.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Import the module under test
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Force-mock boto3 before importing the module so tests behave consistently
+# regardless of whether boto3 is installed on this machine. Save originals and
+# restore after import to prevent MagicMock pollution leaking into later tests.
+_MOCK_DEPS = ["boto3", "botocore", "botocore.exceptions"]
+_SAVED_DEPS = {dep: sys.modules.get(dep) for dep in _MOCK_DEPS}
+for dep in _MOCK_DEPS:
+    sys.modules[dep] = MagicMock()
+
+from tools.cloud import upload_to_cloud as mod
+
+# Restore original modules to avoid polluting later tests
+for dep, original in _SAVED_DEPS.items():
+    if original is None:
+        sys.modules.pop(dep, None)
+    else:
+        sys.modules[dep] = original
+
+
+@pytest.mark.unit
+class TestFindAlbumPathGlobInjection:
+    """album_name with glob metacharacters is rejected before glob expansion (#405)."""
+
+    def _make_config(self, tmp_path):
+        return {
+            "paths": {"audio_root": str(tmp_path)},
+            "artist": {"name": "testartist"},
+        }
+
+    def test_star_rejected_even_when_a_dir_matches(self, tmp_path):
+        # A real album dir exists that the pattern albums/*/* would match.
+        album_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "my-album"
+        album_dir.mkdir(parents=True)
+        # album_name "*" must be rejected outright, NOT resolved to album_dir.
+        with pytest.raises(SystemExit):
+            mod.find_album_path(self._make_config(tmp_path), "*")
+
+    def test_question_mark_rejected_even_when_a_dir_matches(self, tmp_path):
+        # "a?b" would glob-match this dir via albums/*/a?b if the guard is bypassed.
+        matching_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "aXb"
+        matching_dir.mkdir(parents=True)
+        with pytest.raises(SystemExit):
+            mod.find_album_path(self._make_config(tmp_path), "a?b")
+
+    def test_bracket_rejected_even_when_a_dir_matches(self, tmp_path):
+        # "[abc]" would glob-match a single-char dir via albums/*/[abc].
+        matching_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "b"
+        matching_dir.mkdir(parents=True)
+        with pytest.raises(SystemExit):
+            mod.find_album_path(self._make_config(tmp_path), "[abc]")
+
+    def test_normal_album_name_still_resolves(self, tmp_path):
+        album_dir = tmp_path / "artists" / "testartist" / "albums" / "hip-hop" / "my-album"
+        album_dir.mkdir(parents=True)
+        result = mod.find_album_path(self._make_config(tmp_path), "my-album")
+        assert result == album_dir

--- a/tests/unit/hooks/test_check_version_sync_394.py
+++ b/tests/unit/hooks/test_check_version_sync_394.py
@@ -1,0 +1,140 @@
+"""Regression tests for issue #394.
+
+``check_version_sync`` opened ``plugin.json`` / ``marketplace.json`` with a bare
+``open()`` (the platform-default text encoding) and only caught
+``(json.JSONDecodeError, OSError)``. A ``UnicodeDecodeError`` — a ``ValueError``
+subclass, not an ``OSError`` or ``JSONDecodeError`` — raised while decoding a
+manifest that is not valid in the active encoding therefore escaped
+``check_sync()`` and, since ``main()`` does not wrap it, crashed the hook with a
+traceback. These tests lock in graceful degradation: an undecodable manifest
+degrades to ``[]`` and valid manifests (including valid UTF-8 with accents)
+still parse.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Import the standalone hook module via importlib (hooks/ is not a package).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+_MODULE_PATH = _PROJECT_ROOT / "hooks" / "check_version_sync.py"
+_spec = importlib.util.spec_from_file_location("check_version_sync_394", _MODULE_PATH)
+check_version_sync = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_version_sync)
+
+
+# A lone 0xE9 byte is cp1252 'é' but an invalid UTF-8 sequence (bare lead byte),
+# i.e. exactly the "author name with an accent saved in a non-UTF-8 encoding"
+# scenario from the issue.
+_NON_UTF8_PLUGIN = b'{"version": "0.94.0", "author": "Jos\xe9"}'
+_NON_UTF8_MARKETPLACE = b'{"plugins": [{"version": "0.94.0", "name": "Jos\xe9"}]}'
+
+
+def _manifest_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".claude-plugin"
+    d.mkdir()
+    return d
+
+
+def _event(file_path: Path) -> dict:
+    return {"tool_input": {"file_path": str(file_path)}}
+
+
+def _write_plugin(d: Path, version: str) -> Path:
+    p = d / "plugin.json"
+    p.write_text(json.dumps({"version": version}), encoding="utf-8")
+    return p
+
+
+def _write_marketplace(d: Path, version: str) -> Path:
+    p = d / "marketplace.json"
+    p.write_text(json.dumps({"plugins": [{"version": version}]}), encoding="utf-8")
+    return p
+
+
+def test_non_utf8_plugin_manifest_returns_cleanly(tmp_path):
+    """A non-UTF-8 plugin.json must degrade to [] instead of raising."""
+    d = _manifest_dir(tmp_path)
+    plugin = d / "plugin.json"
+    plugin.write_bytes(_NON_UTF8_PLUGIN)
+    _write_marketplace(d, "0.94.0")
+
+    # Under the bug this raised UnicodeDecodeError out of check_sync().
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_non_utf8_marketplace_manifest_returns_cleanly(tmp_path):
+    """The second open() (marketplace.json) must degrade cleanly too."""
+    d = _manifest_dir(tmp_path)
+    plugin = _write_plugin(d, "0.94.0")
+    (d / "marketplace.json").write_bytes(_NON_UTF8_MARKETPLACE)
+
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_valid_matching_versions_returns_empty(tmp_path):
+    """Valid, in-sync manifests still parse and report no issues."""
+    d = _manifest_dir(tmp_path)
+    plugin = _write_plugin(d, "0.94.0")
+    _write_marketplace(d, "0.94.0")
+
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_valid_utf8_accented_author_parses(tmp_path):
+    """Valid UTF-8 content with an accent must parse regardless of locale."""
+    d = _manifest_dir(tmp_path)
+    plugin = d / "plugin.json"
+    plugin.write_text(
+        json.dumps({"version": "0.94.0", "author": "José"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_marketplace(d, "0.94.0")
+
+    assert check_version_sync.check_sync(_event(plugin)) == []
+
+
+def test_valid_mismatched_versions_reports(tmp_path, monkeypatch):
+    """A genuine version mismatch is still detected after the fix."""
+    d = _manifest_dir(tmp_path)
+    plugin = _write_plugin(d, "0.94.0")
+    _write_marketplace(d, "0.93.0")
+
+    # Deterministically take the "other file not mid-edit" branch: pretend the
+    # working tree has no other pending manifest edit.
+    def _fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(check_version_sync.subprocess, "run", _fake_run)
+
+    issues = check_version_sync.check_sync(_event(plugin))
+    assert len(issues) == 1
+    assert "0.94.0" in issues[0]
+    assert "0.93.0" in issues[0]
+
+
+def test_hook_main_does_not_crash_on_non_utf8_manifest(tmp_path):
+    """End-to-end: the hook process exits 0 with no traceback, not a crash."""
+    d = _manifest_dir(tmp_path)
+    plugin = d / "plugin.json"
+    plugin.write_bytes(_NON_UTF8_PLUGIN)
+    _write_marketplace(d, "0.94.0")
+
+    payload = json.dumps({"tool_input": {"file_path": str(plugin)}})
+    result = subprocess.run(
+        [sys.executable, str(_MODULE_PATH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert "Traceback" not in result.stderr, result.stderr
+    assert result.returncode == 0, (result.returncode, result.stderr)

--- a/tests/unit/mastering/test_adm_validation_parallel_345.py
+++ b/tests/unit/mastering/test_adm_validation_parallel_345.py
@@ -1,0 +1,196 @@
+"""Tests for parallel ADM validation (issue #345).
+
+_stage_adm_validation used to encode+decode each mastered track serially
+(two ffmpeg subprocesses per track with a tempdir round-trip), which dominated
+mastering wall-clock time. The stage now runs the per-track ADM checks
+concurrently (bounded to CPU count), while preserving:
+  - result ORDER (results line up with ctx.mastered_files),
+  - error partitioning (ADMValidationError → encoder_errors, warn not halt),
+  - the clip → halt verdict,
+  - propagation of non-ADMValidationError exceptions.
+
+Usage:
+    python -m pytest tests/unit/mastering/test_adm_validation_parallel_345.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers.processing import _album_stages as album_stages_mod  # noqa: E402
+from tools.mastering.adm_validation import ADMValidationError  # noqa: E402
+
+
+def _clean_result(path, encoder="aac", ceiling_db=-1.0):
+    return {
+        "filename": Path(path).name,
+        "encoder_used": encoder,
+        "clip_count": 0,
+        "peak_db_decoded": -1.8,
+        "ceiling_db": ceiling_db,
+        "clips_found": False,
+    }
+
+
+def _make_ctx(tmp_path: Path, wavs: list[Path]):
+    ctx = album_stages_mod.MasterAlbumCtx(
+        album_slug="my-album", genre="", target_lufs=-14.0,
+        ceiling_db=-1.0, cut_highmid=0.0, cut_highs=0.0,
+        source_subfolder="", freeze_signature=False, new_anchor=False,
+        loop=asyncio.get_running_loop(),
+    )
+    ctx.audio_dir = tmp_path
+    ctx.mastered_files = wavs
+    ctx.targets = {"ceiling_db": -1.0, "adm_aac_encoder": "aac"}
+    return ctx
+
+
+@pytest.mark.unit
+class TestParallelExecution:
+    def test_checks_run_concurrently(self, tmp_path, monkeypatch):
+        """The per-track ADM checks overlap — serial code caps concurrency at 1.
+
+        This is the #345 regression pin: on the old serial loop max observed
+        concurrency is 1; the parallel stage reaches >1.
+        """
+        # Pin the concurrency bound so the test is deterministic on any host.
+        monkeypatch.setattr(album_stages_mod.os, "cpu_count", lambda: 4)
+
+        lock = threading.Lock()
+        state = {"current": 0, "max": 0}
+
+        def _slow_check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+            with lock:
+                state["current"] += 1
+                state["max"] = max(state["max"], state["current"])
+            time.sleep(0.05)
+            with lock:
+                state["current"] -= 1
+            return _clean_result(path, encoder, ceiling_db)
+
+        monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _slow_check)
+        wavs = [tmp_path / f"{i:02d}.wav" for i in range(1, 5)]
+        for w in wavs:
+            w.write_bytes(b"\x00")
+
+        async def _run():
+            ctx = _make_ctx(tmp_path, wavs)
+            return await album_stages_mod._stage_adm_validation(ctx), ctx
+
+        result, ctx = asyncio.run(_run())
+
+        assert result is None
+        assert state["max"] >= 2, "ADM checks did not run concurrently"
+        assert len(ctx.adm_validation_results) == 4
+
+    def test_results_preserve_input_order(self, tmp_path, monkeypatch):
+        """results line up with ctx.mastered_files regardless of finish order."""
+        monkeypatch.setattr(album_stages_mod.os, "cpu_count", lambda: 4)
+
+        # Make later files finish FIRST, so order can only be right if the
+        # stage preserves input order rather than completion order.
+        delays = {"01.wav": 0.06, "02.wav": 0.04, "03.wav": 0.02, "04.wav": 0.0}
+
+        def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+            time.sleep(delays[Path(path).name])
+            return _clean_result(path, encoder, ceiling_db)
+
+        monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+        wavs = [tmp_path / f"{i:02d}.wav" for i in range(1, 5)]
+        for w in wavs:
+            w.write_bytes(b"\x00")
+
+        async def _run():
+            ctx = _make_ctx(tmp_path, wavs)
+            await album_stages_mod._stage_adm_validation(ctx)
+            return ctx
+
+        ctx = asyncio.run(_run())
+        assert [r["filename"] for r in ctx.adm_validation_results] == [
+            "01.wav", "02.wav", "03.wav", "04.wav",
+        ]
+
+
+@pytest.mark.unit
+class TestBehaviorPreserved:
+    def test_encoder_error_warns_not_halts_and_partitions(self, tmp_path, monkeypatch):
+        """A track raising ADMValidationError → warn (return None), partitioned."""
+        def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+            if Path(path).name == "02.wav":
+                raise ADMValidationError("ffmpeg boom")
+            return _clean_result(path, encoder, ceiling_db)
+
+        monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+        wavs = [tmp_path / f"{i:02d}.wav" for i in range(1, 4)]
+        for w in wavs:
+            w.write_bytes(b"\x00")
+
+        async def _run():
+            ctx = _make_ctx(tmp_path, wavs)
+            return await album_stages_mod._stage_adm_validation(ctx), ctx
+
+        result, ctx = asyncio.run(_run())
+
+        assert result is None  # encoder error warns, never halts
+        assert ctx.stages["adm_validation"]["status"] == "warn"
+        # Good tracks kept, in order; the failed one is not in results.
+        assert [r["filename"] for r in ctx.adm_validation_results] == [
+            "01.wav", "03.wav",
+        ]
+        assert any("02.wav" in e for e in ctx.stages["adm_validation"]["errors"])
+
+    def test_clipping_track_halts(self, tmp_path, monkeypatch):
+        """A clipping track still halts with failure JSON (verdict unchanged)."""
+        def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+            r = _clean_result(path, encoder, ceiling_db)
+            if Path(path).name == "02.wav":
+                r["clips_found"] = True
+                r["clip_count"] = 5
+                r["peak_db_decoded"] = -0.2
+            return r
+
+        monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+        wavs = [tmp_path / f"{i:02d}.wav" for i in range(1, 4)]
+        for w in wavs:
+            w.write_bytes(b"\x00")
+
+        async def _run():
+            ctx = _make_ctx(tmp_path, wavs)
+            return await album_stages_mod._stage_adm_validation(ctx), ctx
+
+        result, ctx = asyncio.run(_run())
+
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["stages"]["adm_validation"]["status"] == "fail"
+        assert parsed["stages"]["adm_validation"]["tracks_with_clips"] == 1
+
+    def test_non_adm_exception_propagates(self, tmp_path, monkeypatch):
+        """A non-ADMValidationError is not swallowed — it escapes the stage."""
+        def _check(path, *, encoder="aac", ceiling_db=-1.0, bitrate_kbps=256):
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(album_stages_mod, "_adm_check_fn", _check)
+        wav = tmp_path / "01.wav"
+        wav.write_bytes(b"\x00")
+
+        async def _run():
+            ctx = _make_ctx(tmp_path, [wav])
+            return await album_stages_mod._stage_adm_validation(ctx)
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            asyncio.run(_run())

--- a/tests/unit/mastering/test_analyze_tracks.py
+++ b/tests/unit/mastering/test_analyze_tracks.py
@@ -8,8 +8,10 @@ Usage:
     python -m pytest tools/mastering/tests/test_analyze_tracks.py -v
 """
 
+import logging
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -20,7 +22,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from tools.mastering.analyze_tracks import analyze_track
+from tools.mastering.analyze_tracks import analyze_track, main
 
 
 def _generate_sine(freq=440.0, duration=3.0, rate=44100, amplitude=0.5, stereo=True):
@@ -196,3 +198,74 @@ class TestAnalyzeTrackEdgeCases:
     def test_nonexistent_file_raises(self, tmp_path):
         with pytest.raises(Exception):
             analyze_track(str(tmp_path / "nonexistent.wav"))
+
+
+# ─── Tests: main() empty-directory guard ──────────────────────────────
+
+
+def _fake_analysis(path):
+    """Lightweight stand-in for analyze_track — avoids heavy DSP in main() tests."""
+    return {
+        'filename': Path(path).name,
+        'duration': 3.0,
+        'sample_rate': 44100,
+        'lufs': -14.2,
+        'peak_db': -1.0,
+        'rms_db': -18.0,
+        'dynamic_range': 12.0,
+        'band_energy': {
+            'sub_bass': 5.0, 'bass': 20.0, 'low_mid': 20.0, 'mid': 25.0,
+            'high_mid': 15.0, 'high': 10.0, 'air': 5.0,
+        },
+        'is_dark': False,
+        'tinniness_ratio': 0.3,
+        'max_short_term_lufs': -12.0,
+        'max_momentary_lufs': -10.5,
+        'short_term_range': 4.0,
+        'stl_95': -13.0,
+        'low_rms': -20.0,
+        'vocal_rms': None,
+        'signature_meta': {},
+    }
+
+
+class TestMainNoWavFiles:
+    """main() should exit cleanly (no traceback) when no WAV files are found.
+
+    The error must be reported via the module logger (same convention as the
+    sibling directory-not-found path in main()), not via print to stdout.
+    """
+
+    def test_empty_directory_exits_nonzero_with_message(
+            self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr(sys, 'argv', ['analyze_tracks.py', str(tmp_path)])
+        with caplog.at_level(logging.ERROR, logger='tools.mastering.analyze_tracks'):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+        assert excinfo.value.code == 1
+        assert "No tracks to analyze" in caplog.text
+        assert "no WAV files found" in caplog.text
+
+    def test_directory_with_only_non_wav_files_exits_nonzero(
+            self, tmp_path, monkeypatch, caplog):
+        (tmp_path / "notes.txt").write_text("not audio")
+        (tmp_path / "cover.png").write_bytes(b"\x89PNG")
+        (tmp_path / "song.mp3").write_bytes(b"ID3")
+        monkeypatch.setattr(sys, 'argv', ['analyze_tracks.py', str(tmp_path)])
+        with caplog.at_level(logging.ERROR, logger='tools.mastering.analyze_tracks'):
+            with pytest.raises(SystemExit) as excinfo:
+                main()
+        assert excinfo.value.code == 1
+        assert "No tracks to analyze" in caplog.text
+
+    def test_normal_directory_still_analyzes(self, tmp_path, monkeypatch, capsys):
+        """Directories with WAV files must run to completion, unaffected by the guard."""
+        (tmp_path / "track.wav").touch()
+        monkeypatch.setattr(sys, 'argv', ['analyze_tracks.py', str(tmp_path)])
+        with patch('tools.mastering.analyze_tracks.analyze_track',
+                   side_effect=_fake_analysis):
+            main()  # must not raise SystemExit
+        out = capsys.readouterr().out
+        assert "track.wav" in out
+        assert "LUFS range across album" in out
+        assert "No tracks to analyze" not in out

--- a/tests/unit/mastering/test_finite_lufs_aggregates_dry_400.py
+++ b/tests/unit/mastering/test_finite_lufs_aggregates_dry_400.py
@@ -1,0 +1,83 @@
+"""Contract tests for the shared finite-LUFS aggregation helpers (#400).
+
+``_finite_lufs_aggregates`` / ``_round_or_none`` were added by the #400 fix as
+the single source of truth for "aggregate LUFS over finite readings only" and
+are now consumed by ``_stage_analysis`` (the DRY consolidation of the #371
+inline logic), ``_stage_verification`` and ``_stage_ceiling_guard``.
+
+A silent / corrupt track reads -inf LUFS; feeding that into ``np.mean`` /
+``max - min`` poisons the aggregate (avg -> -inf, range -> inf). These tests
+pin the helper contract directly, so a regression in any one call site — or in
+the helper itself — is caught at the source rather than only through a
+stage-level integration test.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers.processing._album_stages import (  # noqa: E402
+    _finite_lufs_aggregates,
+    _round_or_none,
+)
+
+
+def _rows(*lufs_values: float) -> list[dict]:
+    """Build minimal analyze_track-shaped rows carrying the given LUFS values."""
+    return [{"filename": f"{i:02d}.wav", "lufs": v} for i, v in enumerate(lufs_values)]
+
+
+class TestFiniteLufsAggregates:
+    def test_all_finite_matches_naive_mean_and_range(self):
+        """With no silent tracks the helper equals the plain mean / max-min."""
+        values = [-14.0, -13.2, -15.7, -12.9]
+        avg, rng = _finite_lufs_aggregates(_rows(*values))
+        assert avg == float(np.mean(values))
+        assert rng == float(max(values) - min(values))
+
+    def test_negative_inf_is_ignored(self):
+        """A -inf silent track must not poison avg (-> -inf) or range (-> inf)."""
+        avg, rng = _finite_lufs_aggregates(_rows(-14.0, float("-inf"), -13.0))
+        assert avg == float(np.mean([-14.0, -13.0]))
+        assert rng == pytest.approx(1.0)
+        assert math.isfinite(avg) and math.isfinite(rng)
+
+    def test_nan_is_ignored(self):
+        avg, rng = _finite_lufs_aggregates(_rows(-14.0, float("nan"), -16.0))
+        assert avg == float(np.mean([-14.0, -16.0]))
+        assert rng == pytest.approx(2.0)
+
+    def test_all_non_finite_returns_none_none(self):
+        avg, rng = _finite_lufs_aggregates(_rows(float("-inf"), float("nan")))
+        assert avg is None
+        assert rng is None
+
+    def test_empty_returns_none_none(self):
+        assert _finite_lufs_aggregates([]) == (None, None)
+
+    def test_single_finite_value_has_zero_range(self):
+        avg, rng = _finite_lufs_aggregates(_rows(-14.0))
+        assert avg == -14.0
+        assert rng == 0.0
+
+
+class TestRoundOrNone:
+    def test_none_passes_through(self):
+        assert _round_or_none(None, 1) is None
+        assert _round_or_none(None, 2) is None
+
+    def test_finite_rounds_like_builtin(self):
+        assert _round_or_none(-14.037, 1) == round(-14.037, 1)
+        assert _round_or_none(0.126, 2) == round(0.126, 2)

--- a/tests/unit/mastering/test_master_tracks_406_407.py
+++ b/tests/unit/mastering/test_master_tracks_406_407.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression tests for master_tracks.py bugs #406 and #407.
+
+#406 — apply_fade_out must not raise (nor corrupt audio) when the fade
+       duration is so small it rounds to zero samples.
+#407 — result['original_lufs'] must report the loudness of the SOURCE audio
+       (measured right after read), not the loudness measured after the
+       EQ/compression/fade processing chain.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pyloudnorm as pyln
+import pytest
+import soundfile as sf
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering import master_tracks
+from tools.mastering.master_tracks import apply_fade_out, master_track
+
+
+def _stereo_sine(freq=440.0, duration=3.0, rate=44100, amplitude=0.5):
+    t = np.linspace(0, duration, int(rate * duration), endpoint=False)
+    mono = (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float64)
+    return np.column_stack([mono, mono]), rate
+
+
+# ─── #406: sub-sample fade-out must be a safe no-op ───────────────────────
+
+
+class TestFadeOutSubSample:
+    def test_tiny_duration_does_not_raise_stereo(self):
+        """0 < duration < 1/rate => int(rate*duration) == 0 must not crash."""
+        data, rate = _stereo_sine(duration=1.0)
+        # 0.5 sample worth of fade -> int(rate * duration) == 0
+        tiny = 0.5 / rate
+        assert int(rate * tiny) == 0  # precondition that triggered the bug
+        result = apply_fade_out(data, rate, duration=tiny)  # must not raise
+        # A sub-sample fade is effectively nothing: audio stays unchanged.
+        assert np.array_equal(result, data)
+
+    def test_tiny_duration_does_not_raise_mono(self):
+        data, rate = _stereo_sine(duration=1.0)
+        mono = data[:, 0].copy()
+        tiny = 0.5 / rate
+        result = apply_fade_out(mono, rate, duration=tiny)  # must not raise
+        assert np.array_equal(result, mono)
+
+    def test_tiny_duration_linear_curve(self):
+        data, rate = _stereo_sine(duration=1.0)
+        tiny = 0.5 / rate
+        result = apply_fade_out(data, rate, duration=tiny, curve='linear')
+        assert np.array_equal(result, data)
+
+
+# ─── #407: original_lufs must reflect the SOURCE, not processed audio ──────
+
+
+class TestOriginalLufsIsSource:
+    def test_original_lufs_is_source_not_processed(self, tmp_path, monkeypatch):
+        """A processing stage that changes loudness must not leak into
+        the reported 'original_lufs' — it should stay the source value."""
+        data, rate = _stereo_sine(duration=3.0, amplitude=0.5)
+        in_path = tmp_path / "src.wav"
+        out_path = tmp_path / "out.wav"
+        sf.write(str(in_path), data, rate, subtype='PCM_16')
+
+        # Independently measure the true SOURCE loudness the same way the
+        # fix does — read the file back and meter the raw samples.
+        src_data, src_rate = sf.read(str(in_path))
+        src_lufs = pyln.Meter(src_rate).integrated_loudness(src_data)
+        assert np.isfinite(src_lufs)
+
+        # Force a large, deterministic loudness drop *during* processing:
+        # replace the fade stage with a -20 dB (x0.1) attenuation. The old
+        # code measured loudness after this stage and reported it as
+        # 'original_lufs'; the fix measures the source before it.
+        def loudness_dropping_fade(d, r, duration=5.0, curve='exponential'):
+            return d * 0.1
+
+        monkeypatch.setattr(master_tracks, "apply_fade_out",
+                            loudness_dropping_fade)
+
+        result = master_track(str(in_path), str(out_path),
+                              target_lufs=-14.0, fade_out=2.0)
+
+        assert not result.get('skipped', False)
+        # original_lufs must equal the SOURCE loudness...
+        assert result['original_lufs'] == pytest.approx(src_lufs, abs=0.5)
+        # ...and must NOT be the post-processing (~20 dB quieter) value the
+        # buggy code reported.
+        processed_lufs = src_lufs - 20.0
+        assert abs(result['original_lufs'] - processed_lufs) > 10.0

--- a/tests/unit/mastering/test_qc_tracks_batch_408.py
+++ b/tests/unit/mastering/test_qc_tracks_batch_408.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Regression tests for #408 — qc_tracks batch resilience to a bad file.
+
+Both the serial and parallel QC batch paths in ``qc_tracks.main`` used to call
+``qc_track`` / ``future.result()`` with no per-file guard, so a single corrupt
+or unreadable WAV tore down the whole run: in serial mode the remaining files
+were skipped, and in parallel mode the exception re-raised out of
+``future.result()`` and aborted the pool after partial work.
+
+The fix wraps each per-file call in a try/except that emits a per-track FAIL
+row (matching qc_track's result shape) and keeps going, while still signalling
+the failure through a non-zero exit.
+
+Usage:
+    python -m pytest tests/unit/mastering/test_qc_tracks_batch_408.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mastering.qc_tracks import ALL_CHECKS
+from tools.mastering.qc_tracks import main as qc_main
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+
+def _pass_result(name: str) -> dict:
+    """A well-formed all-PASS qc_track result for a good file."""
+    return {
+        "filename": name,
+        "checks": {
+            c: {"status": "PASS", "value": "ok", "detail": "ok"} for c in ALL_CHECKS
+        },
+        "verdict": "PASS",
+    }
+
+
+def _write_valid_wav(path: Path, rate: int = 44100, seconds: float = 0.2) -> None:
+    """Write a small, well-formed stereo PCM_16 WAV that passes the format check."""
+    n = int(rate * seconds)
+    t = np.linspace(0, seconds, n, endpoint=False)
+    mono = (0.2 * np.sin(2 * np.pi * 220 * t)).astype(np.float64)
+    data = np.column_stack([mono, mono])
+    sf.write(str(path), data, rate, subtype="PCM_16")
+
+
+# ─── Tests ────────────────────────────────────────────────────────────
+
+
+def test_serial_batch_continues_past_unreadable_file(tmp_path, monkeypatch, capsys):
+    """Serial path: one file whose qc_track raises must not abort the batch.
+
+    The good files on either side of the bad one still get results, the bad
+    file gets a FAIL row surfacing the read error, and the run signals failure
+    via a non-zero exit instead of dumping a traceback.
+    """
+    good1 = tmp_path / "01-good.wav"
+    bad = tmp_path / "02-bad.wav"
+    good2 = tmp_path / "03-good.wav"
+    for p in (good1, bad, good2):
+        p.touch()  # qc_track is mocked, so contents are irrelevant
+
+    def mock_qc(filepath, checks=None, genre=None):
+        if "bad" in Path(filepath).name:
+            raise RuntimeError("corrupt WAV: could not read frames")
+        return _pass_result(Path(filepath).name)
+
+    monkeypatch.setattr("tools.mastering.qc_tracks.qc_track", mock_qc)
+    monkeypatch.setattr(sys, "argv", ["qc_tracks", str(tmp_path), "-j", "1"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        qc_main()
+
+    assert excinfo.value.code == 1  # failure is signalled
+
+    out = capsys.readouterr().out
+    # Partial progress preserved — every file, including ones AFTER the bad one.
+    assert "01-good.wav" in out
+    assert "02-bad.wav" in out
+    assert "03-good.wav" in out
+    # The bad file renders as a FAIL row; good files as PASS.
+    assert "3 tracks" in out
+    assert "2 PASS" in out
+    assert "1 FAIL" in out
+    assert any("02-bad.wav" in line and "FAIL" in line for line in out.splitlines())
+    # The read error is surfaced (not a raw traceback).
+    assert "Could not read" in out
+
+
+def test_parallel_batch_continues_past_corrupt_file(tmp_path, monkeypatch, capsys):
+    """Parallel path: a genuinely corrupt WAV must not tear down the pool.
+
+    Uses real files with -j 2 so ``future.result()`` re-raises soundfile's
+    read error from the worker; the fix catches it per-future and keeps the
+    other tracks' results.
+    """
+    _write_valid_wav(tmp_path / "01-good.wav")
+    _write_valid_wav(tmp_path / "03-good.wav")
+    # Garbage bytes with a .wav extension — libsndfile cannot parse it.
+    (tmp_path / "02-bad.wav").write_bytes(b"this is definitely not audio \x00\xff" * 4)
+
+    monkeypatch.setattr(
+        sys, "argv", ["qc_tracks", str(tmp_path), "-j", "2", "--checks", "format"]
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        qc_main()
+
+    assert excinfo.value.code == 1
+
+    out = capsys.readouterr().out
+    assert "01-good.wav" in out
+    assert "02-bad.wav" in out
+    assert "03-good.wav" in out
+    assert "3 tracks" in out
+    assert "2 PASS" in out
+    assert "1 FAIL" in out
+    assert any("02-bad.wav" in line and "FAIL" in line for line in out.splitlines())
+
+
+def test_all_good_serial_completes_without_error_exit(tmp_path, monkeypatch, capsys):
+    """Guard: when every file reads cleanly the run must NOT exit non-zero.
+
+    Protects against the failure signal firing spuriously on a healthy batch.
+    """
+    for name in ("01-a.wav", "02-b.wav", "03-c.wav"):
+        (tmp_path / name).touch()
+
+    def mock_qc(filepath, checks=None, genre=None):
+        return _pass_result(Path(filepath).name)
+
+    monkeypatch.setattr("tools.mastering.qc_tracks.qc_track", mock_qc)
+    monkeypatch.setattr(sys, "argv", ["qc_tracks", str(tmp_path), "-j", "1"])
+
+    qc_main()  # must return normally — no SystemExit
+
+    out = capsys.readouterr().out
+    assert "3 tracks" in out
+    assert "3 PASS" in out
+    assert "1 FAIL" not in out

--- a/tests/unit/mastering/test_reference_master_exclude_409.py
+++ b/tests/unit/mastering/test_reference_master_exclude_409.py
@@ -1,0 +1,119 @@
+"""Regression tests for issue #409.
+
+Batch mode must exclude the ``--reference`` WAV from the target list
+regardless of how the reference path is supplied (absolute, ``./``-prefixed,
+or a bare relative name). The original code compared the glob output
+(always relative, e.g. ``PosixPath('ref.wav')``) against ``Path(args.reference)``
+with a lexical ``f != reference_path``; an absolute ``--reference`` never
+compared equal, so the professionally-mastered reference was re-mastered as
+its own target and written into the delivery set.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import the module under test
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+# Force-mock matchering before importing the module so tests behave
+# consistently regardless of whether matchering is installed.
+_MOCK_DEPS = ["matchering"]
+_SAVED_DEPS = {dep: sys.modules.get(dep) for dep in _MOCK_DEPS}
+for dep in _MOCK_DEPS:
+    sys.modules[dep] = MagicMock()
+
+from tools.mastering import reference_master as mod
+
+# Restore original modules to avoid polluting later tests
+for dep, original in _SAVED_DEPS.items():
+    if original is None:
+        sys.modules.pop(dep, None)
+    else:
+        sys.modules[dep] = original
+
+
+def _target_names(mock_master) -> list[str]:
+    """Filenames passed as the *target* (first positional arg) to each call."""
+    return [c.args[0].name for c in mock_master.call_args_list]
+
+
+@pytest.mark.unit
+class TestReferenceExcludedFromBatch:
+    """The reference WAV living inside the batch dir must never be a target."""
+
+    @patch.object(mod, "master_with_reference")
+    def test_absolute_reference_is_excluded(self, mock_master, tmp_path, monkeypatch):
+        # Reference sits *inside* the working dir alongside the tracks.
+        work_dir = tmp_path / "tracks"
+        work_dir.mkdir()
+        (work_dir / "reference.wav").write_bytes(b"ref")
+        (work_dir / "track1.wav").write_bytes(b"t1")
+        (work_dir / "track2.wav").write_bytes(b"t2")
+        monkeypatch.chdir(work_dir)
+
+        # --reference supplied as an ABSOLUTE path (the real #409 trigger).
+        abs_ref = (work_dir / "reference.wav").resolve()
+        assert abs_ref.is_absolute()
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["reference_master.py", "--reference", str(abs_ref),
+             "--output-dir", str(tmp_path / "mastered")],
+        )
+        mod.main()
+
+        targets = _target_names(mock_master)
+        # The reference must NOT be re-mastered as its own target.
+        assert "reference.wav" not in targets, (
+            f"reference re-mastered as a target: {targets}"
+        )
+        assert set(targets) == {"track1.wav", "track2.wav"}
+        assert mock_master.call_count == 2
+
+    @patch.object(mod, "master_with_reference")
+    def test_relative_reference_still_excluded(self, mock_master, tmp_path, monkeypatch):
+        # Regression guard: the bare-relative form must keep working.
+        work_dir = tmp_path / "tracks"
+        work_dir.mkdir()
+        (work_dir / "reference.wav").write_bytes(b"ref")
+        (work_dir / "track1.wav").write_bytes(b"t1")
+        (work_dir / "track2.wav").write_bytes(b"t2")
+        monkeypatch.chdir(work_dir)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["reference_master.py", "--reference", "reference.wav",
+             "--output-dir", str(tmp_path / "mastered")],
+        )
+        mod.main()
+
+        targets = _target_names(mock_master)
+        assert "reference.wav" not in targets
+        assert set(targets) == {"track1.wav", "track2.wav"}
+        assert mock_master.call_count == 2
+
+    @patch.object(mod, "master_with_reference")
+    def test_dot_prefixed_reference_is_excluded(self, mock_master, tmp_path, monkeypatch):
+        # ``./ref.wav`` is normalized by pathlib, but assert it explicitly.
+        work_dir = tmp_path / "tracks"
+        work_dir.mkdir()
+        (work_dir / "reference.wav").write_bytes(b"ref")
+        (work_dir / "track1.wav").write_bytes(b"t1")
+        monkeypatch.chdir(work_dir)
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["reference_master.py", "--reference", "./reference.wav",
+             "--output-dir", str(tmp_path / "mastered")],
+        )
+        mod.main()
+
+        targets = _target_names(mock_master)
+        assert "reference.wav" not in targets
+        assert set(targets) == {"track1.wav"}
+        assert mock_master.call_count == 1

--- a/tests/unit/mastering/test_stage_layout_unicode_399.py
+++ b/tests/unit/mastering/test_stage_layout_unicode_399.py
@@ -1,0 +1,97 @@
+"""_stage_layout must honor its 'Returns: None always, never halt' contract
+even when a pre-existing LAYOUT.md contains invalid UTF-8 bytes.
+
+Regression for issue #399: the read of a prior LAYOUT.md
+(``layout_path.read_text(encoding="utf-8")``) ran OUTSIDE the stage's
+protective try/except, which only caught ``(LayoutError, OSError)``. A corrupt
+or binary LAYOUT.md raises ``UnicodeDecodeError`` (a ``ValueError`` subclass,
+NOT an ``OSError``), so it escaped the guard and aborted the master_album
+pipeline. A corrupt prior layout must instead be logged to warnings while the
+stage degrades gracefully and still writes a fresh LAYOUT.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def _run_layout_stage(audio_dir: Path, mastered_names: list[str]):
+    from handlers.processing._album_stages import MasterAlbumCtx, _stage_layout
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    ctx = MasterAlbumCtx(
+        album_slug="test", genre="pop", target_lufs=-14.0, ceiling_db=-1.0,
+        cut_highmid=0.0, cut_highs=0.0, source_subfolder="",
+        freeze_signature=False, new_anchor=False, loop=loop,
+        audio_dir=audio_dir,
+        mastered_files=[Path(name) for name in mastered_names],
+    )
+    try:
+        result = loop.run_until_complete(_stage_layout(ctx))
+    finally:
+        loop.close()
+    return ctx, result
+
+
+def test_non_utf8_prior_layout_does_not_halt(tmp_path: Path) -> None:
+    """A LAYOUT.md with invalid UTF-8 bytes must not raise out of the stage."""
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    # 0xFF/0xFE/0xC3-0x28 are invalid UTF-8 sequences → read_text(utf-8) raises
+    # UnicodeDecodeError, which is a ValueError (not an OSError).
+    (audio_dir / "LAYOUT.md").write_bytes(b"\xff\xfe\x00\x80 not utf-8 \xc3\x28")
+
+    ctx, result = _run_layout_stage(audio_dir, ["01-a.wav", "02-b.wav"])
+
+    # Contract: the stage returns None and never halts the pipeline.
+    assert result is None
+    # The corrupt prior LAYOUT.md is surfaced to the operator via warnings.
+    assert any("LAYOUT" in str(w) for w in ctx.warnings)
+    # A layout stage result is still recorded (structured result not discarded).
+    assert "layout" in ctx.stages
+
+
+def test_valid_prior_layout_still_parses(tmp_path: Path) -> None:
+    """A well-formed prior LAYOUT.md is read and its hand-edits are preserved."""
+    from tools.mastering.layout import (
+        parse_layout_yaml,
+        render_layout_markdown,
+    )
+
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    prior = [
+        {
+            "from": "01-a.wav",
+            "to": "02-b.wav",
+            "mode": "gapless",
+            "gap_ms": 0,
+            "tail_fade_ms": 0,
+            "head_fade_ms": 0,
+        },
+    ]
+    (audio_dir / "LAYOUT.md").write_text(
+        render_layout_markdown("test", prior), encoding="utf-8"
+    )
+
+    ctx, result = _run_layout_stage(audio_dir, ["01-a.wav", "02-b.wav"])
+
+    assert result is None
+    # No warnings for a clean, valid prior layout.
+    assert not any("LAYOUT" in str(w) for w in ctx.warnings)
+    # The hand-edited gapless transition survived the parse → compute → render
+    # round-trip, proving the prior file was read and fed into the emitter.
+    rewritten = parse_layout_yaml(
+        (audio_dir / "LAYOUT.md").read_text(encoding="utf-8")
+    )
+    assert rewritten[0]["mode"] == "gapless"

--- a/tests/unit/mastering/test_stage_verification_silent_400.py
+++ b/tests/unit/mastering/test_stage_verification_silent_400.py
@@ -1,0 +1,182 @@
+"""_stage_verification (and the ceiling-guard recompute) must not let a
+silent / corrupt mastered track's -inf LUFS poison its avg_lufs / lufs_range
+aggregates or the album-range control flow.
+
+Regression for issue #400 (residual after #371 fixed _stage_analysis): the
+verification-stage aggregation still used unfiltered ``np.mean`` / ``max-min``
+over LUFS values that can include -inf when a zeroed/corrupt mastered WAV is
+globbed into ``ctx.mastered_files``. That leaves -inf/inf in
+``ctx.stages["verification"]`` (the in-memory payload consumers read directly)
+and makes ``album_range_fail = verify_range >= 1.0`` fire spuriously.
+
+Heavy deps (analyze_track) are mocked — no real audio is read.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+for _p in (str(PROJECT_ROOT), str(SERVER_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from handlers.processing import _album_stages
+from handlers.processing._album_stages import MasterAlbumCtx
+
+ANALYZE_TARGET = "tools.mastering.analyze_tracks.analyze_track"
+
+
+def _track(name: str, lufs: float, peak_db: float) -> dict:
+    """A minimally-complete analyze_track result for one mastered file."""
+    return {
+        "filename": name,
+        "lufs": lufs,
+        "peak_db": peak_db,
+        "short_term_range": 6.0,
+        "stl_95": 9.0,
+        "low_rms": -30.0,
+        "vocal_rms": -22.0,
+    }
+
+
+def _make_ctx(tmp_path: Path, names: list[str]) -> MasterAlbumCtx:
+    source_dir = tmp_path / "source"
+    output_dir = tmp_path / "mastered"
+    source_dir.mkdir(exist_ok=True)
+    output_dir.mkdir(exist_ok=True)
+
+    ctx = MasterAlbumCtx(
+        album_slug="test-album",
+        genre="",
+        target_lufs=-14.0,
+        ceiling_db=-1.0,
+        cut_highmid=0.0,
+        cut_highs=0.0,
+        source_subfolder="",
+        freeze_signature=False,
+        new_anchor=False,
+        loop=asyncio.new_event_loop(),
+    )
+    ctx.audio_dir = tmp_path
+    ctx.source_dir = source_dir
+    ctx.output_dir = output_dir
+    # analyze_track is mocked, so these paths need not exist on disk.
+    ctx.mastered_files = [output_dir / n for n in names]
+    ctx.targets = {
+        "output_sample_rate": 48000,
+        "output_bits": 24,
+        "target_lufs": -14.0,
+        "ceiling_db": -1.0,
+    }
+    ctx.settings = {}
+    ctx.effective_lufs = -14.0
+    ctx.effective_ceiling = -1.0
+    ctx.effective_highmid = 0.0
+    ctx.effective_highs = 0.0
+    ctx.effective_compress = 2.5
+    return ctx
+
+
+def _run_verification(ctx: MasterAlbumCtx, fake_analyze) -> str | None:
+    asyncio.set_event_loop(ctx.loop)
+    try:
+        with patch(ANALYZE_TARGET, fake_analyze):
+            return ctx.loop.run_until_complete(
+                _album_stages._stage_verification(ctx),
+            )
+    finally:
+        ctx.loop.close()
+
+
+# ── new helpers ────────────────────────────────────────────────────────────
+
+def test_finite_lufs_aggregates_filters_non_finite() -> None:
+    results = [
+        _track("01-ok.wav", -14.0, -2.0),
+        _track("02-silent.wav", float("-inf"), float("-inf")),
+        _track("03-ok.wav", -13.0, -2.0),
+    ]
+    avg, rng = _album_stages._finite_lufs_aggregates(results)
+    assert avg is not None and math.isfinite(avg)
+    assert rng is not None and math.isfinite(rng)
+    # Aggregated over the two finite tracks only.
+    assert avg == -13.5
+    assert rng == 1.0
+
+
+def test_finite_lufs_aggregates_all_non_finite_returns_none() -> None:
+    results = [
+        _track("01-silent.wav", float("-inf"), float("-inf")),
+        _track("02-silent.wav", float("-inf"), float("-inf")),
+    ]
+    assert _album_stages._finite_lufs_aggregates(results) == (None, None)
+    # Empty input is also None/None (no finite readings at all).
+    assert _album_stages._finite_lufs_aggregates([]) == (None, None)
+
+
+def test_round_or_none_passes_none_through() -> None:
+    assert _album_stages._round_or_none(None, 1) is None
+    assert _album_stages._round_or_none(-13.456, 1) == -13.5
+    assert _album_stages._round_or_none(0.0, 2) == 0.0
+
+
+# ── stage integration ───────────────────────────────────────────────────────
+
+def test_verification_silent_track_keeps_aggregates_finite(tmp_path: Path) -> None:
+    """One in-spec track + one silent (-inf) track. The stage still halts
+    (a silent mastered track is genuinely out of spec), but the reported
+    aggregates must be the finite metrics of the real track, not -inf/inf."""
+    ctx = _make_ctx(tmp_path, ["01-ok.wav", "02-silent.wav"])
+
+    def fake_analyze(path: str) -> dict:
+        name = Path(path).name
+        if "silent" in name:
+            return _track(name, float("-inf"), float("-inf"))
+        return _track(name, -14.0, -2.0)
+
+    result = _run_verification(ctx, fake_analyze)
+
+    stage = ctx.stages["verification"]
+    # Core residual: no -inf/inf may reach the in-memory aggregates.
+    assert stage["avg_lufs"] is not None and math.isfinite(stage["avg_lufs"])
+    assert stage["lufs_range"] is not None and math.isfinite(stage["lufs_range"])
+    # Metrics reflect the one measurable track, not the poisoned union.
+    assert stage["avg_lufs"] == -14.0
+    assert stage["lufs_range"] == 0.0
+
+    # A single silent outlier must not spuriously trip the album-range gate
+    # (range over the finite set is 0.0, well under the 1.0 dB limit).
+    if result is not None:
+        payload = json.loads(result)
+        assert "album_lufs_range" not in payload.get("failure_detail", {})
+        # And nothing serialized as a non-finite JS token.
+        assert "Infinity" not in result and "NaN" not in result
+
+
+def test_verification_all_silent_yields_none_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """Every mastered track silent → no finite readings. Aggregation must
+    yield None (not -inf/nan) and the round() guards must not raise."""
+    ctx = _make_ctx(tmp_path, ["01-silent.wav", "02-silent.wav"])
+
+    def fake_analyze(path: str) -> dict:
+        return _track(Path(path).name, float("-inf"), float("-inf"))
+
+    result = _run_verification(ctx, fake_analyze)
+
+    stage = ctx.stages["verification"]
+    # None is the documented empty sentinel; -inf/nan is the bug.
+    assert stage["avg_lufs"] is None or math.isfinite(stage["avg_lufs"])
+    assert stage["lufs_range"] is None or math.isfinite(stage["lufs_range"])
+    assert stage["avg_lufs"] is None
+    assert stage["lufs_range"] is None
+    if result is not None:
+        assert "Infinity" not in result and "NaN" not in result

--- a/tests/unit/mixing/test_mix_tracks_zerodiv_410.py
+++ b/tests/unit/mixing/test_mix_tracks_zerodiv_410.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Regression tests for issue #410.
+
+gentle_compress / apply_transient_shaper computed time-constant coefficients
+via ``np.exp(-1.0 / (rate * ms / 1000.0))``. When an attack/release time is
+0 ms (reachable through user-override mix presets), the inner
+``rate * ms / 1000.0`` collapses to 0.0 and the Python scalar division
+``-1.0 / 0.0`` raises ZeroDivisionError, aborting the whole polish run.
+
+These tests pin the fix: a 0 ms (or negative) attack/release time must be
+clamped to a tiny positive floor so no exception is raised and output stays
+finite, while a normal positive time still behaves as before.
+
+Usage:
+    python -m pytest tests/unit/mixing/test_mix_tracks_zerodiv_410.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.mixing.mix_tracks import (
+    _MIN_TIME_CONSTANT_MS,
+    apply_transient_shaper,
+    gentle_compress,
+)
+
+
+def _signal(rate: int = 44100, seconds: float = 0.1) -> np.ndarray:
+    """A stereo sine with a transient burst so both code paths do real work."""
+    t = np.arange(int(rate * seconds)) / rate
+    tone = 0.8 * np.sin(2 * np.pi * 440 * t)
+    # Add a sharp transient so the transient shaper has something to detect.
+    tone[len(tone) // 2] += 0.15
+    return np.column_stack([tone, tone]).astype(np.float64)
+
+
+class TestGentleCompressZeroTimes:
+    def test_zero_attack_does_not_raise(self):
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, attack_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_zero_release_does_not_raise(self):
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, release_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_both_zero_does_not_raise(self):
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, attack_ms=0, release_ms=0)
+        assert np.all(np.isfinite(result))
+
+    def test_negative_time_clamps_to_floor(self):
+        """A negative attack time must clamp to the floor, not become a
+        coeff>1 runaway envelope. Output byte-identical to the floor-value
+        run pins the clamp; on unfixed code the negative time diverged (it
+        stayed finite on this short signal, so a bare finiteness check did
+        not catch the regression)."""
+        data = _signal()
+        result = gentle_compress(data, 44100, ratio=4.0, attack_ms=-5.0)
+        clamped = gentle_compress(data, 44100, ratio=4.0,
+                                  attack_ms=_MIN_TIME_CONSTANT_MS)
+        assert np.all(np.isfinite(result))
+        assert np.array_equal(result, clamped)
+
+    def test_normal_attack_still_compresses(self):
+        """A normal positive attack must still reduce peaks above threshold."""
+        data = _signal()
+        result = gentle_compress(data, 44100, threshold_db=-12.0, ratio=4.0,
+                                 attack_ms=10.0, release_ms=100.0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+        assert np.max(np.abs(result)) < np.max(np.abs(data))
+
+
+class TestTransientShaperZeroTimes:
+    def test_zero_fast_attack_does_not_raise(self):
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, attack_gain=6.0,
+                                        fast_attack_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_zero_slow_attack_does_not_raise(self):
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, attack_gain=6.0,
+                                        slow_attack_ms=0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+
+    def test_negative_fast_attack_clamps_to_floor(self):
+        """A negative transient fast-attack time must clamp to the floor,
+        producing output byte-identical to the floor-value run (see #410)."""
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, sustain_gain=3.0,
+                                        fast_attack_ms=-1.0)
+        clamped = apply_transient_shaper(data, 44100, sustain_gain=3.0,
+                                         fast_attack_ms=_MIN_TIME_CONSTANT_MS)
+        assert np.all(np.isfinite(result))
+        assert np.array_equal(result, clamped)
+
+    def test_normal_attack_still_shapes(self):
+        """A normal positive attack must still alter the signal."""
+        data = _signal()
+        result = apply_transient_shaper(data, 44100, attack_gain=6.0,
+                                        fast_attack_ms=0.5, slow_attack_ms=20.0)
+        assert result.shape == data.shape
+        assert np.all(np.isfinite(result))
+        assert not np.allclose(result, data)

--- a/tests/unit/promotion/test_find_mastered_dir_411.py
+++ b/tests/unit/promotion/test_find_mastered_dir_411.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #411.
+
+find_mastered_dir must skip candidate paths that exist as regular files
+instead of crashing with NotADirectoryError when it calls iterdir() on them.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the module under test
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from tools.promotion import generate_all_promos as mod
+
+
+@pytest.mark.unit
+class TestFindMasteredDirFileCandidate:
+    """A candidate path that exists as a FILE must not crash the search (#411)."""
+
+    def test_mastered_file_candidate_is_skipped(self, tmp_path):
+        """'mastered' existing as a file must be skipped, not iterdir()'d."""
+        # album_dir itself has no audio, so the loop advances to sub-candidates.
+        (tmp_path / "mastered").write_bytes(b"not a directory")
+
+        # Before the fix this raised NotADirectoryError; now it falls back.
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == tmp_path
+
+    def test_wavs_file_candidate_is_skipped(self, tmp_path):
+        """'wavs' existing as a file must be skipped, not iterdir()'d."""
+        (tmp_path / "wavs").write_bytes(b"not a directory")
+
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == tmp_path
+
+    def test_file_candidate_skipped_and_real_dir_found(self, tmp_path):
+        """A file candidate is skipped while a later real audio dir is still found."""
+        # 'mastered' is a decoy file (probed before 'wavs' in candidate order).
+        (tmp_path / "mastered").write_bytes(b"not a directory")
+        # 'wavs' is a real directory holding audio.
+        wavs = tmp_path / "wavs"
+        wavs.mkdir()
+        (wavs / "01-track.wav").write_bytes(b"audio")
+
+        result = mod.find_mastered_dir(tmp_path)
+        assert result == wavs

--- a/tests/unit/shared/test_find_best_segment_412.py
+++ b/tests/unit/shared/test_find_best_segment_412.py
@@ -1,0 +1,86 @@
+"""Regression tests for find_best_segment window-range off-by-one (issue #412).
+
+find_best_segment scans overlapping ``window_samples``-long windows across the
+RMS energy envelope to locate the most energetic segment. The valid starting
+frame indices span ``0 .. len(rms) - window_samples`` inclusive. A loop of
+``range(len(rms) - window_samples)`` never evaluates that final window, so when
+the peak-energy segment is the last window of the track it is silently skipped;
+in the degenerate ``len(rms) == window_samples`` case the loop never runs at all
+and the start defaults to 0.0.
+
+These tests mock librosa so the RMS / times arrays are fully controlled while
+numpy stays real. find_best_segment wraps its analysis in a broad
+``except Exception`` that falls back to "20% into the track", so each test
+asserts the *exact* expected start time: an off-by-one (wrong window) or a
+swallowed IndexError (fallback value) both produce a different number and fail.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# Ensure project root on sys.path (conftest normally handles this).
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from tools.shared import media_utils as mod
+
+# With duration=15, sr=120 and the internal hop_length=512:
+#   window_samples = int(15 * 120 / 512) = int(3.515625) = 3
+_SR = 120
+_DURATION = 15
+_TOTAL_DURATION = 1000.0  # >> any window time, so the max_start clamp never bites
+# Value returned by the internal fallback path (librosa error / swallowed exc).
+_FALLBACK = min(_TOTAL_DURATION * 0.2, _TOTAL_DURATION - _DURATION)  # 200.0
+
+
+def _run(rms, times):
+    """Invoke find_best_segment with librosa mocked to yield the given arrays."""
+    rms_arr = np.asarray(rms, dtype=float)
+    fake_librosa = MagicMock()
+    fake_librosa.load.return_value = (np.zeros(8, dtype=float), _SR)
+    # librosa.feature.rms(...) returns shape (1, n_frames); the code takes [0].
+    fake_librosa.feature.rms.return_value = np.array([rms_arr])
+    fake_librosa.times_like.return_value = np.asarray(times, dtype=float)
+    with patch.object(mod, "get_audio_duration", return_value=_TOTAL_DURATION), \
+            patch.dict(sys.modules, {"librosa": fake_librosa}):
+        return mod.find_best_segment(Path("/fake.wav"), duration=_DURATION)
+
+
+@pytest.mark.unit
+class TestFindBestSegmentLastWindow:
+    """The final valid analysis window must be considered."""
+
+    def test_selects_last_valid_window(self):
+        # 6 RMS frames, window_samples=3 -> valid start indices 0,1,2,3.
+        # Energy climbs toward the end so the window starting at index 3 (the
+        # LAST valid window) has the highest mean. Buggy range(3) stops at 2.
+        rms = [0.1, 0.1, 0.1, 1.0, 1.0, 1.0]
+        times = [0.0, 10.0, 20.0, 30.0, 40.0, 50.0]
+        # window means: [0:3]=0.1  [1:4]=0.4  [2:5]=0.7  [3:6]=1.0 (max)
+        result = _run(rms, times)
+        assert result == pytest.approx(30.0)  # times[3]; pre-fix -> 20.0
+
+    def test_normal_case_middle_window_unchanged(self):
+        # Peak window sits in the middle (index 1); pre- and post-fix agree,
+        # confirming the range change does not disturb the normal path.
+        rms = [0.1, 0.9, 0.9, 0.9, 0.1, 0.1]
+        times = [0.0, 10.0, 20.0, 30.0, 40.0, 50.0]
+        # window means: [0:3]=0.633  [1:4]=0.9 (max)  [2:5]=0.633  [3:6]=0.367
+        result = _run(rms, times)
+        assert result == pytest.approx(10.0)  # times[1], unchanged by the fix
+
+    def test_boundary_single_window_no_index_error(self):
+        # len(rms) == window_samples (3): exactly one valid window at index 0.
+        # Pre-fix range(0) never runs -> start defaults to 0.0. The fix must
+        # evaluate index 0 and pick times[0] WITHOUT raising IndexError (a raised
+        # IndexError would be swallowed and return the 200.0 fallback instead).
+        rms = [0.2, 0.3, 0.4]
+        times = [5.0, 6.0, 7.0]
+        result = _run(rms, times)
+        assert result != pytest.approx(_FALLBACK)  # no swallowed IndexError
+        assert result == pytest.approx(5.0)  # times[0]; pre-fix -> 0.0

--- a/tests/unit/sheet_music/test_prepare_singles.py
+++ b/tests/unit/sheet_music/test_prepare_singles.py
@@ -220,6 +220,7 @@ class TestPrepareSinglesLegacy:
 
     @patch.object(mod, "_add_title_page_and_footer")
     def test_processes_xml_and_pdf(self, mock_title_page, tmp_path):
+        mock_title_page.return_value = True  # -> bool contract (#390)
         source = self._make_source(tmp_path, [
             "01-first-pour.xml",
             "01-first-pour.pdf",
@@ -234,6 +235,7 @@ class TestPrepareSinglesLegacy:
 
     @patch.object(mod, "_add_title_page_and_footer")
     def test_processes_multiple_tracks(self, mock_title_page, tmp_path):
+        mock_title_page.return_value = True  # -> bool contract (#390)
         source = self._make_source(tmp_path, [
             "01-first.xml", "01-first.pdf",
             "02-second.xml", "02-second.pdf",
@@ -312,6 +314,7 @@ class TestPrepareSinglesManifest:
 
     @patch.object(mod, "_add_title_page_and_footer")
     def test_manifest_flow_uses_titles(self, mock_title_page, tmp_path):
+        mock_title_page.return_value = True  # -> bool contract (#390)
         source = tmp_path / "source"
         source.mkdir()
 

--- a/tests/unit/sheet_music/test_songbook_title_page_390.py
+++ b/tests/unit/sheet_music/test_songbook_title_page_390.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Regression tests for songbook title-page handling (issue #390).
+
+create_songbook used to infer ``singles_have_title_pages = manifest is not
+None`` and unconditionally skip page 0 of every single. But prepare_singles
+writes ``.manifest.json`` unconditionally while silently skipping the title
+page when pypdf/reportlab are unavailable (or the title-page step raises). In
+that case the singles have NO title page yet the manifest exists, so the
+songbook dropped the real first music page of every track (the entire track
+for a 1-page transcription) and miscounted the TOC.
+
+The fix records the actual per-track title-page fact in the manifest
+(``"title_page": true|false``) and makes the songbook trust that flag.
+
+These tests use real pypdf/reportlab so the actual page slicing is exercised.
+
+Usage:
+    python -m pytest tests/unit/sheet_music/test_songbook_title_page_390.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("pypdf")
+pytest.importorskip("reportlab")
+
+from pypdf import PdfReader, PdfWriter  # noqa: E402
+from reportlab.lib.pagesizes import letter  # noqa: E402
+from reportlab.pdfgen import canvas  # noqa: E402
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def _load(module_name: str, rel_path: str):
+    """Load a hyphenated tools module with REAL deps (no mocking)."""
+    path = _PROJECT_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+songbook = _load("create_songbook_real", "tools/sheet-music/create_songbook.py")
+prepare = _load("prepare_singles_real", "tools/sheet-music/prepare_singles.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build real PDFs with identifiable per-page text
+# ---------------------------------------------------------------------------
+
+
+def _write_pdf(path: Path, page_labels: list[str]) -> None:
+    """Write a PDF with one page per label, each stamped with that label."""
+    c = canvas.Canvas(str(path), pagesize=letter)
+    for label in page_labels:
+        c.drawString(72, 720, label)
+        c.showPage()
+    c.save()
+
+
+def _page_texts(path: Path) -> list[str]:
+    return [(p.extract_text() or "") for p in PdfReader(str(path)).pages]
+
+
+def _make_single(source_dir: Path, filename: str, music_pages: int,
+                 *, title_page: bool) -> str:
+    """Create a single PDF and return the unique marker on its first music page.
+
+    The marker is stamped on the first *music* page so a test can assert the
+    songbook did not drop it. When ``title_page`` is True, a title page is
+    prepended (as prepare_singles would), so the music pages start at index 1.
+    """
+    marker = f"MUSIC::{filename}::p1"
+    labels: list[str] = []
+    if title_page:
+        labels.append(f"TITLEPAGE::{filename}")
+    labels.append(marker)
+    labels.extend(f"MUSIC::{filename}::p{n}" for n in range(2, music_pages + 1))
+    _write_pdf(source_dir / f"{filename}.pdf", labels)
+    return marker
+
+
+def _write_manifest(source_dir: Path, entries: list[dict]) -> None:
+    (source_dir / ".manifest.json").write_text(
+        json.dumps({"tracks": entries}, indent=2), encoding="utf-8"
+    )
+
+
+# ===========================================================================
+# Consumer: create_songbook must not drop music pages (#390 core)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestSongbookHonorsTitlePageFlag:
+    def test_single_without_title_page_keeps_its_only_music_page(self, tmp_path):
+        """A 1-page single with title_page=false must survive intact (#390).
+
+        This is the reported worst case: without the flag the songbook skipped
+        page 0 and dropped the entire track.
+        """
+        src = tmp_path / "singles"
+        src.mkdir()
+        marker = _make_single(src, "01 - Lonely Track", music_pages=1,
+                              title_page=False)
+        _write_manifest(src, [{
+            "number": 1, "title": "Lonely Track",
+            "filename": "01 - Lonely Track", "title_page": False,
+        }])
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        # Front matter (title, copyright, TOC) + the one music page = 4.
+        assert len(texts) == 4
+        assert any(marker in t for t in texts), "the only music page was dropped"
+
+    def test_single_with_title_page_skips_only_the_title_page(self, tmp_path):
+        """title_page=true → the prepended title page is skipped, music kept."""
+        src = tmp_path / "singles"
+        src.mkdir()
+        marker = _make_single(src, "01 - Real Title", music_pages=2,
+                              title_page=True)
+        _write_manifest(src, [{
+            "number": 1, "title": "Real Title",
+            "filename": "01 - Real Title", "title_page": True,
+        }])
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        # 3 front matter + 2 music pages (title page dropped) = 5.
+        assert len(texts) == 5
+        assert any(marker in t for t in texts)
+        assert not any("TITLEPAGE" in t for t in texts), "title page leaked in"
+
+    def test_mixed_flags_across_tracks(self, tmp_path):
+        """Per-track flags are honored independently (one true, one false)."""
+        src = tmp_path / "singles"
+        src.mkdir()
+        m_no = _make_single(src, "01 - No Title", music_pages=1, title_page=False)
+        m_yes = _make_single(src, "02 - Has Title", music_pages=1, title_page=True)
+        _write_manifest(src, [
+            {"number": 1, "title": "No Title",
+             "filename": "01 - No Title", "title_page": False},
+            {"number": 2, "title": "Has Title",
+             "filename": "02 - Has Title", "title_page": True},
+        ])
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        # 3 front matter + 1 (no-title single) + 1 (has-title single, minus its
+        # title page) = 5.
+        assert len(texts) == 5
+        assert any(m_no in t for t in texts)
+        assert any(m_yes in t for t in texts)
+        assert not any("TITLEPAGE" in t for t in texts)
+
+    def test_legacy_manifest_without_flag_unchanged(self, tmp_path):
+        """A manifest lacking the flag keeps the prior assume-title-page path.
+
+        Backward-compat: existing correct singles (title pages present, old
+        manifests) must not regress.
+        """
+        src = tmp_path / "singles"
+        src.mkdir()
+        marker = _make_single(src, "01 - Legacy", music_pages=1, title_page=True)
+        _write_manifest(src, [{
+            "number": 1, "title": "Legacy", "filename": "01 - Legacy",
+        }])  # no "title_page" key
+
+        out = tmp_path / "songbook.pdf"
+        ok = songbook.create_songbook(src, out, "Book", "Artist")
+
+        assert ok is True
+        texts = _page_texts(out)
+        assert len(texts) == 4  # title page skipped as before
+        assert any(marker in t for t in texts)
+
+
+# ===========================================================================
+# Producer: prepare_singles records the real title-page fact
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestAddTitlePageReturnsFact:
+    def test_returns_true_and_prepends_page_on_success(self, tmp_path):
+        pdf = tmp_path / "track.pdf"
+        _write_pdf(pdf, ["MUSIC::only-page"])
+        assert PdfReader(str(pdf)).pages.__len__() == 1
+
+        added = prepare._add_title_page_and_footer(
+            pdf, "My Track", "Artist", None, None, "letter"
+        )
+
+        assert added is True
+        # Title page prepended: now 2 pages, page 0 is the title page.
+        pages = _page_texts(pdf)
+        assert len(pages) == 2
+        assert "MUSIC::only-page" in pages[1]
+
+    def test_returns_false_when_title_page_cannot_be_added(self, tmp_path):
+        """A read/parse failure hits the broad except → returns False.
+
+        This is the silent-skip path that must be recorded as title_page=false
+        so the songbook does not later skip a non-existent title page.
+        """
+        missing = tmp_path / "does-not-exist.pdf"
+
+        added = prepare._add_title_page_and_footer(
+            missing, "My Track", "Artist", None, None, "letter"
+        )
+
+        assert added is False
+
+
+@pytest.mark.unit
+class TestPrepareSinglesRecordsTitlePageFact:
+    """prepare_singles must write the real title-page fact into the manifest."""
+
+    def _make_source(self, tmp_path: Path) -> Path:
+        source = tmp_path / "source"
+        source.mkdir()
+        (source / "First Pour.xml").write_text(
+            "<score><work-title>First Pour</work-title></score>"
+        )
+        (source / "First Pour.pdf").write_text("pdf content")
+        (source / ".manifest.json").write_text(json.dumps({
+            "tracks": [
+                {"number": 1, "source_slug": "01-first-pour", "title": "First Pour"}
+            ]
+        }))
+        return source
+
+    def test_manifest_records_title_page_true_when_added(self, tmp_path):
+        source = self._make_source(tmp_path)
+        with patch.object(prepare, "_add_title_page_and_footer", return_value=True):
+            result = prepare.prepare_singles(source, tmp_path / "singles")
+        entry = result["manifest"]["tracks"][0]
+        assert entry["title_page"] is True
+
+    def test_manifest_records_title_page_false_when_skipped(self, tmp_path):
+        """The bug's trigger: deps missing → title page skipped → flag False."""
+        source = self._make_source(tmp_path)
+        with patch.object(prepare, "_add_title_page_and_footer", return_value=False):
+            result = prepare.prepare_singles(source, tmp_path / "singles")
+        entry = result["manifest"]["tracks"][0]
+        assert entry["title_page"] is False
+
+        # And the persisted manifest on disk carries the same fact.
+        written = json.loads(
+            (tmp_path / "singles" / ".manifest.json").read_text(encoding="utf-8")
+        )
+        assert written["tracks"][0]["title_page"] is False

--- a/tests/unit/state/test_create_idea_dup_395.py
+++ b/tests/unit/state/test_create_idea_dup_395.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Regression tests for handlers/ideas.py — create_idea duplicate guard (#395).
+
+create_idea's duplicate check must be case-insensitive to match the readers
+(_find_idea_in_state / get_ideas / promote_idea), which compare titles via
+``title.strip().lower()``. Before the fix the guard did an exact-case
+substring match (``f"### {title.strip()}\n" in text``), so "cyberpunk dreams"
+could be created alongside an existing "Cyberpunk Dreams", producing two
+entries the readers then treat as the same idea.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_idea_dup_395.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import re
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# Mock the MCP SDK if not installed
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_dup395", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import ideas as _ideas_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    """In-memory state cache; rebuild() is a no-op that records calls."""
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+        self.rebuild_called = 0
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self):
+        self.rebuild_called += 1
+        return self._state
+
+
+def _make_state(content_root: Path) -> dict:
+    return {
+        "version": 2,
+        "config": {"content_root": str(content_root), "artist_name": "test-artist"},
+        "albums": {},
+        "ideas": {"counts": {}, "items": [], "total": 0},
+        "session": {},
+    }
+
+
+def _count_headers(text: str) -> int:
+    """Count '### <title>' idea headers in IDEAS.md text."""
+    return len(re.findall(r'^###\s+', text, re.MULTILINE))
+
+
+@pytest.fixture
+def content_root(tmp_path: Path) -> Path:
+    root = tmp_path / "content"
+    root.mkdir(parents=True)
+    return root
+
+
+@pytest.fixture
+def use_cache(content_root: Path):
+    """Install a MockStateCache pointing at content_root; restore afterward."""
+    orig_cache = _shared_mod.cache
+    cache = MockStateCache(_make_state(content_root))
+    _shared_mod.cache = cache
+    yield cache
+    _shared_mod.cache = orig_cache
+
+
+def _write_ideas_md(content_root: Path, body: str) -> Path:
+    ideas_path = content_root / "IDEAS.md"
+    ideas_path.write_text(body, encoding="utf-8")
+    return ideas_path
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive duplicate guard (#395)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIdeaCaseInsensitiveDuplicate:
+    def test_lowercase_dup_of_titlecase_rejected(self, content_root, use_cache):
+        """"cyberpunk dreams" is a duplicate of an existing "Cyberpunk Dreams"."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n"
+            "**Genre**: electronic\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("cyberpunk dreams")))
+
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        # No second section was written.
+        text = ideas_path.read_text(encoding="utf-8")
+        assert _count_headers(text) == 1
+        assert "### cyberpunk dreams" not in text
+
+    def test_uppercase_dup_of_titlecase_rejected(self, content_root, use_cache):
+        """Uppercasing an existing title is still a duplicate."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("CYBERPUNK DREAMS")))
+
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        assert _count_headers(ideas_path.read_text(encoding="utf-8")) == 1
+
+    def test_exact_case_dup_still_rejected(self, content_root, use_cache):
+        """Existing exact-case behavior is preserved."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("Cyberpunk Dreams")))
+
+        assert result["created"] is False
+        assert "already exists" in result["error"]
+        assert _count_headers(ideas_path.read_text(encoding="utf-8")) == 1
+
+
+class TestCreateIdeaGenuinelyNew:
+    def test_new_distinct_title_still_created(self, content_root, use_cache):
+        """A title that isn't a case-variant of any existing idea is created."""
+        ideas_path = _write_ideas_md(
+            content_root,
+            "# Album Ideas\n\n## Ideas\n\n### Cyberpunk Dreams\n**Status**: Pending\n",
+        )
+
+        result = json.loads(_run(_ideas_mod.create_idea("Synthwave Nights")))
+
+        assert result["created"] is True
+        assert result["title"] == "Synthwave Nights"
+        text = ideas_path.read_text(encoding="utf-8")
+        # Both the original and the new idea are present.
+        assert "### Cyberpunk Dreams" in text
+        assert "### Synthwave Nights" in text
+        assert _count_headers(text) == 2
+
+    def test_new_title_created_into_empty_ideas(self, content_root, use_cache):
+        """Sanity: a first idea into a fresh file is created."""
+        ideas_path = _write_ideas_md(content_root, "# Album Ideas\n\n## Ideas\n")
+
+        result = json.loads(_run(_ideas_mod.create_idea("Cyberpunk Dreams")))
+
+        assert result["created"] is True
+        assert _count_headers(ideas_path.read_text(encoding="utf-8")) == 1

--- a/tests/unit/state/test_create_track_title_unicode_403.py
+++ b/tests/unit/state/test_create_track_title_unicode_403.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Unit tests for create_track frontmatter non-ASCII readability (issue #403 polish).
+
+The #403 fix writes the frontmatter title via ``json.dumps(title)``. With the
+default ``ensure_ascii=True`` a non-ASCII title is emitted as ``\\uXXXX``
+escapes inside the quoted scalar (e.g. ``title: "caf\\u00e9"`` for ``café``).
+It round-trips (YAML decodes the escape back to ``café``), but the on-disk
+frontmatter no longer matches the human-readable body (H1/table keep the raw
+``café``). Passing ``ensure_ascii=False`` keeps quotes/backslashes escaped
+while preserving readable unicode, aligning the frontmatter with the body.
+
+These tests pin the readable-frontmatter behavior; they FAIL on the
+``ensure_ascii=True`` output and PASS once ``ensure_ascii=False`` is used.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_track_title_unicode_403.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_create_track_validation.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_track_unicode", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import status as _status_mod  # noqa: E402
+from tools.state.parsers import parse_frontmatter  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic filesystem layout + mock cache (mirrors
+# test_create_track_title_yaml_403.py)
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+@pytest.fixture
+def cache_with_album(tmp_path: Path):
+    """Install a mock cache populated with a single album with a tracks/ dir."""
+    content_root = tmp_path / "content"
+    album_dir = (
+        content_root / "artists" / "test-artist" / "albums" / "electronic"
+        / "test-album"
+    )
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+    (album_dir / "README.md").write_text(
+        "# Test Album\n\n## Album Details\n\n| **Title** | Test Album |\n",
+        encoding="utf-8",
+    )
+
+    album_data = {
+        "title": "Test Album",
+        "status": "In Progress",
+        "genre": "electronic",
+        "explicit": False,
+        "path": str(album_dir),
+        "track_count": 0,
+        "tracks_completed": 0,
+        "tracks": {},
+    }
+
+    state = {
+        "version": 2,
+        "config": {
+            "content_root": str(content_root),
+            "artist_name": "test-artist",
+            "generation": {},
+        },
+        "albums": {"test-album": album_data},
+        "session": {},
+    }
+
+    orig_cache = _shared_mod.cache
+    orig_plugin_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.cache = MockStateCache(state)
+    # Real template lives at PROJECT_ROOT/templates/track.md
+    _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+
+    yield state, tracks_dir
+
+    _shared_mod.cache = orig_cache
+    _shared_mod.PLUGIN_ROOT = orig_plugin_root
+
+
+def _create(title: str, track_number="1") -> dict:
+    return json.loads(_run(
+        _status_mod.create_track("test-album", track_number, title)
+    ))
+
+
+def _written_content(tracks_dir: Path) -> str:
+    files = list(tracks_dir.iterdir())
+    assert len(files) == 1, f"expected exactly one track file, got {files}"
+    return files[0].read_text(encoding="utf-8")
+
+
+# ===========================================================================
+# Non-ASCII titles stay human-readable in the frontmatter scalar
+# ===========================================================================
+
+
+class TestFrontmatterTitleUnicodeReadable:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "café",
+            "naïve",
+            "Björk",
+            "Résumé",
+            "日本語",
+        ],
+    )
+    def test_non_ascii_title_written_readable(self, cache_with_album, title):
+        """The frontmatter scalar keeps readable unicode, not \\uXXXX escapes."""
+        _state, tracks_dir = cache_with_album
+
+        result = _create(title)
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+
+        # The readable, unescaped title appears verbatim in the quoted scalar
+        # (this is what ensure_ascii=False produces; ensure_ascii=True would
+        # instead emit \uXXXX escapes and this line would be absent).
+        assert f'title: "{title}"' in content
+
+        # Frontmatter still parses cleanly and the title round-trips exactly.
+        fm = parse_frontmatter(content)
+        assert "_error" not in fm, fm.get("_error")
+        assert fm.get("title") == title
+
+    def test_frontmatter_matches_readable_body(self, cache_with_album):
+        """Frontmatter title reads the same as the H1/table body (no escapes)."""
+        _state, tracks_dir = cache_with_album
+
+        _create("café")
+        content = _written_content(tracks_dir)
+
+        # Body keeps the raw unicode ...
+        assert "# café" in content
+        assert "| **Title** | café |" in content
+        # ... and the frontmatter now matches it, with no \uXXXX artifact.
+        assert 'title: "café"' in content
+        assert "caf\\u00e9" not in content
+
+
+# ===========================================================================
+# A double quote must still be escaped (the original #403 correctness fix) —
+# ensure_ascii=False must not regress quote/backslash escaping.
+# ===========================================================================
+
+
+class TestSpecialCharsStillEscaped:
+    def test_double_quote_title_still_valid_yaml(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create('Say "Goodbye"')
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+        fm = parse_frontmatter(content)
+        assert "_error" not in fm
+        assert fm.get("title") == 'Say "Goodbye"'
+        # The raw unescaped quotes must never leak into the scalar.
+        assert 'title: "Say "Goodbye""' not in content
+
+    def test_ascii_title_byte_identical_scalar(self, cache_with_album):
+        """A plain ASCII title is unaffected by ensure_ascii=False."""
+        _state, tracks_dir = cache_with_album
+
+        _create("My New Track")
+        content = _written_content(tracks_dir)
+        assert 'title: "My New Track"' in content

--- a/tests/unit/state/test_create_track_title_yaml_403.py
+++ b/tests/unit/state/test_create_track_title_yaml_403.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Unit tests for create_track frontmatter YAML escaping (issue #403).
+
+create_track filled the template with a blanket
+``template.replace("[Track Title]", title)``. Because the template
+frontmatter carries the title as a quoted scalar (``title: "[Track Title]"``),
+a title containing a double quote (e.g. ``Say "Goodbye"``) produced
+``title: "Say "Goodbye""`` — invalid YAML. parse_frontmatter() then failed and
+every frontmatter field (title, track_number, explicit) was silently dropped.
+
+The frontmatter title must receive a properly escaped YAML double-quoted
+scalar (json.dumps output is valid YAML) so the whole frontmatter block still
+parses and the title round-trips exactly, while the human-readable body (H1,
+details table) keeps the raw title.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_track_title_yaml_403.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_create_track_validation.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_track_yaml", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import status as _status_mod  # noqa: E402
+from tools.state.parsers import parse_frontmatter  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic filesystem layout + mock cache (mirrors
+# test_create_track_validation.py)
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+@pytest.fixture
+def cache_with_album(tmp_path: Path):
+    """Install a mock cache populated with a single album with a tracks/ dir."""
+    content_root = tmp_path / "content"
+    album_dir = (
+        content_root / "artists" / "test-artist" / "albums" / "electronic"
+        / "test-album"
+    )
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+    (album_dir / "README.md").write_text(
+        "# Test Album\n\n## Album Details\n\n| **Title** | Test Album |\n",
+        encoding="utf-8",
+    )
+
+    album_data = {
+        "title": "Test Album",
+        "status": "In Progress",
+        "genre": "electronic",
+        "explicit": False,
+        "path": str(album_dir),
+        "track_count": 0,
+        "tracks_completed": 0,
+        "tracks": {},
+    }
+
+    state = {
+        "version": 2,
+        "config": {
+            "content_root": str(content_root),
+            "artist_name": "test-artist",
+            "generation": {},
+        },
+        "albums": {"test-album": album_data},
+        "session": {},
+    }
+
+    orig_cache = _shared_mod.cache
+    orig_plugin_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.cache = MockStateCache(state)
+    # Real template lives at PROJECT_ROOT/templates/track.md
+    _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+
+    yield state, tracks_dir
+
+    _shared_mod.cache = orig_cache
+    _shared_mod.PLUGIN_ROOT = orig_plugin_root
+
+
+def _create(title: str, track_number="1") -> dict:
+    return json.loads(_run(
+        _status_mod.create_track("test-album", track_number, title)
+    ))
+
+
+def _written_content(tracks_dir: Path) -> str:
+    files = list(tracks_dir.iterdir())
+    assert len(files) == 1, f"expected exactly one track file, got {files}"
+    return files[0].read_text(encoding="utf-8")
+
+
+# ===========================================================================
+# Frontmatter must stay valid YAML and the title must round-trip exactly
+# ===========================================================================
+
+
+class TestFrontmatterTitleEscaping:
+    # NOTE: titles containing a backslash are rejected earlier by
+    # _normalize_slug (path-separator guard) and never reach the frontmatter
+    # fill, so they are out of scope here. #403 is specifically about a
+    # double quote breaking the quoted YAML scalar. json.dumps still escapes
+    # backslashes correctly for any title that does reach the fill.
+    @pytest.mark.parametrize(
+        "title",
+        [
+            'Say "Goodbye"',
+            'Quote "Test" Song',
+            '"Leading quote',
+            'Trailing quote"',
+            "It's a \"trap\"",
+        ],
+    )
+    def test_special_char_title_frontmatter_round_trips(
+        self, cache_with_album, title
+    ):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(title)
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+        fm = parse_frontmatter(content)
+
+        # Frontmatter must parse cleanly (no degraded _error) ...
+        assert "_error" not in fm, fm.get("_error")
+        # ... and the title must survive verbatim.
+        assert fm.get("title") == title
+
+    def test_double_quote_title_preserves_sibling_frontmatter_fields(
+        self, cache_with_album
+    ):
+        """The bug dropped *all* frontmatter fields, not just the title."""
+        _state, tracks_dir = cache_with_album
+
+        result = _create('Say "Goodbye"', track_number="4")
+        assert result["created"] is True
+
+        fm = parse_frontmatter(_written_content(tracks_dir))
+        assert "_error" not in fm
+        assert fm.get("track_number") == 4
+        assert fm.get("explicit") is False
+        assert fm.get("instrumental") is False
+
+    def test_double_quote_title_kept_readable_in_body(self, cache_with_album):
+        """Human-readable body (H1 + details table) keeps the raw title."""
+        _state, tracks_dir = cache_with_album
+
+        _create('Say "Goodbye"')
+        content = _written_content(tracks_dir)
+
+        assert '# Say "Goodbye"' in content
+        assert '| **Title** | Say "Goodbye" |' in content
+        # The unescaped raw title must never leak into the frontmatter scalar.
+        assert 'title: "Say "Goodbye""' not in content
+
+
+# ===========================================================================
+# Normal titles keep working
+# ===========================================================================
+
+
+class TestNormalTitleUnaffected:
+    def test_plain_title_round_trips(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create("My New Track")
+        assert result["created"] is True
+
+        content = _written_content(tracks_dir)
+        fm = parse_frontmatter(content)
+        assert "_error" not in fm
+        assert fm.get("title") == "My New Track"
+        assert fm.get("track_number") == 1
+        assert "# My New Track" in content
+        assert "| **Title** | My New Track |" in content

--- a/tests/unit/state/test_create_track_validation.py
+++ b/tests/unit/state/test_create_track_validation.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Unit tests for create_track track_number validation (issue #372).
+
+create_track previously crashed with an unhandled ValueError when
+track_number contained non-digits (e.g. "1a"), and silently created a
+spurious track "00" for empty/whitespace input. It must instead return the
+module's structured ``{"error": ...}`` JSON for any track_number that is not
+a positive integer, and preserve normal behavior for valid ints and numeric
+strings.
+
+Usage:
+    python -m pytest tests/unit/state/test_create_track_validation.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_handlers_rename.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+    class _FakeFastMCP:
+        def __init__(self, name: str = "") -> None:
+            self.name = name
+            self._tools: dict = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport: str = "stdio") -> None:
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_create_track", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import status as _status_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: realistic filesystem layout + mock cache
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+@pytest.fixture
+def cache_with_album(tmp_path: Path):
+    """Install a mock cache populated with a single album with a tracks/ dir."""
+    content_root = tmp_path / "content"
+    album_dir = (
+        content_root / "artists" / "test-artist" / "albums" / "electronic"
+        / "test-album"
+    )
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+    (album_dir / "README.md").write_text(
+        "# Test Album\n\n## Album Details\n\n| **Title** | Test Album |\n",
+        encoding="utf-8",
+    )
+
+    album_data = {
+        "title": "Test Album",
+        "status": "In Progress",
+        "genre": "electronic",
+        "explicit": False,
+        "path": str(album_dir),
+        "track_count": 0,
+        "tracks_completed": 0,
+        "tracks": {},
+    }
+
+    state = {
+        "version": 2,
+        "config": {
+            "content_root": str(content_root),
+            "artist_name": "test-artist",
+            "generation": {},
+        },
+        "albums": {"test-album": album_data},
+        "session": {},
+    }
+
+    orig_cache = _shared_mod.cache
+    orig_plugin_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.cache = MockStateCache(state)
+    # Real template lives at PROJECT_ROOT/templates/track.md
+    _shared_mod.PLUGIN_ROOT = PROJECT_ROOT
+
+    yield state, tracks_dir
+
+    _shared_mod.cache = orig_cache
+    _shared_mod.PLUGIN_ROOT = orig_plugin_root
+
+
+def _create(track_number, title: str = "My New Track") -> dict:
+    return json.loads(_run(
+        _status_mod.create_track("test-album", track_number, title)
+    ))
+
+
+# ===========================================================================
+# Invalid track_number values — structured error, no exception, no file
+# ===========================================================================
+
+
+class TestCreateTrackInvalidNumbers:
+    @pytest.mark.parametrize("bad", ["abc", "1a", "v2", "track1", "", " "])
+    def test_non_numeric_string_returns_structured_error(self, cache_with_album, bad):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(bad)
+
+        assert "error" in result
+        assert "track_number" in result["error"]
+        assert list(tracks_dir.iterdir()) == []
+
+    def test_error_names_the_invalid_value(self, cache_with_album):
+        result = _create("1a")
+
+        assert "error" in result
+        assert "1a" in result["error"]
+
+    def test_none_returns_structured_error(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(None)
+
+        assert "error" in result
+        assert list(tracks_dir.iterdir()) == []
+
+    @pytest.mark.parametrize("bad", [-1, 0])
+    def test_non_positive_int_returns_structured_error(self, cache_with_album, bad):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(bad)
+
+        assert "error" in result
+        assert str(bad) in result["error"]
+        assert list(tracks_dir.iterdir()) == []
+
+    @pytest.mark.parametrize("bad", ["-1", "0", "00"])
+    def test_non_positive_numeric_string_returns_structured_error(
+        self, cache_with_album, bad
+    ):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(bad)
+
+        assert "error" in result
+        assert list(tracks_dir.iterdir()) == []
+
+    def test_bool_true_returns_structured_error(self, cache_with_album):
+        """bool is an int subclass — True must not become track 01."""
+        _state, tracks_dir = cache_with_album
+
+        result = _create(True)
+
+        assert "error" in result
+        assert "True" in result["error"]
+        assert list(tracks_dir.iterdir()) == []
+
+
+# ===========================================================================
+# Valid track_number values — normal behavior preserved
+# ===========================================================================
+
+
+class TestCreateTrackValidNumbers:
+    def test_numeric_string_creates_zero_padded_track(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create("7")
+
+        assert result["created"] is True
+        assert result["filename"] == "07-my-new-track.md"
+        assert result["track_slug"] == "07-my-new-track"
+        track_path = tracks_dir / "07-my-new-track.md"
+        assert track_path.exists()
+        content = track_path.read_text(encoding="utf-8")
+        assert "track_number: 7" in content
+        assert "| **Track #** | 07 |" in content
+
+    def test_plain_int_creates_zero_padded_track(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create(7)
+
+        assert result["created"] is True
+        assert result["filename"] == "07-my-new-track.md"
+        assert (tracks_dir / "07-my-new-track.md").exists()
+
+    def test_zero_padded_string_preserved(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+
+        result = _create("03")
+
+        assert result["created"] is True
+        assert result["filename"] == "03-my-new-track.md"
+        content = (tracks_dir / "03-my-new-track.md").read_text(encoding="utf-8")
+        assert "track_number: 3" in content
+
+    def test_two_digit_number_not_repadded(self, cache_with_album):
+        _state, _tracks_dir = cache_with_album
+
+        result = _create("12")
+
+        assert result["created"] is True
+        assert result["filename"] == "12-my-new-track.md"
+
+    def test_existing_track_still_reports_duplicate(self, cache_with_album):
+        _state, tracks_dir = cache_with_album
+        (tracks_dir / "07-my-new-track.md").write_text("stub", encoding="utf-8")
+
+        result = _create("7")
+
+        assert result["created"] is False
+        assert "error" in result

--- a/tests/unit/state/test_frontmatter_block_validation.py
+++ b/tests/unit/state/test_frontmatter_block_validation.py
@@ -1,0 +1,72 @@
+"""Tests for _update_frontmatter_block non-mapping frontmatter validation (issue #378).
+
+``_update_frontmatter_block`` documents a ``(True, None)`` / ``(False, error)``
+contract, but frontmatter that parses to a YAML list or scalar used to raise
+``TypeError`` at ``fm[key] = values``. These tests pin the contract: non-dict
+frontmatter must return ``(False, error_string)`` and leave the file untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers._shared import _update_frontmatter_block  # noqa: E402
+
+
+class TestNonMappingFrontmatter:
+    """Non-dict frontmatter must return (False, error), never raise."""
+
+    def test_list_frontmatter_returns_false_error(self, tmp_path: Path) -> None:
+        md = tmp_path / "track.md"
+        original = "---\n- a\n- b\n---\n# Body\n"
+        md.write_text(original, encoding="utf-8")
+
+        ok, err = _update_frontmatter_block(md, "sheet_music", {"pdf": "http://x/y.pdf"})
+
+        assert ok is False
+        assert err is not None
+        assert "not a mapping" in err
+        assert str(md) in err
+        assert "list" in err
+        # File must be left untouched on failure.
+        assert md.read_text(encoding="utf-8") == original
+
+    def test_scalar_frontmatter_returns_false_error(self, tmp_path: Path) -> None:
+        md = tmp_path / "track.md"
+        original = "---\njust a string\n---\n# Body\n"
+        md.write_text(original, encoding="utf-8")
+
+        ok, err = _update_frontmatter_block(md, "sheet_music", {"pdf": "http://x/y.pdf"})
+
+        assert ok is False
+        assert err is not None
+        assert "not a mapping" in err
+        assert str(md) in err
+        assert "str" in err
+        assert md.read_text(encoding="utf-8") == original
+
+
+class TestValidMappingFrontmatter:
+    """Regression guard: dict frontmatter keeps working."""
+
+    def test_mapping_frontmatter_updates_successfully(self, tmp_path: Path) -> None:
+        md = tmp_path / "track.md"
+        md.write_text("---\ntitle: Song\n---\n# Body\n", encoding="utf-8")
+
+        ok, err = _update_frontmatter_block(md, "sheet_music", {"pdf": "http://x/y.pdf"})
+
+        assert ok is True
+        assert err is None
+        text = md.read_text(encoding="utf-8")
+        assert "title: Song" in text
+        assert "sheet_music:" in text
+        assert "pdf: http://x/y.pdf" in text
+        assert "# Body" in text

--- a/tests/unit/state/test_handlers_content.py
+++ b/tests/unit/state/test_handlers_content.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Unit tests for handlers/content.py — overrides, reference files, clipboard.
+
+Covers the three public MCP tools:
+
+    load_override(override_name)          — user override file loading
+    get_reference(name, section)          — plugin reference file reads
+    format_for_clipboard(album, track, …) — track section extraction/format
+
+Each tool gets a happy path plus a missing-file / unknown-name error and a
+malformed-input case (path traversal or invalid content-type). Follows the
+fixture/mocking style of test_handlers_streaming.py: mock StateCache via
+``_shared.cache``, an ``asyncio.run`` helper, and structured-JSON assertions.
+
+Usage:
+    python -m pytest tests/unit/state/test_handlers_content.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path for imports
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_content", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import content as _content_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Mock cache + sample track content
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+
+# A full track file with every section format_for_clipboard understands.
+FULL_TRACK_MD = """# First Track
+
+## Style Box
+
+```
+synthwave, retro, 118 BPM, driving bassline
+```
+
+## Exclude Styles
+
+```
+country, banjo, twang
+```
+
+## Lyrics Box
+
+```
+[Verse 1]
+Neon rain on the boulevard tonight
+```
+
+## Streaming Lyrics
+
+```
+Neon rain on the boulevard tonight
+```
+"""
+
+# A bare track file with only a Lyrics Box — used for "section missing" cases.
+BARE_TRACK_MD = """# Bare Track
+
+## Lyrics Box
+
+```
+[Verse 1]
+Just the words, nothing else here
+```
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def override_env(tmp_path):
+    """Overrides directory on disk + a mock cache pointing config at it."""
+    overrides_dir = tmp_path / "overrides"
+    overrides_dir.mkdir()
+    (overrides_dir / "pronunciation-guide.md").write_text(
+        "# Pronunciation\n\nbitwize -> bit-wize\n", encoding="utf-8",
+    )
+
+    state = {"config": {"overrides_dir": str(overrides_dir)}}
+    orig_cache = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    yield overrides_dir
+    _shared_mod.cache = orig_cache
+
+
+@pytest.fixture
+def reference_env(tmp_path):
+    """Temp plugin root with a reference/ tree; installs into _shared.PLUGIN_ROOT."""
+    ref_dir = tmp_path / "reference" / "suno"
+    ref_dir.mkdir(parents=True)
+    (ref_dir / "test-guide.md").write_text(
+        "# Test Guide\n\nIntro line.\n\n"
+        "## Section A\n\nAlpha content here.\n\n"
+        "## Section B\n\nBeta content here.\n",
+        encoding="utf-8",
+    )
+
+    orig_root = _shared_mod.PLUGIN_ROOT
+    _shared_mod.PLUGIN_ROOT = tmp_path
+    yield tmp_path
+    _shared_mod.PLUGIN_ROOT = orig_root
+
+
+@pytest.fixture
+def clipboard_env(tmp_path):
+    """Album with three tracks (full / bare / no-path) plus a mock cache."""
+    album_dir = tmp_path / "album"
+    tracks_dir = album_dir / "tracks"
+    tracks_dir.mkdir(parents=True)
+
+    full_path = tracks_dir / "01-first-track.md"
+    full_path.write_text(FULL_TRACK_MD, encoding="utf-8")
+    bare_path = tracks_dir / "02-bare-track.md"
+    bare_path.write_text(BARE_TRACK_MD, encoding="utf-8")
+
+    state = {
+        "config": {"content_root": str(tmp_path)},
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "genre": "electronic",
+                "path": str(album_dir),
+                "tracks": {
+                    "01-first-track": {"title": "First Track", "path": str(full_path)},
+                    "02-bare-track": {"title": "Bare Track", "path": str(bare_path)},
+                    "03-no-path": {"title": "No Path", "path": ""},
+                },
+            },
+        },
+    }
+    orig_cache = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    yield album_dir
+    _shared_mod.cache = orig_cache
+
+
+# ===========================================================================
+# load_override
+# ===========================================================================
+
+
+class TestLoadOverride:
+    def test_existing_override_returns_content(self, override_env):
+        result = json.loads(_run(_content_mod.load_override("pronunciation-guide.md")))
+        assert result["found"] is True
+        assert result["override_name"] == "pronunciation-guide.md"
+        assert "bit-wize" in result["content"]
+        assert result["size"] == len(result["content"])
+
+    def test_missing_override_returns_not_found(self, override_env):
+        result = json.loads(_run(_content_mod.load_override("does-not-exist.md")))
+        assert result["found"] is False
+        assert result["override_name"] == "does-not-exist.md"
+
+    def test_path_traversal_is_rejected(self, override_env):
+        result = json.loads(_run(_content_mod.load_override("../secret.txt")))
+        assert "error" in result
+        assert "escape" in result["error"].lower()
+
+    def test_no_config_returns_error(self):
+        orig = _shared_mod.cache
+        _shared_mod.cache = MockStateCache({})
+        try:
+            result = json.loads(_run(_content_mod.load_override("anything.md")))
+        finally:
+            _shared_mod.cache = orig
+        assert "error" in result
+        assert "config" in result["error"].lower()
+
+    def test_falls_back_to_content_root_overrides(self, tmp_path):
+        """With no overrides_dir set, config.content_root/overrides is used."""
+        overrides_dir = tmp_path / "overrides"
+        overrides_dir.mkdir()
+        (overrides_dir / "CLAUDE.md").write_text("custom rules", encoding="utf-8")
+
+        orig = _shared_mod.cache
+        _shared_mod.cache = MockStateCache({"config": {"content_root": str(tmp_path)}})
+        try:
+            result = json.loads(_run(_content_mod.load_override("CLAUDE.md")))
+        finally:
+            _shared_mod.cache = orig
+        assert result["found"] is True
+        assert result["content"] == "custom rules"
+
+
+# ===========================================================================
+# get_reference
+# ===========================================================================
+
+
+class TestGetReference:
+    def test_full_file_returned(self, reference_env):
+        result = json.loads(_run(_content_mod.get_reference("suno/test-guide")))
+        assert result["found"] is True
+        assert "Alpha content here." in result["content"]
+        assert "Beta content here." in result["content"]
+        assert result["size"] == len(result["content"])
+
+    def test_missing_md_extension_is_added(self, reference_env):
+        """A name without a .md suffix still resolves the .md file."""
+        with_ext = json.loads(_run(_content_mod.get_reference("suno/test-guide.md")))
+        without_ext = json.loads(_run(_content_mod.get_reference("suno/test-guide")))
+        assert with_ext["content"] == without_ext["content"]
+
+    def test_section_extracted(self, reference_env):
+        result = json.loads(
+            _run(_content_mod.get_reference("suno/test-guide", section="Section A"))
+        )
+        assert result["found"] is True
+        assert result["section"] == "Section A"
+        assert result["content"] == "Alpha content here."
+        assert "Beta" not in result["content"]
+
+    def test_unknown_section_returns_error(self, reference_env):
+        result = json.loads(
+            _run(_content_mod.get_reference("suno/test-guide", section="Nowhere"))
+        )
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_missing_reference_returns_error(self, reference_env):
+        result = json.loads(_run(_content_mod.get_reference("suno/nonexistent")))
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_path_traversal_is_rejected(self, reference_env):
+        result = json.loads(_run(_content_mod.get_reference("../secret")))
+        assert "error" in result
+        assert "escape" in result["error"].lower()
+
+
+# ===========================================================================
+# format_for_clipboard
+# ===========================================================================
+
+
+class TestFormatForClipboard:
+    def test_lyrics_extracted(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "01-first-track", "lyrics"))
+        )
+        assert result["found"] is True
+        assert result["content_type"] == "lyrics"
+        assert "Neon rain on the boulevard" in result["content"]
+
+    def test_style_includes_exclude(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "01-first-track", "style"))
+        )
+        assert result["found"] is True
+        # Style Box + Exclude Styles are joined when both are present.
+        assert "synthwave" in result["content"]
+        assert "country" in result["content"]
+
+    def test_all_combines_sections(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "01-first-track", "all"))
+        )
+        assert result["found"] is True
+        assert "synthwave" in result["content"]
+        assert "Exclude:" in result["content"]
+        assert "Neon rain on the boulevard" in result["content"]
+
+    def test_suno_returns_json_object(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "01-first-track", "suno"))
+        )
+        assert result["found"] is True
+        payload = json.loads(result["content"])
+        assert payload["title"] == "First Track"
+        assert "synthwave" in payload["style"]
+        assert "country" in payload["exclude_styles"]
+        assert "Neon rain on the boulevard" in payload["lyrics"]
+
+    def test_prefix_track_match_works(self, clipboard_env):
+        """A bare track number resolves via prefix match."""
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "01", "lyrics"))
+        )
+        assert result["found"] is True
+        assert result["track_slug"] == "01-first-track"
+
+    def test_invalid_content_type_returns_error(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "01-first-track", "bogus"))
+        )
+        assert "error" in result
+        assert "invalid content_type" in result["error"].lower()
+
+    def test_album_not_found(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("nonexistent", "01-first-track", "lyrics"))
+        )
+        assert result["found"] is False
+
+    def test_track_not_found(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "99-ghost", "lyrics"))
+        )
+        assert result["found"] is False
+
+    def test_missing_section_returns_not_found(self, clipboard_env):
+        """The bare track has no Style Box, so a 'style' request finds nothing."""
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "02-bare-track", "style"))
+        )
+        assert result["found"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_track_without_path_returns_not_found(self, clipboard_env):
+        result = json.loads(
+            _run(_content_mod.format_for_clipboard("test-album", "03-no-path", "lyrics"))
+        )
+        assert result["found"] is False
+        assert "no path" in result["error"].lower()

--- a/tests/unit/state/test_handlers_database_validation.py
+++ b/tests/unit/state/test_handlers_database_validation.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Input-validation tests for handlers/database.py MCP tool handlers.
+
+Malformed slugs (path separators, null bytes, traversal sequences) must
+produce a structured JSON error via _safe_json — never an exception that
+escapes the handler to the FastMCP layer.
+
+Structured one class per tool so later issues can append their own classes.
+
+Covers:
+    - issue #379: db_sync_album crashed with an uncaught ValueError on
+      malformed album_slug because _find_album_or_error ran outside the
+      handler's try block.
+    - issue #380: db_create_tweet silently dropped the track link (inserted
+      track_id NULL) and falsely echoed the requested track_number when the
+      track row was not found for the album.
+
+Usage:
+    python -m pytest tests/unit/state/test_handlers_database_validation.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the MCP server source is importable as the `handlers` package
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import database as _database_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(coro: Any) -> str:
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+SAMPLE_STATE: dict[str, Any] = {
+    "albums": {
+        "test-album": {
+            "title": "Test Album",
+            "genre": "electronic",
+            "status": "In Progress",
+            "track_count": 1,
+            "explicit": False,
+            "release_date": None,
+            "streaming_urls": {},
+            "tracks": {
+                "01-first-track": {"title": "First Track"},
+            },
+        },
+    },
+}
+
+
+class MockStateCache:
+    """Minimal StateCache stand-in for _shared.cache."""
+
+    def __init__(self, state: dict[str, Any] | None = None):
+        self._state = state if state is not None else copy.deepcopy(SAMPLE_STATE)
+
+    def get_state(self) -> dict[str, Any]:
+        return self._state
+
+    def get_state_ref(self) -> dict[str, Any]:
+        return self._state
+
+
+class _FakeSyncCursor:
+    """Cursor stand-in for db_sync_album's INSERT ... RETURNING queries."""
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        pass
+
+    def fetchone(self) -> dict[str, Any]:
+        return {"id": 1}
+
+
+class _PatchedDb:
+    """Patch DB deps, connection, and psycopg2 import for handler tests."""
+
+    def __init__(self) -> None:
+        self.conn = MagicMock()
+        self.conn.cursor.return_value = _FakeSyncCursor()
+
+        fake_extras = MagicMock()
+        fake_extras.RealDictCursor = "RealDictCursor"
+        fake_psycopg2 = MagicMock()
+        fake_psycopg2.extras = fake_extras
+
+        self._patches = [
+            patch("handlers.database._check_db_deps", return_value=None),
+            patch(
+                "handlers.database._get_db_connection",
+                return_value=(self.conn, None),
+            ),
+            patch.dict(sys.modules, {
+                "psycopg2": fake_psycopg2,
+                "psycopg2.extras": fake_extras,
+            }),
+        ]
+
+    def __enter__(self) -> "_PatchedDb":
+        for p in self._patches:
+            p.__enter__()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        for p in reversed(self._patches):
+            p.__exit__(*args)
+
+
+# =============================================================================
+# db_sync_album — issue #379
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDbSyncAlbumSlugValidation:
+    """db_sync_album must return a JSON error on malformed album_slug (#379)."""
+
+    def setup_method(self) -> None:
+        self._orig_cache = _shared_mod.cache
+        _shared_mod.cache = MockStateCache()
+
+    def teardown_method(self) -> None:
+        _shared_mod.cache = self._orig_cache
+
+    @pytest.mark.parametrize("bad_slug", [
+        "../etc",
+        "a/b",
+        "a\\b",
+        "nul\0byte",
+    ])
+    def test_malformed_slug_returns_json_error(self, bad_slug: str) -> None:
+        """Malformed slugs return a structured JSON error, not an exception."""
+        with _PatchedDb():
+            result = _run(_database_mod.db_sync_album(bad_slug))
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "Invalid" in parsed["error"]
+        assert "synced" not in parsed
+
+    def test_valid_slug_not_found_returns_not_found_error(self) -> None:
+        """Valid but unknown slug still returns the album-not-found JSON."""
+        with _PatchedDb():
+            result = _run(_database_mod.db_sync_album("no-such-album"))
+        parsed = json.loads(result)
+        assert parsed["found"] is False
+        assert "not found" in parsed["error"]
+        assert "available_albums" in parsed
+
+    def test_valid_slug_syncs_album(self) -> None:
+        """Valid existing slug syncs album and tracks (behavior unchanged)."""
+        with _PatchedDb() as db:
+            result = _run(_database_mod.db_sync_album("test-album"))
+        parsed = json.loads(result)
+        assert parsed == {
+            "synced": True,
+            "album_slug": "test-album",
+            "album_id": 1,
+            "tracks_synced": 1,
+        }
+        db.conn.commit.assert_called_once()
+        db.conn.close.assert_called_once()
+
+
+# =============================================================================
+# db_create_tweet — issue #380
+# =============================================================================
+
+
+class _FakeTweetCursor:
+    """Cursor stand-in for db_create_tweet's SELECT/INSERT queries.
+
+    Dispatches fetchone() results based on the last executed SQL so a
+    single cursor can serve the album lookup, the track lookup, and the
+    INSERT ... RETURNING in sequence.
+    """
+
+    def __init__(self, track_exists: bool = True) -> None:
+        self.track_exists = track_exists
+        self.executed: list[str] = []
+        self._last_sql = ""
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self._last_sql = sql
+        self.executed.append(sql)
+
+    def fetchone(self) -> dict[str, Any] | None:
+        if "FROM albums" in self._last_sql:
+            return {"id": 1}
+        if "FROM tracks" in self._last_sql:
+            return {"id": 42} if self.track_exists else None
+        if "INSERT INTO tweets" in self._last_sql:
+            return {
+                "id": 7,
+                "tweet_text": "check out this track",
+                "platform": "twitter",
+                "content_type": "promo",
+                "media_path": None,
+                "posted": False,
+                "enabled": True,
+                "times_posted": 0,
+                "created_at": "2026-01-01T00:00:00",
+            }
+        return None
+
+    @property
+    def inserted(self) -> bool:
+        return any("INSERT INTO tweets" in sql for sql in self.executed)
+
+
+@pytest.mark.unit
+class TestDbCreateTweetTrackLink:
+    """db_create_tweet must not silently drop a requested track link (#380)."""
+
+    def test_missing_track_returns_json_error(self) -> None:
+        """track_number > 0 with no matching track row → structured error."""
+        cursor = _FakeTweetCursor(track_exists=False)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            result = _run(_database_mod.db_create_tweet(
+                "test-album", "check out this track", track_number=5,
+            ))
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "5" in parsed["error"]
+        assert "created" not in parsed
+        assert "track_number" not in parsed.get("tweet", {})
+
+    def test_missing_track_does_not_insert_or_commit(self) -> None:
+        """No tweet row is inserted or committed when the track is missing."""
+        cursor = _FakeTweetCursor(track_exists=False)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            _run(_database_mod.db_create_tweet(
+                "test-album", "check out this track", track_number=5,
+            ))
+        assert not cursor.inserted
+        db.conn.commit.assert_not_called()
+        db.conn.close.assert_called_once()
+
+    def test_track_found_reports_track_number(self) -> None:
+        """Existing track → tweet created with the correct track_number."""
+        cursor = _FakeTweetCursor(track_exists=True)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            result = _run(_database_mod.db_create_tweet(
+                "test-album", "check out this track", track_number=5,
+            ))
+        parsed = json.loads(result)
+        assert parsed["created"] is True
+        assert parsed["tweet"]["track_number"] == 5
+        assert parsed["tweet"]["album_slug"] == "test-album"
+        assert cursor.inserted
+        db.conn.commit.assert_called_once()
+        db.conn.close.assert_called_once()
+
+    def test_album_level_tweet_skips_track_lookup(self) -> None:
+        """track_number=0 → album-level tweet, track_number null (unchanged)."""
+        cursor = _FakeTweetCursor(track_exists=False)
+        with _PatchedDb() as db:
+            db.conn.cursor.return_value = cursor
+            result = _run(_database_mod.db_create_tweet(
+                "test-album", "album announcement", track_number=0,
+            ))
+        parsed = json.loads(result)
+        assert parsed["created"] is True
+        assert parsed["tweet"]["track_number"] is None
+        assert not any("FROM tracks" in sql for sql in cursor.executed)
+        db.conn.commit.assert_called_once()

--- a/tests/unit/state/test_handlers_maintenance.py
+++ b/tests/unit/state/test_handlers_maintenance.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Unit tests for handlers/maintenance.py — reset, legacy cleanup, migration.
+
+Covers the three public MCP tools:
+
+    reset_mastering(album_slug, subfolders, dry_run) — delete mastered/polished
+    cleanup_legacy_venvs(dry_run)                    — remove stale per-tool venvs
+    migrate_audio_layout(album_slug, dry_run)        — move root WAVs into originals/
+
+``migrate_audio_layout`` is the priority: prior to this file it had only
+slug-validation coverage, so its behaviour (dry-run, real move, skip reasons,
+all-vs-single album) is exercised in depth here. Every destructive path is
+driven through ``dry_run`` or a ``tmp_path`` sandbox so nothing real is touched.
+
+Follows the fixture/mocking style of test_handlers_streaming.py: mock
+StateCache via ``_shared.cache``, an ``asyncio.run`` helper, and structured-JSON
+assertions.
+
+Usage:
+    python -m pytest tests/unit/state/test_handlers_maintenance.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path for imports
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_maintenance", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import maintenance as _maintenance_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Mock cache + helpers
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+
+ARTIST = "test-artist"
+
+
+def _state(audio_root, albums, artist=ARTIST):
+    return {
+        "config": {"audio_root": str(audio_root), "artist_name": artist},
+        "albums": albums,
+    }
+
+
+def _album_audio_dir(audio_root: Path, genre: str, slug: str, artist: str = ARTIST) -> Path:
+    return audio_root / "artists" / artist / "albums" / genre / slug
+
+
+def _make_album_audio(
+    audio_root: Path,
+    genre: str,
+    slug: str,
+    wavs=(),
+    originals=False,
+    extra_files=(),
+) -> Path:
+    """Create an on-disk album audio dir; return its Path."""
+    audio_dir = _album_audio_dir(audio_root, genre, slug)
+    audio_dir.mkdir(parents=True, exist_ok=True)
+    for name in wavs:
+        (audio_dir / name).write_bytes(b"RIFF0000WAVE")
+    for name in extra_files:
+        (audio_dir / name).write_text("not audio", encoding="utf-8")
+    if originals:
+        (audio_dir / "originals").mkdir(exist_ok=True)
+    return audio_dir
+
+
+def _result_for(result: dict, slug: str) -> dict:
+    """Pull the per-album result dict for *slug* out of a migrate response."""
+    return next(a for a in result["albums"] if a["slug"] == slug)
+
+
+# ===========================================================================
+# migrate_audio_layout — PRIORITY (least-tested before this file)
+# ===========================================================================
+
+
+class TestMigrateAudioLayoutDryRun:
+    def test_dry_run_reports_without_moving(self, tmp_path):
+        audio_dir = _make_album_audio(
+            tmp_path, "electronic", "test-album", wavs=["01-a.wav", "02-b.wav"],
+        )
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=True)
+            ))
+
+        assert result["dry_run"] is True
+        entry = _result_for(result, "test-album")
+        assert entry["status"] == "would_migrate"
+        assert sorted(entry["files_moved"]) == ["01-a.wav", "02-b.wav"]
+        assert result["summary"]["migrated"] == 1
+        assert result["summary"]["total_files_moved"] == 2
+        # Nothing actually moved.
+        assert (audio_dir / "01-a.wav").exists()
+        assert not (audio_dir / "originals").exists()
+
+    def test_dry_run_is_the_default(self, tmp_path):
+        _make_album_audio(tmp_path, "electronic", "test-album", wavs=["01-a.wav"])
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album")
+            ))
+
+        assert result["dry_run"] is True
+        assert _result_for(result, "test-album")["status"] == "would_migrate"
+
+
+class TestMigrateAudioLayoutRealMove:
+    def test_moves_root_wavs_into_originals(self, tmp_path):
+        audio_dir = _make_album_audio(
+            tmp_path, "electronic", "test-album", wavs=["01-a.wav", "02-b.wav"],
+        )
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=False)
+            ))
+
+        assert result["dry_run"] is False
+        assert _result_for(result, "test-album")["status"] == "migrated"
+        originals = audio_dir / "originals"
+        assert (originals / "01-a.wav").exists()
+        assert (originals / "02-b.wav").exists()
+        # Root no longer holds the WAV files.
+        assert not (audio_dir / "01-a.wav").exists()
+
+    def test_non_wav_files_stay_in_root(self, tmp_path):
+        audio_dir = _make_album_audio(
+            tmp_path, "electronic", "test-album",
+            wavs=["01-a.wav"], extra_files=["notes.txt", "cover.png"],
+        )
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=False)
+            ))
+
+        entry = _result_for(result, "test-album")
+        assert entry["files_moved"] == ["01-a.wav"]
+        assert (audio_dir / "originals" / "01-a.wav").exists()
+        # Non-audio files are left untouched in the album root.
+        assert (audio_dir / "notes.txt").exists()
+        assert (audio_dir / "cover.png").exists()
+
+    def test_uppercase_extension_is_migrated(self, tmp_path):
+        """The handler matches on a case-insensitive .wav suffix."""
+        audio_dir = _make_album_audio(
+            tmp_path, "electronic", "test-album", wavs=["Track.WAV"],
+        )
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=False)
+            ))
+
+        assert _result_for(result, "test-album")["files_moved"] == ["Track.WAV"]
+        assert (audio_dir / "originals" / "Track.WAV").exists()
+
+
+class TestMigrateAudioLayoutSkips:
+    def test_already_migrated_when_originals_present(self, tmp_path):
+        _make_album_audio(
+            tmp_path, "electronic", "test-album", wavs=["01-a.wav"], originals=True,
+        )
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=False)
+            ))
+
+        entry = _result_for(result, "test-album")
+        assert entry["status"] == "already_migrated"
+        assert entry["files_moved"] == []
+        assert result["summary"]["already_migrated"] == 1
+
+    def test_no_wav_files_skipped(self, tmp_path):
+        _make_album_audio(
+            tmp_path, "electronic", "test-album", extra_files=["readme.txt"],
+        )
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=True)
+            ))
+
+        entry = _result_for(result, "test-album")
+        assert entry["status"] == "skipped"
+        assert entry["skip_reason"] == "no WAV files in root"
+
+    def test_missing_genre_skipped(self, tmp_path):
+        state = _state(tmp_path, {"test-album": {"genre": ""}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=True)
+            ))
+
+        entry = _result_for(result, "test-album")
+        assert entry["status"] == "skipped"
+        assert entry["skip_reason"] == "no genre in state"
+
+    def test_missing_audio_dir_skipped(self, tmp_path):
+        # Album is in state with a genre, but no audio dir exists on disk.
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=True)
+            ))
+
+        entry = _result_for(result, "test-album")
+        assert entry["status"] == "skipped"
+        assert entry["skip_reason"] == "no audio dir"
+
+
+class TestMigrateAudioLayoutAllAlbums:
+    def test_all_albums_processed_with_mixed_outcomes(self, tmp_path):
+        _make_album_audio(tmp_path, "electronic", "fresh-album", wavs=["01-a.wav"])
+        _make_album_audio(tmp_path, "rock", "done-album", wavs=["01-b.wav"], originals=True)
+        state = _state(tmp_path, {
+            "fresh-album": {"genre": "electronic"},
+            "done-album": {"genre": "rock"},
+        })
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            # Empty album_slug means "all albums".
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("", dry_run=True)
+            ))
+
+        assert result["summary"]["total_albums"] == 2
+        assert result["summary"]["migrated"] == 1
+        assert result["summary"]["already_migrated"] == 1
+        assert _result_for(result, "fresh-album")["status"] == "would_migrate"
+        assert _result_for(result, "done-album")["status"] == "already_migrated"
+
+
+class TestMigrateAudioLayoutErrors:
+    def test_specific_album_not_in_state(self, tmp_path):
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("ghost-album", dry_run=True)
+            ))
+
+        assert "error" in result
+        assert "not found" in result["error"].lower()
+
+    def test_unconfigured_audio_root_returns_error(self, tmp_path):
+        state = _state("", {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout("test-album", dry_run=True)
+            ))
+
+        assert "error" in result
+        assert "not configured" in result["error"].lower()
+
+
+# ===========================================================================
+# reset_mastering
+# ===========================================================================
+
+
+class TestResetMastering:
+    def _make_audio_with_subfolder(self, tmp_path, subfolder="mastered"):
+        audio_dir = _album_audio_dir(tmp_path, "electronic", "test-album")
+        target = audio_dir / subfolder
+        target.mkdir(parents=True)
+        (target / "01-track.wav").write_bytes(b"\x00" * 2048)
+        return audio_dir
+
+    def test_dry_run_reports_would_delete(self, tmp_path):
+        audio_dir = self._make_audio_with_subfolder(tmp_path)
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering("test-album", dry_run=True)
+            ))
+
+        assert result["dry_run"] is True
+        assert result["results"]["mastered"]["status"] == "would_delete"
+        assert result["results"]["mastered"]["file_count"] == 1
+        # Dry run leaves the directory in place.
+        assert (audio_dir / "mastered").is_dir()
+
+    def test_actual_delete_removes_subfolder(self, tmp_path):
+        audio_dir = self._make_audio_with_subfolder(tmp_path)
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering("test-album", dry_run=False)
+            ))
+
+        assert result["results"]["mastered"]["status"] == "deleted"
+        assert not (audio_dir / "mastered").exists()
+
+    def test_disallowed_subfolder_rejected(self, tmp_path):
+        """originals/ is protected and cannot be reset."""
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering("test-album", subfolders=["originals"])
+            ))
+
+        assert "error" in result
+        assert "originals" in str(result)
+        assert "mastered" in result["allowed"]
+
+    def test_absent_subfolder_reported_not_found(self, tmp_path):
+        # Only mastered/ exists; asking for polished/ too reports not_found.
+        self._make_audio_with_subfolder(tmp_path, "mastered")
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering(
+                    "test-album", subfolders=["mastered", "polished"], dry_run=True,
+                )
+            ))
+
+        assert result["results"]["mastered"]["status"] == "would_delete"
+        assert result["results"]["polished"]["status"] == "not_found"
+
+    def test_missing_audio_dir_returns_error(self, tmp_path):
+        # No audio dir on disk for this album at all.
+        state = _state(tmp_path, {"test-album": {"genre": "electronic"}})
+
+        with patch.object(_shared_mod, "cache", MockStateCache(state)):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering("test-album", dry_run=True)
+            ))
+
+        assert "error" in result
+
+
+# ===========================================================================
+# cleanup_legacy_venvs
+# ===========================================================================
+
+
+class TestCleanupLegacyVenvs:
+    def test_dry_run_lists_stale_venv(self, tmp_path):
+        tools_root = tmp_path / ".bitwize-music"
+        stale = tools_root / "mastering-env"
+        stale.mkdir(parents=True)
+        (stale / "pyvenv.cfg").write_bytes(b"\x00" * 256)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = json.loads(_run(_maintenance_mod.cleanup_legacy_venvs(dry_run=True)))
+
+        assert result["dry_run"] is True
+        assert result["stale_venvs_found"] == 1
+        assert result["results"]["mastering-env"]["status"] == "would_delete"
+        assert result["results"]["promotion-env"]["status"] == "not_found"
+        # Dry run leaves the directory alone.
+        assert stale.exists()
+
+    def test_no_legacy_dirs_all_not_found(self, tmp_path):
+        (tmp_path / ".bitwize-music").mkdir()
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = json.loads(_run(_maintenance_mod.cleanup_legacy_venvs(dry_run=True)))
+
+        assert result["stale_venvs_found"] == 0
+        for name in ("mastering-env", "promotion-env", "cloud-env"):
+            assert result["results"][name]["status"] == "not_found"
+
+    def test_actual_removal_deletes_all(self, tmp_path):
+        tools_root = tmp_path / ".bitwize-music"
+        for name in ("mastering-env", "promotion-env", "cloud-env"):
+            d = tools_root / name
+            d.mkdir(parents=True)
+            (d / "marker").write_bytes(b"\x00" * 64)
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            result = json.loads(_run(_maintenance_mod.cleanup_legacy_venvs(dry_run=False)))
+
+        assert result["stale_venvs_found"] == 3
+        for name in ("mastering-env", "promotion-env", "cloud-env"):
+            assert result["results"][name]["status"] == "deleted"
+            assert not (tools_root / name).exists()

--- a/tests/unit/state/test_handlers_promo.py
+++ b/tests/unit/state/test_handlers_promo.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Unit tests for handlers/promo.py — promo directory status and content.
+
+Covers the two public MCP tools:
+
+    get_promo_status(album_slug)            — per-file promo/ population report
+    get_promo_content(album_slug, platform) — single promo file read
+
+Each tool gets a happy path plus album-not-found and a malformed-slug case;
+get_promo_content also gets the unknown-platform case. Follows the fixture/mocking style of
+test_handlers_streaming.py: mock StateCache via ``_shared.cache``, an
+``asyncio.run`` helper, and structured-JSON assertions. Real files on disk are
+used because both handlers do genuine filesystem reads and word counting.
+
+Usage:
+    python -m pytest tests/unit/state/test_handlers_promo.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root is on sys.path for imports
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (same pattern as test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_promo", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import promo as _promo_mod  # noqa: E402
+from handlers.status import _PROMO_FILES  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Mock cache
+# ---------------------------------------------------------------------------
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+
+# A block of real prose that clears the handler's >20-word "populated" threshold.
+_POPULATED_TEXT = (
+    "The record drops this Friday and it is the loudest, most honest set of "
+    "songs we have ever committed to tape, so turn it up and tell a friend "
+    "because this one is going to move you all the way through the night."
+)
+
+
+def _install_cache(album_dir: Path):
+    state = {
+        "config": {"content_root": str(album_dir.parent)},
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "genre": "electronic",
+                "path": str(album_dir),
+                "tracks": {},
+            },
+        },
+    }
+    orig = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    return orig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def album_no_promo(tmp_path):
+    """Album directory that exists but has no promo/ subdirectory."""
+    album_dir = tmp_path / "album"
+    album_dir.mkdir()
+    orig = _install_cache(album_dir)
+    yield album_dir
+    _shared_mod.cache = orig
+
+
+@pytest.fixture
+def album_full_promo(tmp_path):
+    """Album with every promo file populated with real prose."""
+    album_dir = tmp_path / "album"
+    promo_dir = album_dir / "promo"
+    promo_dir.mkdir(parents=True)
+    for fname in _PROMO_FILES:
+        (promo_dir / fname).write_text(
+            f"# {fname}\n\n{_POPULATED_TEXT}\n", encoding="utf-8",
+        )
+    orig = _install_cache(album_dir)
+    yield album_dir, promo_dir
+    _shared_mod.cache = orig
+
+
+@pytest.fixture
+def album_partial_promo(tmp_path):
+    """Album where only one promo file has real content; the rest are placeholders."""
+    album_dir = tmp_path / "album"
+    promo_dir = album_dir / "promo"
+    promo_dir.mkdir(parents=True)
+    for i, fname in enumerate(_PROMO_FILES):
+        if i == 0:
+            body = _POPULATED_TEXT
+        else:
+            # Heading + a bracketed placeholder line — counts as zero real words.
+            body = "[replace this with your copy]"
+        (promo_dir / fname).write_text(f"# {fname}\n\n{body}\n", encoding="utf-8")
+    orig = _install_cache(album_dir)
+    yield album_dir, promo_dir
+    _shared_mod.cache = orig
+
+
+# ===========================================================================
+# get_promo_status
+# ===========================================================================
+
+
+class TestGetPromoStatus:
+    def test_all_populated_is_ready(self, album_full_promo):
+        _album_dir, _promo_dir = album_full_promo
+        result = json.loads(_run(_promo_mod.get_promo_status("test-album")))
+        assert result["found"] is True
+        assert result["promo_exists"] is True
+        assert result["total"] == len(_PROMO_FILES)
+        assert result["populated"] == len(_PROMO_FILES)
+        assert result["ready"] is True
+        assert len(result["files"]) == len(_PROMO_FILES)
+        assert all(f["populated"] for f in result["files"])
+
+    def test_partial_population_not_ready(self, album_partial_promo):
+        _album_dir, _promo_dir = album_partial_promo
+        result = json.loads(_run(_promo_mod.get_promo_status("test-album")))
+        assert result["found"] is True
+        assert result["populated"] == 1
+        assert result["ready"] is False
+        placeholder_files = [f for f in result["files"] if not f["populated"]]
+        assert len(placeholder_files) == len(_PROMO_FILES) - 1
+        # Bracketed placeholder lines are excluded from the word count.
+        assert all(f["word_count"] == 0 for f in placeholder_files)
+
+    def test_no_promo_directory(self, album_no_promo):
+        result = json.loads(_run(_promo_mod.get_promo_status("test-album")))
+        assert result["found"] is True
+        assert result["promo_exists"] is False
+        assert result["files"] == []
+        assert result["populated"] == 0
+        assert result["total"] == len(_PROMO_FILES)
+
+    def test_album_not_found(self, album_full_promo):
+        result = json.loads(_run(_promo_mod.get_promo_status("no-such-album")))
+        assert result["found"] is False
+        assert "not found" in result["error"].lower()
+
+    # BAD_SLUGS mirrors test_slug_validation_handlers.py: the first three hit
+    # the separator/null-byte raise branch via '/' or '\\', "a\0b" via a null
+    # byte, and "a..b" (no separator) exercises the '..' traversal branch.
+    @pytest.mark.parametrize("bad_slug", ["../evil", "a/b", "a\\b", "a\0b", "a..b"])
+    def test_malformed_slug_returns_structured_error(self, album_full_promo, bad_slug):
+        """A slug with a path separator, null byte, or traversal sequence is
+        rejected with a structured JSON error, not an escaped ValueError."""
+        result = json.loads(_run(_promo_mod.get_promo_status(bad_slug)))
+        assert result["found"] is False
+        assert "Invalid name" in result["error"]
+
+
+# ===========================================================================
+# get_promo_content
+# ===========================================================================
+
+
+class TestGetPromoContent:
+    def test_reads_platform_file(self, album_full_promo):
+        _album_dir, _promo_dir = album_full_promo
+        result = json.loads(_run(_promo_mod.get_promo_content("test-album", "twitter")))
+        assert result["found"] is True
+        assert result["platform"] == "twitter"
+        assert _POPULATED_TEXT in result["content"]
+        assert result["path"].endswith("twitter.md")
+
+    def test_platform_name_is_normalized(self, album_full_promo):
+        """Mixed case and surrounding whitespace resolve to the canonical file."""
+        _album_dir, _promo_dir = album_full_promo
+        result = json.loads(_run(_promo_mod.get_promo_content("test-album", "  Twitter  ")))
+        assert result["found"] is True
+        assert result["platform"] == "twitter"
+
+    def test_unknown_platform_returns_error(self, album_full_promo):
+        result = json.loads(_run(_promo_mod.get_promo_content("test-album", "snapchat")))
+        assert "error" in result
+        assert "unknown platform" in result["error"].lower()
+
+    def test_album_not_found(self, album_full_promo):
+        result = json.loads(_run(_promo_mod.get_promo_content("no-such-album", "twitter")))
+        assert result["found"] is False
+        assert "not found" in result["error"].lower()
+
+    def test_promo_file_missing_on_disk(self, album_no_promo):
+        """Valid platform but the file does not exist under promo/."""
+        result = json.loads(_run(_promo_mod.get_promo_content("test-album", "twitter")))
+        assert result["found"] is False
+        assert "not found" in result["error"].lower()
+        assert result["platform"] == "twitter"

--- a/tests/unit/state/test_mixing_edge_cases_401_402.py
+++ b/tests/unit/state/test_mixing_edge_cases_401_402.py
@@ -1,0 +1,152 @@
+"""Edge-case regression tests for the mix analyzer (#401, #402).
+
+Exercises `_build_analyzer().analyze_one` directly (the callable is split out
+of `analyze_mix_issues` precisely so its logic can be tested without mounting
+an album directory) to cover two degenerate audio buffers:
+
+- #401: a zero-length WAV (0 samples) must not crash the analyze/polish run
+  with a ValueError from reducing an empty array.
+- #402: a sub-10-sample buffer must not produce a NaN noise floor (which
+  serializes to the invalid JSON token ``NaN``) or emit a RuntimeWarning.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+
+def _analyzer():
+    from handlers.processing.mixing import _build_analyzer
+
+    return _build_analyzer(dark_ratio=0.10, harsh_ratio=0.25)
+
+
+# --------------------------------------------------------------------------
+# #401 — zero-length WAV must not crash the reduction path
+# --------------------------------------------------------------------------
+
+def test_zero_length_stereo_returns_structured_error_no_exception():
+    """A (0, 2) buffer returns a structured per-file error, never raises.
+
+    Before the fix, ``np.max(np.abs(data))`` raised ``ValueError: zero-size
+    array to reduction operation maximum which has no identity``.
+    """
+    analyze_one = _analyzer()
+    data = np.zeros((0, 2), dtype=np.float64)
+
+    result = analyze_one(data, 44100, filename="empty.wav")
+
+    assert result["filename"] == "empty.wav"
+    assert "empty_audio" in result["issues"]
+    assert "error" in result
+    assert "0 samples" in result["error"]
+    # No metrics should have been computed from the empty array.
+    assert "peak" not in result
+    assert "noise_floor" not in result
+
+
+def test_zero_length_mono_1d_is_guarded_before_2d_indexing():
+    """A 1-D (0,) buffer is caught by the length guard before ``data[:, 0]``.
+
+    Guards against the guard itself throwing IndexError on a 1-D empty array.
+    """
+    analyze_one = _analyzer()
+    data = np.zeros((0,), dtype=np.float64)
+
+    result = analyze_one(data, 44100, filename="empty-mono.wav")
+
+    assert "empty_audio" in result["issues"]
+    assert "error" in result
+
+
+def test_zero_length_result_serializes_to_valid_json():
+    """The empty-audio error dict round-trips through _safe_json cleanly."""
+    from handlers._shared import _safe_json
+
+    analyze_one = _analyzer()
+    result = analyze_one(np.zeros((0, 2), dtype=np.float64), 44100, filename="empty.wav")
+
+    encoded = _safe_json(result)
+    assert "NaN" not in encoded
+    decoded = json.loads(encoded)
+    assert decoded["issues"] == ["empty_audio"]
+
+
+# --------------------------------------------------------------------------
+# #402 — sub-10-sample buffer must yield a clean noise floor, no NaN/warning
+# --------------------------------------------------------------------------
+
+def test_short_buffer_noise_floor_is_none_and_no_runtime_warning():
+    """A 5-sample buffer yields noise_floor=None with no RuntimeWarning.
+
+    ``len(sorted_abs) // 10 == 0`` makes the quietest-10% slice empty; before
+    the fix ``np.mean([])`` returned NaN and emitted a RuntimeWarning.
+    """
+    analyze_one = _analyzer()
+    mono = np.linspace(0.0, 0.01, 5, dtype=np.float64)
+    data = np.column_stack([mono, mono])
+
+    with warnings.catch_warnings():
+        # Any RuntimeWarning (e.g. "Mean of empty slice") becomes an error.
+        warnings.simplefilter("error", RuntimeWarning)
+        result = analyze_one(data, 44100, filename="short.wav")
+
+    assert result["noise_floor"] is None
+    # Sentinel None means the elevated-noise guard never fires.
+    assert "elevated_noise_floor" not in result["issues"]
+
+
+@pytest.mark.parametrize("n_samples", [1, 5, 9])
+def test_sub_10_sample_buffers_never_produce_nan_json(n_samples):
+    """Buffers of 1-9 samples serialize without the invalid ``NaN`` token."""
+    from handlers._shared import _safe_json
+
+    analyze_one = _analyzer()
+    mono = np.linspace(0.0, 0.02, n_samples, dtype=np.float64)
+    data = np.column_stack([mono, mono])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = analyze_one(data, 44100, filename=f"n{n_samples}.wav")
+
+    assert result["noise_floor"] is None
+    encoded = _safe_json(result)
+    assert "NaN" not in encoded
+    assert json.loads(encoded)["noise_floor"] is None
+
+
+# --------------------------------------------------------------------------
+# Regression guard — a normal buffer still analyzes correctly
+# --------------------------------------------------------------------------
+
+def test_normal_buffer_still_computes_finite_noise_floor():
+    """A full-length signal still produces a finite noise floor and metrics."""
+    analyze_one = _analyzer()
+    rate = 48000
+    t = np.linspace(0.0, 2.0, 2 * rate, endpoint=False)
+    mono = (0.3 * np.sin(2 * np.pi * 100 * t)).astype(np.float64)
+    data = np.column_stack([mono, mono])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        result = analyze_one(data, rate, filename="normal.wav")
+
+    assert isinstance(result["noise_floor"], float)
+    assert np.isfinite(result["noise_floor"])
+    assert isinstance(result["peak"], float)
+    assert result["peak"] == pytest.approx(0.3, abs=1e-3)
+    assert "error" not in result
+    assert isinstance(result["issues"], list) and result["issues"]

--- a/tests/unit/state/test_rhyme_tail_396.py
+++ b/tests/unit/state/test_rhyme_tail_396.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #396 — rhyme-tail spelling normalization.
+
+_get_rhyme_tail derived a rhyme key from spelling, but the plural-strip
+(dropping a trailing 's') ran before the vowel-cluster logic, so clearly
+rhyming end-word pairs landed in different tails:
+
+    "eyes"  -> "eye"  vs "cries" -> "ie"    (no match)
+    "times" -> "ime"  vs "rhymes" -> "yme"  (no match)
+
+These tests pin the fix: rhyming pairs must share a tail (and a rhyme
+group), while genuinely non-rhyming pairs must stay distinct.
+
+Usage:
+    python -m pytest tests/unit/state/test_rhyme_tail_396.py -v
+"""
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Import server module from hyphenated directory via importlib. Executing the
+# server puts ``servers/bitwize-music-server`` on sys.path so ``handlers`` is
+# importable. Mirror the mcp mock used by the other lyrics tests so this file
+# runs even when the real ``mcp`` package is not installed.
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_rhyme396", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_server = _import_server()
+from handlers import lyrics_analysis as _lyrics_analysis_mod
+
+_get_rhyme_tail = _lyrics_analysis_mod._get_rhyme_tail
+analyze_rhyme_scheme = _lyrics_analysis_mod.analyze_rhyme_scheme
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestRhymeTailNormalization396:
+    """_get_rhyme_tail must fold spelling variants of the same rhyme sound."""
+
+    def test_eyes_cries_share_tail(self):
+        # Both /aɪz/ — the plural-strip must not split "eye" from "ie".
+        assert _get_rhyme_tail("eyes") == _get_rhyme_tail("cries")
+
+    def test_times_rhymes_share_tail(self):
+        # Both /aɪmz/ — the y/i spelling difference must not split them.
+        assert _get_rhyme_tail("times") == _get_rhyme_tail("rhymes")
+
+    def test_non_rhyme_pair_stays_distinct(self):
+        # "eyes" and "cat" do not rhyme — the fix must not over-broaden.
+        assert _get_rhyme_tail("eyes") != _get_rhyme_tail("cat")
+
+    def test_tails_have_groupable_length(self):
+        # analyze_rhyme_scheme only groups tails of length >= 2, so the
+        # normalized tails for these pairs must clear that bar.
+        assert len(_get_rhyme_tail("eyes")) >= 2
+        assert len(_get_rhyme_tail("times")) >= 2
+
+
+class TestAnalyzeRhymeScheme396:
+    """analyze_rhyme_scheme must report the corrected scheme for #396 pairs."""
+
+    STANZA = (
+        "[Verse]\n"
+        "I cannot hide behind my eyes\n"
+        "The lonely stranger softly cries\n"
+        "I've heard this melody a thousand times\n"
+        "The quiet poet speaks in rhymes\n"
+    )
+
+    def test_scheme_is_aabb(self):
+        result = json.loads(_run(analyze_rhyme_scheme(self.STANZA)))
+        section = result["sections"][0]
+        assert section["scheme"] == "AABB"
+
+    def test_rhyming_pairs_grouped(self):
+        result = json.loads(_run(analyze_rhyme_scheme(self.STANZA)))
+        lines = result["sections"][0]["lines"]
+        # eyes/cries share a group; times/rhymes share a group...
+        assert lines[0]["rhyme_group"] == lines[1]["rhyme_group"]
+        assert lines[2]["rhyme_group"] == lines[3]["rhyme_group"]
+        # ...and the two pairs are distinct groups.
+        assert lines[0]["rhyme_group"] != lines[2]["rhyme_group"]
+
+    def test_end_words_captured(self):
+        result = json.loads(_run(analyze_rhyme_scheme(self.STANZA)))
+        end_words = [ld["end_word"] for ld in result["sections"][0]["lines"]]
+        assert end_words == ["eyes", "cries", "times", "rhymes"]

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -6532,7 +6532,7 @@ class TestCreateTrack:
         assert "No path" in result["error"]
 
     def test_track_number_all_zeros(self, tmp_path):
-        """Track number '00' produces '00-slug.md'."""
+        """Track number '00' is rejected — track numbers are 1-based (#372)."""
         mock_cache, album_dir, tracks_dir = self._make_cache_with_album(tmp_path)
         template_dir = tmp_path / "templates"
         template_dir.mkdir()
@@ -6540,9 +6540,10 @@ class TestCreateTrack:
         with patch.object(_shared_mod, "cache", mock_cache), \
              patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path):
             result = json.loads(_run(server.create_track("test-album", "00", "Intro")))
-        assert result["created"] is True
-        assert result["track_slug"] == "00-intro"
-        assert result["filename"] == "00-intro.md"
+        assert "error" in result
+        assert "track_number" in result["error"]
+        # No spurious 00-intro.md file is created
+        assert list(tracks_dir.iterdir()) == []
 
     def test_special_chars_in_title(self, tmp_path):
         """Special characters in title are handled by slug normalization."""

--- a/tests/unit/state/test_silent_exceptions.py
+++ b/tests/unit/state/test_silent_exceptions.py
@@ -245,7 +245,7 @@ class TestSheetMusicConfigWarning:
                 "sys.modules",
                 {"tools.shared.config": types.ModuleType("tools.shared.config")},
             ),
-            caplog.at_level("WARNING", logger="handlers.processing._helpers"),
+            caplog.at_level("WARNING", logger="handlers.processing.sheet_music"),
         ):
             stub = sys.modules["tools.shared.config"]
             stub.load_config = MagicMock(side_effect=ImportError("no module"))
@@ -256,9 +256,19 @@ class TestSheetMusicConfigWarning:
             except Exception:
                 pass  # We only care about the logged warning
 
+        # Pin the emitter: the warning must originate from the sheet_music
+        # module's logger (handlers.processing.sheet_music), not _helpers or
+        # any other module. Asserting on r.name makes this test fail if the
+        # warning is ever emitted from the wrong logger (#344).
         assert any(
-            "Could not load sheet music config" in r.message for r in caplog.records
-        ), f"Expected sheet music config warning. Records: {[r.message for r in caplog.records]}"
+            r.name == "handlers.processing.sheet_music"
+            and "Could not load sheet music config" in r.message
+            for r in caplog.records
+        ), (
+            "Expected 'Could not load sheet music config' warning from the "
+            "handlers.processing.sheet_music logger. "
+            f"Records: {[(r.name, r.message) for r in caplog.records]}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/state/test_slug_validation_boundary_443.py
+++ b/tests/unit/state/test_slug_validation_boundary_443.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tests for the MCP-wide slug-validation error boundary (issue #443).
+
+#397/#442 caught the slug-``ValueError`` leak in three handlers at the call
+site. #443 addresses the whole class: the shared helpers
+``_find_album_or_error`` / ``_resolve_audio_dir`` / ``_find_track_or_error``
+call ``_normalize_slug`` (which raises on path separators / null bytes /
+traversal), and ~13 tool handlers call it directly. The fix:
+
+  * the three shared helpers now convert the ValueError to their structured
+    error tuple, and
+  * ``install_error_boundary`` wraps every registered tool so any leaked
+    ValueError becomes a ``{"error": ...}`` JSON response instead of an
+    opaque MCP-layer crash.
+
+Usage:
+    python -m pytest tests/unit/state/test_slug_validation_boundary_443.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import core as _core_mod  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+BAD_SLUGS = ["../evil", "a/b", "a\\b", "a\0b", "a..b"]
+
+
+class MockStateCache:
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+    def rebuild(self) -> dict:
+        return self._state
+
+
+def _base_state() -> dict:
+    return copy.deepcopy({
+        "config": {"audio_root": "/tmp/audio", "artist_name": "test-artist"},
+        "albums": {
+            "test-album": {
+                "genre": "electronic", "title": "Test Album",
+                "status": "In Progress", "tracks": {"01-a": {"title": "A"}},
+            },
+        },
+    })
+
+
+# ===========================================================================
+# _json_error_boundary — unit behavior
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestJsonErrorBoundary:
+    def test_value_error_becomes_json(self):
+        async def handler(slug: str) -> str:
+            raise ValueError("Invalid name: bad")
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        result = json.loads(_run(wrapped("../x")))
+        assert result["error"] == "Invalid name: bad"
+
+    def test_normal_return_passes_through(self):
+        async def handler(slug: str) -> str:
+            return json.dumps({"ok": slug})
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        assert json.loads(_run(wrapped("fine")))["ok"] == "fine"
+
+    def test_non_value_error_still_propagates(self):
+        """Only ValueError is caught — real bugs must not be masked."""
+        async def handler(slug: str) -> str:
+            raise KeyError("genuine bug")
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        with pytest.raises(KeyError):
+            _run(wrapped("x"))
+
+    def test_wrapped_handler_stays_a_coroutine_function(self):
+        """FastMCP must still see an async tool (schema/dispatch depend on it)."""
+        import inspect
+
+        async def handler(slug: str) -> str:
+            return "ok"
+
+        wrapped = _shared_mod._json_error_boundary(handler)
+        assert inspect.iscoroutinefunction(wrapped)
+        # functools.wraps preserves the signature FastMCP introspects.
+        assert list(inspect.signature(wrapped).parameters) == ["slug"]
+        assert wrapped.__name__ == "handler"
+
+
+# ===========================================================================
+# End-to-end: a previously-unguarded direct-call handler via the boundary
+# ===========================================================================
+
+
+class _FakeMCP:
+    """Minimal FastMCP stand-in that stores registered tools by name."""
+
+    def __init__(self) -> None:
+        self._tools: dict = {}
+
+    def tool(self):
+        def decorator(fn):
+            self._tools[fn.__name__] = fn
+            return fn
+        return decorator
+
+
+@pytest.mark.unit
+class TestBoundaryProtectsDirectCallHandlers:
+    """find_album calls _normalize_slug directly — before #443 it raised.
+
+    The boundary installed at registration must turn that into JSON.
+    """
+
+    def setup_method(self) -> None:
+        self._orig = _shared_mod.cache
+        _shared_mod.cache = MockStateCache(_base_state())
+
+    def teardown_method(self) -> None:
+        _shared_mod.cache = self._orig
+
+    def _registered_find_album(self):
+        mcp = _FakeMCP()
+        _shared_mod.install_error_boundary(mcp)
+        _core_mod.register(mcp)
+        return mcp._tools["find_album"]
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_slug_returns_json_not_raise(self, bad_slug):
+        find_album = self._registered_find_album()
+        result = json.loads(_run(find_album(bad_slug)))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_name_unchanged_through_boundary(self):
+        find_album = self._registered_find_album()
+        result = json.loads(_run(find_album("test-album")))
+        assert result.get("found") is True
+
+    def test_direct_unwrapped_call_still_raises(self):
+        """Sanity: the module-level fn is unguarded; the boundary is the fix."""
+        with pytest.raises(ValueError):
+            _run(_core_mod.find_album("../evil"))
+
+
+# ===========================================================================
+# Shared helpers convert the ValueError in-flow (contract-shaped errors)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestHelpersHardened:
+    def setup_method(self) -> None:
+        self._orig = _shared_mod.cache
+        _shared_mod.cache = MockStateCache(_base_state())
+
+    def teardown_method(self) -> None:
+        _shared_mod.cache = self._orig
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_find_album_or_error_returns_error_tuple(self, bad_slug):
+        slug, album, err = _shared_mod._find_album_or_error(bad_slug)
+        assert album is None
+        assert err is not None
+        assert "Invalid name" in json.loads(err)["error"]
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_resolve_audio_dir_returns_error(self, bad_slug):
+        err, path = _shared_mod._resolve_audio_dir(bad_slug)
+        assert path is None
+        assert err is not None
+        assert "Invalid name" in json.loads(err)["error"]
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_find_track_or_error_returns_error_tuple(self, bad_slug):
+        tracks = {"01-a": {"title": "A"}}
+        slug, data, err = _shared_mod._find_track_or_error(tracks, bad_slug)
+        assert data is None
+        assert err is not None
+        assert "Invalid name" in json.loads(err)["error"]
+
+    def test_valid_album_still_resolves(self):
+        slug, album, err = _shared_mod._find_album_or_error("test-album")
+        assert err is None
+        assert album is not None

--- a/tests/unit/state/test_slug_validation_handlers.py
+++ b/tests/unit/state/test_slug_validation_handlers.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Unit tests for slug-validation error handling in MCP handlers (issue #397).
+
+``_normalize_slug`` raises ValueError on path separators, null bytes, and
+traversal sequences. The handler-level call sites in ``handlers/maintenance.py``
+(migrate_audio_layout, reset_mastering via _resolve_audio_dir) and
+``handlers/skills.py`` (get_skill) must catch that ValueError and return the
+module's structured JSON error (``{"error": ...}``) instead of letting the
+exception propagate to the FastMCP layer as an opaque tool error.
+
+Usage:
+    python -m pytest tests/unit/state/test_slug_validation_handlers.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure project root and server directory are on sys.path
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+SERVER_DIR = PROJECT_ROOT / "servers" / "bitwize-music-server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import maintenance as _maintenance_mod  # noqa: E402
+from handlers import skills as _skills_mod  # noqa: E402
+
+# Slugs that _normalize_slug rejects with ValueError. The first three hit
+# the separator/null-byte branch via '/' or '\\'; "a\0b" hits the same
+# branch via a null byte alone; "a..b" has no separator, so it reaches and
+# exercises the second ('..' traversal) raise branch.
+BAD_SLUGS = ["../evil", "a/b", "a\\b", "a\0b", "a..b"]
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.run(coro)
+
+
+class MockStateCache:
+    """In-memory StateCache stand-in (no filesystem I/O)."""
+
+    def __init__(self, state: dict) -> None:
+        self._state = state
+
+    def get_state(self) -> dict:
+        return self._state
+
+    def get_state_ref(self) -> dict:
+        return self._state
+
+
+def _base_state(audio_root: str = "/tmp/test/audio") -> dict:
+    """Minimal state with config, one album, and one skill."""
+    return copy.deepcopy({
+        "config": {
+            "audio_root": audio_root,
+            "artist_name": "test-artist",
+        },
+        "albums": {
+            "test-album": {
+                "genre": "electronic",
+                "title": "Test Album",
+                "status": "In Progress",
+                "tracks": {},
+            },
+        },
+        "skills": {
+            "count": 1,
+            "model_counts": {"opus": 1},
+            "items": {
+                "lyric-writer": {
+                    "description": "Writes or reviews lyrics.",
+                    "model": "claude-opus-4-6",
+                    "model_tier": "opus",
+                    "user_invocable": True,
+                    "argument_hint": None,
+                },
+            },
+        },
+    })
+
+
+# =============================================================================
+# migrate_audio_layout — invalid slugs return structured error JSON
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestMigrateAudioLayoutSlugValidation:
+    """migrate_audio_layout must reject bad slugs with a JSON error, not raise."""
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_slug_returns_structured_error(self, bad_slug):
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout(album_slug=bad_slug, dry_run=True)
+            ))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_slug_behavior_unchanged(self):
+        """A valid slug with no audio dir on disk is skipped, not errored."""
+        mock_cache = MockStateCache(_base_state(audio_root="/nonexistent/audio"))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout(album_slug="test-album", dry_run=True)
+            ))
+        assert "error" not in result
+        assert result["summary"]["total_albums"] == 1
+        assert result["albums"][0]["slug"] == "test-album"
+        assert result["albums"][0]["status"] == "skipped"
+        assert result["albums"][0]["skip_reason"] == "no audio dir"
+
+    def test_valid_slug_not_in_state_returns_not_found(self):
+        """A well-formed but unknown slug still gets the not-found error."""
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.migrate_audio_layout(album_slug="no-such-album", dry_run=True)
+            ))
+        assert "error" in result
+        assert "not found" in result["error"]
+
+
+# =============================================================================
+# reset_mastering — invalid slugs return structured error JSON
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestResetMasteringSlugValidation:
+    """reset_mastering must reject bad slugs with a JSON error, not raise."""
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_slug_returns_structured_error(self, bad_slug):
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering(album_slug=bad_slug, dry_run=True)
+            ))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_slug_behavior_unchanged(self, tmp_path):
+        """A valid slug with a real audio dir still runs the dry-run report."""
+        audio_root = tmp_path / "audio"
+        album_dir = (
+            audio_root / "artists" / "test-artist" / "albums" / "electronic" / "test-album"
+        )
+        mastered = album_dir / "mastered"
+        mastered.mkdir(parents=True)
+        (mastered / "01-track.wav").write_bytes(b"\x00" * 16)
+
+        mock_cache = MockStateCache(_base_state(audio_root=str(audio_root)))
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(
+                _maintenance_mod.reset_mastering(album_slug="test-album", dry_run=True)
+            ))
+        assert "error" not in result
+        assert result["dry_run"] is True
+        assert result["results"]["mastered"]["status"] == "would_delete"
+        assert result["results"]["mastered"]["file_count"] == 1
+        # Dry run must not delete anything
+        assert mastered.is_dir()
+
+
+# =============================================================================
+# get_skill — invalid names return structured error JSON
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetSkillSlugValidation:
+    """get_skill must reject bad names with a JSON error, not raise."""
+
+    @pytest.mark.parametrize("bad_slug", BAD_SLUGS)
+    def test_bad_name_returns_structured_error(self, bad_slug):
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(_skills_mod.get_skill(name=bad_slug)))
+        assert "error" in result
+        assert "Invalid name" in result["error"]
+
+    def test_valid_name_behavior_unchanged(self):
+        """An exact skill name still resolves to found=True."""
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(_skills_mod.get_skill(name="lyric-writer")))
+        assert result["found"] is True
+        assert result["name"] == "lyric-writer"
+
+    def test_valid_name_normalization_unchanged(self):
+        """Names with spaces/case still normalize to the slug and match."""
+        mock_cache = MockStateCache(_base_state())
+        with patch.object(_shared_mod, "cache", mock_cache):
+            result = json.loads(_run(_skills_mod.get_skill(name="Lyric Writer")))
+        assert result["found"] is True
+        assert result["name"] == "lyric-writer"

--- a/tests/unit/state/test_update_streaming_url_unicode_404.py
+++ b/tests/unit/state/test_update_streaming_url_unicode_404.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Regression tests for update_streaming_url unicode round-trip (issue #404 polish).
+
+The #404 fix writes the URL into the in-place frontmatter scalar via
+``json.dumps(url)``. With the default ``ensure_ascii=True`` a
+supplementary-plane character (e.g. an emoji, U+1F3B5) is emitted as a
+UTF-16 surrogate pair (``\\ud83c\\udfb5``). PyYAML parses that back as two
+lone surrogates, not the original character — a lossy round-trip — even
+though the YAML stays valid (so #404's malformed-YAML/silent-drop failure
+does not recur). This is inconsistent with the same function's yaml.dump
+fallback, which uses ``allow_unicode=True`` and preserves the character.
+
+Passing ``ensure_ascii=False`` keeps quotes/backslashes escaped while
+preserving the raw character, so every URL round-trips exactly. These tests
+FAIL on the ``ensure_ascii=True`` output (astral char lost) and PASS once
+``ensure_ascii=False`` is used, while a BMP-unicode case and the existing
+special-char guards keep passing.
+
+Usage:
+    python -m pytest tests/unit/state/test_update_streaming_url_unicode_404.py -v
+"""
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (mirrors test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location(
+        "state_server_streaming_unicode_404", SERVER_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import streaming as _streaming_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+    def rebuild(self):
+        return self._state
+
+
+def _state_for(album_path: str) -> dict:
+    return {
+        "version": 2,
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "status": "Released",
+                "genre": "electronic",
+                "path": album_path,
+                "streaming_urls": {
+                    "spotify": "https://old-url.com",
+                },
+                "tracks": {},
+            },
+        },
+    }
+
+
+# Existing streaming block so the in-place edit path (the one under test) is
+# taken instead of the yaml.dump fallback.
+_README_TEMPLATE = """\
+---
+title: Test Album
+streaming:
+  spotify: "https://old-url.com"
+---
+
+# Test Album
+
+| **Status** | Released |
+"""
+
+
+def _write_readme(tmp_path: Path) -> Path:
+    readme = tmp_path / "README.md"
+    readme.write_text(_README_TEMPLATE, encoding="utf-8")
+    return readme
+
+
+def _do_update(tmp_path: Path, platform: str, url: str) -> dict:
+    """Run update_streaming_url against a real README, real parser.
+
+    write_state and the DB sync are stubbed out; everything else (file I/O,
+    parse_album_readme) is exercised for real so the round-trip is genuine.
+    """
+    readme = _write_readme(tmp_path)
+    state = _state_for(str(tmp_path))
+    orig_cache = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    try:
+        with patch("tools.state.indexer.write_state"), \
+             patch("handlers.database._check_db_deps",
+                   side_effect=ImportError("no db")):
+            result = json.loads(
+                _run(_streaming_mod.update_streaming_url("test-album", platform, url))
+            )
+    finally:
+        _shared_mod.cache = orig_cache
+    result["_readme_text"] = readme.read_text(encoding="utf-8")
+    result["_state_streaming"] = copy.deepcopy(
+        state["albums"]["test-album"]["streaming_urls"]
+    )
+    return result
+
+
+def _reparse_streaming(readme_text: str) -> dict:
+    """Parse the streaming block back out of the written README frontmatter."""
+    lines = readme_text.split("\n")
+    end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
+    fm = yaml.safe_load("\n".join(lines[1:end])) or {}
+    return fm.get("streaming", {}) or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStreamingUrlUnicodeRoundTrip:
+    """Issue #404: the written URL must round-trip every character exactly."""
+
+    def test_supplementary_plane_char_round_trips(self, tmp_path):
+        """An astral char (emoji) must survive the YAML round-trip, not become
+        two lone surrogates (the ensure_ascii=True failure mode)."""
+        url = "https://example.com/track?n=\U0001f3b5"  # U+1F3B5 musical note
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert result["url"] == url
+
+        # Frontmatter stays valid YAML and round-trips the exact URL ...
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        # ... and the state-cache re-parse kept the exact URL (not a lossy
+        # surrogate-pair variant).
+        assert result["_state_streaming"].get("spotify") == url
+        # The raw character is present on disk (readable), not escaped.
+        assert url in result["_readme_text"]
+        assert "\\ud83c" not in result["_readme_text"]
+
+    def test_bmp_unicode_url_round_trips(self, tmp_path):
+        """A BMP accented URL round-trips under both settings; guard it stays so."""
+        url = "https://exämple.com/café"
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+
+class TestSpecialCharsStillEscaped:
+    """ensure_ascii=False must not regress the original #404 quote/backslash fix."""
+
+    def test_url_with_double_quote_stays_valid_yaml(self, tmp_path):
+        url = 'https://example.com/track?ref="promo"&id=5'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_url_with_backslash_stays_valid_yaml(self, tmp_path):
+        url = 'https://example.com/track\\weird?q="x"'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_plain_ascii_url_scalar_unaffected(self, tmp_path):
+        """An ASCII URL needing no escaping is written byte-identically."""
+        url = "https://open.spotify.com/album/abc123"
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert f'spotify: "{url}"' in result["_readme_text"]
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/unit/state/test_update_streaming_url_yaml_404.py
+++ b/tests/unit/state/test_update_streaming_url_yaml_404.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Regression tests for issue #404 — update_streaming_url YAML escaping.
+
+The in-place frontmatter edit path in update_streaming_url must YAML-escape
+the URL before writing it into a double-quoted scalar. A URL containing a
+double-quote or backslash previously produced malformed YAML, which the
+immediate re-parse then dropped (silently losing the URL from the state
+cache while leaving the README file corrupt).
+
+These tests drive a real README.md through the handler and the real
+parse_album_readme parser to prove the written frontmatter stays valid and
+the URL round-trips.
+
+Usage:
+    python -m pytest tests/unit/state/test_update_streaming_url_yaml_404.py -v
+"""
+
+import asyncio
+import copy
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# Ensure project root is on sys.path for imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+# ---------------------------------------------------------------------------
+# Mock MCP SDK if not installed (mirrors test_handlers_streaming.py)
+# ---------------------------------------------------------------------------
+
+SERVER_PATH = PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py"
+
+try:
+    import mcp  # noqa: F401
+except ImportError:
+
+    class _FakeFastMCP:
+        def __init__(self, name=""):
+            self.name = name
+            self._tools = {}
+
+        def tool(self):
+            def decorator(fn):
+                self._tools[fn.__name__] = fn
+                return fn
+            return decorator
+
+        def run(self, transport="stdio"):
+            pass
+
+    mcp_mod = types.ModuleType("mcp")
+    mcp_server_mod = types.ModuleType("mcp.server")
+    mcp_fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    mcp_fastmcp_mod.FastMCP = _FakeFastMCP
+    mcp_mod.server = mcp_server_mod
+    mcp_server_mod.fastmcp = mcp_fastmcp_mod
+
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = mcp_server_mod
+    sys.modules["mcp.server.fastmcp"] = mcp_fastmcp_mod
+
+
+def _import_server():
+    spec = importlib.util.spec_from_file_location("state_server_streaming_404", SERVER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+server = _import_server()
+
+from handlers import _shared as _shared_mod  # noqa: E402
+from handlers import streaming as _streaming_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class MockStateCache:
+    def __init__(self, state):
+        self._state = state
+
+    def get_state(self):
+        return self._state
+
+    def get_state_ref(self):
+        return self._state or {}
+
+    def rebuild(self):
+        return self._state
+
+
+def _state_for(album_path: str) -> dict:
+    return {
+        "version": 2,
+        "albums": {
+            "test-album": {
+                "title": "Test Album",
+                "status": "Released",
+                "genre": "electronic",
+                "path": album_path,
+                "streaming_urls": {
+                    "spotify": "https://old-url.com",
+                },
+                "tracks": {},
+            },
+        },
+    }
+
+
+# Existing streaming block so the in-place edit path (the buggy one) is taken
+# instead of the yaml.dump fallback.
+_README_TEMPLATE = """\
+---
+title: Test Album
+streaming:
+  spotify: "https://old-url.com"
+---
+
+# Test Album
+
+| **Status** | Released |
+"""
+
+
+def _write_readme(tmp_path: Path) -> Path:
+    readme = tmp_path / "README.md"
+    readme.write_text(_README_TEMPLATE, encoding="utf-8")
+    return readme
+
+
+def _do_update(tmp_path: Path, platform: str, url: str) -> dict:
+    """Run update_streaming_url against a real README, real parser.
+
+    write_state and the DB sync are stubbed out; everything else (file I/O,
+    parse_album_readme) is exercised for real so the round-trip is genuine.
+    """
+    readme = _write_readme(tmp_path)
+    state = _state_for(str(tmp_path))
+    orig_cache = _shared_mod.cache
+    _shared_mod.cache = MockStateCache(state)
+    try:
+        with patch("tools.state.indexer.write_state"), \
+             patch("handlers.database._check_db_deps",
+                   side_effect=ImportError("no db")):
+            result = json.loads(
+                _run(_streaming_mod.update_streaming_url("test-album", platform, url))
+            )
+    finally:
+        _shared_mod.cache = orig_cache
+    result["_readme_text"] = readme.read_text(encoding="utf-8")
+    result["_state_streaming"] = copy.deepcopy(
+        state["albums"]["test-album"]["streaming_urls"]
+    )
+    return result
+
+
+def _reparse_streaming(readme_text: str) -> dict:
+    """Parse the streaming block back out of the written README frontmatter.
+
+    Raises yaml.YAMLError if the frontmatter is malformed — which is exactly
+    the failure mode issue #404 describes.
+    """
+    lines = readme_text.split("\n")
+    end = next(i for i, ln in enumerate(lines[1:], 1) if ln.strip() == "---")
+    fm = yaml.safe_load("\n".join(lines[1:end])) or {}
+    return fm.get("streaming", {}) or {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStreamingUrlYamlEscaping:
+    """Issue #404: in-place frontmatter edit must YAML-escape the URL."""
+
+    def test_url_with_double_quote_stays_valid_yaml(self, tmp_path):
+        """A URL containing a double-quote must not corrupt the frontmatter."""
+        url = 'https://example.com/track?ref="promo"&id=5'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert result["url"] == url
+
+        # Frontmatter must still be valid YAML and round-trip the exact URL.
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+
+        # And the state cache re-parse must have kept the URL (not silently
+        # dropped it because the frontmatter went malformed).
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_url_with_backslash_stays_valid_yaml(self, tmp_path):
+        """A URL containing a backslash must not corrupt the frontmatter."""
+        url = 'https://example.com/track\\weird?q="x"'
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url
+
+    def test_normal_url_still_round_trips(self, tmp_path):
+        """Regression guard: an ordinary URL keeps working after the fix."""
+        url = "https://open.spotify.com/album/abc123"
+        result = _do_update(tmp_path, "spotify", url)
+
+        assert result["success"] is True
+        assert result["url"] == url
+
+        # Written frontmatter should not contain JSON-escape artifacts for a
+        # URL that needs no escaping.
+        assert f'spotify: "{url}"' in result["_readme_text"]
+
+        streaming = _reparse_streaming(result["_readme_text"])
+        assert streaming.get("spotify") == url
+        assert result["_state_streaming"].get("spotify") == url

--- a/tools/cloud/upload_to_cloud.py
+++ b/tools/cloud/upload_to_cloud.py
@@ -174,6 +174,13 @@ def find_album_path(config: dict[str, Any], album_name: str, audio_root_override
     artist: str = config["artist"]["name"]
     checked: list[str] = []
 
+    # Validate album_name before ANY glob use (prevent path traversal and glob
+    # injection). Must run before the mirrored-structure branch below, which
+    # interpolates album_name into a glob pattern (#405).
+    if os.sep in album_name or '/' in album_name or any(c in album_name for c in '*?[]'):
+        logger.error("Album name '%s' contains invalid characters (path separators or glob patterns)", album_name)
+        sys.exit(1)
+
     # Try mirrored structure: {audio_root}/artists/{artist}/albums/{genre}/{album}
     genre_glob = audio_root / "artists" / artist / "albums" / "*" / album_name
     genre_matches = sorted(genre_glob.parent.parent.glob(f"*/{album_name}"))
@@ -187,11 +194,6 @@ def find_album_path(config: dict[str, Any], album_name: str, audio_root_override
     checked.append(str(album_path_direct))
     if album_path_direct.exists() and _is_within(album_path_direct, audio_root):
         return album_path_direct
-
-    # Validate album_name before glob search (prevent path traversal and glob injection)
-    if os.sep in album_name or '/' in album_name or any(c in album_name for c in '*?[]'):
-        logger.error("Album name '%s' contains invalid characters (path separators or glob patterns)", album_name)
-        sys.exit(1)
 
     # Glob search as fallback (handles genre folders, mirrored structures)
     matches = sorted(audio_root.rglob(album_name))

--- a/tools/mastering/analyze_tracks.py
+++ b/tools/mastering/analyze_tracks.py
@@ -298,6 +298,11 @@ def main() -> None:
     print()
 
     filterable = [f for f in wav_files if 'venv' not in str(f)]
+
+    if not filterable:
+        logger.error("No tracks to analyze (no WAV files found in %s).", wav_dir)
+        sys.exit(1)
+
     workers = args.jobs if args.jobs > 0 else os.cpu_count()
     progress = ProgressBar(len(filterable), prefix="Analyzing")
 

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -569,7 +569,8 @@ def apply_fade_out(data: Any, rate: int, duration: float = 5.0, curve: str = 'ex
         data: Audio data (samples,) for mono or (samples, channels) for stereo
         rate: Sample rate
         duration: Fade duration in seconds (default: 5.0).
-            If <= 0, returns data unchanged (passthrough).
+            If <= 0, or so small it rounds to zero samples, returns data
+            unchanged (passthrough).
             If > audio length, fades the entire track.
         curve: 'exponential' for (1-t)**3, 'linear' for 1-t
 
@@ -581,6 +582,12 @@ def apply_fade_out(data: Any, rate: int, duration: float = 5.0, curve: str = 'ex
 
     total_samples = data.shape[0]
     fade_samples = int(rate * duration)
+
+    # A sub-sample fade (0 < duration < 1/rate) rounds to zero samples.
+    # Return unchanged rather than letting result[-0:] select the whole
+    # array and broadcast against an empty envelope (ValueError).
+    if fade_samples < 1:
+        return data
 
     # If fade is longer than audio, fade the entire track
     if fade_samples > total_samples:
@@ -1058,6 +1065,12 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if was_mono:
         data = np.column_stack([data, data])
 
+    # Measure the SOURCE loudness up-front, before any processing stage
+    # touches the signal, so the reported 'original_lufs' reflects the true
+    # input rather than the post-EQ/compression/fade loudness. Measured on
+    # the (stereo) processing layout to stay comparable with final_lufs.
+    original_lufs = pyln.Meter(rate).integrated_loudness(data)
+
     # DC offset removal (first processing stage)
     dc_freq = p.get('dc_filter_freq', 5.0)
     if dc_freq > 0:
@@ -1191,7 +1204,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
     if not np.isfinite(current_lufs):
         logger.warning("Audio is silent or near-silent, skipping: %s", input_path)
         return {
-            'original_lufs': float('-inf'),
+            'original_lufs': original_lufs,
             'final_lufs': float('-inf'),
             'gain_applied': 0.0,
             'final_peak': float('-inf'),
@@ -1269,7 +1282,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
             if not np.isfinite(current_lufs):
                 logger.warning("Audio became silent after LRA targeting, skipping: %s", input_path)
                 return {
-                    'original_lufs': float('-inf'),
+                    'original_lufs': original_lufs,
                     'final_lufs': float('-inf'),
                     'gain_applied': 0.0,
                     'final_peak': float('-inf'),
@@ -1356,7 +1369,7 @@ def master_track(input_path: Path | str, output_path: Path | str,
     sf.write(output_path, data, rate, subtype=subtype)
 
     result = {
-        'original_lufs': current_lufs,
+        'original_lufs': original_lufs,
         'final_lufs': final_lufs,
         'gain_applied': gain_db,
         'final_peak': final_peak,

--- a/tools/mastering/qc_tracks.py
+++ b/tools/mastering/qc_tracks.py
@@ -556,6 +556,28 @@ def qc_track(
     }
 
 
+def _error_result(filepath: Path | str, exc: Exception) -> dict[str, Any]:
+    """Build a QC result row for a file that could not be read or processed.
+
+    Mirrors the shape returned by :func:`qc_track` (``filename`` / ``checks`` /
+    ``verdict``) so a corrupt or unreadable file renders as an ordinary
+    per-track FAIL row in the table, summary count, and ISSUES section instead
+    of tearing down the whole batch with a traceback (#408). The read failure
+    is surfaced through a single synthetic ``read`` check.
+    """
+    return {
+        "filename": os.path.basename(str(filepath)),
+        "checks": {
+            "read": {
+                "status": "FAIL",
+                "value": "unreadable",
+                "detail": f"Could not read/QC file: {exc}",
+            }
+        },
+        "verdict": "FAIL",
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Technical audio QC checks.")
     parser.add_argument(
@@ -622,11 +644,20 @@ def main() -> None:
     workers = args.jobs if args.jobs > 0 else os.cpu_count()
     progress = ProgressBar(len(filterable), prefix="QC scanning")
 
+    # A single corrupt/unreadable file must not abort the batch — catch its
+    # failure, emit a per-track FAIL row, and keep scanning the rest (#408).
+    had_read_error = False
+
     if workers == 1:
         results = []
         for wav_file in filterable:
             progress.update(wav_file.name)
-            result = qc_track(str(wav_file), checks=active_checks, genre=genre)
+            try:
+                result = qc_track(str(wav_file), checks=active_checks, genre=genre)
+            except Exception as exc:
+                logger.warning("QC failed for %s: %s", wav_file.name, exc)
+                result = _error_result(wav_file, exc)
+                had_read_error = True
             results.append(result)
     else:
         logger.info("Using %d parallel workers", workers)
@@ -639,7 +670,12 @@ def main() -> None:
             for future in as_completed(futures):
                 idx = futures[future]
                 progress.update(filterable[idx].name)
-                ordered[idx] = future.result()
+                try:
+                    ordered[idx] = future.result()
+                except Exception as exc:
+                    logger.warning("QC failed for %s: %s", filterable[idx].name, exc)
+                    ordered[idx] = _error_result(filterable[idx], exc)
+                    had_read_error = True
         results = [ordered[i] for i in sorted(ordered)]
 
     # Determine which checks were run
@@ -697,6 +733,11 @@ def main() -> None:
                 print(f"    [{info['status']}] {check}: {info['detail']}")
 
     print()
+
+    # Signal partial failure to callers/CI when any file could not be QC'd —
+    # every other track's result has already been printed above (#408).
+    if had_read_error:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/mastering/reference_master.py
+++ b/tools/mastering/reference_master.py
@@ -110,9 +110,14 @@ Examples:
         master_with_reference(target_path, reference_path, output_path)
     else:
         # Batch mode - process all WAVs in current directory
+        # Compare resolved paths so the reference is excluded regardless of
+        # how --reference was supplied (absolute, './'-prefixed, or relative);
+        # glob output is always relative to '.', so a lexical compare misses
+        # an absolute --reference and re-masters it as its own target (#409).
+        reference_resolved = reference_path.resolve()
         wav_files = sorted([f for f in Path('.').glob('*.wav')
                            if 'venv' not in str(f)
-                           and f != reference_path])
+                           and f.resolve() != reference_resolved])
 
         if not wav_files:
             logger.error("No WAV files found in current directory")

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -426,6 +426,25 @@ else:
     _envelope_follower = _envelope_follower_python
 
 
+# Floor for attack/release times (ms) in envelope-follower time constants.
+# A 0 ms (or negative) time — reachable via user-override mix presets — would
+# make `rate * ms / 1000.0` collapse to 0.0 and raise ZeroDivisionError. This
+# tiny positive floor yields a coefficient of ~0.0 (instantaneous response),
+# which is the correct limit for a "zero" time, without dividing by zero.
+_MIN_TIME_CONSTANT_MS = 1e-3
+
+
+def _time_constant_coeff(rate: int, time_ms: float) -> float:
+    """Smoothing coefficient for an envelope-follower attack/release time.
+
+    Clamps ``time_ms`` to a small positive floor (``_MIN_TIME_CONSTANT_MS``)
+    so a 0 ms or negative time cannot raise ZeroDivisionError; the clamped
+    value produces a coefficient near 0.0 (near-instant tracking).
+    """
+    time_ms = max(float(time_ms), _MIN_TIME_CONSTANT_MS)
+    return float(np.exp(-1.0 / (rate * time_ms / 1000.0)))
+
+
 def gentle_compress(data: Any, rate: int, threshold_db: float = -15.0, ratio: float = 2.5,
                     attack_ms: float = 10.0, release_ms: float = 100.0) -> Any:
     """Apply gentle dynamic compression using envelope following.
@@ -446,9 +465,9 @@ def gentle_compress(data: Any, rate: int, threshold_db: float = -15.0, ratio: fl
 
     threshold_linear = 10 ** (threshold_db / 20)
 
-    # Time constants
-    attack_coeff = np.exp(-1.0 / (rate * attack_ms / 1000.0))
-    release_coeff = np.exp(-1.0 / (rate * release_ms / 1000.0))
+    # Time constants (times clamped to a positive floor to avoid div-by-zero)
+    attack_coeff = _time_constant_coeff(rate, attack_ms)
+    release_coeff = _time_constant_coeff(rate, release_ms)
 
     def _compress_channel(channel: Any) -> Any:
         abs_signal = np.abs(channel)
@@ -852,11 +871,11 @@ def apply_transient_shaper(data: Any, rate: int, attack_gain: float = 0.0,
     if attack_gain == 0 and sustain_gain == 0:
         return data
 
-    # Time constants
-    fast_attack = np.exp(-1.0 / (rate * fast_attack_ms / 1000.0))
-    fast_release = np.exp(-1.0 / (rate * 5.0 / 1000.0))  # 5ms release
-    slow_attack = np.exp(-1.0 / (rate * slow_attack_ms / 1000.0))
-    slow_release = np.exp(-1.0 / (rate * 50.0 / 1000.0))  # 50ms release
+    # Time constants (times clamped to a positive floor to avoid div-by-zero)
+    fast_attack = _time_constant_coeff(rate, fast_attack_ms)
+    fast_release = _time_constant_coeff(rate, 5.0)  # 5ms release
+    slow_attack = _time_constant_coeff(rate, slow_attack_ms)
+    slow_release = _time_constant_coeff(rate, 50.0)  # 50ms release
 
     attack_linear = 10 ** (attack_gain / 20)
     sustain_linear = 10 ** (sustain_gain / 20)

--- a/tools/promotion/generate_all_promos.py
+++ b/tools/promotion/generate_all_promos.py
@@ -39,7 +39,7 @@ def find_mastered_dir(album_dir: Path) -> Path:
     ]
 
     for candidate in candidates:
-        if candidate.exists():
+        if candidate.is_dir():
             # Check if it has audio files
             audio_extensions = {'.wav', '.mp3', '.flac', '.m4a'}
             has_audio = any(f.suffix.lower() in audio_extensions

--- a/tools/shared/media_utils.py
+++ b/tools/shared/media_utils.py
@@ -134,7 +134,7 @@ def find_best_segment(audio_path: Path, duration: int = 15) -> float:
         best_start: float = 0.0
         best_energy: float = 0.0
 
-        for i in range(len(rms) - window_samples):
+        for i in range(len(rms) - window_samples + 1):
             window_energy = np.mean(rms[i:i + window_samples])
             if window_energy > best_energy:
                 best_energy = window_energy

--- a/tools/sheet-music/create_songbook.py
+++ b/tools/sheet-music/create_songbook.py
@@ -497,9 +497,26 @@ def create_songbook(
             if entry_title:
                 manifest_title_lookup[entry_title] = entry_title
 
-    # When manifest is present, all singles from prepare_singles have title pages.
-    # Without manifest, only non-numbered files (clean-titled) have title pages.
-    singles_have_title_pages = manifest is not None
+    # Whether each single actually has a prepended title page. prepare_singles
+    # records this per track in the manifest ("title_page"), because it silently
+    # skips the title page when pypdf/reportlab are unavailable — so a manifest
+    # merely existing does NOT imply a title page is present (#390). Trust the
+    # recorded flag when it is there; fall back (legacy manifests, or no
+    # manifest) to the filename heuristic: numbered files have no title page.
+    manifest_title_page_lookup = {}
+    if manifest:
+        for entry in manifest.get("tracks", []):
+            filename = entry.get("filename", "")
+            if filename and "title_page" in entry:
+                manifest_title_page_lookup[filename] = bool(entry["title_page"])
+
+    def _has_title_page(pdf_file: Path) -> bool:
+        if pdf_file.stem in manifest_title_page_lookup:
+            return manifest_title_page_lookup[pdf_file.stem]
+        if manifest is not None:
+            # Legacy manifest without the per-track flag: preserve prior behavior.
+            return True
+        return not re.match(r'^\d+', pdf_file.stem)
 
     # Get page counts for TOC
     tracks = []
@@ -512,12 +529,8 @@ def create_songbook(
         else:
             track_name = pdf_file.stem
         page_count = get_pdf_page_count(pdf_file)
-        # Singles have a prepended title page — don't count it for the songbook
-        if singles_have_title_pages:
-            has_title_page = True
-        else:
-            has_title_page = not re.match(r'^\d+', pdf_file.stem)
-        if has_title_page:
+        # A prepended title page is not counted in the songbook TOC (#390).
+        if _has_title_page(pdf_file):
             page_count -= 1
         if include_section_headers:
             page_count += 1  # Add section header page
@@ -551,11 +564,7 @@ def create_songbook(
         # Singles have a prepended title page — skip it in the songbook
         # (the songbook has its own front matter and optional section headers)
         reader = PdfReader(pdf_file)
-        if singles_have_title_pages:
-            has_title_page = True
-        else:
-            has_title_page = not re.match(r'^\d+', pdf_file.stem)
-        start_page = 1 if has_title_page else 0
+        start_page = 1 if _has_title_page(pdf_file) else 0
         for page in reader.pages[start_page:]:
             writer.add_page(page)
 

--- a/tools/sheet-music/prepare_singles.py
+++ b/tools/sheet-music/prepare_singles.py
@@ -194,11 +194,16 @@ def prepare_xml(source_xml: Path, singles_dir: Path, title: str, dry_run: bool =
     return out_path
 
 
-def _add_title_page_and_footer(pdf_path: Path, title: str, artist: str | None, cover_image: str | None, footer_url: str | None, page_size_name: str) -> None:
+def _add_title_page_and_footer(pdf_path: Path, title: str, artist: str | None, cover_image: str | None, footer_url: str | None, page_size_name: str) -> bool:
     """Prepend a title page and add footer URL to every page of a single PDF.
 
     Uses shared helpers from create_songbook module. Gracefully skips
     if pypdf/reportlab are not available (they're optional deps).
+
+    Returns:
+        True if a title page was actually prepended, False if the step was
+        skipped (missing deps) or failed. Callers record this in the manifest
+        so create_songbook knows whether page 0 is a title page (#390).
     """
     try:
         # Late import — songbook module needs pypdf/reportlab
@@ -237,10 +242,13 @@ def _add_title_page_and_footer(pdf_path: Path, title: str, artist: str | None, c
             writer.write(f)
 
         logger.info("  Added title page + footer to %s", pdf_path.name)
+        return True
     except ImportError:
         logger.warning("  pypdf/reportlab not installed — skipping title page and footer for %s", pdf_path.name)
+        return False
     except Exception as e:
         logger.warning("  Could not add title page to %s: %s", pdf_path.name, e)
+        return False
 
 
 def resolve_source_dir(given_path: str | Path) -> tuple[Path, Path]:
@@ -405,12 +413,18 @@ def prepare_singles(source_dir: str | Path, singles_dir: str | Path, musescore: 
 
         print(f"\n  [{lookup_key}] -> \"{singles_name}\"")
 
-        manifest_tracks.append({
+        # `title_page` records whether a title page was actually prepended to
+        # this single (updated after _add_title_page_and_footer runs). It
+        # stays False when no PDF is produced or the title-page step is
+        # skipped, so create_songbook never skips a page that isn't there (#390).
+        manifest_entry: dict[str, Any] = {
             "number": track_num,
             "source_slug": source_slug,
             "title": title,
             "filename": singles_name,
-        })
+            "title_page": False,
+        }
+        manifest_tracks.append(manifest_entry)
 
         track_result: dict[str, Any] = {"source": source_slug, "title": title, "filename": singles_name, "files": []}
 
@@ -453,7 +467,7 @@ def prepare_singles(source_dir: str | Path, singles_dir: str | Path, musescore: 
 
             # Add title page and footer to the PDF
             if pdf_written and not dry_run:
-                _add_title_page_and_footer(
+                manifest_entry["title_page"] = _add_title_page_and_footer(
                     pdf_dst, title, artist, cover_image, footer_url, page_size_name
                 )
                 track_result["files"].append(pdf_dst.name)


### PR DESCRIPTION
## Release 0.95.0

Bugfix + docs release rolling up everything since 0.94.0 — **8 PRs**, the full crash-hardening/correctness sweep plus Suno reference and workflow documentation.

### Fixed — crash-hardening & correctness
- **Input validation + slug-ValueError boundary** (#442, #443): handlers return structured JSON instead of crashing on bad `track_number`, non-mapping frontmatter, or malformed slugs; a registration-time error boundary covers every MCP tool.
- **Songbook title-page fact recorded in the manifest** (#390): no more dropping the first music page of every track.
- **Audio/DSP edge cases** (#447): silent-track LUFS poisoning, zero-length/tiny buffers, sub-sample fades, 0 ms envelope times, file-vs-dir paths, and an off-by-one window (#400/#401/#402/#406/#407/#410/#411/#412).
- **Handler & CLI correctness** (#448): YAML escaping for quoted titles/URLs, UTF-8 manifest reads, case-insensitive idea dedup, rhyme-tail grouping, glob-before-validation ordering, and batch robustness (#394/#395/#396/#399/#403/#404/#405/#408/#409).

### Performance
- **ADM validation runs per-track checks in parallel** (#345), bounded to CPU count, behavior-preserving.

### Docs & Tests
- Suno Song Editor / Creative Sliders / Covers & Personas guides, expanded error-recovery, and dedicated handler test coverage (#450: #236/#237/#238/#239/#240/#344).
- **Expanded Suno metatag reference coverage + suno-engineer prompt workflow** (#449) — external contribution by @markus-michalski.

### Release mechanics
- CHANGELOG `[Unreleased]` stamped as `[0.95.0] - 2026-07-04`.
- `plugin.json` + `marketplace.json` bumped `0.95.0-dev` → `0.95.0` (in sync).
- Full local gate on the release head: ruff + bandit + mypy clean, **4252 tests**, 88.12% coverage.

⚠️ **Merge with a MERGE COMMIT — never squash** (squashing permanently diverges develop/main and conflicts every future release; see CLAUDE.md release rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MABMjtap1aw69gdipemmjd