### PR TITLE
chore: release 0.96.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.96.0-dev",
+      "version": "0.96.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "bitwize-music",
       "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-      "version": "0.95.0",
+      "version": "0.96.0-dev",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.95.0",
+  "version": "0.96.0-dev",
   "author": {
     "name": "bitwize-music"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bitwize-music",
   "description": "AI music generation workflow for Suno - album concepts, lyrics, prompts, mastering, release",
-  "version": "0.96.0-dev",
+  "version": "0.96.0",
   "author": {
     "name": "bitwize-music"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Added
+- **Pre-generation gates now check the Style Box descriptor and Performance Cues standards** (#456).
+  `run_pre_generation_gates` previously only verified the Style Box was non-empty, so it would pass a
+  20-descriptor synonym-pile or all-bare `[Verse]`/`[Chorus]` tags — the exact defects the
+  `suno-engineer` Quality Standards (0.95.0) tell you to fix first. Added two advisory (non-blocking
+  `WARN`) gates: **Style Box Descriptor Count** (flags >7 descriptors, counted across the period- and
+  comma-delimited blocks) and **Performance Cues** (flags ≥2 structure tags with no per-section cues
+  like `[Verse 1 - cold, regal]`). Closes #456.
+
 ## [0.95.0] - 2026-07-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+## [0.96.0] - 2026-07-05
+
 ### Added
 - **Pre-generation gates now check the Style Box descriptor and Performance Cues standards** (#456).
   `run_pre_generation_gates` previously only verified the Style Box was non-empty, so it would pass a

--- a/servers/bitwize-music-server/handlers/gates.py
+++ b/servers/bitwize-music-server/handlers/gates.py
@@ -71,6 +71,7 @@ def _check_pre_gen_gates_for_track(
     gates: list[dict[str, Any]] = []
     blocking = 0
     warning_count = 0
+    is_instrumental = bool(file_text and re.search(r"(?mi)^instrumental:\s*true\b", file_text))
 
     # Gate 1: Sources Verified
     sources = t_data.get("sources_verified", "N/A")
@@ -156,6 +157,23 @@ def _check_pre_gen_gates_for_track(
         gates.append({"gate": "Style Prompt Complete", "status": "PASS",
                       "detail": f"Style prompt: {len(style_content)} chars"})
 
+    # Gate 5b: Style Box descriptor budget (advisory) — V5 sweet spot is 4-7
+    if style_content and style_content.strip():
+        descriptors = [d for d in re.split(r"[,.\n]", style_content) if d.strip()]
+        n_desc = len(descriptors)
+        if n_desc > 7:
+            gates.append({"gate": "Style Box Descriptor Count", "status": "WARN",
+                          "severity": "WARNING",
+                          "detail": f"{n_desc} descriptors — V5 sweet spot is 4-7; "
+                                    "trim synonym-piles to avoid prompt fatigue"})
+            warning_count += 1
+        else:
+            gates.append({"gate": "Style Box Descriptor Count", "status": "PASS",
+                          "detail": f"{n_desc} descriptors (within 4-7 sweet spot)"})
+    else:
+        gates.append({"gate": "Style Box Descriptor Count", "status": "SKIP",
+                      "detail": "No style prompt to check"})
+
     # Gate 6: Artist Names Cleared (uses pre-compiled patterns)
     if style_content:
         found_artists = []
@@ -216,6 +234,29 @@ def _check_pre_gen_gates_for_track(
                           "detail": f"{wc} words (limit {max_lyric_words})"})
     else:
         gates.append({"gate": "Lyric Length", "status": "SKIP",
+                      "detail": "No lyrics to check"})
+
+    # Performance Cues on structure tags (advisory) — bare tags cause flat output.
+    # Instrumental tracks legitimately use bare structural tags, so skip the check.
+    if is_instrumental:
+        gates.append({"gate": "Performance Cues", "status": "SKIP",
+                      "detail": "Instrumental track — per-section cues optional"})
+    elif lyrics_content and lyrics_content.strip():
+        struct_tags = [line.strip() for line in lyrics_content.split("\n")
+                       if _SECTION_TAG_RE.match(line.strip())]
+        cue_bearing = [t for t in struct_tags if re.search(r"\[[^\]]* - [^\]]*\]", t)]
+        if len(struct_tags) >= 2 and not cue_bearing:
+            gates.append({"gate": "Performance Cues", "status": "WARN", "severity": "WARNING",
+                          "detail": f"{len(struct_tags)} structure tags carry no Performance Cues "
+                                    "(e.g. [Verse 1 - cold, regal]); bare tags are a common cause "
+                                    "of flat, generic output"})
+            warning_count += 1
+        else:
+            gates.append({"gate": "Performance Cues", "status": "PASS",
+                          "detail": (f"{len(cue_bearing)}/{len(struct_tags)} structure tags carry cues"
+                                     if struct_tags else "No structure tags to check")})
+    else:
+        gates.append({"gate": "Performance Cues", "status": "SKIP",
                       "detail": "No lyrics to check"})
 
     return blocking, warning_count, gates

--- a/skills/pre-generation-check/SKILL.md
+++ b/skills/pre-generation-check/SKILL.md
@@ -86,6 +86,8 @@ Do NOT proceed with gate evaluation until the mismatch is resolved — the wrong
 - **Check**: Style Box includes vocal description
 - **Check**: Section tags present in Lyrics Box (`[Verse]`, `[Chorus]`, etc.)
 - **Fail if**: Empty Style Box or missing section tags
+- **Advisory (WARN, non-blocking)**: Style Box descriptor count — flags >7 descriptors (V5 sweet spot is 4-7; trim synonym-piles to avoid prompt fatigue)
+- **Advisory (WARN, non-blocking)**: Performance Cues — flags ≥2 structure tags with no per-section cues (`[Verse 1 - cold, regal]`); bare tags are a common cause of flat, generic output
 - **Fix**: Style Box is created by suno-engineer, which is normally auto-invoked by lyric-writer. Run `/bitwize-music:suno-engineer [track]` to create the missing Style Box.
 - **Severity**: BLOCKING
 

--- a/tests/unit/state/test_handlers_gates.py
+++ b/tests/unit/state/test_handlers_gates.py
@@ -750,12 +750,98 @@ class TestBlockingAggregation:
         )
         assert blocking >= 2
 
-    def test_returns_eight_gates(self):
+    def test_returns_ten_gates(self):
         t_data = {"sources_verified": "N/A", "explicit": False}
         blocking, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
             t_data, TRACK_FILE_COMPLETE, blocklist=[],
         )
-        assert len(gates) == 8
+        # 8 core gates + 2 advisory (Style Box Descriptor Count, Performance Cues)
+        assert len(gates) == 10
+
+
+def _track_with(style, lyrics):
+    """Minimal gate-complete track file with a custom Style Box and Lyrics Box."""
+    return (
+        "---\ntitle: T\nstatus: In Progress\nexplicit: false\n---\n\n"
+        f"## Lyrics Box\n\n```\n{lyrics}\n```\n\n"
+        f"## Style Box\n\n```\n{style}\n```\n\n"
+        "## Pronunciation Notes\n\n| Word | Phonetic | Note |\n| --- | --- | --- |\n| — | — | — |\n"
+    )
+
+
+class TestStyleBoxDescriptorCount:
+    """Gate 5b: advisory Style Box descriptor budget (4-7 sweet spot)."""
+
+    def test_over_seven_descriptors_warns(self):
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        style = "imperious, commanding, regal, grand, theatrical, explosive, cinematic, bombastic"
+        _, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Style Box Descriptor Count")
+        assert g["status"] == "WARN"
+        assert g["severity"] == "WARNING"
+        assert warnings >= 1
+
+    def test_within_budget_passes(self):
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        style = "male baritone. alt rock, clean guitar, driving bass. modern production"
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Style Box Descriptor Count")
+        assert g["status"] == "PASS"
+
+    def test_counts_across_periods_and_commas(self):
+        # 8 descriptors split by BOTH periods and commas must be counted (not commas only)
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        style = ("male baritone, passionate delivery, storytelling vocal. "
+                 "alt rock, clean guitar, driving bass, tight drums. modern production")
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Style Box Descriptor Count")
+        assert g["status"] == "WARN"
+
+
+class TestPerformanceCuesGate:
+    """Advisory Performance Cues check on structure tags."""
+
+    def test_all_bare_tags_warn(self):
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        lyrics = "[Verse 1]\nla la\n\n[Chorus]\nna na\n\n[Verse 2]\nla la"
+        _, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with("pop, synth, 120 BPM", lyrics), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Performance Cues")
+        assert g["status"] == "WARN"
+        assert warnings >= 1
+
+    def test_tags_with_cues_pass(self):
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        lyrics = "[Verse 1 - cold, regal]\nla la\n\n[Chorus - big, anthemic]\nna na"
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with("pop, synth, 120 BPM", lyrics), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Performance Cues")
+        assert g["status"] == "PASS"
+
+    def test_single_bare_tag_does_not_warn(self):
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with("pop, synth, 120 BPM", "[Verse 1]\nla la"), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Performance Cues")
+        assert g["status"] == "PASS"  # only 1 structure tag -> not flagged
+
+    def test_instrumental_track_skipped(self):
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        f = ("---\ntitle: T\nstatus: In Progress\nexplicit: false\ninstrumental: true\n---\n\n"
+             "## Lyrics Box\n\n```\n[Intro]\n\n[Main Theme]\n\n[Bridge]\n\n[Outro]\n```\n\n"
+             "## Style Box\n\n```\ncinematic orchestral, strings, brass\n```\n")
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(t_data, f, blocklist=[])
+        g = next(x for x in gates if x["gate"] == "Performance Cues")
+        assert g["status"] == "SKIP"  # instrumental -> cues optional, not warned
 
 
 # =============================================================================

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -4599,7 +4599,9 @@ class TestRunPreGenerationGates:
         assert "Artist Names Cleared" in gate_names
         assert "Homograph Check" in gate_names
         assert "Lyric Length" in gate_names
-        assert len(gates) == 8
+        assert "Style Box Descriptor Count" in gate_names
+        assert "Performance Cues" in gate_names
+        assert len(gates) == 10
 
     def test_track_no_file_path(self):
         """Track with no file path gets SKIP for file-dependent gates."""
@@ -4731,7 +4733,7 @@ class TestRunPreGenerationGates:
         assert result["found"] is True
         track = result["tracks"][0]
         # Should still produce gates (file-dependent ones SKIP or FAIL)
-        assert len(track["gates"]) == 8
+        assert len(track["gates"]) == 10
 
     def test_permission_error_track_file(self, tmp_path):
         """Track with permission-denied file still produces gate results."""
@@ -4752,7 +4754,7 @@ class TestRunPreGenerationGates:
                 result = json.loads(_run(server.run_pre_generation_gates("test-album", "05-denied")))
             assert result["found"] is True
             track = result["tracks"][0]
-            assert len(track["gates"]) == 8
+            assert len(track["gates"]) == 10
         finally:
             track_file.chmod(0o644)
 

--- a/tests/unit/state/test_server_features.py
+++ b/tests/unit/state/test_server_features.py
@@ -479,8 +479,8 @@ class TestInstrumentalGateSkipping:
         track = result["tracks"][0]
         gates = track["gates"]
         gate_names = [g["gate"] for g in gates]
-        # All 8 gates should be present
-        assert len(gates) == 8
+        # 8 core gates + 2 advisory
+        assert len(gates) == 10
         assert "Sources Verified" in gate_names
         assert "Lyrics Reviewed" in gate_names
         assert "Pronunciation Resolved" in gate_names
@@ -489,6 +489,8 @@ class TestInstrumentalGateSkipping:
         assert "Artist Names Cleared" in gate_names
         assert "Homograph Check" in gate_names
         assert "Lyric Length" in gate_names
+        assert "Style Box Descriptor Count" in gate_names
+        assert "Performance Cues" in gate_names
 
     def test_gates_run_for_instrumental_track(self, tmp_path):
         """Gates still run for instrumental tracks (current behavior).
@@ -507,8 +509,8 @@ class TestInstrumentalGateSkipping:
         assert result["found"] is True
         track = result["tracks"][0]
         gates = track["gates"]
-        # All gates still run (no skip logic for instrumental yet)
-        assert len(gates) == 8
+        # All gates still run; Performance Cues SKIPs for instrumental tracks
+        assert len(gates) == 10
 
     def test_instrumental_track_style_gate_still_runs(self, tmp_path):
         """Gate 5 (Style Prompt) still runs for instrumental tracks."""

--- a/tests/unit/state/test_server_integration.py
+++ b/tests/unit/state/test_server_integration.py
@@ -1581,14 +1581,15 @@ class TestRunPreGenerationGatesExtended:
         result = json.loads(_run(server.run_pre_generation_gates("nonexistent")))
         assert result["found"] is False
 
-    def test_eight_gates_per_track(self, integration_env):
-        """Each track should be checked against all 8 gates."""
+    def test_gates_per_track(self, integration_env):
+        """Each track should be checked against all core + advisory gates."""
         with patch.object(_text_analysis_mod, "_artist_blocklist_cache", None):
             result = json.loads(_run(server.run_pre_generation_gates(
                 "integration-test-album", "01"
             )))
         track = result["tracks"][0]
-        assert len(track["gates"]) == 8
+        # 8 core gates + 2 advisory (Style Box Descriptor Count, Performance Cues)
+        assert len(track["gates"]) == 10
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Promotes `develop` → `main` for the **0.96.0** release.

## Added
- **Pre-generation gates now check the Style Box descriptor and Performance Cues standards** (#456, #457). Two advisory (non-blocking `WARN`) gates in `run_pre_generation_gates`:
  - **Style Box Descriptor Count** — flags >7 descriptors (counted across period- and comma-delimited blocks)
  - **Performance Cues** — flags ≥2 structure tags with no per-section cues; `SKIP` for instrumental tracks

So `/bitwize-music:pre-generation-check` now catches the exact defects the `suno-engineer` Quality Standards (shipped in 0.95.0) tell you to fix — a 20-descriptor synonym-pile or all-bare `[Verse]`/`[Chorus]` tags — instead of green-lighting them.

## Version
- `plugin.json` + `marketplace.json`: 0.95.0 → **0.96.0** (in sync)
- CHANGELOG `[Unreleased]` → `[0.96.0] - 2026-07-05`

Full suite green (4259 passed, 2 xfailed); ruff/mypy/bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)