### PR TITLE
fix: cross-platform venv paths, UTF-8 text I/O, and native-Windows support tier docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -366,6 +366,12 @@ jobs:
       run: |
         ruff check tools/ servers/
 
+    # PLW1514 (unspecified-encoding) is preview-only, so it runs as a
+    # dedicated scoped invocation instead of enabling preview repo-wide
+    - name: Run ruff encoding check (PLW1514)
+      run: |
+        ruff check tools/ servers/ --select PLW1514 --preview
+
     - name: Run bandit security linter
       run: |
         bandit -r tools/ servers/ -ll -q -s B108,B608

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ test: $(VENV)/bin/activate
 
 lint: $(VENV)/bin/activate
 	$(RUFF) check tools/ servers/
+	# PLW1514 (unspecified-encoding) is preview-only, so it runs as a
+	# dedicated scoped invocation instead of enabling preview repo-wide
+	$(RUFF) check tools/ servers/ --select PLW1514 --preview
 	# -s B108: tmpfile paths (reviewed manually)
 	# -s B608: SQL string construction (all callsites use %s params; nosec
 	#         markers remain as documentation but bandit noise at -ll level

--- a/reference/cross-platform/tool-compatibility-matrix.md
+++ b/reference/cross-platform/tool-compatibility-matrix.md
@@ -12,7 +12,7 @@ What works on each platform for the Claude AI Music Skills plugin.
 | **Linux** (native) | Full | Tested on Ubuntu 22.04+ |
 | **WSL2** | Full | See [WSL Setup Guide](wsl-setup-guide.md) |
 | **WSL1** | Partial | Works but slower, some limitations |
-| **Windows (native)** | Not Supported | Use WSL |
+| **Windows (native)** | Core (best-effort) | MCP server, state cache, and non-audio workflow (albums, tracks, ideas, research docs, status tracking) — CI-tested on windows-latest. Audio tooling (ffmpeg/AnthemScore/MuseScore) not supported natively; use WSL2 |
 
 ---
 
@@ -141,11 +141,11 @@ playwright install-deps chromium
 
 | Feature | Minimum Python | Recommended |
 |---------|----------------|-------------|
-| Core plugin | 3.8 | 3.10+ |
-| Audio mastering | 3.8 | 3.10+ |
-| Promo videos | 3.8 | 3.10+ |
-| Document hunter | 3.8 | 3.10+ |
-| Sheet music tools | 3.8 | 3.10+ |
+| Core plugin | 3.10+ (per requirements.txt) | 3.10+ |
+| Audio mastering | 3.10+ (per requirements.txt) | 3.10+ |
+| Promo videos | 3.10+ (per requirements.txt) | 3.10+ |
+| Document hunter | 3.10+ (per requirements.txt) | 3.10+ |
+| Sheet music tools | 3.10+ (per requirements.txt) | 3.10+ |
 
 ---
 

--- a/servers/bitwize-music-server/handlers/core.py
+++ b/servers/bitwize-music-server/handlers/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +29,7 @@ from handlers._shared import (
     _normalize_slug,
     _safe_json,
 )
-from tools.shared.venv import venv_python
+from tools.shared.venv import venv_dir, venv_python
 from tools.state.indexer import write_state
 from tools.state.parsers import parse_track_file
 
@@ -459,9 +460,10 @@ async def get_python_command() -> str:
     }
 
     if not venv_exists:
+        create_cmd = "py -3" if sys.platform == "win32" else "python3"
         result["warning"] = (
-            "Venv not found at ~/.bitwize-music/venv. "
-            "Create it with: python3 -m venv ~/.bitwize-music/venv && "
+            f"Venv not found at {venv_dir()}. "
+            f'Create it with: {create_cmd} -m venv "{venv_dir()}" && '
             f'"{venv_python_path}" -m pip install pyloudnorm scipy numpy '
             "soundfile matchering pillow pyyaml boto3"
         )

--- a/servers/bitwize-music-server/handlers/core.py
+++ b/servers/bitwize-music-server/handlers/core.py
@@ -28,6 +28,7 @@ from handlers._shared import (
     _normalize_slug,
     _safe_json,
 )
+from tools.shared.venv import venv_python
 from tools.state.indexer import write_state
 from tools.state.parsers import parse_track_file
 
@@ -440,27 +441,28 @@ async def get_python_command() -> str:
 
     Returns:
         JSON with:
