### PR TITLE
feat(suno): V5.5 mid-year research sweep — stem overhaul, descriptor-gate reframe, comma-free cues

### DIFF
--- a/reference/suno/CHANGELOG.md
+++ b/reference/suno/CHANGELOG.md
@@ -4,6 +4,52 @@ This file tracks all updates to the Suno reference documentation, including new 
 
 ---
 
+## 2026-07-07 - V5.5 Mid-Year Research Sweep
+
+Deep multi-source research pass (Suno primary docs + community guides, adversarially fact-checked). Headline: the genuinely new/vetted material since the April V5.5 update is **feature-driven**, not a new prompt grammar. Most third-party "V5.5 prompt-grammar" tips failed verification and were **not adopted** (see Refuted below).
+
+### Features
+- **Stem separation overhauled** (June 11, 2026) into three selectable modes: **Auto Split** (the classic 12-category model), **Split from Mix** (pull one instrument/voice out → 2 stems: the target + everything-else), and **Advanced Split** (extract one instrument chosen from ~100; Premier, per-extraction credit cost). The system now *generatively regenerates* each stem rather than frequency-carving the mix, so pulls are cleaner.
+
+### Changes
+- **Descriptor-count guidance reframed.** The "4-7 descriptor sweet spot" is a starting heuristic, **not a Suno-official rule** — real style boxes routinely run ~10 focused descriptors. The advisory pre-generation gate now flags only genuine synonym-pile bloat (**>12**, was >7) and no longer mislabels sparse boxes. The failure mode is *duplication*, not count.
+- **Negative prompting clarified.** Suno's dedicated **Exclude Styles** field (Custom Mode → Advanced Options, Pro/Premier) is the reliable path; inline `no X` in the main style prompt is a weaker free-tier fallback. Added group-vocal suppression vocabulary (choir, crowd vocals, backing vocals, gang vocals, call-and-response, vocal harmonies, layered vocals). Exclusion is probabilistic — it shifts odds, not a hard filter.
+- **Audio Influence × Voices.** When using Voices (voice cloning), keep Audio Influence high (~0.70–0.85) for voice resemblance.
+- **Subtle-descriptor claim softened.** "V5.5 honors subtle descriptors more reliably" is engine-reported, not independently verified — reworded from a factual claim to a hedged one.
+- **Performance-Cue formatting.** Cues are now written as a short comma-free phrase: `[Outro - chant fading]`, not `[Outro - chant, fading]`. Convention change only — the gate detects cues by the ` - ` separator, so behavior is unchanged.
+- **Corrected V5 release date** in the V4→V5 migration guide (was "October 2024"; now "September 2025" to match the repo's own Suno Studio / v5-generation dating).
+
+### Refuted / Not Adopted
+Adversarial verification (majority-refute to kill) rejected these widely-circulated claims; do **not** re-add them:
+- **"4-7 descriptors is the optimal/required count"** — traces to a single commercial guide; no evidence-based number exists (reframed as a heuristic).
+- **Four-layer style template** ending in 2-3 `no` negatives — unsupported.
+- **Per-section parameterized tags** like `[Verse: whispered vocals, acoustic only]` — unsupported (this plugin already rejected them as tag soup).
+- **Inline `no autotune`/`no reverb` in the style field** as a reliable mechanism — the dedicated Exclude Styles field is the real one.
+- **"V5.5 honors subtle production descriptors better than v4.5"** — refuted for lack of evidence (softened, not removed).
+- **"V5.5 follows structural metatags more reliably"** — unsupported.
+
+### Documentation
+- v5-best-practices.md: Stem Extraction (3 modes), Keep It Simple (descriptor reframe), V5.5 table (subtle-descriptor hedge), Negative Prompting (dedicated field + group vocals), V5 Key Improvements table (stem row).
+- suno-engineer/SKILL.md: descriptor-mix guidance, Exclude Styles, workflow steps, quality checklist.
+- creative-sliders.md: Audio Influence × Voices; softened 4-7 cross-refs.
+- structure-tags.md, voice-tags.md, templates/track.md: comma-free Performance Cue convention.
+- pre-generation-check/SKILL.md + handlers/gates.py: descriptor gate >12 threshold; comma-free cue example.
+- mix-engineer/SKILL.md: split-mode cross-reference.
+- version-history/v5-changes.md: corrected V5 date.
+
+**Sources**:
+- https://suno.com/release-notes (official - stem-separation overhaul, Creative Sliders)
+- https://suno.com/blog/stem-separation-updates (official - Advanced Split / Split from Mix / Auto Split)
+- https://help.suno.com/en/articles/12702337 (official - stem separation)
+- https://help.suno.com/en/articles/6141377 (official - Creative Sliders behavior)
+- https://help.suno.com/en/articles/11362369 (official - Voices; "Audio Influence slider up fairly high")
+- https://suno.com/release-notes/introducing-v5-5-voices-custom-models-and-my-taste (official - V5.5 launch)
+- https://jackrighteous.com/en-us/blogs/guides-using-suno-ai-music-creation/stop-suno-adding-crowd-vocals-choirs-backing-voices (community - group-vocal exclusion)
+- https://jackrighteous.com/en-us/blogs/guides-using-suno-ai-music-creation/how-to-use-suno-s-advanced-sliders-weirdness-style-audio-influence (community - sliders)
+- Refuted-claim sources (recorded for traceability): blakecrosley.com/guides/suno, songaifarm.com/blog/suno-prompts-v5-5, hookgenius.app/learn/suno-v5-5-guide, learnstemlab.com/suno-ai-song-control-metatags-guide
+
+---
+
 ## 2026-04-12 - V5.5 Research Update
 
 ### Features

--- a/reference/suno/creative-sliders.md
+++ b/reference/suno/creative-sliders.md
@@ -53,7 +53,7 @@ Controls how tightly the output adheres to your style prompt — genre hallmarks
 
 ## Audio Influence
 
-Controls how much a piece of **uploaded reference audio** shapes the output. This slider **appears only when audio is uploaded** — via Cover, Upload Audio, or Sample to Song. With no reference audio, it isn't shown.
+Controls how much a piece of **uploaded reference audio** shapes the output. This slider **appears only when audio is uploaded** — via Cover, Upload Audio, Sample to Song, or **Voices**. With no reference audio, it isn't shown.
 
 | Position | Behavior |
 |----------|----------|
@@ -62,6 +62,8 @@ Controls how much a piece of **uploaded reference audio** shapes the output. Thi
 | **High** (`0.65–1.00`) | The output hews closely to the uploaded audio's melody, feel, and arrangement. Safest for faithful covers and cross-track consistency. |
 
 **Raise it** when a cover or reworked upload isn't resembling the source enough. **Lower it** when you want more transformation and less of the original bleeding through.
+
+**With Voices (voice cloning):** keep Audio Influence **fairly high (~0.70–0.85)** so the result resembles the cloned voice — too low and Suno drifts toward a generic vocal. See [Voices & Custom Models](v5-best-practices.md#voices--custom-models).
 
 ---
 
@@ -114,7 +116,7 @@ The single most useful habit: diagnose whether a bad result is a **prompt proble
 - The **style prompt** decides *what* the track is — genre, instruments, mood, tempo, vocal identity. A slider can't add a banjo, fix a mispronunciation, or change the tempo.
 - The **sliders** decide *how strictly* Suno commits to that prompt and *how far* it may wander. They're fine-tuning, not a rescue for a vague or wrong prompt.
 
-**Change the prompt when** the output has the wrong genre, wrong instruments, wrong mood or tempo, a missing element, or the vocal character is off. No slider fixes content. (Keep the prompt to 4–7 descriptors — a bloated prompt won't be rescued by sliders either; see [Keep It Simple](v5-best-practices.md#prompt-construction).)
+**Change the prompt when** the output has the wrong genre, wrong instruments, wrong mood or tempo, a missing element, or the vocal character is off. No slider fixes content. (Keep the prompt focused — every descriptor doing distinct work; a bloated synonym-pile won't be rescued by sliders either; see [Keep It Simple](v5-best-practices.md#prompt-construction).)
 
 **Adjust a slider when** the prompt is already right but the *interpretation* is off:
 
@@ -135,7 +137,7 @@ The single most useful habit: diagnose whether a bad result is a **prompt proble
 
 ## Quick Workflow
 
-1. **Write a clear prompt first** — 4–7 descriptors, genre + instruments + mood + vocal.
+1. **Write a clear, focused prompt first** — genre + instruments + mood + vocal, every descriptor doing distinct work.
 2. **Generate at the default slider positions.** Don't pre-adjust blind.
 3. **Listen, then diagnose** — is this a prompt problem or a slider problem? (Use the table above.)
 4. **If it's a slider problem, move ONE slider a small step** and regenerate.

--- a/reference/suno/structure-tags.md
+++ b/reference/suno/structure-tags.md
@@ -177,20 +177,20 @@ Numbers represent target bar counts. Results are approximate — Suno treats the
 
 ## Performance Cues
 
-Add **1–3 performance cues per section** to influence delivery without overloading:
+Add a **brief performance-cue phrase per section** (a word or two after the dash) to influence delivery without overloading:
 
 ```
-[Verse 1 - quiet, intimate]
+[Verse 1 - quiet intimate]
 Lyrics here...
 
-[Chorus - building, anthemic]
+[Chorus - building anthemic]
 Lyrics here...
 
-[Bridge - raw, exposed]
+[Bridge - raw exposed]
 Lyrics here...
 ```
 
-**Rule**: More than 3 cues per section causes noise. Keep it focused.
+**Rule**: Keep the cue short — a word or two. Long cue lists cause noise.
 
 ---
 

--- a/reference/suno/v5-best-practices.md
+++ b/reference/suno/v5-best-practices.md
@@ -15,7 +15,7 @@ What changed is engine responsiveness and personalization:
 
 | Change | Impact on prompting |
 |--------|---------------------|
-| Nuanced phrasing, stronger dynamic range | Subtle descriptors land more reliably (e.g., "slightly detuned vintage keys" actually delivers) |
+| Nuanced phrasing, stronger dynamic range | Worth trying finer descriptors (e.g., "slightly detuned vintage keys") — improved nuance is engine-reported, not independently verified |
 | Better instrument separation | Busy arrangements stay readable — less mud on dense prompts |
 | More expressive vocals | Emotion tags (breathy, yearning, resigned) track closer to intent |
 | Voices (Pro/Premier) | Voice cloning replaces vocal persona descriptors — see below |
@@ -48,7 +48,7 @@ nostalgic, melancholic, 85 BPM, male vocals, gravelly voice, introspective
 | Studio-Grade Audio | 44.1 kHz output with fuller, more balanced mixes |
 | Vocal Engine | Human-like vocals with breath, emotion, vibrato control |
 | 10x Faster | Seconds instead of minutes for generation |
-| 12 Stem Extraction | Vocals, drums, bass, guitar, keyboard, strings, brass, etc. |
+| Stem Separation (3 modes) | Auto Split (12 stems), Split from Mix (target + the rest), Advanced Split (~100 instruments) — generative regeneration |
 | Extended Length | Up to 8 minutes per generation |
 | Persistent Memory | Vocal characters and instruments remain stable across project generations |
 | Granular Controls | Tempo, key, dynamics, arrangement with optional automation |
@@ -65,10 +65,12 @@ V5 listens differently and needs less instruction. Write new prompts and experim
 
 ### Keep It Simple — Avoid Prompt Fatigue
 
-V5 is literal. Complex descriptions confuse it. The **sweet spot is 4–7 descriptors** — fewer than 4 lacks direction, more than 7 causes "prompt fatigue" where V5 dilutes or ignores tags.
+V5 is literal, and it dilutes attention when descriptors repeat the same idea. **Every descriptor should earn its place** — genre, instrument, vocal identity, production texture, mood, tempo. A focused style box of ~10 descriptors works well; what hurts is a *synonym-pile* (five mood words that all mean "soft") that gives V5 nothing new to act on.
+
+> **On the "4–7 descriptors" rule of thumb**: 4–7 is a useful starting point, **not a Suno-official rule**. Rich ~10-descriptor style boxes are common and effective when every term does distinct work. Trim *synonyms*, not *detail*. (The hard "cut everything past 7" version of this rule traces to a single third-party guide and isn't borne out in practice — real style boxes routinely run richer.)
 
 ```
-❌ Bad (prompt fatigue — too many tags):
+❌ Bad (synonym-pile — overlapping mood words that add nothing new):
 "Ethereal indie folk with vintage analog warmth and melancholic
 undertones, finger-picked acoustic, tape hiss, lo-fi, intimate,
 breathy, whispery, nostalgic, contemplative, minimalist production"
@@ -76,11 +78,11 @@ breathy, whispery, nostalgic, contemplative, minimalist production"
 ❌ Bad (too vague):
 "Nice upbeat music"
 
-✅ Good (4-7 descriptors):
+✅ Good (every descriptor pulls its weight):
 "Sad indie folk, acoustic, gentle, breathy female vocal, intimate"
 ```
 
-**Rule of thumb**: If your prompt has 8+ comma-separated descriptors, cut it. V5 understands context and fills in gaps intelligently.
+**Rule of thumb**: if descriptors start restating the same idea (intimate / breathy / whispery / soft), collapse them into one. Don't pad — but don't strip out genuinely distinct instrument, vocal, or production detail just to hit a number.
 
 ### The Four-Part Anatomy
 
@@ -354,12 +356,19 @@ Do not change any words. Sing exactly as written.
 
 ## Negative Prompting
 
-V5 handles exclusions reliably.
+Exclusions **shift the odds** against an element — they're probabilistic, not a hard filter, and won't override a prompt that strongly implies the thing you're excluding.
+
+**Two ways to exclude:**
+- **Dedicated Exclude Styles field** (Custom Mode → Advanced Options, **Pro/Premier**) — the reliable path. Put exclusions here, not buried in the main style prompt.
+- **Inline `no [element]`** appended to the style box — the fallback when you don't have the field (free tier). Weaker; the engine may still slip the element in.
+
+Keep it to **2–4 items** — over-specifying dilutes the effect.
 
 ### What You Can Exclude
 - Instruments: "no drums", "no electric guitar"
 - Vocal effects: "no autotune", "no heavy reverb"
 - Stylistic elements: "no EDM drops", "no screaming"
+- **Unwanted group vocals** (a common Suno over-add): "no choir", "no crowd vocals", "no backing vocals", "no gang vocals", "no call-and-response", "no vocal harmonies", "no layered vocals"
 
 ### Best Practices
 
@@ -370,6 +379,8 @@ V5 handles exclusions reliably.
 ❌ Bad (over-specified):
 "No drums, no bass, no synths, no reverb, no distortion, no..."
 ```
+
+> **Group vocals** are probabilistic to suppress: excluding "choir / crowd / backing vocals" improves your odds, but a big anthemic prompt can still pull them back in. Pair the exclusion with a leaner, more intimate style prompt for the strongest effect.
 
 ---
 
@@ -538,8 +549,17 @@ These are typical loudness levels Suno generates — **not** final mastering tar
 
 ## Stem Extraction
 
-### Available Stems (12 total)
+Suno's stem separation was overhauled (June 2026) into **three selectable modes**, and it now *generatively regenerates* each stem rather than frequency-carving the mix — extracted parts sound cleaner and more natural than the old model.
 
+### Split Modes
+
+| Mode | What it does | Output |
+|------|--------------|--------|
+| **Auto Split** | The classic model — splits a song into 12 stem categories at once | 12 stems |
+| **Split from Mix** | Pulls one chosen instrument or voice out of the mix | 2 stems: the target, and everything-else-without-it |
+| **Advanced Split** | Extracts one specific instrument chosen from a list of ~100 (drum kit to didgeridoo) | 1 targeted stem *(Premier; per-extraction credit cost)* |
+
+**Auto Split — the 12 stems:**
 ```
 Vocals, Backing Vocals, Drums, Bass, Guitar,
 Keyboard, Strings, Brass, Woodwinds,
@@ -550,14 +570,14 @@ Percussion, Synth, FX/Other
 
 1. Click **More Actions (...)** on any clip
 2. Hover over **Get Stems**
-3. Choose **Original** or **12 Track**
+3. Choose your split mode — **Auto Split** (all 12), **Split from Mix** (one target + the rest), or **Advanced Split** (one instrument from ~100)
 4. Import into DAW
 
-### Double-Processing for Cleaner Vocals
+### Cleaner Single-Stem Pulls
 
-If vocals still contain background:
-1. Run Get Stems on original
-2. Run Get Stems again on extracted vocal
+For an isolated vocal or instrument, **Split from Mix** targeting that part is usually cleaner in one pass than the old carve-and-repeat trick (a benefit of the generative model). If a stem still bleeds, run extraction again on the extracted stem.
+
+> **Tier note:** Advanced Split is Premier-tier with a per-extraction credit cost (exact costs vary — check Suno's current pricing). Auto Split / Split from Mix availability follows your plan.
 
 ---
 

--- a/reference/suno/version-history/v5-changes.md
+++ b/reference/suno/version-history/v5-changes.md
@@ -1,6 +1,6 @@
 # Suno V4 → V5 Migration Guide
 
-**V5 Release Date**: October 2024
+**V5 Release Date**: September 2025
 **Availability**: All plans
 **Status**: Stable
 

--- a/reference/suno/voice-tags.md
+++ b/reference/suno/voice-tags.md
@@ -163,7 +163,7 @@ chorus slightly wider and warmer with gentle vibrato on sustained notes;
 bridge raw and exposed, single-take feel.
 ```
 
-This lets you create an **emotional arc** across the song rather than a flat vocal performance throughout. This Style-Box "Performance:" method and per-section **Performance Cues** in the Lyrics Box ([structure-tags.md](structure-tags.md) § Performance Cues, e.g. `[Verse 1 - quiet, intimate]`) are two routes to the same arc — pick one per track rather than splitting it across both.
+This lets you create an **emotional arc** across the song rather than a flat vocal performance throughout. This Style-Box "Performance:" method and per-section **Performance Cues** in the Lyrics Box ([structure-tags.md](structure-tags.md) § Performance Cues, e.g. `[Verse 1 - quiet intimate]`) are two routes to the same arc — pick one per track rather than splitting it across both.
 
 ## Advanced Vocal Workflow
 

--- a/servers/bitwize-music-server/handlers/gates.py
+++ b/servers/bitwize-music-server/handlers/gates.py
@@ -157,19 +157,27 @@ def _check_pre_gen_gates_for_track(
         gates.append({"gate": "Style Prompt Complete", "status": "PASS",
                       "detail": f"Style prompt: {len(style_content)} chars"})
 
-    # Gate 5b: Style Box descriptor budget (advisory) — V5 sweet spot is 4-7
+    # Gate 5b: Style Box descriptor budget (advisory). The old "4-7 sweet spot"
+    # cutoff traced to a single commercial guide, not Suno-official guidance, and
+    # flagged the majority of real (deliberately rich, ~10-descriptor) style boxes.
+    # Only flag genuine synonym-pile bloat (>12); note very sparse boxes without
+    # warning. The principle — every descriptor should add distinct info — stands.
     if style_content and style_content.strip():
         descriptors = [d for d in re.split(r"[,.\n]", style_content) if d.strip()]
         n_desc = len(descriptors)
-        if n_desc > 7:
+        if n_desc > 12:
             gates.append({"gate": "Style Box Descriptor Count", "status": "WARN",
                           "severity": "WARNING",
-                          "detail": f"{n_desc} descriptors — V5 sweet spot is 4-7; "
-                                    "trim synonym-piles to avoid prompt fatigue"})
+                          "detail": f"{n_desc} descriptors — likely synonym-pile bloat; "
+                                    "trim duplicative descriptors (each should add distinct info)"})
             warning_count += 1
+        elif n_desc < 3:
+            gates.append({"gate": "Style Box Descriptor Count", "status": "PASS",
+                          "detail": f"{n_desc} descriptors (sparse — consider one more "
+                                    "distinguishing descriptor)"})
         else:
             gates.append({"gate": "Style Box Descriptor Count", "status": "PASS",
-                          "detail": f"{n_desc} descriptors (within 4-7 sweet spot)"})
+                          "detail": f"{n_desc} descriptors"})
     else:
         gates.append({"gate": "Style Box Descriptor Count", "status": "SKIP",
                       "detail": "No style prompt to check"})
@@ -248,7 +256,7 @@ def _check_pre_gen_gates_for_track(
         if len(struct_tags) >= 2 and not cue_bearing:
             gates.append({"gate": "Performance Cues", "status": "WARN", "severity": "WARNING",
                           "detail": f"{len(struct_tags)} structure tags carry no Performance Cues "
-                                    "(e.g. [Verse 1 - cold, regal]); bare tags are a common cause "
+                                    "(e.g. [Verse 1 - cold regal]); bare tags are a common cause "
                                     "of flat, generic output"})
             warning_count += 1
         else:

--- a/skills/mix-engineer/SKILL.md
+++ b/skills/mix-engineer/SKILL.md
@@ -58,6 +58,8 @@ You are an audio mix polish specialist for AI-generated music. You take raw Suno
 ### Stems First
 Suno's `split_stem` provides up to 12 separate stem WAVs (vocals, backing vocals, drums, bass, guitar, keyboard, strings, brass, woodwinds, percussion, synth, other/FX). Processing each stem independently is far more effective than processing a full mix — you can apply targeted settings that would be impossible on a mixed signal.
 
+> Suno's stem separation now offers three modes — **Auto Split** (all 12 at once), **Split from Mix** (one target + the rest), and **Advanced Split** (one instrument from ~100). For a single clean stem, Split from Mix often beats pulling all 12. See `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Stem Extraction.
+
 ### Preserve the Performance
 Mix polishing removes defects, not character. Be conservative with processing. Over-processing sounds worse than under-processing.
 

--- a/skills/pre-generation-check/SKILL.md
+++ b/skills/pre-generation-check/SKILL.md
@@ -86,8 +86,8 @@ Do NOT proceed with gate evaluation until the mismatch is resolved — the wrong
 - **Check**: Style Box includes vocal description
 - **Check**: Section tags present in Lyrics Box (`[Verse]`, `[Chorus]`, etc.)
 - **Fail if**: Empty Style Box or missing section tags
-- **Advisory (WARN, non-blocking)**: Style Box descriptor count — flags >7 descriptors (V5 sweet spot is 4-7; trim synonym-piles to avoid prompt fatigue)
-- **Advisory (WARN, non-blocking)**: Performance Cues — flags ≥2 structure tags with no per-section cues (`[Verse 1 - cold, regal]`); bare tags are a common cause of flat, generic output
+- **Advisory (WARN, non-blocking)**: Style Box descriptor count — flags genuine bloat (>12 descriptors; trim duplicative synonym-piles). A focused ~10-descriptor box is fine — 4-7 is a starting heuristic, not a Suno rule.
+- **Advisory (WARN, non-blocking)**: Performance Cues — flags ≥2 structure tags with no per-section cues (`[Verse 1 - cold regal]`); bare tags are a common cause of flat, generic output
 - **Fix**: Style Box is created by suno-engineer, which is normally auto-invoked by lyric-writer. Run `/bitwize-music:suno-engineer [track]` to create the missing Style Box.
 - **Severity**: BLOCKING
 

--- a/skills/suno-engineer/SKILL.md
+++ b/skills/suno-engineer/SKILL.md
@@ -67,7 +67,7 @@ Structure your songs with explicit section markers:
 - `[Intro]`, `[Verse]`, `[Chorus]`, `[Pre-Chorus]`, `[Bridge]`, `[Outro]`, `[End]` — see `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` for the full set (including `[Post-Chorus]`, `[Break]`, `[Interlude]`, `[Fade In]`/`[Fade Out]`)
 - V5 uses these to shape arrangement
 - Without tags, structure can be unpredictable
-- **Default, not optional — Performance Cues**: append 1-3 delivery cues directly to each structure tag (`[Verse 1 - cold, regal, controlled]`, `[Bridge - raw, breaking, desperate]`) — see the same reference's "Performance Cues" section. This is how an emotional arc is carried across a song. Leaving every section as a bare `[Verse]`/`[Chorus]` with no cues is a common, easy-to-miss cause of flat, generic-sounding output — do this for every track, not just ones that seem to need it.
+- **Default, not optional — Performance Cues**: append a brief delivery-cue phrase (a word or two) directly to each structure tag (`[Verse 1 - cold regal]`, `[Bridge - raw breaking]`) — see the same reference's "Performance Cues" section. This is how an emotional arc is carried across a song. Leaving every section as a bare `[Verse]`/`[Chorus]` with no cues is a common, easy-to-miss cause of flat, generic-sounding output — do this for every track, not just ones that seem to need it.
 - **Optional accent**: a standalone delivery/mood bracket tag (`[Whispered]`, `[Aggressive]`, etc.) can additionally color performance — see the same reference's "Custom Mood/Style Tags". Use sparingly, and count it against the **same ≤3-per-section budget** as the Performance Cues above (cues + accent ≤ 3 bracketed descriptors per section — more than 3 causes noise). This is not a substitute for Style Box mood/energy prose.
 
 ### Vocals First
@@ -173,17 +173,21 @@ Male baritone, storytelling delivery. Alternative rock, clean electric guitar,
 driving bass, tight drums. Modern production.
 ```
 
-**Before finalizing, count every descriptor across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`), so counting commas alone undercounts. V5's sweet spot is 4-7 total; 8+ causes "prompt fatigue" where V5 dilutes or ignores tags (see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Watch for synonym-piles — stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse to 1-2 words per concept (vocal identity, genre, tempo, 2-3 instruments, 1 production note) to keep the total within 4-7. Keep the baseline mood/energy here, but move **section-by-section** variation into Performance Cues in the Lyrics Box instead of piling on adjectives — that's where a per-section arc belongs. (An alternative arc technique — mapping sections in Style-Box "Performance:" prose — lives in `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` § Emotion Arc Mapping; use one approach per track, not both.)
+**Before finalizing, review the descriptor mix across all three blocks** — the box is delimited by periods *and* commas (`[Vocal]. [Genre]. [Production]`). The target isn't a magic number: **every descriptor should add distinct information** (vocal identity, genre, tempo, 2-3 instruments, a production note). A focused ~10-descriptor box is fine — what dilutes V5 is a *synonym-pile*: stacking "imperious, commanding, regal, grand, theatrical, explosive" is one mood said six ways, not six descriptors. Collapse synonyms to 1-2 words per concept, but don't strip genuinely distinct detail just to hit a count (4-7 is a starting heuristic, not a Suno rule; the advisory gate only flags real bloat above ~12 — see `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Keep It Simple). Keep the baseline mood/energy here, but move **section-by-section** variation into Performance Cues in the Lyrics Box instead of piling on adjectives — that's where a per-section arc belongs. (An alternative arc technique — mapping sections in Style-Box "Performance:" prose — lives in `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` § Emotion Arc Mapping; use one approach per track, not both.)
 
 ### Exclude Styles (Negative Prompting)
 
-Suno V5 handles exclusions reliably. Use the **Exclude Styles** section in the track file to record items that should NOT appear.
+Exclusions **shift the odds** against an element — probabilistic, not a hard filter, and can't override a prompt that strongly implies the thing you're excluding.
+
+**Where they go:**
+- **Pro/Premier** → Suno's dedicated **Exclude Styles** field (Custom Mode → Advanced Options). The reliable path.
+- **Free tier / no field** → append inline `no [element]` to the Style Box. Weaker, but still nudges the result.
 
 **Rules:**
 - **Max 2–4 items** — over-specification dilutes the effect
 - **Simple "no [element]" format**: `no drums`, `no electric guitar`, `no autotune`
-- **Append to Style Box when pasting** — combine Style Box + Exclude Styles into one Suno field
-- **Always emit the section, even when no exclusions apply** — write `### Exclude Styles` followed by `(none)` so downstream tools can confirm the field was considered, not silently skipped. Most tracks land here.
+- **Suppressing unwanted group vocals** (a common Suno over-add): `no choir`, `no crowd vocals`, `no backing vocals`, `no gang vocals`, `no call-and-response`, `no vocal harmonies`, `no layered vocals` — still probabilistic; pair with a leaner style prompt
+- **Always record them in the track file's Exclude Styles section, even when none apply** — write `### Exclude Styles` followed by `(none)` so downstream tools can confirm the field was considered, not silently skipped. Most tracks land here.
 
 **Auto-populate guidance:** Consider whether genre/instrumentation context implies exclusions:
 - Acoustic folk → `no electric instruments, no drums`
@@ -306,10 +310,10 @@ As the Suno engineer, you:
 3. **Check artist persona** - Review saved voice profile (if applicable)
 4. **Select genre** - Choose appropriate genre tags
 5. **Define vocals** - Specify voice type, delivery, energy. Pull a concrete texture/style descriptor from `${CLAUDE_PLUGIN_ROOT}/reference/suno/voice-tags.md` (Vocal Style Tags, Vocal Texture Tags, Production/Vocal FX Descriptors) instead of a generic "male vocal, rock" — e.g. "gravelly, belting" beats "powerful"
-6. **Choose instruments** - Select key instruments and sonic texture. Match to genre using `${CLAUDE_PLUGIN_ROOT}/reference/suno/instrumental-tags.md` § Genre-Specific Instruments (2-3 key instruments, not a full list — keeps the Style Box total within 4-7)
+6. **Choose instruments** - Select key instruments and sonic texture. Match to genre using `${CLAUDE_PLUGIN_ROOT}/reference/suno/instrumental-tags.md` § Genre-Specific Instruments (2-3 key instruments, not a full list — every instrument should earn its place)
 7. **Check for sound effects/atmosphere** - If the lyrics reference rain, footsteps, crowds, laughter, or similar, add matching tags per `${CLAUDE_PLUGIN_ROOT}/reference/suno/v5-best-practices.md` § Sound Effects / Atmospheric Effects (mention in both Lyrics Box and Style Prompt for atmospheric/environmental sounds)
-8. **Add Performance Cues** - Append 1-3 delivery cues to each structure tag in the Lyrics Box (`[Verse 1 - cold, regal]`, `[Bridge - raw, breaking]`) so the emotional arc plays out section-by-section, per `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` § Performance Cues — do this by default, not only when a track "seems to need it"
-9. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed, then count comma-separated descriptors and trim to the 4-7 sweet spot (collapse synonym-piles; see § Style Prompt above)
+8. **Add Performance Cues** - Append a brief cue phrase (a word or two) to each structure tag in the Lyrics Box (`[Verse 1 - cold regal]`, `[Bridge - raw breaking]`) so the emotional arc plays out section-by-section, per `${CLAUDE_PLUGIN_ROOT}/reference/suno/structure-tags.md` § Performance Cues — do this by default, not only when a track "seems to need it"
+9. **Build style prompt** - Assemble final prompt (vocals FIRST), populate Exclude Styles if needed, then review the descriptor mix — collapse synonym-piles so every term adds distinct info (a focused ~10 is fine; trim only real bloat; see § Style Prompt above)
 10. **Generate in Suno** - Create track with assembled inputs
 11. **Iterate if needed** - Refine based on output quality
 12. **Log results** - Document in Generation Log with rating
@@ -328,7 +332,7 @@ Only mark track as "Generated" when output meets:
 - [ ] No unwanted instruments/elements present (verify exclusions were effective)
 
 Before generating, also verify the prompt itself is built for reliable output, not just the resulting audio:
-- [ ] Style Box stays within the 4-7 descriptor sweet spot (no synonym-stacking)
+- [ ] Style Box: every descriptor adds distinct information (no synonym-stacking; a focused ~10 is fine — only real bloat above ~12 is flagged)
 - [ ] Structure tags carry Performance Cues on every section by default (not left as bare `[Verse]`/`[Chorus]`), with the sharpest variation where the emotional arc shifts
 
 ---
@@ -365,6 +369,6 @@ When you discover new Suno behavior or techniques, **update the reference docume
 4. **Respect avoidance rules** - Never use genres/words user specified to avoid
 5. **Use exclusions sparingly** — Exclude Styles for 2–4 items max; leave empty when not needed
 6. **Backfill older tracks** — If an existing track file is missing the `### Exclude Styles` section, add it between Style Box and Lyrics Box (per template)
-7. **Fight prompt fatigue by default** — Style Box: 4-7 descriptors, not 20 synonym-stacked ones. Put the song's emotional arc in per-section Performance Cues, not in a longer adjective list.
+7. **Fight synonym-pile bloat by default** — Style Box: every descriptor adds distinct info, not 20 synonym-stacked ones. Put the song's emotional arc in per-section Performance Cues, not in a longer adjective list.
 
 Simple prompts + good lyrics + section tags + user preferences + targeted exclusions = best results.

--- a/templates/track.md
+++ b/templates/track.md
@@ -217,22 +217,22 @@ Suno Inputs below with the destination genre/mood, then note here what to preser
 <!-- VOCAL TRACKS: WARNING: Suno sings EVERYTHING literally including parenthetical directions.
      NEVER use (whispered), (softly), (screaming), (spoken), (laughing), etc.
      Use standalone metatags like [Whispered], or append per-section Performance Cues to the
-     section tag (e.g. [Verse 1 - cold, regal]) — never parentheticals. -->
+     section tag (e.g. [Verse 1 - cold regal]) — never parentheticals. -->
 
 ```
-[Verse 1 - calm, reflective]
+[Verse 1 - calm reflective]
 [Lyrics here...]
 
-[Chorus - big, anthemic]
+[Chorus - big anthemic]
 [Lyrics here...]
 
-[Verse 2 - restless, driving]
+[Verse 2 - restless driving]
 [Lyrics here...]
 
-[Bridge - stripped, intimate]
+[Bridge - stripped intimate]
 [Lyrics here...]
 
-[Outro - resolved, fading]
+[Outro - resolved fading]
 [Lyrics here...]
 ```
 <!-- /SERVICE: suno -->

--- a/tests/unit/state/test_handlers_gates.py
+++ b/tests/unit/state/test_handlers_gates.py
@@ -770,11 +770,12 @@ def _track_with(style, lyrics):
 
 
 class TestStyleBoxDescriptorCount:
-    """Gate 5b: advisory Style Box descriptor budget (4-7 sweet spot)."""
+    """Gate 5b: advisory Style Box descriptor budget — flags synonym-pile bloat (>12)."""
 
-    def test_over_seven_descriptors_warns(self):
+    def test_over_twelve_descriptors_warns(self):
         t_data = {"sources_verified": "N/A", "explicit": False}
-        style = "imperious, commanding, regal, grand, theatrical, explosive, cinematic, bombastic"
+        style = ("imperious, commanding, regal, grand, theatrical, explosive, "
+                 "cinematic, bombastic, sweeping, ominous, brooding, relentless, thunderous")
         _, warnings, gates = _gates_mod._check_pre_gen_gates_for_track(
             t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
         )
@@ -792,11 +793,38 @@ class TestStyleBoxDescriptorCount:
         g = next(x for x in gates if x["gate"] == "Style Box Descriptor Count")
         assert g["status"] == "PASS"
 
-    def test_counts_across_periods_and_commas(self):
-        # 8 descriptors split by BOTH periods and commas must be counted (not commas only)
+    def test_rich_box_within_budget_passes(self):
+        # ~10 focused descriptors is a normal, effective style box — must PASS,
+        # not the false positive the old >7 gate produced on most real style boxes
         t_data = {"sources_verified": "N/A", "explicit": False}
-        style = ("male baritone, passionate delivery, storytelling vocal. "
-                 "alt rock, clean guitar, driving bass, tight drums. modern production")
+        style = ("gritty male baritone, weary delivery. doom metal, sludge, "
+                 "downtuned guitar, thick bass, pounding drums. cavernous production, "
+                 "analog warmth, lead vocal upfront")
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Style Box Descriptor Count")
+        assert g["status"] == "PASS"
+
+    def test_sparse_box_passes_without_sweet_spot_label(self):
+        # <3 descriptors passes with an informational note, never the old "sweet spot" mislabel
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        style = "dark synthwave, analog"
+        _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
+            t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
+        )
+        g = next(x for x in gates if x["gate"] == "Style Box Descriptor Count")
+        assert g["status"] == "PASS"
+        assert "sweet spot" not in g["detail"]
+        assert "sparse" in g["detail"]
+
+    def test_counts_across_periods_and_commas(self):
+        # >12 descriptors split by BOTH periods and commas must be counted:
+        # commas-only would total 11 and wrongly PASS; period-splitting pushes it to WARN
+        t_data = {"sources_verified": "N/A", "explicit": False}
+        style = ("male baritone, passionate delivery, storytelling vocal, gritty tone. "
+                 "alt rock, clean guitar, driving bass, tight drums, warm keys. "
+                 "modern production, analog warmth, tape saturation, upfront vocals")
         _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
             t_data, _track_with(style, "[Verse 1 - cold]\nla la"), blocklist=[],
         )
@@ -819,7 +847,7 @@ class TestPerformanceCuesGate:
 
     def test_tags_with_cues_pass(self):
         t_data = {"sources_verified": "N/A", "explicit": False}
-        lyrics = "[Verse 1 - cold, regal]\nla la\n\n[Chorus - big, anthemic]\nna na"
+        lyrics = "[Verse 1 - cold regal]\nla la\n\n[Chorus - big anthemic]\nna na"
         _, _, gates = _gates_mod._check_pre_gen_gates_for_track(
             t_data, _track_with("pop, synth, 120 BPM", lyrics), blocklist=[],
         )


### PR DESCRIPTION
Closes #460

## Summary

Deep research pass (Suno primary docs + community guides, adversarially verified). The genuinely new/vetted material since the April V5.5 update is **feature-driven, not a new prompt grammar** — most third-party "V5.5 prompt-grammar" tips failed verification and are recorded as *not adopted* in the Suno CHANGELOG.

## Changes

**Knowledge / features**
- Document the June 2026 stem-separation overhaul: Auto Split, Split from Mix, and Advanced Split (~100 instruments), now generatively regenerated (`v5-best-practices.md` + `mix-engineer` cross-ref).
- Clarify Exclude Styles as a dedicated Pro/Premier field vs. an inline fallback; add group-vocal suppression vocabulary.
- Note Audio Influence ~0.70–0.85 when using Voices.

**Behavior**
- Reframe the advisory Style Box descriptor gate to flag genuine synonym-pile bloat (`>12`) instead of `>7`, and drop the "within 4-7 sweet spot" mislabel on sparse boxes. The old 4-7 cutoff was an unvetted single-source rule that fired on the majority of real (~10-descriptor) style boxes. Guidance across `suno-engineer` / `v5-best-practices` / `pre-generation-check` reframed to match; tests updated.

**Corrections**
- Hedge the unverified "V5.5 honors subtle descriptors better" claim.
- Fix the V5 release date in the migration guide (October 2024 → September 2025) to match our own Suno Studio / v5-generation dating.

**Convention**
- Standardize Performance Cues as a short comma-free phrase (`[Outro - chant fading]`); the gate detects cues by the ` - ` separator, so gate behavior is unchanged.

**CHANGELOG**
- New `2026-07-07` Suno CHANGELOG entry with sources and a "Refuted / Not Adopted" section (records the killed claims so they don't get re-added).

## Verification

- `ruff` / `mypy` / `bandit` clean; `pytest` 4260 passed, coverage 88%.
- Functional gate check: a ~10-descriptor Style Box PASSes, 13+ WARNs, a sparse box PASSes without the old mislabel, and comma-free cue tags are still detected as cues.
- One pre-existing, unrelated mastering test is flaky under the parallel runner and passes in isolation — not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
