### PR TITLE
fix: complete help index; validator enforces help-comprehensive / CLAUDE.md-curated policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to claude-ai-music-skills.
 
 This project uses [Conventional Commits](https://conventionalcommits.org/) and [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Help index completed, validator policy re-encoded** — `skills/help/SKILL.md` now lists all 53 skills (9 were missing); `tools/validate_help_completeness.py` enforces the help-comprehensive / CLAUDE.md-curated contract (CLAUDE.md references are ghost-checked, not completeness-checked), with new unit tests; contributor checklist updated to match
+
 ## [0.98.0] - 2026-07-11
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ When adding a new skill, you MUST update all of these files:
 
 **Required (skill won't work without these):**
 - [ ] Create `/skills/your-skill/SKILL.md` with skill documentation
-- [ ] Add entry to `CLAUDE.md` skills table (alphabetically in correct category)
+- [ ] Add a routing rule to `CLAUDE.md` Key Routing Rules ONLY if users reach the skill through workflow triggers (CLAUDE.md is a curated router — most skills belong in the help index, not CLAUDE.md)
 - [ ] Add entry to `skills/help/SKILL.md` in appropriate category
 - [ ] Add entry to `skills/help/SKILL.md` Common Workflows section (if applicable)
 - [ ] Update `CHANGELOG.md` under "Unreleased" → "Added"
@@ -82,7 +82,7 @@ When adding a new skill, you MUST update all of these files:
 - [ ] Run `/bitwize-music:test all` to ensure no regressions
 - [ ] Test skill invocation: `/bitwize-music:your-skill`
 - [ ] Verify skill appears in `/bitwize-music:help` output
-- [ ] Check skill in skills table works as expected
+- [ ] Run `tools/validate_help_completeness.py` — must exit 0 (help index complete, no CLAUDE.md ghost references)
 
 **Common mistakes to avoid:**
 - ❌ Forgetting to add skill to help system

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -31,7 +31,9 @@ Display this help information to the user in a clear, organized format.
 - `/bitwize-music:new-album` - Create new album with directory structure
 - `/bitwize-music:album-conceptualizer` - Album concepts and tracklist architecture
 - `/bitwize-music:lyric-writer` - Write/review lyrics, fix prosody
+- `/bitwize-music:lyric-refiner` - Multi-pass lyric refinement and album cohesion
 - `/bitwize-music:suno-engineer` - Technical Suno prompting and genre selection
+- `/bitwize-music:genre-creator` - Add new genre documentation to the library
 
 **Research & Sources**
 - `/bitwize-music:researcher` - Main research coordinator, fact-checking
@@ -46,6 +48,7 @@ Display this help information to the user in a clear, organized format.
 - `/bitwize-music:researchers-biographical` - Personal backgrounds
 - `/bitwize-music:researchers-primary-source` - Tweets, blogs, forums
 - `/bitwize-music:researchers-verifier` - Quality control, citation validation
+- `/bitwize-music:verify-sources` - Human source verification gate (required before generation)
 
 **Quality Control**
 - `/bitwize-music:lyric-reviewer` - Pre-generation QC gate (14-point checklist)
@@ -58,8 +61,11 @@ Display this help information to the user in a clear, organized format.
 
 **Production & Release**
 - `/bitwize-music:album-art-director` - Visual concepts and AI art prompts
+- `/bitwize-music:mix-engineer` - Per-stem audio polish before mastering
 - `/bitwize-music:mastering-engineer` - Audio mastering guidance
 - `/bitwize-music:promo-director` - Generate promo videos for social media
+- `/bitwize-music:promo-writer` - Generate platform-specific social media copy
+- `/bitwize-music:promo-reviewer` - Review and polish promo copy before release
 - `/bitwize-music:cloud-uploader` - Upload promo videos to Cloudflare R2 or AWS S3
 - `/bitwize-music:sheet-music-publisher` - Convert audio to sheet music
 - `/bitwize-music:release-director` - Release coordination and distribution
@@ -68,6 +74,7 @@ Display this help information to the user in a clear, organized format.
 - `/bitwize-music:import-track` - Move track .md files to album location
 - `/bitwize-music:import-audio` - Move audio files to album location
 - `/bitwize-music:import-art` - Place album art in correct locations
+- `/bitwize-music:rename` - Rename an album or track (updates slugs and all paths)
 - `/bitwize-music:clipboard` - Copy track lyrics/prompts to clipboard
 
 **Workflow & Status**
@@ -77,6 +84,8 @@ Display this help information to the user in a clear, organized format.
 
 **System & Maintenance**
 - `/bitwize-music:configure` - Edit plugin configuration
+- `/bitwize-music:setup` - Detect environment and install plugin dependencies
+- `/bitwize-music:health-check` - Check venv and skill registration health
 - `/bitwize-music:test` - Run automated tests
 - `/bitwize-music:help` - Show this help (you are here!)
 - `/bitwize-music:about` - About bitwize and the plugin
@@ -91,7 +100,7 @@ Display this help information to the user in a clear, organized format.
 3. Write lyrics for each track
 4. Run `/bitwize-music:lyric-reviewer` before generation
 5. Generate in Suno, log results
-6. Master audio with `/bitwize-music:mastering-engineer`
+6. Polish stems with `/bitwize-music:mix-engineer`, then master with `/bitwize-music:mastering-engineer`
 7. [Optional] Generate promo videos with `/bitwize-music:promo-director`
 8. [Optional] Upload to cloud with `/bitwize-music:cloud-uploader`
 9. Release with `/bitwize-music:release-director`

--- a/skills/test/test-definitions.md
+++ b/skills/test/test-definitions.md
@@ -185,7 +185,7 @@ done
 3. Must match
 
 ### TEST: All skills documented in CLAUDE.md
-DROPPED — CLAUDE.md has no comprehensive skill table anymore; it lists only a curated subset of skills in "### Key Routing Rules" by design (as of this sweep, 24 of 53 skills — including 10 researcher sub-skills — aren't named there today — whether each needs a reference is exactly what the script-based test below adjudicates). The authoritative version of this claim is "All skills documented in help system" below, which runs `tools/validate_help_completeness.py` and checks each skill's `/bitwize-music:{name}` reference against CLAUDE.md and skills/help/SKILL.md programmatically. Keeping both risks a manual-read verdict contradicting the script's verdict for the same repo state.
+DROPPED — CLAUDE.md has no comprehensive skill table anymore; it lists only a curated subset of skills in "### Key Routing Rules" by design (as of this sweep, 24 of 53 skills — including 10 researcher sub-skills — aren't named there today, and that's expected: CLAUDE.md is a curated router, not a completeness list). The authoritative version of this claim is "All skills documented in help system" below, which runs `tools/validate_help_completeness.py`: it requires every skill to be referenced in skills/help/SKILL.md, and separately checks CLAUDE.md only for ghost references (a `/bitwize-music:{name}` mention pointing at a skill that no longer exists) — it does not require CLAUDE.md to reference every skill. Keeping both risks a manual-read verdict contradicting the script's verdict for the same repo state.
 
 ### TEST: All skills documented in README.md
 README.md no longer has skill tables — they moved to `docs/skills.md`. Extract skill names from skills/ directory and verify each appears (as `` `skill-name` ``) in one of `docs/skills.md`'s tables (Core Production, Research System, Quality Control, Release & Distribution, Album Management, Setup & Maintenance).
@@ -889,13 +889,13 @@ $PYTHON "$PLUGIN_DIR/tools/validate_help_completeness.py"
 ```
 
 This checks:
-1. All skills have SKILL.md file
-2. All skills are listed in CLAUDE.md skills table
-3. All skills are listed in skills/help/SKILL.md
+1. All skills have a SKILL.md file
+2. Every skill is referenced (`/bitwize-music:{name}`) in skills/help/SKILL.md — help must document every skill
+3. CLAUDE.md is a curated router, not a completeness list — the script only fails if CLAUDE.md references a `/bitwize-music:{name}` skill that doesn't exist (a ghost reference); it does not require every skill to appear there
 
 If this test fails:
-- Add missing skill to CLAUDE.md skills table (alphabetically)
 - Add missing skill to skills/help/SKILL.md (in appropriate category)
+- Fix or remove any CLAUDE.md reference to a nonexistent skill
 - Update CHANGELOG.md
 
 **Note:** This is critical - if a skill isn't in the help system, users can't discover it!

--- a/tests/unit/test_validate_help_completeness.py
+++ b/tests/unit/test_validate_help_completeness.py
@@ -1,19 +1,18 @@
 """Tests for tools/validate_help_completeness.py."""
 
-import importlib.util
 import sys
 from pathlib import Path
 
-# Import the standalone tools/ script via importlib (validate_help_completeness.py
-# is a top-level tools/ script, not a member of a tools.* subpackage).
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
+# Ensure project root is on sys.path
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
-_MODULE_PATH = _PROJECT_ROOT / "tools" / "validate_help_completeness.py"
-_spec = importlib.util.spec_from_file_location("validate_help_completeness", _MODULE_PATH)
-vhc = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(vhc)
+from tools.validate_help_completeness import (
+    check_claude_md_ghosts,
+    check_help_skill,
+    get_all_skills,
+)
 
 
 def make_repo(
@@ -38,29 +37,29 @@ def make_repo(
 
 def test_help_gap_detected(tmp_path):
     root = make_repo(tmp_path, ["alpha", "beta"], help_refs=["alpha", "help"], claude_refs=[])
-    skills = vhc.get_all_skills(root)
-    assert "beta" in vhc.check_help_skill(root, skills)
+    skills = get_all_skills(root)
+    assert "beta" in check_help_skill(root, skills)
 
 
 def test_help_complete_passes(tmp_path):
     root = make_repo(tmp_path, ["alpha", "beta"], help_refs=["alpha", "beta", "help"], claude_refs=[])
-    skills = vhc.get_all_skills(root)
-    assert vhc.check_help_skill(root, skills) == []
+    skills = get_all_skills(root)
+    assert check_help_skill(root, skills) == []
 
 
 def test_claude_ghost_detected(tmp_path):
     root = make_repo(tmp_path, ["alpha"], help_refs=["alpha", "help"], claude_refs=["alpha", "no-such-skill"])
-    skills = vhc.get_all_skills(root)
-    assert vhc.check_claude_md_ghosts(root, skills) == ["no-such-skill"]
+    skills = get_all_skills(root)
+    assert check_claude_md_ghosts(root, skills) == ["no-such-skill"]
 
 
 def test_claude_curated_is_not_a_finding(tmp_path):
     root = make_repo(tmp_path, ["alpha", "beta"], help_refs=["alpha", "beta", "help"], claude_refs=["alpha"])
-    skills = vhc.get_all_skills(root)
-    assert vhc.check_claude_md_ghosts(root, skills) == []
+    skills = get_all_skills(root)
+    assert check_claude_md_ghosts(root, skills) == []
 
 
 def test_discovery_ignores_dirs_without_skill_md(tmp_path):
     root = make_repo(tmp_path, ["alpha"], help_refs=["alpha", "help"], claude_refs=[])
     (root / "skills" / "not-a-skill").mkdir()
-    assert "not-a-skill" not in vhc.get_all_skills(root)
+    assert "not-a-skill" not in get_all_skills(root)

--- a/tests/unit/test_validate_help_completeness.py
+++ b/tests/unit/test_validate_help_completeness.py
@@ -1,0 +1,66 @@
+"""Tests for tools/validate_help_completeness.py."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the standalone tools/ script via importlib (validate_help_completeness.py
+# is a top-level tools/ script, not a member of a tools.* subpackage).
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+_MODULE_PATH = _PROJECT_ROOT / "tools" / "validate_help_completeness.py"
+_spec = importlib.util.spec_from_file_location("validate_help_completeness", _MODULE_PATH)
+vhc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vhc)
+
+
+def make_repo(
+    tmp_path: Path,
+    skills: list[str],
+    help_refs: list[str],
+    claude_refs: list[str],
+) -> Path:
+    """Build a minimal fake plugin repo."""
+    for name in skills:
+        skill_dir = tmp_path / "skills" / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\nbody\n")
+    help_dir = tmp_path / "skills" / "help"
+    help_dir.mkdir(parents=True, exist_ok=True)
+    help_lines = "\n".join(f"- `/bitwize-music:{r}` - desc" for r in help_refs)
+    (help_dir / "SKILL.md").write_text(f"---\nname: help\n---\n{help_lines}\n")
+    claude_lines = "\n".join(f"- use `/bitwize-music:{r}` here" for r in claude_refs)
+    (tmp_path / "CLAUDE.md").write_text(f"# Test\n{claude_lines}\n")
+    return tmp_path
+
+
+def test_help_gap_detected(tmp_path):
+    root = make_repo(tmp_path, ["alpha", "beta"], help_refs=["alpha", "help"], claude_refs=[])
+    skills = vhc.get_all_skills(root)
+    assert "beta" in vhc.check_help_skill(root, skills)
+
+
+def test_help_complete_passes(tmp_path):
+    root = make_repo(tmp_path, ["alpha", "beta"], help_refs=["alpha", "beta", "help"], claude_refs=[])
+    skills = vhc.get_all_skills(root)
+    assert vhc.check_help_skill(root, skills) == []
+
+
+def test_claude_ghost_detected(tmp_path):
+    root = make_repo(tmp_path, ["alpha"], help_refs=["alpha", "help"], claude_refs=["alpha", "no-such-skill"])
+    skills = vhc.get_all_skills(root)
+    assert vhc.check_claude_md_ghosts(root, skills) == ["no-such-skill"]
+
+
+def test_claude_curated_is_not_a_finding(tmp_path):
+    root = make_repo(tmp_path, ["alpha", "beta"], help_refs=["alpha", "beta", "help"], claude_refs=["alpha"])
+    skills = vhc.get_all_skills(root)
+    assert vhc.check_claude_md_ghosts(root, skills) == []
+
+
+def test_discovery_ignores_dirs_without_skill_md(tmp_path):
+    root = make_repo(tmp_path, ["alpha"], help_refs=["alpha", "help"], claude_refs=[])
+    (root / "skills" / "not-a-skill").mkdir()
+    assert "not-a-skill" not in vhc.get_all_skills(root)

--- a/tools/validate_help_completeness.py
+++ b/tools/validate_help_completeness.py
@@ -9,6 +9,7 @@ Run this before committing changes that add new skills.
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -43,30 +44,19 @@ def get_all_skills(plugin_root: Path) -> list[str]:
 
     return skills
 
-def check_claude_md(plugin_root: Path, skills: list[str]) -> list[str]:
-    """Check which skills are missing from CLAUDE.md."""
-    claude_file = plugin_root / "CLAUDE.md"
+def check_claude_md_ghosts(plugin_root: Path, skills: list[str]) -> list[str]:
+    """Find CLAUDE.md references to skills that don't exist.
 
+    CLAUDE.md is a curated router by design: it need not reference every
+    skill, but every /bitwize-music:{name} it does reference must exist.
+    """
+    claude_file = plugin_root / "CLAUDE.md"
     if not claude_file.exists():
         logger.error("CLAUDE.md not found!")
-        return skills
-
-    claude_content = claude_file.read_text()
-    missing = []
-
-    # Skip system/internal skills
-    skip_skills = {'help', 'about', 'configure', 'test'}
-
-    for skill in skills:
-        if skill in skip_skills:
-            continue
-
-        # Check for skill reference
-        skill_pattern = f"/bitwize-music:{skill}"
-        if skill_pattern not in claude_content:
-            missing.append(skill)
-
-    return missing
+        return []
+    content = claude_file.read_text()
+    referenced = set(re.findall(r"/bitwize-music:([a-z0-9][a-z0-9-]*)", content))
+    return sorted(referenced - set(skills))
 
 def check_help_skill(plugin_root: Path, skills: list[str]) -> list[str]:
     """Check which skills are missing from skills/help/SKILL.md."""
@@ -114,16 +104,16 @@ def main() -> int:
     errors = 0
 
     # Check CLAUDE.md
-    logger.info("Checking CLAUDE.md skills table...")
-    missing_claude = check_claude_md(plugin_root, all_skills)
+    logger.info("Checking CLAUDE.md for ghost skill references...")
+    claude_ghosts = check_claude_md_ghosts(plugin_root, all_skills)
 
-    if not missing_claude:
-        print(f"{GREEN}[OK] All skills documented in CLAUDE.md{NC}")
+    if not claude_ghosts:
+        print(f"{GREEN}[OK] All CLAUDE.md skill references are valid{NC}")
     else:
-        print(f"{RED}[FAIL] Skills missing from CLAUDE.md:{NC}")
-        for skill in missing_claude:
+        print(f"{RED}[FAIL] CLAUDE.md references nonexistent skills:{NC}")
+        for skill in claude_ghosts:
             print(f"  - {skill}")
-        errors += len(missing_claude)
+        errors += len(claude_ghosts)
     print()
 
     # Check help system
@@ -145,15 +135,15 @@ def main() -> int:
         print(f"{GREEN}[OK] All skills properly documented!{NC}")
         print()
         print("All skills are listed in:")
-        print("  - CLAUDE.md (main skills table)")
-        print("  - skills/help/SKILL.md (help system)")
+        print("  - skills/help/SKILL.md (help system, every skill)")
+        print("  - CLAUDE.md (curated router, ghost-free)")
         return 0
     else:
         print(f"{RED}[FAIL] Found {errors} documentation issues{NC}")
         print()
         print("To fix:")
-        print("  1. Add missing skills to CLAUDE.md skills table")
-        print("  2. Add missing skills to skills/help/SKILL.md")
+        print("  1. Add missing skills to skills/help/SKILL.md (help must list every skill)")
+        print("  2. Fix or remove CLAUDE.md references to nonexistent skills")
         print("  3. Update CHANGELOG.md with the changes")
         print()
         print("See CONTRIBUTING.md for complete checklist")


### PR DESCRIPTION
## Summary

Follow-on from #471: `validate_help_completeness.py` reported 34 gaps — 9 skills missing from the help system and 25 unreferenced in CLAUDE.md. Per the decided policy (help comprehensive, CLAUDE.md curated):

- `skills/help/SKILL.md` now references all 53 skills (added genre-creator, health-check, lyric-refiner, mix-engineer, promo-reviewer, promo-writer, rename, setup, verify-sources into their categories) and the Creating-a-New-Album workflow shows polish -> master.
- `tools/validate_help_completeness.py`: help check unchanged (every skill must appear); the CLAUDE.md check is now a ghost-check — curation is fine, references to nonexistent skills are not. New unit tests cover both behaviors (5 tests, TDD).
- `skills/test/test-definitions.md`: the help-system test description and the related DROPPED note updated to the new contract.
- `CONTRIBUTING.md`: the two checklist lines mandating the old CLAUDE.md-skills-table policy replaced (final-review finding); CHANGELOG entry added under [Unreleased].

## Verification

- `tools/validate_help_completeness.py` -> both checks [OK], exit 0 (independently reproduced by the final reviewer)
- ruff + bandit + mypy clean; pytest 4266 passed (incl. 5 new validator tests), 88.17% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)