-            python: Absolute path to ~/.bitwize-music/venv/bin/python3
+            python: Absolute path to the venv Python interpreter
+                (Scripts\\python.exe on Windows, bin/python3 elsewhere)
             plugin_root: Absolute path to the plugin directory
             venv_exists: Whether the venv exists
             usage: Ready-to-paste command template
             warning: Only present if venv is missing, with install instructions
     """
-    venv_python = Path.home() / ".bitwize-music" / "venv" / "bin" / "python3"
-    venv_exists = venv_python.is_file()
+    venv_python_path = venv_python()
+    venv_exists = venv_python_path.is_file()
 
     result: dict[str, Any] = {
-        "python": str(venv_python),
+        "python": str(venv_python_path),
         "plugin_root": str(_shared.PLUGIN_ROOT),
         "venv_exists": venv_exists,
-        "usage": f'{venv_python} "$PLUGIN_DIR/tools/<script>.py" <args>',
+        "usage": f'"{venv_python_path}" "$PLUGIN_DIR/tools/<script>.py" <args>',
     }
 
     if not venv_exists:
         result["warning"] = (
             "Venv not found at ~/.bitwize-music/venv. "
             "Create it with: python3 -m venv ~/.bitwize-music/venv && "
-            "~/.bitwize-music/venv/bin/pip install pyloudnorm scipy numpy "
+            f'"{venv_python_path}" -m pip install pyloudnorm scipy numpy '
             "soundfile matchering pillow pyyaml boto3"
         )
 

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -298,7 +298,7 @@ async def check_venv_health() -> str:
 
     if status == "stale":
         result["fix_command"] = (
-            f'"{venv_python_path}" -m pip install -r {req_path}'
+            f'"{venv_python_path}" -m pip install -r "{req_path}"'
         )
 
     return _safe_json(result)

--- a/servers/bitwize-music-server/handlers/health.py
+++ b/servers/bitwize-music-server/handlers/health.py
@@ -12,6 +12,7 @@ from typing import Any
 from handlers import _shared
 from handlers._shared import _safe_json
 from handlers._shared import get_plugin_version as _read_plugin_version
+from tools.shared.venv import venv_python
 from tools.state import indexer
 
 logger = logging.getLogger(__name__)
@@ -247,8 +248,8 @@ async def check_venv_health() -> str:
         JSON with status ("ok", "stale", "no_venv", "error"),
         mismatches, missing packages, counts, and fix command.
     """
