### PR TITLE
fix: resolve plugin-suite findings — 4 repo fixes + test-definitions stale-sweep (#471)

### DIFF
--- a/skills/about/SKILL.md
+++ b/skills/about/SKILL.md
@@ -2,6 +2,8 @@
 name: about
 description: Provides information about the bitwize-music plugin, its version, and its creator. Use when the user asks about the plugin, its purpose, version, or capabilities.
 model: haiku
+allowed-tools:
+  - Read
 ---
 
 Read the version from `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` (the `version` field), then display:

--- a/skills/genre-creator/SKILL.md
+++ b/skills/genre-creator/SKILL.md
@@ -4,6 +4,12 @@ description: Create new genre documentation files for the bitwize-music genre li
 model: sonnet
 effort: medium
 argument-hint: <genre-name e.g. "Math Rock" or "Nu-Metal">
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - WebSearch
 ---
 
 # Genre Creator

--- a/skills/test/test-definitions.md
+++ b/skills/test/test-definitions.md
@@ -58,20 +58,21 @@ Verify inline comments use "Examples:" or "Example:" format
 ### TEST: Config location consistently documented as ~/.bitwize-music
 Search these files for config path references:
 - CLAUDE.md
-- README.md
+- docs/configuration.md
 - config/README.md
 - skills/configure/SKILL.md
 - skills/tutorial/SKILL.md
 
 All should reference `~/.bitwize-music/config.yaml` or `~/.bitwize-music/`
 
+(README.md no longer documents the config path directly — it points readers to docs/configuration.md instead.)
+
 ### TEST: Config must be read before path operations (regression)
-Read CLAUDE.md "When to Read Config" section.
+Read CLAUDE.md "Configuration & Path Resolution" section (formerly "When to Read Config").
 Verify it includes:
 1. "ALWAYS read" instruction before moving/creating files
 2. "ALWAYS read" instruction before resolving paths
-3. "Do not assume or remember values" instruction
-4. Reference to context summarization as reason to re-read
+3. "Never assume or remember values" instruction
 
 This test was added after paths were incorrectly resolved because config values were assumed instead of read.
 
@@ -180,20 +181,17 @@ done
 
 ### TEST: Skill count in README matches actual
 1. Count: `ls -1 skills/ | wc -l`
-2. Find in README: "collection of **XX specialized skills**"
+2. Find in README: "### Skill System (XX Skills)" heading (the old "collection of **XX specialized skills**" phrasing is gone)
 3. Must match
 
 ### TEST: All skills documented in CLAUDE.md
-Extract skill names from skills/ directory.
-Each must appear in CLAUDE.md skill table (except researcher sub-skills which are documented separately).
+DROPPED — CLAUDE.md has no comprehensive skill table anymore; it lists only a curated subset of skills in "### Key Routing Rules" by design (as of this sweep, 24 of 53 skills — including 10 researcher sub-skills — aren't named in CLAUDE.md at all, and that's expected). The authoritative version of this claim is "All skills documented in help system" below, which runs `tools/validate_help_completeness.py` and checks each skill's `/bitwize-music:{name}` reference against CLAUDE.md and skills/help/SKILL.md programmatically. Keeping both risks a manual-read verdict contradicting the script's verdict for the same repo state.
 
 ### TEST: All skills documented in README.md
-Each skill must appear in README.md skill tables.
+README.md no longer has skill tables — they moved to `docs/skills.md`. Extract skill names from skills/ directory and verify each appears (as `` `skill-name` ``) in one of `docs/skills.md`'s tables (Core Production, Research System, Quality Control, Release & Distribution, Album Management, Setup & Maintenance).
 
-### TEST: /resume skill documented in README (quick win #1)
-Read README.md Skills Reference section.
-Verify `/bitwize-music:resume` appears in the Setup & Maintenance table.
-Verify description includes: "Resume work on an album - finds album, shows status and next steps"
+### TEST: /resume skill documented (quick win #1)
+Read `docs/skills.md`. Verify `resume` appears in the "Album Management" table (not "Setup & Maintenance" — it moved tables) with description "Find album, show status, recommend next steps".
 
 ### TEST: /configure skill has all commands
 Read skills/configure/SKILL.md and verify these are documented:
@@ -204,7 +202,7 @@ Read skills/configure/SKILL.md and verify these are documented:
 - `reset`
 
 ### TEST: /test skill covers all categories
-This skill should document tests for: config, skills, templates, workflow, suno, research, mastering, sheet-music, release, consistency, terminology, behavior, quality
+This skill should document tests for: config, skills, templates, workflow, suno, research, mastering, sheet-music, release, consistency, terminology, behavior, quality, e2e (14 categories total)
 
 ### TEST: /album-ideas skill exists
 ```
@@ -237,7 +235,8 @@ Read skills/clipboard/SKILL.md and verify these content types are documented:
 - `lyrics` - Suno Lyrics Box
 - `style` - Suno Style Box
 - `streaming-lyrics` - Streaming Lyrics for distributors
-- `all` - Combined Style + Lyrics
+- `all` - All Suno inputs (Style + Exclude + Lyrics combined)
+- `suno` - JSON object for Suno auto-fill (added since the original 4-type list; verify it's documented too)
 
 ### TEST: /clipboard skill has correct argument format
 Read skills/clipboard/SKILL.md and verify:
@@ -264,6 +263,8 @@ Each should have:
 3. Subsection "### How to Use Override" with behavior
 4. Reference to loading override in "Remember" section
 
+**Exception**: `skills/explicit-checker/SKILL.md` merges overrides automatically via the `check_explicit_content` MCP tool — it has "## Override Support" but documents this with a "### Override File Format" subsection instead of "### Loading Override" / "### How to Use Override" steps, and references overrides in "Remember" via "Override additions"/"Override removals" bullets. Accept this structure for explicit-checker only; require the full 4-part structure for the other 9 skills.
+
 ---
 
 ## 3. TEMPLATES TESTS (`/test templates`)
@@ -279,8 +280,8 @@ These files must exist:
 - `templates/sources.md`
 
 ### TEST: Templates referenced in CLAUDE.md exist
-Search CLAUDE.md for `${CLAUDE_PLUGIN_ROOT}/templates/` references.
-Each referenced template must exist.
+Search CLAUDE.md for `{plugin_root}/templates/` references (CLAUDE.md now references the templates directory generically rather than naming individual files).
+Verify the templates/ directory exists and contains the required template files (album.md, track.md, artist.md, research.md, sources.md).
 
 ### TEST: IDEAS.md template uses consistent status values (quick win #4)
 Read templates/ideas.md.
@@ -313,15 +314,16 @@ Read templates/sources.md and verify "Downloaded Documents" section exists.
 Tests for album creation workflow documentation.
 
 ### TEST: 7 planning phases documented in CLAUDE.md
-Read CLAUDE.md "Building a New Album" section.
-Verify all 7 phases are documented:
-1. Foundation
-2. Concept Deep Dive
-3. Sonic Direction
-4. Structure Planning
-5. Album Art
-6. Practical Details
-7. Confirmation
+CLAUDE.md has no "Building a New Album" section. Verify instead:
+1. CLAUDE.md "Key Routing Rules" contains the line: `**Planning album** → apply /bitwize-music:album-conceptualizer (7 planning phases required)`
+2. `skills/album-conceptualizer/SKILL.md` documents all 7 phases under "## Building the Album: The 7 Planning Phases":
+   1. Foundation
+   2. Concept Deep Dive
+   3. Sonic Direction
+   4. Structure Planning
+   5. Album Art
+   6. Practical Details
+   7. Confirmation
 
 ### TEST: Album status values documented
 Verify CLAUDE.md documents these album statuses:
@@ -367,54 +369,54 @@ Verify it includes:
 This test was added after audio files were repeatedly moved to `{audio_root}/[album]/` without the artist folder.
 
 ### TEST: Session start procedure documented
-Read CLAUDE.md "Session Start" section.
-Verify step 1 is loading configuration.
-Verify step 1b is loading overrides (if present).
-Verify step 3 is checking album ideas file.
-Verify it mentions /configure when config missing.
-Verify it mentions /bitwize-music:album-ideas for detailed ideas list.
+Read CLAUDE.md "Session Start" section (numbered steps 1, 1.5, 2, 3, 4, 4.5, 5, 6, 7, 8).
+Verify step 2 is "Load config" (reads `~/.bitwize-music/config.yaml`).
+Verify step 3 is "Load overrides" (checks `paths.overrides`, if present).
+Verify step 4 ("Load state via MCP") calls `get_ideas` to get idea counts.
+Verify it mentions `/bitwize-music:configure` when config missing (step 1 and step 2).
+Verify step 7 mentions `/bitwize-music:album-ideas list` when ideas exist.
 
 ### TEST: Session startup contextual tips system documented
-Read CLAUDE.md "Session Start" section after the 6 status check steps.
-Verify section exists: "Show contextual tips based on detected state:"
+Read CLAUDE.md "Session Start" section, step 7.
+Verify section exists: "**Show contextual tips** based on state:"
 Verify all conditional tip categories are documented:
-- If no albums exist → tutorial tip
-- If IDEAS.md has content → album-ideas tip
-- If in-progress albums exist → resume tip
-- If overrides don't exist → customization tip
-- If overrides loaded → confirmation message
-- If pending source verifications exist → verification warning
+- No albums → tutorial tip
+- Ideas exist → album-ideas tip
+- In-progress albums → resume tip
+- Overrides loaded → note it; missing → suggest creating them
+- Pending verifications → verification warning
+- One contextual tip from: resume, researcher, pronunciation, clipboard, mastering (pick based on most relevant album state)
+
+(The old "If IDEAS.md has content" framing is gone — ideas are now sourced from the `get_ideas` MCP tool, not a direct IDEAS.md file check.)
 
 ### TEST: Session startup general productivity tips exist
-Read CLAUDE.md "Session Start" section.
-Verify section exists: "Always show one general productivity tip (rotate randomly):"
-Verify it contains at least 4 different productivity tips.
-Verify tips reference actual skills (e.g., /bitwize-music:resume, /bitwize-music:researcher).
+DROPPED — the standalone "Always show one general productivity tip (rotate randomly)" section no longer exists. It was merged into step 7's "One contextual tip from: resume, researcher, pronunciation, clipboard, mastering" bullet — there is no separate rotating productivity-tips system anymore. No current doc makes this claim.
 
 ### TEST: Session startup ends with question
 Read CLAUDE.md "Session Start" section.
-Verify final instruction says: "Finally, ask:" followed by "What would you like to work on?"
+Verify the final step (8) is: `**Ask**: "What would you like to work on?"`
 
 ### TEST: Contextual tips use correct skill commands
-Read CLAUDE.md session startup tips section.
-Verify all skill references use correct format:
+Read CLAUDE.md "Session Start" section, step 7.
+Verify these skill references use correct `/bitwize-music:` prefix format:
 - `/bitwize-music:tutorial` (not /tutorial)
 - `/bitwize-music:album-ideas` (not /album-ideas)
 - `/bitwize-music:resume` (not /resume)
-- `/bitwize-music:researcher` (not /researcher)
-- `/bitwize-music:pronunciation-specialist` (not /pronunciation-specialist)
-- `/bitwize-music:clipboard` (not /clipboard)
+
+Note: `researcher`, `pronunciation`, `clipboard`, and `mastering` appear only as bare topic labels in the "One contextual tip from: ..." bullet, not as full `/bitwize-music:` command invocations — that's expected, since the bullet names topics to choose from rather than commands to run.
 
 ### TEST: Contextual tips reference overrides path variable
-Read CLAUDE.md session startup tips section.
-Verify overrides tips use `{overrides}` path variable (not hardcoded path).
+Read CLAUDE.md "Session Start" section, step 3 ("Load overrides").
+Verify overrides references use the `{overrides}` path variable (e.g. `{overrides}/CLAUDE.md`, `{overrides}/pronunciation-guide.md`), not a hardcoded path.
 
 ### TEST: Checkpoints documented
-Verify these checkpoints exist in CLAUDE.md:
-- Ready to Generate Checkpoint
-- Album Generation Complete Checkpoint
-- Ready to Master Checkpoint
-- Ready to Release Checkpoint
+CLAUDE.md no longer names checkpoints directly. Verify instead:
+1. `reference/workflows/checkpoint-scripts.md` documents these checkpoints:
+   - Ready to Generate Checkpoint
+   - Album Generation Complete Checkpoint
+   - Ready to Master Checkpoint
+   - Ready to Release Checkpoint
+2. At least one skill (e.g. `skills/resume/SKILL.md` or `skills/explicit-checker/SKILL.md`) references the "Ready to Generate Checkpoint" by name.
 
 ---
 
@@ -504,8 +506,8 @@ Verify "## See Also" section exists with:
 - ${CLAUDE_PLUGIN_ROOT}/skills/mastering-engineer/SKILL.md reference
 
 ### TEST: Explicit content word list documented
-Read CLAUDE.md "Explicit Content Guidelines" section.
-Verify explicit words table exists.
+Read `reference/distribution.md` "Explicit Content Guidelines" section (moved out of CLAUDE.md).
+Verify the "Explicit Words (require Explicit = Yes)" table exists.
 
 ### TEST: /explicit-checker skill exists
 ```
@@ -520,7 +522,7 @@ Verify it has "Artist/Band Name Warning" section that:
 - Provides style description alternatives
 
 ### TEST: CLAUDE.md mentions artist names forbidden
-Verify CLAUDE.md Suno Reference section mentions artist names are forbidden.
+DROPPED — CLAUDE.md no longer has a "Suno Reference" section, and no top-level mention of artist-name-forbidden remains anywhere in CLAUDE.md (it was trimmed out along with other domain detail that now lives solely in skill files). The guidance itself is not gone — it's fully covered by "Artist/band name warning documented" (skills/suno-engineer/SKILL.md) above. Keeping both would require CLAUDE.md to duplicate content it no longer duplicates by design.
 
 ### TEST: No band names in Suno example prompts (regression)
 Search skills/suno-engineer/SKILL.md for common band/artist name patterns in example prompts.
@@ -573,21 +575,19 @@ Glob: skills/document-hunter/SKILL.md
 ```
 
 ### TEST: Source verification workflow documented
-Read CLAUDE.md "Sources & Verification" section.
-Verify it documents:
-- Source hierarchy
-- Track status workflow (Pending → Verified)
-- Human verification handoff triggers
+CLAUDE.md's "Sources & Verification" section was renamed to "### Source Verification Gate". Verify:
+1. CLAUDE.md "Source Verification Gate" documents the Pending → Verified track status flow and that generation is blocked until verification is complete
+2. `reference/workflows/source-verification-handoff.md` documents the human verification handoff triggers (its "When to Stop and Request Verification" section) and the Track Status Workflow
+3. `skills/researcher/SKILL.md` "Core Principles" documents source-priority/hierarchy guidance (e.g. "Primary Sources Are Mandatory")
 
 ### TEST: documents_root path documented
 Verify CLAUDE.md and config docs explain `{documents_root}` path variable.
 
 ### TEST: Research files must be saved to album directory (regression)
-Read CLAUDE.md "Sources & Verification" section.
+Read CLAUDE.md "Source Verification Gate" section (formerly "Sources & Verification").
 Verify it includes:
-1. Rule about saving RESEARCH.md and SOURCES.md to album directory
-2. Path format: `{content_root}/artists/{artist}/albums/{genre}/{album}/`
-3. "Never save to current working directory" warning
+1. Rule about saving RESEARCH.md and SOURCES.md to album directory (never cwd)
+2. Path format for the album directory: `{content_root}/artists/[artist]/albums/[genre]/[album]/` — documented in CLAUDE.md's "Content Structure" section
 
 Read skills/researcher/SKILL.md.
 Verify it includes:
@@ -625,67 +625,55 @@ Glob: reference/mastering/mastering-workflow.md
 Glob: skills/mastering-engineer/SKILL.md
 ```
 
-### TEST: /mastering-engineer skill uses dynamic plugin path (regression)
-Read skills/mastering-engineer/SKILL.md.
-Verify it includes:
-1. "Important: Script Location" section with CRITICAL warning
-2. Dynamic plugin directory finding using find command with sort -V
-3. All script invocations use "$PLUGIN_DIR/tools/mastering/script.py" format
-4. Scripts receive audio path as argument (not run from audio directory)
-5. NO instructions to copy scripts to audio folders
-6. "Common Mistakes" section with subsection "Don't: Copy scripts to audio folders"
-7. "Common Mistakes" section with subsection "Don't: Hardcode plugin version number"
+### TEST: /mastering-engineer skill uses MCP tools, not direct script invocation (regression)
+The plugin-path problem this test guarded against (scripts copied to audio folders, hardcoded `$PLUGIN_DIR` paths breaking after updates) was solved architecturally: mastering-engineer no longer shells out to `tools/mastering/*.py` at all. Read skills/mastering-engineer/SKILL.md and verify:
+1. "## Path Resolution (REQUIRED)" section resolves the audio path via the `resolve_path("audio", album_slug)` MCP tool — no manual path construction
+2. The mastering workflow uses MCP tools (`analyze_audio`, `qc_audio`, `master_audio`, `master_album`) rather than `bash python3 tools/mastering/*.py` invocations
+3. "## Common Mistakes" section has subsection "❌ Don't: Run Python scripts via bash" warning against calling `tools/mastering/*.py` directly (system Python lacks the venv's dependencies) and directing to the equivalent MCP tool instead
+4. NO instructions to copy scripts to audio folders anywhere in the skill
 
-This test was added after a bug where scripts were copied to audio folders instead of being run from plugin directory, breaking after plugin updates.
+This test was added after a bug where scripts were copied to audio folders instead of being run from plugin directory, breaking after plugin updates. The fix has since evolved from "always invoke via a dynamically-found $PLUGIN_DIR" to "never invoke the scripts directly — use MCP tools," which sidesteps the plugin-path problem entirely.
 
 ### TEST: /import-audio skill exists
 ```
 Glob: skills/import-audio/SKILL.md
 ```
 
-### TEST: /import-audio skill reads config first
-Read skills/import-audio/SKILL.md.
-Verify it includes:
-1. Step to read `~/.bitwize-music/config.yaml` marked as REQUIRED
-2. Extracts `paths.audio_root` and `artist.name`
-3. CRITICAL warning about including artist folder
-4. Example showing correct path structure
+### TEST: /import-audio skill resolves paths via MCP (regression)
+The skill no longer reads config manually — it resolves paths via MCP instead. Read skills/import-audio/SKILL.md and verify it includes:
+1. "## Step 2: Resolve Audio Path via MCP" calling `resolve_path("audio", album_slug)`
+2. CRITICAL warning: "Always use `resolve_path` — never construct paths manually"
+3. Example showing the resolved path includes the artist folder (mirrored structure)
+4. Error handling for "Config file missing" pointing to `/configure`
 
 ### TEST: /import-audio skill has Common Mistakes section (quick win #7)
 Read skills/import-audio/SKILL.md.
 Verify "## Common Mistakes" section exists.
 Verify it includes these subsections:
-- Don't skip reading config
-- Don't forget to include artist in path
-- Don't use hardcoded artist name
-- Don't assume current working directory
-- Don't mix up content_root and audio_root
-Each subsection should have Wrong/Right examples and "Why it matters" explanation
+- ❌ Don't: Manually read config and construct paths
+- ❌ Don't: Mix up content_root and audio_root
+Each subsection should have Wrong/Right examples and a "Why it matters" explanation
 
 ### TEST: /import-track skill exists
 ```
 Glob: skills/import-track/SKILL.md
 ```
 
-### TEST: /import-track skill reads config first
-Read skills/import-track/SKILL.md.
-Verify it includes:
-1. Step to read `~/.bitwize-music/config.yaml` marked as REQUIRED
-2. Extracts `paths.content_root` and `artist.name`
-3. Finds album to determine genre folder
-4. Example showing correct path: `{content_root}/artists/{artist}/albums/{genre}/{album}/tracks/`
+### TEST: /import-track skill resolves paths via MCP (regression)
+The skill no longer reads config manually — it resolves paths via MCP instead. Read skills/import-track/SKILL.md and verify it includes:
+1. "## Step 2: Find Album and Resolve Path via MCP" calling `find_album(album_name)` then `resolve_path("tracks", album_slug)`
+2. Example showing correct path: `{content_root}/artists/{artist}/albums/{genre}/{album}/tracks/{XX}-{track-name}.md`
+3. Error handling for "Config file missing" pointing to `/configure`
 
 ### TEST: /import-track skill has Common Mistakes section (quick win #7)
 Read skills/import-track/SKILL.md.
 Verify "## Common Mistakes" section exists.
 Verify it includes these subsections:
-- Don't skip reading config
-- Don't search from wrong location
-- Don't forget the tracks/ subdirectory
-- Don't use hardcoded artist name
-- Don't skip track number validation
-- Don't assume album location without searching
-Each subsection should have Wrong/Right examples and "Why it matters" explanation
+- ❌ Don't: Manually read config and search for albums
+- ❌ Don't: Forget the tracks/ subdirectory
+- ❌ Don't: Skip track number validation
+- ❌ Don't: Assume album location without searching
+Each subsection should have Wrong/Right examples and a "Why it matters" explanation
 
 ### TEST: /import-art skill exists
 ```
@@ -695,46 +683,39 @@ Glob: skills/import-art/SKILL.md
 ### TEST: /import-art skill handles both destinations
 Read skills/import-art/SKILL.md.
 Verify it includes:
-1. Step to read `~/.bitwize-music/config.yaml` marked as REQUIRED
-2. Copies to audio folder: `{audio_root}/artists/{artist}/albums/{genre}/{album}/`
-3. Copies to content folder: `{content_root}/artists/{artist}/albums/{genre}/{album}/`
-4. CRITICAL warning about including artist folder in audio path
+1. "## Step 2: Find Album and Resolve Paths via MCP" calling `resolve_path("audio", album_slug)` and `resolve_path("content", album_slug)` (no manual config read)
+2. Copies to audio folder: `{audio_path}/album.png`
+3. Copies to content folder: `{content_path}/album-art.{ext}`
+4. CRITICAL warning that `resolve_path` includes the artist folder automatically
 
 ### TEST: /import-art skill has Common Mistakes section (quick win #7)
 Read skills/import-art/SKILL.md.
 Verify "## Common Mistakes" section exists.
 Verify it includes these subsections:
-- Don't skip reading config
-- Don't forget to include artist in audio path
-- Don't place art in only one location
-- Don't mix up the filenames
-- Don't search from wrong location
-- Don't forget to create directories
-Each subsection should have Wrong/Right examples and "Why it matters" explanation
+- ❌ Don't: Manually read config and construct paths
+- ❌ Don't: Place art in only one location
+- ❌ Don't: Mix up the filenames
+- ❌ Don't: Search for albums manually
+- ❌ Don't: Forget to create directories
+Each subsection should have Wrong/Right examples and a "Why it matters" explanation
 
 ### TEST: /new-album skill exists
 ```
 Glob: skills/new-album/SKILL.md
 ```
 
-### TEST: /new-album skill reads config first
-Read skills/new-album/SKILL.md.
-Verify it includes:
-1. Step to read `~/.bitwize-music/config.yaml` marked as REQUIRED
-2. Extracts `paths.content_root` and `artist.name`
-3. Creates correct path: `{content_root}/artists/{artist}/albums/{genre}/{album}/tracks/`
-4. Copies templates from plugin directory
+### TEST: /new-album skill creates album via MCP (regression)
+The skill no longer reads config manually or copies templates itself — a single MCP call handles everything. Read skills/new-album/SKILL.md and verify it includes:
+1. "## Step 2: Create Album via MCP" calling `create_album_structure(album_slug, genre, documentary)`
+2. Description of the resulting path: `{content_root}/artists/{artist}/albums/{genre}/{album-name}/`
+3. Error handling for "Config file missing" pointing to `/configure`
 
 ### TEST: /new-album skill has Common Mistakes section (quick win #7)
 Read skills/new-album/SKILL.md.
 Verify "## Common Mistakes" section exists.
-Verify it includes these subsections:
-- Don't skip reading config
-- Don't use current working directory
-- Don't hardcode artist name
-- Don't forget path structure
-- Don't use wrong genre category
-Each subsection should have Wrong/Right examples and explanation
+Verify it includes:
+- ❌ Don't: Create directories manually (Wrong/Right example, explaining `create_album_structure` handles config, paths, and templates automatically)
+- ✅ Do: Use the specific genre slug (examples of valid genre slugs)
 
 ### TEST: /new-album skill offers interactive planning option
 Read skills/new-album/SKILL.md confirmation message.
@@ -768,13 +749,13 @@ Glob: skills/sheet-music-publisher/SKILL.md
 ### TEST: Sheet music tools exist
 These scripts must exist:
 - `tools/sheet-music/transcribe.py`
-- `tools/sheet-music/fix_titles.py`
+- `tools/sheet-music/prepare_singles.py` (renamed from `fix_titles.py`)
 - `tools/sheet-music/create_songbook.py`
 
 ### TEST: Sheet music scripts are executable
 ```bash
 test -x tools/sheet-music/transcribe.py
-test -x tools/sheet-music/fix_titles.py
+test -x tools/sheet-music/prepare_singles.py
 test -x tools/sheet-music/create_songbook.py
 ```
 
@@ -793,10 +774,9 @@ Verify it has `requirements:` section with:
 - `external:` listing AnthemScore and MuseScore
 - `python:` listing pypdf, reportlab, pyyaml
 
-### TEST: Sheet music requirements documented in CLAUDE.md
-Read CLAUDE.md "Sheet Music Generation (Optional)" section.
-Verify it documents:
-- AnthemScore requirement ($42 Professional)
+### TEST: Sheet music requirements documented
+CLAUDE.md has no "Sheet Music Generation (Optional)" section — this detail lives entirely in the skill's own docs now. Read `skills/sheet-music-publisher/REQUIREMENTS.md` and verify it documents:
+- AnthemScore requirement ($42 Professional recommended)
 - MuseScore requirement (Free)
 - Python dependencies
 - Links to software downloads
@@ -823,7 +803,7 @@ Verify it includes:
 2. Paths for macOS, Linux, Windows
 3. `show_install_instructions()` function
 
-Read tools/sheet-music/fix_titles.py.
+Read tools/sheet-music/prepare_singles.py (renamed from fix_titles.py).
 Verify it includes:
 1. `find_musescore()` function with platform detection
 2. Paths for macOS, Linux, Windows
@@ -836,19 +816,14 @@ Verify output directory is constructed as:
 
 Verify it INCLUDES artist folder (not `{audio_root}/{album}/sheet-music/`)
 
-### TEST: Sheet music documented in CLAUDE.md workflow
-Read CLAUDE.md.
-Verify "Sheet Music Generation (Optional)" section exists.
-Verify it shows workflow position: "Generate → Master → [Sheet Music] → Release"
+### TEST: Sheet music workflow position documented
+CLAUDE.md's Workflow Overview line (`Concept → Research → Write ... → Master → Promo Videos (optional) → Promo Copy (optional) → Release`) does not mention sheet music at all, and there is no "Sheet Music Generation (Optional)" CLAUDE.md section or sheet-music-publisher routing rule. Sheet music's position is documented only via its own skill: verify `skills/sheet-music-publisher/SKILL.md` frontmatter `description:` states "Use after mastering when the user wants sheet music or a songbook for their album."
 
 ### TEST: Sheet music in Album Completion Checklist
-Read CLAUDE.md "Album Completion Checklist" section.
-Verify it includes:
-`- [ ] Sheet music generated (optional)`
+DROPPED — no current doc states this. CLAUDE.md has no "Album Completion Checklist" section, and the actual checklist content (now `reference/workflows/release-procedures.md` "### 1. Verify Completion Checklist") does not include a sheet-music line item. Sheet music is documented purely as an optional, on-request, post-mastering skill (see "Sheet music workflow position documented" above) — nothing currently claims it belongs on the release checklist.
 
 ### TEST: Sheet music skill in skills table
-Read CLAUDE.md skills table.
-Verify `/bitwize-music:sheet-music-publisher` is listed.
+CLAUDE.md has no skills table anymore. Read `docs/skills.md` "Release & Distribution" table and verify `sheet-music-publisher` is listed.
 
 ### TEST: Config has sheet_music section
 Read config/config.example.yaml.
@@ -867,11 +842,11 @@ Verify that if `find_anthemscore()` returns None:
 2. Exits with non-zero status
 3. Does not proceed with transcription
 
-Read tools/sheet-music/fix_titles.py.
-Verify that if `find_musescore()` returns None:
+Read tools/sheet-music/prepare_singles.py (renamed from fix_titles.py).
+Verify that if `find_musescore()` returns None (and `--xml-only` was not passed):
 1. Shows install instructions
-2. Offers `--xml-only` option
-3. Exits with non-zero status (if not --xml-only)
+2. Warns and continues without exiting — PDFs are copied from source instead of exported via MuseScore (this behavior changed from the old fix_titles.py, which exited non-zero; prepare_singles.py now degrades gracefully)
+3. `--xml-only` remains available as a flag that skips the MuseScore lookup entirely
 
 ---
 
@@ -885,23 +860,21 @@ Glob: skills/release-director/SKILL.md
 ```
 
 ### TEST: Album completion checklist documented
-Read CLAUDE.md "Album Completion Checklist" section.
-Verify checklist items exist.
+CLAUDE.md has no "Album Completion Checklist" section. Read `reference/workflows/release-procedures.md` "### 1. Verify Completion Checklist" and verify checklist items exist (all tracks Final with Suno Links, album art generated, audio mastered, streaming lyrics filled in).
 
 ### TEST: Post-release actions documented
-Read CLAUDE.md "Post-Release Immediate Actions" section.
-Verify it documents SoundCloud upload, announcements.
+CLAUDE.md has no "Post-Release Immediate Actions" section. Verify instead:
+1. `reference/workflows/release-procedures.md` "### 3. Upload to Platforms" documents uploading to SoundCloud/distributor and adding platform URLs to the album README
+2. `reference/workflows/checkpoint-scripts.md` "## Post-Release Message" documents the release announcement template
 
 ### TEST: Streaming lyrics format documented
-Read CLAUDE.md "Streaming Lyrics Format" section.
-Verify format rules are documented.
+CLAUDE.md has no "Streaming Lyrics Format" section — it moved to `reference/distribution.md`. Read `reference/distribution.md` "## Streaming Lyrics Format" / "### Format Rules" and verify format rules are documented.
 
 ### TEST: Album art workflow documented
-Read CLAUDE.md "Album Art Generation" section.
-Verify it documents:
-- When to generate
-- Prompt location
-- File naming standards
+CLAUDE.md has no "Album Art Generation" section — it moved to `reference/workflows/release-procedures.md`. Read that file's "## Album Art Generation" section and verify it documents:
+- When to generate ("### When to Generate Album Art")
+- Prompt location ("### Workflow" step 1, "Verify Prompt Exists" — prompt lives in the album README's "Album Art" section)
+- File naming standards ("### File Naming Standards")
 
 ---
 
@@ -931,6 +904,8 @@ If this test fails:
 Search entire repo for:
 - `media_root` (should be `audio_root`)
 - `paths.media_root` (should be `paths.audio_root`)
+
+Exclude `tests/plugin/test_terminology.py` — it defines these deprecated terms as detection patterns for its own automated check; matches there are the detector itself, not violations.
 
 ### TEST: Path variables consistent
 Verify these path variables are used consistently:
@@ -1001,7 +976,7 @@ Search for paths that should be variables:
 - `C:\` (except in examples)
 
 ### TEST: Consistent service name
-All references should use `suno` (lowercase) not `Suno` when referring to the config value.
+Prose and headings use "Suno" (brand casing). Config values, slugs, file names, tags, and URLs use lowercase "suno". Identifiers are exempt from casing complaints. Flag only prose that uses lowercase "suno" or config values that use "Suno".
 
 ### TEST: Consistent plugin name
 Plugin should be referred to as:
@@ -1019,34 +994,31 @@ Brand should always be "bitwize-music" (lowercase with hyphen).
 Scenario-based tests verifying correct instructions.
 
 ### TEST: Missing config recommends /configure
-Read CLAUDE.md session start section.
-Verify it mentions `/configure` as Option 1 when config missing.
+Read CLAUDE.md "Session Start" section.
+Verify it mentions `/bitwize-music:configure` when config is missing (step 1: "If config missing → suggest: `/bitwize-music:configure`"; step 2: "Load config ... If missing, tell user to run `/bitwize-music:configure`"). (The old "as Option 1" numbered-options framing is gone — it's now a bulleted fallback under each relevant step.)
 
 Read skills/tutorial/SKILL.md.
 Verify it mentions `/configure` when config missing.
 
 ### TEST: Album creation requires planning phases first
-Read CLAUDE.md "Building a New Album" section.
-Verify it states planning phases must complete before writing.
+CLAUDE.md has no "Building a New Album" section. Read `reference/workflows/album-planning-phases.md` and verify it states: "**Before writing any lyrics or creating tracks**, work through these phases with the user" (also see its Phase 7 "Required before writing" checklist).
 
 ### TEST: Source verification required before generation
-Read CLAUDE.md "Sources & Verification" section.
-Verify it states human verification required before production.
+CLAUDE.md's "Sources & Verification" section was renamed to "### Source Verification Gate". Verify it states human verification is required before generation (item 4: "Block generation if verification incomplete — `/bitwize-music:pre-generation-check` enforces this").
 
 ### TEST: Tutorial skill checks config first
 Read skills/tutorial/SKILL.md.
 Verify it reads config as first step.
 
 ### TEST: Automatic lyrics review documented
-Read CLAUDE.md "Automatic Lyrics Review" section.
-Verify it lists all check types:
-- Rhyme check
-- Prosody check
-- Pronunciation check
-- POV/Tense check
-- Source verification
-- Structure check
-- Pitfalls check
+CLAUDE.md has no "Automatic Lyrics Review" section. The closest current equivalents are `skills/lyric-reviewer/SKILL.md` "## The 14-Point Checklist" (see also `skills/lyric-reviewer/checklist-reference.md`) and CLAUDE.md's "Core Principles" bullet ("When user says 'let's work on [track]', scan full lyrics for issues BEFORE doing anything else..."). Verify the 14-point checklist includes, by name:
+- Rhyme Check
+- Prosody Check
+- Pronunciation Check
+- POV/Tense Check
+- Structure Check
+
+"Source verification" and "Pitfalls check" don't exist as named checklist items — the closest analogs are the checklist's "Documentary Check" and "Factual Check" (conditional, source/claim verification). Don't fail the test solely for the absence of those two exact names.
 
 ---
 
@@ -1062,6 +1034,8 @@ Search for `TODO|FIXME|XXX|HACK` in:
 - skills/*/SKILL.md
 
 (Exclude test definitions)
+
+Search ONLY the four files/globs listed above. Code files (tools/, servers/) are OUT of scope — detection patterns in code (e.g. gates.py's `[TODO]` regex, or terminology-checker pattern lists) are not findings.
 
 ### TEST: No empty markdown links
 Search for `\[\]\(\)` (empty link text and href).
@@ -1079,18 +1053,17 @@ Search for triple backticks without language:
 (Should be ```bash, ```yaml, ```markdown, etc.)
 
 ### TEST: README has required sections
-Read README.md and verify these sections exist:
-- What Is This
-- Installation
-- Quick Start
-- Skills reference tables
-- Configuration
-- Requirements
+README.md was restructured around a shorter narrative + a "Detailed Documentation" table pointing to docs/. Read README.md and verify these sections exist:
+- Intro/"What it actually does" paragraph (no heading — the opening paragraphs after the title)
+- "## Install"
+- "## Architecture" (with subsections: Skill System, Multi-Model Orchestration, MCP Server, Research System, Quality Gates, Genre Coverage, CI/CD)
+- "## Project Structure"
+- "## Detailed Documentation" (table linking to docs/skills.md, docs/configuration.md, docs/troubleshooting.md, etc.)
 
-### TEST: README has Troubleshooting section (quick win #2)
-Read README.md.
-Verify "## Troubleshooting" section exists.
-Verify it includes these subsections:
+(The old "What Is This / Installation / Quick Start / Skills reference tables / Configuration / Requirements" headings no longer exist by those names — skill tables and configuration detail moved to docs/skills.md and docs/configuration.md respectively.)
+
+### TEST: Troubleshooting doc has required subsections (quick win #2)
+README.md no longer has a "## Troubleshooting" section — it moved to `docs/troubleshooting.md`. Read `docs/troubleshooting.md` and verify it includes these subsections:
 - Config Not Found
 - Album Not Found When Resuming
 - Path Resolution Issues
@@ -1100,52 +1073,43 @@ Verify it includes these subsections:
 - Skills Not Showing Up
 - Still Stuck?
 
-### TEST: README has Getting Started Checklist (quick win #3)
-Read README.md.
-Verify "## Getting Started Checklist" section exists.
-Verify it appears before "## Quick Start" section.
-Verify it includes:
-- Install plugin step
-- Create config directory step
-- Copy config template step
-- Edit config step
-- Optional mastering dependencies step
-- Optional document hunter dependencies step
-- Start Claude and begin step
+### TEST: README Install section has setup steps (quick win #3)
+README.md has neither "Getting Started Checklist" nor "Quick Start" — both were replaced by a single "## Install" section. Read README.md "## Install" and verify it includes:
+- The `/plugin marketplace add` and `/plugin install` commands
+- A mention of `/bitwize-music:setup` (detect environment, install dependencies)
+- A mention of `/bitwize-music:configure` (set artist name and workspace paths)
 
-### TEST: README has Model Strategy section (quick win #5)
-Read README.md.
-Verify "## Model Strategy" section exists.
-Verify it includes:
-- Table showing model/when used/skills mapping
-- Opus 4.5 for critical creative outputs
-- Sonnet 4.5 for most tasks
-- Haiku 4.5 for pattern matching
-- "Why different models?" explanation
+(Drop the "must appear before Quick Start" ordering assertion — there is no separate Quick Start section to order against.)
 
-### TEST: README has visual workflow diagram (quick win #6)
-Read README.md "## How It Works" section.
-Verify it includes ASCII box diagram showing:
-- Concept → Research → Write → Generate → Master → Release
-- Specific actions under each phase
-- Visual representation (not just text list)
+### TEST: Model Strategy documented (quick win #5)
+README.md has no "## Model Strategy" heading — it has "### Multi-Model Orchestration" under "## Architecture" instead, which links out to `reference/model-strategy.md` for the full per-skill rationale. Verify:
+- README.md "### Multi-Model Orchestration" includes a table showing Tier / Model / Skill count / Rationale, covering Opus, Sonnet, and Haiku tiers
+- `reference/model-strategy.md` exists and explains the rationale per tier (don't assert specific model version numbers like "4.5" — tiers use aliases that float to the current frontier model, so pinned versions in a test would itself go stale)
+
+### TEST: README has workflow illustration (quick win #6)
+README.md has no "## How It Works" section or ASCII box diagram — it has "## Example Workflow" instead, showing a terminal-style You:/Claude: dialogue transcript. Read README.md "## Example Workflow" and verify it illustrates the pipeline (concept → research → write → generate → master → release) through example dialogue, not a text list.
 
 ### TEST: README skill count matches actual (regression)
 1. Count skill directories: `ls -1 skills/ | wc -l`
-2. Read README.md and extract the number from "collection of **XX specialized skills**"
+2. Read README.md and extract the number from "### Skill System (XX Skills)" (the old "collection of **XX specialized skills**" phrasing is gone)
 3. The counts must match exactly
+4. Also cross-check against "skills/              XX skill definitions" in "## Project Structure" and "All XX skills" in the "## Detailed Documentation" table — all three numbers must agree
 
 This test was added after the README claimed 32 skills when there were actually 38.
 
 ### TEST: CLAUDE.md has required sections
-Read CLAUDE.md and verify these sections exist:
-- Project Overview
-- Configuration
+Read CLAUDE.md and verify these top-level (`##`) sections exist:
+- ⚠️ CRITICAL: Finding Albums When User Mentions Them
+- Configuration & Path Resolution
+- MCP Server — Preferred Data Access
 - Session Start
 - Core Principles
-- Skills table
-- Directory Structure
-- Workflow
+- Workflow Overview
+- Content Structure
+- Versioning & Development
+- Mid-Session Rules
+
+(The old "Project Overview / Configuration / Skills table / Directory Structure / Workflow" names no longer exist as headings — CLAUDE.md has no comprehensive skills table at all now, and "Directory Structure" content lives under "Content Structure".)
 
 ---
 

--- a/skills/test/test-definitions.md
+++ b/skills/test/test-definitions.md
@@ -185,7 +185,7 @@ done
 3. Must match
 
 ### TEST: All skills documented in CLAUDE.md
-DROPPED — CLAUDE.md has no comprehensive skill table anymore; it lists only a curated subset of skills in "### Key Routing Rules" by design (as of this sweep, 24 of 53 skills — including 10 researcher sub-skills — aren't named in CLAUDE.md at all, and that's expected). The authoritative version of this claim is "All skills documented in help system" below, which runs `tools/validate_help_completeness.py` and checks each skill's `/bitwize-music:{name}` reference against CLAUDE.md and skills/help/SKILL.md programmatically. Keeping both risks a manual-read verdict contradicting the script's verdict for the same repo state.
+DROPPED — CLAUDE.md has no comprehensive skill table anymore; it lists only a curated subset of skills in "### Key Routing Rules" by design (as of this sweep, 24 of 53 skills — including 10 researcher sub-skills — aren't named there today — whether each needs a reference is exactly what the script-based test below adjudicates). The authoritative version of this claim is "All skills documented in help system" below, which runs `tools/validate_help_completeness.py` and checks each skill's `/bitwize-music:{name}` reference against CLAUDE.md and skills/help/SKILL.md programmatically. Keeping both risks a manual-read verdict contradicting the script's verdict for the same repo state.
 
 ### TEST: All skills documented in README.md
 README.md no longer has skill tables — they moved to `docs/skills.md`. Extract skill names from skills/ directory and verify each appears (as `` `skill-name` ``) in one of `docs/skills.md`'s tables (Core Production, Research System, Quality Control, Release & Distribution, Album Management, Setup & Maintenance).
@@ -416,7 +416,7 @@ CLAUDE.md no longer names checkpoints directly. Verify instead:
    - Album Generation Complete Checkpoint
    - Ready to Master Checkpoint
    - Ready to Release Checkpoint
-2. At least one skill (e.g. `skills/resume/SKILL.md` or `skills/explicit-checker/SKILL.md`) references the "Ready to Generate Checkpoint" by name.
+2. At least one skill (e.g. `skills/explicit-checker/SKILL.md`) references the "Ready to Generate Checkpoint" by name.
 
 ---
 

--- a/tools/mastering/qc_tracks.py
+++ b/tools/mastering/qc_tracks.py
@@ -319,7 +319,9 @@ def _check_silence(
     trailing_sec = 0.0
     internal_gap_count = 0
 
-    for rs, re in zip(region_starts, region_ends, strict=False):
+    # region_starts/region_ends pair exactly: both derive from the same
+    # [False]-padded boolean diff, so every +1 transition has a matching -1.
+    for rs, re in zip(region_starts, region_ends, strict=True):
         length_samples = int(re - rs)
         length_sec = length_samples / rate
         is_leading = False

--- a/tools/promotion/generate_album_sampler.py
+++ b/tools/promotion/generate_album_sampler.py
@@ -7,7 +7,7 @@ with short clips, designed to fit Twitter's 2:20 (140 second) limit.
 
 Requirements:
     - ffmpeg with drawtext filter (brew install ffmpeg)
-    - Python 3.8+
+    - Python 3.11+
 
 Usage:
     python generate_album_sampler.py /path/to/mastered --artwork album.png -o sampler.mp4

--- a/tools/promotion/generate_promo_video.py
+++ b/tools/promotion/generate_promo_video.py
@@ -7,7 +7,7 @@ Uses ffmpeg to combine audio, album artwork, and waveform visualization.
 
 Requirements:
     - ffmpeg with drawtext filter (brew install ffmpeg)
-    - Python 3.8+
+    - Python 3.11+
 
 Usage:
     # Single track


### PR DESCRIPTION
## Summary

**Real repo fixes (4):**
- `allowed-tools:` frontmatter added to `skills/about` (`[Read]`) and `skills/genre-creator` (`[Read, Edit, Write, Glob, WebSearch]`) — the only 2 of 53 skills missing it; both lists verified complete against each skill's actual workflow
- `tools/promotion/` docstrings: Python 3.8+ -> 3.11+ (repo floor)
- `tools/mastering/qc_tracks.py`: zip `strict=True` with the equal-length invariant documented
- `templates/album.md`: audited — all 5 required sections already present; the reported "missing heading" was a judge false positive, no change

**test-definitions.md stale-sweep:**
All 141 test definitions audited against the current repo. ~34 retargeted to today's structure (`fix_titles.py` -> `prepare_singles.py`, planning phases -> album-conceptualizer, Album Completion Checklist -> Status Tracking, README Getting Started -> Install, plus wider drift from the CLAUDE.md/README modularization). 4 dropped with in-file `DROPPED —` audit-trail entries. Scope fences added to the TODO and Suno-terminology checks so the LLM judge can't over-reach again. 2 ambiguous regression-guard checks (concrete-path examples trimmed from CLAUDE.md) deliberately left unchanged pending a maintainer ruling.

## Verification

- ruff + bandit + mypy clean; pytest 4261 passed, 2 xfailed, 88.17% coverage; `strict=True` raised no ValueError anywhere
- Acceptance caveat, honestly stated: in-session `/bitwize-music:test all` judges the **installed plugin cache (v0.89.0)**, not this tree — its 2 high-priority findings are exactly the 2 defects this branch fixes. Tree-level acceptance = the 141-test audit + two rounds of independent retarget sampling across reviewers (17 of 26 non-mandated retargets verified, 0 discrepancies). True skill-level validation becomes possible after the next release + plugin update.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)