### PR TITLE
fix(suno-engineer): reconcile Performance-Cues/descriptor guidance (#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
   adding Performance Cues to all 12 of its section tags produced a subjectively much more
   dynamic, less generic-sounding generation — the before/after difference is what prompted
   this fix.
+- **`suno-engineer` guidance-consistency follow-ups** (#454, follow-up to #453). Trimmed the
+  Style Prompt example to the 4-7 sweet spot (it modeled 9 descriptors); reconciled the
+  emotional-arc location between `suno-engineer/SKILL.md` and `voice-tags.md` § Emotion Arc
+  Mapping (baseline mood in Style Box prose, per-section variation in Performance Cues,
+  cross-referenced both ways); updated `templates/track.md` to model per-section Performance
+  Cues instead of bare section tags and to stop redirecting delivery notes to the Style Box;
+  and clarified that Performance Cues plus the optional standalone accent share one
+  ≤3-per-section budget.
 
 ## [0.95.0] - 2026-07-04
 

--- a/reference/suno/voice-tags.md
+++ b/reference/suno/voice-tags.md
@@ -163,7 +163,7 @@ chorus slightly wider and warmer with gentle vibrato on sustained notes;
 bridge raw and exposed, single-take feel.
 ```
 
-This lets you create an **emotional arc** across the song rather than a flat vocal performance throughout.
+This lets you create an **emotional arc** across the song rather than a flat vocal performance throughout. This Style-Box "Performance:" method and per-section **Performance Cues** in the Lyrics Box ([structure-tags.md](structure-tags.md) § Performance Cues, e.g. `[Verse 1 - quiet, intimate]`) are two routes to the same arc — pick one per track rather than splitting it across both.
 
 ## Advanced Vocal Workflow
 

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -68,7 +68,7 @@ Structure your songs with explicit section markers:
 - V5 uses these to shape arrangement
 - Without tags, structure can be unpredictable
 - **Default, not optional — Performance Cues**: append 1-3 delivery cues directly to each structure tag (`[Verse 1 - cold, regal, controlled]`, `[Bridge - raw, breaking, desperate]`) — see the same reference's "Performance Cues" section. This is how an emotional arc is carried across a song. Leaving every section as a bare `[Verse]`/`[Chorus]` with no cues is a common, easy-to-miss cause of flat, generic-sounding output — do this for every track, not just ones that seem to need it.
-- **Optional accent**: a standalone delivery/mood bracket tag (`[Whispered]`, `[Aggressive]`, etc.) can additionally color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly (1 per section); this is not a substitute for Style Box mood/energy prose.
+- **Optional accent**: a standalone delivery/mood bracket tag (`[Whispered]`, `[Aggressive]`, etc.) can additionally color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly, and count it against the **same ≤3-per-section budget** as the Performance Cues above (cues + accent ≤ 3 bracketed descriptors per section — more than 3 causes noise). This is not a substitute for Style Box mood/energy prose.
 
 ### Vocals First
 In Style Prompt, put vocal description FIRST:
@@ -169,11 +169,11 @@ Chorus lyrics here
 
 **Example**:
 ```
-Male baritone, passionate delivery, storytelling vocal. Alternative rock,
-clean electric guitar, driving bassline, tight drums. Modern production, dynamic range.
+Male baritone, storytelling delivery. Alternative rock, clean electric guitar,
+driving bass, tight drums. Modern production.
 ```
 
-**Before finalizing, count every descriptor across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`), so counting commas alone undercounts. V5's sweet spot is 4-7 total; 8+ causes "prompt fatigue" where V5 dilutes or ignores tags (see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Watch for synonym-piles — stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse to 1-2 words per concept (vocal identity, genre, tempo, 2-3 instruments, 1 production note) to keep the total within 4-7. Move section-by-section emotional variation into Performance Cues in the Lyrics Box instead of adding more adjectives here — that is the correct place for an arc, not the Style Box.
+**Before finalizing, count every descriptor across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`), so counting commas alone undercounts. V5's sweet spot is 4-7 total; 8+ causes "prompt fatigue" where V5 dilutes or ignores tags (see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Watch for synonym-piles — stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse to 1-2 words per concept (vocal identity, genre, tempo, 2-3 instruments, 1 production note) to keep the total within 4-7. Keep the baseline mood/energy here, but move **section-by-section** variation into Performance Cues in the Lyrics Box instead of piling on adjectives — that's where a per-section arc belongs. (An alternative arc technique — mapping sections in Style-Box "Performance:" prose — lives in `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` § Emotion Arc Mapping; use one approach per track, not both.)
 
 ### Exclude Styles (Negative Prompting)
 

--- a/templates/track.md
+++ b/templates/track.md
@@ -216,22 +216,23 @@ Suno Inputs below with the destination genre/mood, then note here what to preser
 
 <!-- VOCAL TRACKS: WARNING: Suno sings EVERYTHING literally including parenthetical directions.
      NEVER use (whispered), (softly), (screaming), (spoken), (laughing), etc.
-     Use metatags like [Whispered] or put delivery notes in the Style Box instead. -->
+     Use standalone metatags like [Whispered], or append per-section Performance Cues to the
+     section tag (e.g. [Verse 1 - cold, regal]) — never parentheticals. -->
 
 ```
-[Verse 1]
+[Verse 1 - calm, reflective]
 [Lyrics here...]
 
-[Chorus]
+[Chorus - big, anthemic]
 [Lyrics here...]
 
-[Verse 2]
+[Verse 2 - restless, driving]
 [Lyrics here...]
 
-[Bridge]
+[Bridge - stripped, intimate]
 [Lyrics here...]
 
-[Outro]
+[Outro - resolved, fading]
 [Lyrics here...]
 ```
 <!-- /SERVICE: suno -->


### PR DESCRIPTION
## Summary

Follow-up to #453 (merged), closing #454. #453 wired the 4-7 descriptor ceiling and per-section Performance Cues into `suno-engineer`; a deep review of that PR surfaced four consistency items that needed a judgment call or multi-file edits rather than one-line suggestions. This PR resolves them.

## Changes

- **Style Prompt example trimmed to the sweet spot** (`skills/suno-engineer/SKILL.md`). The flagship example modeled **9** descriptors (3 vocal, 2 production) — it failed the period-aware counting rule printed directly beneath it. Trimmed to **7**.
- **Emotional-arc location reconciled** (`skills/suno-engineer/SKILL.md` + `reference/suno/voice-tags.md`). The skill said the arc belongs in Lyrics-Box cues "not the Style Box," while `voice-tags.md` § Emotion Arc Mapping teaches building it in Style-Box "Performance:" prose — a direct doc-vs-doc contradiction. Now: **baseline** mood → Style Box prose; **per-section** variation → Performance Cues; both docs cross-reference each other and say "pick one approach per track, not both."
- **Template no longer models the anti-pattern** (`templates/track.md`). The example Lyrics Box now carries per-section Performance Cues (`[Verse 1 - calm, reflective]` …), and the delivery-notes comment points to Performance Cues instead of redirecting delivery to the Style Box.
- **Shared per-section bracket budget stated** (`skills/suno-engineer/SKILL.md`). Performance Cues (1-3) plus the optional standalone accent now explicitly share one **≤3-per-section** ceiling, matching `structure-tags.md`'s combined cap.
- **CHANGELOG** `[Unreleased]` entry.

Closes #454.

## Test plan

- [x] Full `pytest` suite via the existing `.venv`: **4252 passed, 2 xfailed** (8m24s)
- [x] `ruff check tools/ servers/` (the CI command) clean; Markdown-only change, no `.py` touched
- [x] Style Prompt example now counts to 7 descriptors (comma + period split)
- [x] No new headings/anchors; the one new Markdown link (`voice-tags.md` → `structure-tags.md`) resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)