-    venv_python = Path.home() / ".bitwize-music" / "venv" / "bin" / "python3"
-    if not venv_python.exists():
+    venv_python_path = venv_python()
+    if not venv_python_path.exists():
         return _safe_json({
             "status": "no_venv",
             "message": "Venv not found at ~/.bitwize-music/venv",
@@ -297,7 +298,7 @@ async def check_venv_health() -> str:
 
     if status == "stale":
         result["fix_command"] = (
-            f"~/.bitwize-music/venv/bin/pip install -r {req_path}"
+            f'"{venv_python_path}" -m pip install -r {req_path}'
         )
 
     return _safe_json(result)

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -76,19 +76,20 @@ except ImportError:
     print("Install with ONE of these methods:", file=sys.stderr)
     print("", file=sys.stderr)
     print("  1. User install (recommended):", file=sys.stderr)
-    print("     pip install --user 'mcp[cli]>=1.2.0' pyyaml", file=sys.stderr)
+    print('     pip install --user "mcp[cli]>=1.2.0" pyyaml', file=sys.stderr)
     print("", file=sys.stderr)
     print("  2. Using pipx:", file=sys.stderr)
     print("     pipx install mcp", file=sys.stderr)
     print("", file=sys.stderr)
     print("  3. Virtual environment:", file=sys.stderr)
-    print("     python3 -m venv ~/.bitwize-music/venv", file=sys.stderr)
-    _venv_python_hint = (
-        r"%USERPROFILE%\.bitwize-music\venv\Scripts\python.exe"
-        if sys.platform == "win32"
-        else "~/.bitwize-music/venv/bin/python3"
-    )
-    print(f"     \"{_venv_python_hint}\" -m pip install 'mcp[cli]>=1.2.0' pyyaml", file=sys.stderr)
+    if sys.platform == "win32":
+        _venv_create_hint = r'py -3 -m venv "%USERPROFILE%\.bitwize-music\venv"'
+        _venv_python_hint = r"%USERPROFILE%\.bitwize-music\venv\Scripts\python.exe"
+    else:
+        _venv_create_hint = "python3 -m venv ~/.bitwize-music/venv"
+        _venv_python_hint = "$HOME/.bitwize-music/venv/bin/python3"
+    print(f"     {_venv_create_hint}", file=sys.stderr)
+    print(f'     "{_venv_python_hint}" -m pip install "mcp[cli]>=1.2.0" pyyaml', file=sys.stderr)
     print("", file=sys.stderr)
     print("After installing, restart Claude Code to reload the plugin.", file=sys.stderr)
     print("=" * 70, file=sys.stderr)

--- a/servers/bitwize-music-server/server.py
+++ b/servers/bitwize-music-server/server.py
@@ -83,7 +83,12 @@ except ImportError:
     print("", file=sys.stderr)
     print("  3. Virtual environment:", file=sys.stderr)
     print("     python3 -m venv ~/.bitwize-music/venv", file=sys.stderr)
-    print("     ~/.bitwize-music/venv/bin/pip install 'mcp[cli]>=1.2.0' pyyaml", file=sys.stderr)
+    _venv_python_hint = (
+        r"%USERPROFILE%\.bitwize-music\venv\Scripts\python.exe"
+        if sys.platform == "win32"
+        else "~/.bitwize-music/venv/bin/python3"
+    )
+    print(f"     \"{_venv_python_hint}\" -m pip install 'mcp[cli]>=1.2.0' pyyaml", file=sys.stderr)
     print("", file=sys.stderr)
     print("After installing, restart Claude Code to reload the plugin.", file=sys.stderr)
     print("=" * 70, file=sys.stderr)

--- a/tests/unit/shared/test_venv.py
+++ b/tests/unit/shared/test_venv.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the cross-platform venv-path helper.
+
+Usage:
+    python -m pytest tests/unit/shared/test_venv.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from tools.shared.venv import venv_dir, venv_python
+
+
+@pytest.mark.unit
+class TestVenvDir:
+    """Tests for venv_dir()."""
+
+    def test_default_home(self):
+        """With no override, resolves under Path.home()."""
+        result = venv_dir()
+        assert result == Path.home() / ".bitwize-music" / "venv"
+
+    def test_home_override(self, tmp_path):
+        """With home= override, resolves under the given path."""
+        result = venv_dir(home=tmp_path)
+        assert result == tmp_path / ".bitwize-music" / "venv"
+
+
+@pytest.mark.unit
+class TestVenvPython:
+    """Tests for venv_python()."""
+
+    @pytest.mark.parametrize(
+        "platform, parent, filename",
+        [
+            ("win32", "Scripts", "python.exe"),
+            ("linux", "bin", "python3"),
+            ("darwin", "bin", "python3"),
+        ],
+    )
+    def test_platform_specific_path(self, monkeypatch, platform, parent, filename):
+        """venv_python() picks the right interpreter path per sys.platform."""
+        monkeypatch.setattr(sys, "platform", platform)
+        result = venv_python()
+        assert result.name == filename
+        assert result.parent.name == parent
+        assert result == Path.home() / ".bitwize-music" / "venv" / parent / filename
+
+    def test_checks_platform_at_call_time(self, monkeypatch):
+        """sys.platform is read inside the function, not cached at import time."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        assert venv_python().name == "python3"
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        assert venv_python().name == "python.exe"
+
+    def test_home_override(self, tmp_path, monkeypatch):
+        """With home= override, resolves under the given path."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        result = venv_python(home=tmp_path)
+        assert result == tmp_path / ".bitwize-music" / "venv" / "bin" / "python3"
+
+    def test_home_override_windows(self, tmp_path, monkeypatch):
+        """home= override also applies on the win32 branch."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        result = venv_python(home=tmp_path)
+        assert result == tmp_path / ".bitwize-music" / "venv" / "Scripts" / "python.exe"

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -7584,7 +7584,7 @@ class TestCheckVenvHealth:
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "stale"
         assert "Scripts" in result["fix_command"]
-        assert result["fix_command"] == f'"{fake_python}" -m pip install -r {req}'
+        assert result["fix_command"] == f'"{fake_python}" -m pip install -r "{req}"'
 
 
 # =============================================================================

--- a/tests/unit/state/test_server.py
+++ b/tests/unit/state/test_server.py
@@ -97,6 +97,7 @@ from handlers import _shared as _shared_mod
 # For lazy-imported functions that need patching at their source module
 import tools.state.parsers as _parsers_mod
 from handlers import core as _core_mod
+from tools.shared.venv import venv_python
 
 
 # ---------------------------------------------------------------------------
@@ -1327,17 +1328,17 @@ class TestGetPythonCommand:
     """Tests for the get_python_command MCP tool."""
 
     def test_venv_exists(self, tmp_path):
-        """When venv python3 exists, returns path and venv_exists=True."""
-        venv_python = tmp_path / ".bitwize-music" / "venv" / "bin" / "python3"
-        venv_python.parent.mkdir(parents=True)
-        venv_python.touch()
-        venv_python.chmod(0o755)
+        """When the venv interpreter exists, returns path and venv_exists=True."""
+        fake_python = venv_python(home=tmp_path)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
+        fake_python.chmod(0o755)
 
         with patch.object(Path, "home", return_value=tmp_path):
             result = json.loads(_run(server.get_python_command()))
 
         assert result["venv_exists"] is True
-        assert str(venv_python) == result["python"]
+        assert result["python"] == str(fake_python)
         assert "plugin_root" in result
         assert "usage" in result
         assert "warning" not in result
@@ -1350,6 +1351,7 @@ class TestGetPythonCommand:
         assert result["venv_exists"] is False
         assert "warning" in result
         assert "python3 -m venv" in result["warning"]
+        assert f'"{venv_python(home=tmp_path)}" -m pip install' in result["warning"]
 
     def test_plugin_root_included(self):
         """Result always includes plugin_root."""
@@ -1358,11 +1360,29 @@ class TestGetPythonCommand:
         assert result["plugin_root"]  # non-empty
 
     def test_usage_template(self, tmp_path):
-        """Usage field contains a ready-to-paste command template."""
+        """Usage field contains a ready-to-paste, quoted command template."""
         with patch.object(Path, "home", return_value=tmp_path):
             result = json.loads(_run(server.get_python_command()))
         assert "PLUGIN_DIR" in result["usage"]
-        assert "python3" in result["python"]
+        assert result["python"] == str(venv_python(home=tmp_path))
+        assert f'"{venv_python(home=tmp_path)}"' in result["usage"]
+
+    def test_win32_python_path_and_quoted_usage(self, tmp_path, monkeypatch):
+        """On Windows, python path uses Scripts\\python.exe and usage quotes it.
+
+        This is the regression test for the original bug: get_python_command
+        hardcoded the POSIX bin/python3 layout, so on native Windows it
+        returned a path that could never exist.
+        """
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            result = json.loads(_run(server.get_python_command()))
+
+        assert "Scripts" in result["python"]
+        assert result["python"].endswith("python.exe")
+        assert result["python"] == str(venv_python(home=tmp_path))
+        assert f'"{result["python"]}"' in result["usage"]
 
 
 # =============================================================================
@@ -7414,13 +7434,14 @@ class TestCheckVenvHealth:
                 return versions[pkg]
             raise importlib.metadata.PackageNotFoundError(pkg)
 
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "python3").touch()
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
              patch("importlib.metadata.version", side_effect=mock_version), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "ok"
         assert result["ok_count"] == 2
@@ -7432,13 +7453,14 @@ class TestCheckVenvHealth:
         req = tmp_path / "requirements.txt"
         req.write_text("requests==2.31.0\n")
 
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "python3").touch()
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
              patch("importlib.metadata.version", return_value="2.28.0"), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "stale"
         assert len(result["mismatches"]) == 1
@@ -7451,16 +7473,17 @@ class TestCheckVenvHealth:
         req = tmp_path / "requirements.txt"
         req.write_text("requests==2.31.0\n")
 
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "python3").touch()
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
 
         def mock_version(pkg):
             raise importlib.metadata.PackageNotFoundError(pkg)
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
              patch("importlib.metadata.version", side_effect=mock_version), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "stale"
         assert len(result["missing"]) == 1
@@ -7468,23 +7491,24 @@ class TestCheckVenvHealth:
 
     def test_no_venv_returns_no_venv(self, tmp_path):
         """Missing venv returns no_venv status."""
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music"
-        venv_dir.mkdir(parents=True)
-        # No venv/bin/python3
+        fake_home = tmp_path / "fakehome"
+        (fake_home / ".bitwize-music").mkdir(parents=True)
+        # No venv interpreter created under fake_home
 
-        with patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+        with patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "no_venv"
 
     def test_missing_requirements_returns_error(self, tmp_path):
         """Missing requirements.txt returns error status."""
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "python3").touch()
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
         # No requirements.txt in PLUGIN_ROOT
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "error"
 
@@ -7500,13 +7524,14 @@ class TestCheckVenvHealth:
                 return "1.9.0"  # mismatch
             raise importlib.metadata.PackageNotFoundError(pkg)  # ccc missing
 
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "python3").touch()
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
              patch("importlib.metadata.version", side_effect=mock_version), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "stale"
         assert result["ok_count"] == 1
@@ -7514,24 +7539,52 @@ class TestCheckVenvHealth:
         assert len(result["missing"]) == 1
 
     def test_fix_command_includes_plugin_root(self, tmp_path):
-        """Fix command references the correct requirements.txt path."""
+        """Fix command references the correct requirements.txt path and interpreter."""
         req = tmp_path / "requirements.txt"
         req.write_text("requests==2.31.0\n")
 
-        venv_dir = tmp_path / "fakehome" / ".bitwize-music" / "venv" / "bin"
-        venv_dir.mkdir(parents=True)
-        (venv_dir / "python3").touch()
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
 
         def mock_version(pkg):
             raise importlib.metadata.PackageNotFoundError(pkg)
 
         with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
              patch("importlib.metadata.version", side_effect=mock_version), \
-             patch.object(Path, "home", return_value=tmp_path / "fakehome"):
+             patch.object(Path, "home", return_value=fake_home):
             result = json.loads(_run(server.check_venv_health()))
         assert result["status"] == "stale"
-        assert str(tmp_path / "requirements.txt") in result["fix_command"]
-        assert "~/.bitwize-music/venv/bin/pip" in result["fix_command"]
+        assert str(req) in result["fix_command"]
+        assert f'"{fake_python}" -m pip install' in result["fix_command"]
+
+    def test_win32_fix_command_uses_interpreter_and_pip(self, tmp_path, monkeypatch):
+        """On Windows, fix_command uses Scripts\\python.exe with -m pip install.
+
+        Regression test for the original bug: check_venv_health hardcoded
+        the POSIX venv/bin/pip layout, which never exists on native Windows.
+        """
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        req = tmp_path / "requirements.txt"
+        req.write_text("requests==2.31.0\n")
+
+        fake_home = tmp_path / "fakehome"
+        fake_python = venv_python(home=fake_home)
+        fake_python.parent.mkdir(parents=True)
+        fake_python.touch()
+
+        def mock_version(pkg):
+            raise importlib.metadata.PackageNotFoundError(pkg)
+
+        with patch.object(_shared_mod, "PLUGIN_ROOT", tmp_path), \
+             patch("importlib.metadata.version", side_effect=mock_version), \
+             patch.object(Path, "home", return_value=fake_home):
+            result = json.loads(_run(server.check_venv_health()))
+        assert result["status"] == "stale"
+        assert "Scripts" in result["fix_command"]
+        assert result["fix_command"] == f'"{fake_python}" -m pip install -r {req}'
 
 
 # =============================================================================

--- a/tools/database/connection.py
+++ b/tools/database/connection.py
@@ -42,7 +42,7 @@ def get_db_config() -> dict[str, Any] | None:
         return None
 
     try:
-        with open(CONFIG_PATH) as f:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
     except Exception as e:
         logger.error("Cannot read config: %s", e)

--- a/tools/mastering/master_tracks.py
+++ b/tools/mastering/master_tracks.py
@@ -53,7 +53,7 @@ def _load_yaml_file(path: Path) -> dict[str, Any]:
         logger.debug("PyYAML not installed, cannot load %s", path)  # type: ignore[unreachable]
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     except (yaml.YAMLError, OSError) as e:
         logger.warning("Cannot read %s: %s", path, e)

--- a/tools/mixing/mix_tracks.py
+++ b/tools/mixing/mix_tracks.py
@@ -149,7 +149,7 @@ def _load_yaml_file(path: Path) -> dict[str, Any]:
         logger.debug("PyYAML not installed, cannot load %s", path)  # type: ignore[unreachable]
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             return yaml.safe_load(f) or {}
     except (yaml.YAMLError, OSError) as e:
         logger.warning("Cannot read %s: %s", path, e)

--- a/tools/promotion/generate_promo_video.py
+++ b/tools/promotion/generate_promo_video.py
@@ -186,14 +186,14 @@ def generate_waveform_video(
     # Write title and artist to temp files so ffmpeg reads them via textfile=
     # This avoids all escaping issues with drawtext's text= parameter,
     # preventing injection of ffmpeg filter directives through track titles.
-    title_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)  # noqa: SIM115
+    title_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')  # noqa: SIM115
     os.chmod(title_file.name, 0o600)
     title_file.write(title)
     title_file.close()
     title_file_path = title_file.name
     _temp_files_to_cleanup.append(title_file_path)
 
-    artist_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False)  # noqa: SIM115
+    artist_file = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')  # noqa: SIM115
     os.chmod(artist_file.name, 0o600)
     artist_file.write(artist_name)
     artist_file.close()
@@ -375,7 +375,7 @@ def generate_waveform_video(
 def get_title_from_markdown(track_md_path: Path) -> str | None:
     """Extract title from track markdown frontmatter."""
     try:
-        content = track_md_path.read_text()
+        content = track_md_path.read_text(encoding='utf-8')
         if content.startswith('---'):
             # Parse YAML frontmatter
             parts = content.split('---', 2)

--- a/tools/shared/config.py
+++ b/tools/shared/config.py
@@ -105,7 +105,7 @@ def load_config(
         return fallback
 
     try:
-        with open(CONFIG_PATH) as f:
+        with open(CONFIG_PATH, encoding='utf-8') as f:
             data = yaml.safe_load(f)
     except (yaml.YAMLError, OSError) as e:
         logger.error("Error reading config: %s", e)
@@ -189,7 +189,7 @@ def validate_overrides(overrides_dir: Path) -> list[dict[str, str]]:
             # Check content pattern
             if spec['must_contain'] is not None:
                 try:
-                    content = entry.read_text()
+                    content = entry.read_text(encoding='utf-8')
                     if not spec['must_contain'].search(content):
                         issues.append({
                             'file': entry.name,

--- a/tools/shared/venv.py
+++ b/tools/shared/venv.py
@@ -1,0 +1,17 @@
+"""Locate the user-level plugin venv (~/.bitwize-music/venv) cross-platform."""
+
+import sys
+from pathlib import Path
+
+
+def venv_dir(home: Path | None = None) -> Path:
+    """Return the plugin venv directory (~/.bitwize-music/venv)."""
+    return (home or Path.home()) / ".bitwize-music" / "venv"
+
+
+def venv_python(home: Path | None = None) -> Path:
+    """Return the venv's Python interpreter path (platform-specific)."""
+    d = venv_dir(home)
+    if sys.platform == "win32":
+        return d / "Scripts" / "python.exe"
+    return d / "bin" / "python3"

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -120,7 +120,7 @@ def _read_plugin_version(plugin_root: Path) -> str | None:
     if not plugin_json.exists():
         return None
     try:
-        with open(plugin_json) as f:
+        with open(plugin_json, encoding='utf-8') as f:
             data = json.load(f)
         version = data.get('version')
         return version if isinstance(version, str) else None
@@ -199,7 +199,7 @@ def read_config() -> dict[str, Any] | None:
     if not CONFIG_FILE.exists():
         return None
     try:
-        with open(CONFIG_FILE) as f:
+        with open(CONFIG_FILE, encoding='utf-8') as f:
             data = yaml.safe_load(f)
     except (yaml.YAMLError, OSError) as e:
         logger.error("Cannot read config: %s", e)
@@ -974,13 +974,13 @@ def write_state(state: dict[str, Any]) -> None:
     try:
         # Append mode: 'w' would truncate, which fails on Windows while
         # another process holds a byte-range lock on the file.
-        lock_fd = open(LOCK_FILE, 'a')  # noqa: SIM115
+        lock_fd = open(LOCK_FILE, 'a', encoding='utf-8')  # noqa: SIM115
         _acquire_lock_with_timeout(lock_fd)
 
         # Use tempfile for unpredictable filename in the same directory
         tmp_fd = tempfile.NamedTemporaryFile(  # noqa: SIM115
             mode='w', dir=CACHE_DIR, suffix='.tmp',
-            prefix='.state_', delete=False
+            prefix='.state_', delete=False, encoding='utf-8'
         )
         tmp_path = Path(tmp_fd.name)
         # Restrict temp file to owner-only access
@@ -1032,7 +1032,7 @@ def read_state() -> dict[str, Any] | None:
     if not STATE_FILE.exists():
         return None
     try:
-        with open(STATE_FILE) as f:
+        with open(STATE_FILE, encoding='utf-8') as f:
             data = json.load(f)
     except (json.JSONDecodeError, OSError) as e:
         return _quarantine_corrupt_state(f"Corrupted state file: {e}")

--- a/tools/validate_help_completeness.py
+++ b/tools/validate_help_completeness.py
@@ -54,7 +54,7 @@ def check_claude_md_ghosts(plugin_root: Path, skills: list[str]) -> list[str]:
     if not claude_file.exists():
         logger.error("CLAUDE.md not found!")
         return []
-    content = claude_file.read_text()
+    content = claude_file.read_text(encoding='utf-8')
     referenced = set(re.findall(r"/bitwize-music:([a-z0-9][a-z0-9-]*)", content))
     return sorted(referenced - set(skills))
 
@@ -66,7 +66,7 @@ def check_help_skill(plugin_root: Path, skills: list[str]) -> list[str]:
         logger.error("skills/help/SKILL.md not found!")
         return skills
 
-    help_content = help_file.read_text()
+    help_content = help_file.read_text(encoding='utf-8')
     missing = []
 
     # Skip the help skill itself


### PR DESCRIPTION
## Summary

PR 1 of 4 in the cross-platform CI hardening effort ([plan context](https://github.com/bitwize-music-studio/claude-ai-music-skills/pull/477): PR #477 added native-Windows MCP support; this series makes it real and CI-tested).

- **Cross-platform venv paths**: new stdlib-only `tools/shared/venv.py` (`venv_python()`/`venv_dir()`: `Scripts\python.exe` on win32, `bin/python3` elsewhere, resolved at call time). Fixes `get_python_command` (core.py) and `check_venv_health` (health.py), which hardcoded the POSIX layout and returned nonexistent interpreter paths on native Windows. All interpreter/requirements paths in user-facing strings are double-quoted (Windows homes contain spaces), pip hints use the portable `"<python>" -m pip` form, and venv-creation hints are platform-branched (`py -3` on win32). The MCP boot-path install hint in server.py is now shell-correct on both platforms (`$HOME` on POSIX, `%USERPROFILE%`/cmd on Windows).
- **Explicit UTF-8 text I/O**: `encoding="utf-8"` added to all 15 text-mode I/O sites in `tools/` and `servers/` (Windows locale is cp1252; repo content is em-dash-heavy). Enforced going forward by a scoped `ruff check tools/ servers/ --select PLW1514 --preview` gate in `make lint` and the CI Lint job (the rule is preview-only in ruff 0.15.x, so it runs as a dedicated invocation instead of enabling preview repo-wide).
- **Docs**: `reference/cross-platform/tool-compatibility-matrix.md` now states the decided support tier — native Windows = Core (best-effort): MCP server, state cache, non-audio workflow supported and CI-tested; audio externals (ffmpeg pipeline, AnthemScore, MuseScore) remain WSL2-recommended. Python minimum corrected 3.8 → 3.10+.

## Tests

- New `tests/unit/shared/test_venv.py` (win32/linux/darwin parametrized) and win32-simulation tests for both handlers that would have caught the original bug on Linux CI.
- `TestGetPythonCommand`/`TestCheckVenvHealth` rebuilt via the helper, so they pass unmodified on all three OSes.
- Full local verification: pytest 4275 passed (coverage 88.13%, gate 75%), ruff + scoped PLW1514 gate + bandit + mypy clean.

## Follow-ups (later PRs in this series)

- PR 2: run the full pytest suite on windows/macos runners (3-OS matrix) + test-suite portability fixes
- PR 3: richer cross-OS MCP e2e scenario
- PR 4: nightly deep-test workflow
- Post-series: drop `--preview` from the PLW1514 gate when ruff stabilizes the rule; sweep the remaining POSIX-only `venv/bin` command templates in skill/doc markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)