### PR TITLE
ci: end-to-end state-workflow scenario in the 3-OS MCP boot test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
       env:
         CLAUDE_PLUGIN_ROOT: ${{ github.workspace }}
       run: |
-        python tests/e2e/mcp_boot_check.py --timeout 120 --call-tool health_check -- \
+        python tests/e2e/mcp_boot_check.py --timeout 120 --call-tool health_check --scenario state-workflow -- \
           "$GITHUB_WORKSPACE/servers/bitwize-music-server/mcp-launch"
 
     - name: Boot check via mcp-launch.cmd (Windows)
@@ -312,7 +312,7 @@ jobs:
       env:
         CLAUDE_PLUGIN_ROOT: ${{ github.workspace }}
       run: |
-        python tests/e2e/mcp_boot_check.py --timeout 180 --call-tool health_check -- \
+        python tests/e2e/mcp_boot_check.py --timeout 240 --call-tool health_check --scenario state-workflow -- \
           "$GITHUB_WORKSPACE/servers/bitwize-music-server/mcp-launch.cmd"
 
   lint:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,17 @@ def _isolate_state_cache(monkeypatch, tmp_path):
     fixture makes every test safe by default; tests that need a specific cache
     path (e.g. test_indexer.py) can still monkeypatch.setattr(indexer, ...)
     themselves afterward — that simply overrides this for that test.
+
+    The MCP server module needs the same treatment separately: server.py does
+    ``from tools.state.indexer import STATE_FILE, CONFIG_FILE`` — a by-VALUE
+    copy — and StateCache._is_stale() / _update_mtimes() stat those module
+    globals, so patching the indexer alone still leaves server-module code
+    statting the developer's real ~/.bitwize-music files (read-only, but a
+    concurrent session touching them mid-test can spuriously flip _is_stale).
+    Test files load server.py under assorted sys.modules names via
+    importlib.util.spec_from_file_location ("state_server",
+    "state_server_features", "state_server_streaming", ...), so match loaded
+    modules by __file__ rather than by name and patch every copy.
     """
     import tools.state.indexer as indexer_mod
 
@@ -53,6 +64,20 @@ def _isolate_state_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(indexer_mod, "CACHE_DIR", cache_dir)
     monkeypatch.setattr(indexer_mod, "STATE_FILE", cache_dir / "state.json")
     monkeypatch.setattr(indexer_mod, "LOCK_FILE", cache_dir / "state.lock")
+
+    server_py = str(
+        (PROJECT_ROOT / "servers" / "bitwize-music-server" / "server.py").resolve()
+    )
+    for module in list(sys.modules.values()):
+        module_file = getattr(module, "__file__", None)
+        # Cheap basename short-circuit before the resolve() so the scan stays
+        # a string comparison for the thousands of non-matching modules.
+        if not module_file or not module_file.endswith("server.py"):
+            continue
+        if str(Path(module_file).resolve()) != server_py:
+            continue
+        monkeypatch.setattr(module, "STATE_FILE", cache_dir / "state.json")
+        monkeypatch.setattr(module, "CONFIG_FILE", cache_dir / "config.yaml")
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,33 @@ from tests.fixtures.audio import (
 from tools.state.parsers import parse_frontmatter
 
 
+@pytest.fixture(autouse=True)
+def _isolate_state_cache(monkeypatch, tmp_path):
+    """Redirect the state-cache indexer away from the real ~/.bitwize-music cache.
+
+    Many flows funnel through ``tools.state.indexer.write_state``/``read_state``
+    (master_album's status_update stage, rename, streaming URL updates, album
+    status transitions, cache rebuilds, ...). Several call sites import
+    ``write_state`` lazily inside the calling function
+    (``from tools.state.indexer import write_state``), so patching a *different*
+    module's attribute (e.g. ``server.write_state``) does not intercept them —
+    only patching the globals ``write_state`` itself reads
+    (``tools.state.indexer.CACHE_DIR`` / ``STATE_FILE`` / ``LOCK_FILE``) works
+    regardless of how/where the function was imported. A test file that forgot
+    (or incorrectly targeted) this patch was silently clobbering a developer's
+    real state.json with fixture data on every full-suite run. This autouse
+    fixture makes every test safe by default; tests that need a specific cache
+    path (e.g. test_indexer.py) can still monkeypatch.setattr(indexer, ...)
+    themselves afterward — that simply overrides this for that test.
+    """
+    import tools.state.indexer as indexer_mod
+
+    cache_dir = tmp_path / "_isolated_state_cache"
+    monkeypatch.setattr(indexer_mod, "CACHE_DIR", cache_dir)
+    monkeypatch.setattr(indexer_mod, "STATE_FILE", cache_dir / "state.json")
+    monkeypatch.setattr(indexer_mod, "LOCK_FILE", cache_dir / "state.lock")
+
+
 @pytest.fixture(scope="session")
 def project_root() -> Path:
     """Path to the repository root."""

--- a/tests/e2e/mcp_boot_check.py
+++ b/tests/e2e/mcp_boot_check.py
@@ -745,7 +745,15 @@ def main(argv: list[str]) -> int:
         # not block, so reap briefly (no-op if it already exited cleanly).
         if server is not None:
             server.kill_tree()
-            server.wait(timeout=5.0)
+            if server.wait(timeout=5.0) is None:
+                # The one theoretically-unsafe path: an unreaped server could
+                # rewrite state.json after the restore. Make it diagnosable.
+                print(
+                    "[WARN] scenario: server still alive after kill; "
+                    "restoring anyway",
+                    file=sys.stderr,
+                    flush=True,
+                )
         if env is not None:
             env.teardown()
 

--- a/tests/e2e/mcp_boot_check.py
+++ b/tests/e2e/mcp_boot_check.py
@@ -6,6 +6,15 @@ JSON-RPC handshake over its pipes: ``initialize`` -> ``notifications/initialized
 -> ``tools/list`` -> (optional) ``tools/call health_check``. Then closes stdin
 and asserts the server shuts down cleanly on EOF.
 
+With ``--scenario state-workflow`` it additionally proves the core state
+workflow end-to-end: it seeds a temp content tree (1 album / 2 tracks, one
+track title carrying a non-ASCII em dash for UTF-8 regression coverage),
+points ``~/.bitwize-music/config.yaml`` at it, then drives ``rebuild_state``
+-> ``list_albums`` -> ``find_album`` -> ``get_config`` -> ``list_tracks``
+and asserts the real payloads. Any pre-existing ``config.yaml`` and
+``cache/state.json`` are renamed aside first and restored in a ``finally``
+no matter how the run ends, so the scenario is safe on a developer machine.
+
 This exists because the unit suite imports ``server.py`` in-process with a mocked
 FastMCP whose ``run()`` is a no-op, so it can never catch process-level startup
 failures like issue #476 (``import fcntl`` crashing the server on Windows). This
@@ -28,6 +37,10 @@ Options:
     --expect-tool NAME     Tool that must appear in tools/list (repeatable;
                            default: health_check).
     --call-tool NAME       Call this tool with {} arguments after tools/list.
+    --scenario NAME        Extra end-to-end scenario after the handshake.
+                           Currently: state-workflow (seed config + content
+                           tree, rebuild state, query albums/tracks/config,
+                           assert a UTF-8 title round-trips).
 
 Exit codes:
     0  server booted, responded, and shut down cleanly
@@ -37,7 +50,7 @@ Exit codes:
 
 Local verification (Linux dev box) — drive the same launcher .mcp.json uses:
     CLAUDE_PLUGIN_ROOT="$PWD" python3 tests/e2e/mcp_boot_check.py \\
-        --call-tool health_check -- \\
+        --call-tool health_check --scenario state-workflow -- \\
         "$PWD/servers/bitwize-music-server/mcp-launch"
 """
 
@@ -48,12 +61,15 @@ import contextlib
 import json
 import os
 import queue
+import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections import deque
+from pathlib import Path
 from typing import Any
 
 SERVER_NAME = "bitwize-music-mcp"
@@ -66,6 +82,22 @@ EXIT_OK = 0
 EXIT_PROTOCOL = 1
 EXIT_TIMEOUT = 2
 EXIT_SPAWN = 3
+
+# --scenario state-workflow constants. The seeded markdown mirrors the shapes
+# proven by tests/unit/state/test_indexer.py (_make_album_tree /
+# _make_track_content) — README frontmatter + `| **Status** |` row, and the
+# `## Track Details` table in track files.
+BACKUP_SUFFIX = ".boot-check-bak"
+SCENARIO_ARTIST = "ci-artist"
+SCENARIO_GENRE = "electronic"
+SCENARIO_ALBUM = "ci-test-album"
+SCENARIO_ALBUM_TITLE = "Ci Test Album"
+SCENARIO_TRACK1_SLUG = "01-first-track"
+# The em dash is deliberate: end-to-end UTF-8 round-trip coverage (file on
+# disk -> parser -> state cache -> JSON payload), especially on Windows.
+SCENARIO_TRACK1_TITLE = "First Track — Reprise"
+SCENARIO_TRACK2_SLUG = "02-second-track"
+SCENARIO_TRACK2_TITLE = "Second Track"
 
 
 class BootError(Exception):
@@ -242,6 +274,71 @@ def _ok(phase: str, detail: str) -> None:
     print(f"[OK] {phase}: {detail}", flush=True)
 
 
+def call_tool_json(
+    server: ServerProc,
+    req_id: int,
+    name: str,
+    arguments: dict[str, Any],
+    deadline: float,
+    phase: str = "tools/call",
+) -> dict[str, Any]:
+    """Call a tool and return its parsed JSON payload.
+
+    MCP tool results carry the handler's JSON string as text content
+    (``result["content"][0]["text"]``); a tool-level failure surfaces as
+    ``result.isError == True`` (still a JSON-RPC success). Raises BootError
+    on isError, a malformed content array, or a non-JSON payload.
+    """
+    server.send(
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        }
+    )
+    result = server.recv_result(req_id, deadline)
+    if result.get("isError") is True:
+        raise BootError(
+            phase,
+            f"{name} returned isError=true: {result.get('content')!r}",
+            EXIT_PROTOCOL,
+        )
+    content = result.get("content")
+    if not isinstance(content, list) or not content:
+        raise BootError(
+            phase,
+            f"{name}: expected a non-empty content array, got {content!r}",
+            EXIT_PROTOCOL,
+        )
+    first = content[0]
+    if (
+        not isinstance(first, dict)
+        or first.get("type") != "text"
+        or not isinstance(first.get("text"), str)
+    ):
+        raise BootError(
+            phase,
+            f"{name}: expected a text content item, got {first!r}",
+            EXIT_PROTOCOL,
+        )
+    try:
+        payload = json.loads(first["text"])
+    except json.JSONDecodeError as exc:
+        raise BootError(
+            phase,
+            f"{name}: payload is not JSON ({exc}): {first['text'][:200]!r}",
+            EXIT_PROTOCOL,
+        ) from exc
+    if not isinstance(payload, dict):
+        raise BootError(
+            phase,
+            f"{name}: payload is not a JSON object: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    return payload
+
+
 def run_handshake(
     server: ServerProc,
     deadline: float,
@@ -304,26 +401,259 @@ def run_handshake(
 
     # 4. optional tools/call
     if call_tool is not None:
-        server.send(
-            {
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "tools/call",
-                "params": {"name": call_tool, "arguments": {}},
-            }
-        )
-        call_result = server.recv_result(3, deadline)
-        # A tool-level failure surfaces as result.isError == True (JSON-RPC
-        # success). health_check legitimately returns overall "warn" in CI
-        # (no plugin cache), so assert only that the call did not error out.
-        if call_result.get("isError") is True:
-            content = call_result.get("content")
-            raise BootError(
-                "tools/call",
-                f"{call_tool} returned isError=true: {content!r}",
-                EXIT_PROTOCOL,
-            )
+        # health_check legitimately returns overall "warn" in CI (no plugin
+        # cache), so assert only that the call did not error out and that the
+        # payload is well-formed JSON.
+        call_tool_json(server, 3, call_tool, {}, deadline)
         _ok("tools/call", f"{call_tool} responded without error")
+
+
+def _yaml_sq(value: str) -> str:
+    """Quote a string as a single-quoted YAML scalar.
+
+    The only escape in single-quoted YAML is doubling the quote itself;
+    Windows backslashes pass through literally, so temp paths are safe.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _album_readme() -> str:
+    """README.md matching test_indexer.py::_make_album_tree's default shape."""
+    return f"""---
+title: "{SCENARIO_ALBUM_TITLE}"
+genres: ["{SCENARIO_GENRE}"]
+explicit: false
+---
+
+# {SCENARIO_ALBUM_TITLE}
+
+## Album Details
+
+| Attribute | Detail |
+|-----------|--------|
+| **Status** | Concept |
+| **Tracks** | 2 |
+"""
+
+
+def _track_md(title: str) -> str:
+    """Track markdown matching test_indexer.py::_make_track_content's shape."""
+    return f"""# {title}
+
+## Track Details
+
+| Attribute | Detail |
+|-----------|--------|
+| **Title** | {title} |
+| **Status** | Not Started |
+| **Suno Link** | — |
+| **Explicit** | No |
+| **Sources Verified** | N/A |
+"""
+
+
+class StateWorkflowEnv:
+    """Isolated home state for ``--scenario state-workflow``.
+
+    Renames any real ``~/.bitwize-music/config.yaml`` and
+    ``~/.bitwize-music/cache/state.json`` aside (``*.boot-check-bak``), seeds
+    a temp content tree plus a config pointing at it, and puts everything
+    back in ``teardown()`` — which main() runs in a ``finally`` after the
+    server is dead, so a crash anywhere still restores the user's files.
+    ``Path.home()`` is used on purpose: on Windows it follows USERPROFILE,
+    agreeing byte-for-byte with the server's own config discovery.
+    """
+
+    def __init__(self) -> None:
+        base = Path.home() / ".bitwize-music"
+        self._config_path = base / "config.yaml"
+        self._state_path = base / "cache" / "state.json"
+        # (target, backup-or-None) per file whose backup step completed;
+        # teardown only ever touches processed targets, so a failure halfway
+        # through setup can never delete a file that was not backed up.
+        self._processed: list[tuple[Path, Path | None]] = []
+        self.temp_root: Path | None = None
+        self.content_root: Path | None = None
+
+    def setup(self) -> None:
+        for target in (self._config_path, self._state_path):
+            backup = target.with_name(target.name + BACKUP_SUFFIX)
+            if backup.exists():
+                raise BootError(
+                    "scenario",
+                    f"stale backup {backup} exists (a previous run crashed "
+                    f"mid-restore?) — restore or remove it manually, then retry",
+                    EXIT_PROTOCOL,
+                )
+            if target.exists():
+                target.rename(backup)
+                self._processed.append((target, backup))
+                _ok("scenario", f"backed up {target} -> {backup.name}")
+            else:
+                self._processed.append((target, None))
+
+        self.temp_root = Path(tempfile.mkdtemp(prefix="bitwize-boot-check-"))
+        content_root = self.temp_root / "content"
+        audio_root = self.temp_root / "audio"
+        documents_root = self.temp_root / "documents"
+        tracks_dir = (
+            content_root / "artists" / SCENARIO_ARTIST / "albums"
+            / SCENARIO_GENRE / SCENARIO_ALBUM / "tracks"
+        )
+        tracks_dir.mkdir(parents=True)
+        audio_root.mkdir()
+        documents_root.mkdir()
+        album_dir = tracks_dir.parent
+        (album_dir / "README.md").write_text(_album_readme(), encoding="utf-8")
+        (tracks_dir / f"{SCENARIO_TRACK1_SLUG}.md").write_text(
+            _track_md(SCENARIO_TRACK1_TITLE), encoding="utf-8"
+        )
+        (tracks_dir / f"{SCENARIO_TRACK2_SLUG}.md").write_text(
+            _track_md(SCENARIO_TRACK2_TITLE), encoding="utf-8"
+        )
+        # Resolve once, after creation, so the get_config comparison uses the
+        # same symlink-free form the server computes (macOS /var -> /private/var).
+        self.content_root = content_root.resolve()
+        _ok("scenario", f"seeded temp content tree at {self.content_root}")
+
+        self._config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_text = (
+            "# Temporary config written by tests/e2e/mcp_boot_check.py"
+            " --scenario state-workflow.\n"
+            f"# If this file survived a run, restore config.yaml{BACKUP_SUFFIX}"
+            " over it.\n"
+            "artist:\n"
+            f"  name: {_yaml_sq(SCENARIO_ARTIST)}\n"
+            "paths:\n"
+            f"  content_root: {_yaml_sq(str(self.content_root))}\n"
+            f"  audio_root: {_yaml_sq(str(audio_root.resolve()))}\n"
+            f"  documents_root: {_yaml_sq(str(documents_root.resolve()))}\n"
+        )
+        self._config_path.write_text(config_text, encoding="utf-8")
+        _ok("scenario", f"wrote scenario config -> {self._config_path}")
+
+    def teardown(self) -> None:
+        """Restore the user's real files; best-effort but loud on failure."""
+        for target, backup in reversed(self._processed):
+            try:
+                if target.exists():
+                    target.unlink()
+                if backup is not None:
+                    backup.rename(target)
+                    _ok("scenario", f"restored {target} from {backup.name}")
+            except OSError as exc:
+                print(
+                    f"[WARN] scenario: could not restore {target}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        self._processed.clear()
+        if self.temp_root is not None:
+            shutil.rmtree(self.temp_root, ignore_errors=True)
+            self.temp_root = None
+
+
+def run_state_workflow(server: ServerProc, deadline: float, env: StateWorkflowEnv) -> None:
+    """Drive config -> rebuild_state -> queries -> UTF-8 round-trip."""
+    # 1. rebuild_state must index exactly the seeded tree: 1 album / 2 tracks.
+    payload = call_tool_json(server, 4, "rebuild_state", {}, deadline, phase="scenario")
+    if payload.get("success") is not True:
+        raise BootError(
+            "scenario",
+            f"rebuild_state did not report success: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    if payload.get("albums") != 1 or payload.get("tracks") != 2:
+        raise BootError(
+            "scenario",
+            f"rebuild_state indexed albums={payload.get('albums')!r} "
+            f"tracks={payload.get('tracks')!r}, expected 1 album / 2 tracks "
+            f"from the seeded tree: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", "rebuild_state indexed 1 album / 2 tracks from the seeded tree")
+
+    # 2. list_albums must show exactly the seeded album.
+    payload = call_tool_json(server, 5, "list_albums", {}, deadline, phase="scenario")
+    albums = payload.get("albums")
+    slugs = (
+        [a.get("slug") for a in albums if isinstance(a, dict)]
+        if isinstance(albums, list)
+        else []
+    )
+    if slugs != [SCENARIO_ALBUM]:
+        raise BootError(
+            "scenario",
+            f"list_albums returned slugs {slugs!r}, expected [{SCENARIO_ALBUM!r}]",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", f"list_albums shows {SCENARIO_ALBUM}")
+
+    # 3. find_album fuzzy match: spaces normalize to the hyphenated slug.
+    payload = call_tool_json(
+        server, 6, "find_album", {"name": "ci test album"}, deadline, phase="scenario"
+    )
+    if payload.get("found") is not True or payload.get("slug") != SCENARIO_ALBUM:
+        raise BootError(
+            "scenario",
+            f"find_album('ci test album') did not resolve to "
+            f"{SCENARIO_ALBUM!r}: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", f"find_album resolved 'ci test album' -> {SCENARIO_ALBUM}")
+
+    # 4. get_config round-trips artist name and content_root. Compare paths
+    # via pathlib (not raw strings) so Windows separator/case differences
+    # cannot cause a false failure.
+    payload = call_tool_json(server, 7, "get_config", {}, deadline, phase="scenario")
+    config = payload.get("config")
+    if not isinstance(config, dict):
+        raise BootError(
+            "scenario", f"get_config returned no config object: {payload!r}", EXIT_PROTOCOL
+        )
+    if config.get("artist_name") != SCENARIO_ARTIST:
+        raise BootError(
+            "scenario",
+            f"get_config artist_name={config.get('artist_name')!r}, "
+            f"expected {SCENARIO_ARTIST!r}",
+            EXIT_PROTOCOL,
+        )
+    got_root = config.get("content_root")
+    assert env.content_root is not None  # set by setup()
+    if not isinstance(got_root, str) or Path(got_root) != env.content_root:
+        raise BootError(
+            "scenario",
+            f"get_config content_root={got_root!r} != seeded {env.content_root}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", "get_config round-trips artist_name and content_root")
+
+    # 5. UTF-8 round-trip: the em-dash title must come back byte-identical.
+    payload = call_tool_json(
+        server, 8, "list_tracks", {"album_slug": SCENARIO_ALBUM}, deadline, phase="scenario"
+    )
+    tracks = payload.get("tracks")
+    titles = (
+        {t.get("slug"): t.get("title") for t in tracks if isinstance(t, dict)}
+        if isinstance(tracks, list)
+        else {}
+    )
+    got_title = titles.get(SCENARIO_TRACK1_SLUG)
+    if got_title != SCENARIO_TRACK1_TITLE:
+        raise BootError(
+            "scenario",
+            f"UTF-8 title did not round-trip: got {got_title!a}, "
+            f"expected {SCENARIO_TRACK1_TITLE!a}",
+            EXIT_PROTOCOL,
+        )
+    if titles.get(SCENARIO_TRACK2_SLUG) != SCENARIO_TRACK2_TITLE:
+        raise BootError(
+            "scenario",
+            f"list_tracks track titles wrong: {titles!r}",
+            EXIT_PROTOCOL,
+        )
+    # !a (ascii) keeps this line safe on non-UTF-8 Windows consoles.
+    _ok("scenario", f"UTF-8 track title round-tripped intact ({got_title!a})")
 
 
 def shutdown(server: ServerProc, grace: float) -> None:
@@ -354,6 +684,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--shutdown-grace", type=float, default=20.0)
     parser.add_argument("--expect-tool", action="append", dest="expect_tools", default=None)
     parser.add_argument("--call-tool", default=None)
+    parser.add_argument("--scenario", choices=["state-workflow"], default=None)
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 
@@ -370,13 +701,26 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
+    # Diagnostics may embed non-ASCII (the scenario's em-dash title); never
+    # let a non-UTF-8 Windows console turn a report into a UnicodeEncodeError.
+    for stream in (sys.stdout, sys.stderr):
+        with contextlib.suppress(Exception):
+            stream.reconfigure(errors="backslashreplace")  # type: ignore[union-attr]
     deadline = time.monotonic() + args.timeout
 
+    env: StateWorkflowEnv | None = None
     server: ServerProc | None = None
     try:
+        if args.scenario == "state-workflow":
+            # Back up the real config/state and seed the temp tree BEFORE
+            # spawning: the server reads config.yaml at tool-call time.
+            env = StateWorkflowEnv()
+            env.setup()
         server = ServerProc(args.cmd)
         _ok("spawn", f"launched pid {server.proc.pid}: {' '.join(args.cmd)}")
         run_handshake(server, deadline, args.expect_tools, args.call_tool)
+        if env is not None:
+            run_state_workflow(server, deadline, env)
         shutdown(server, args.shutdown_grace)
         print("[OK] MCP server booted, responded, and shut down cleanly", flush=True)
         return EXIT_OK
@@ -396,8 +740,14 @@ def main(argv: list[str]) -> int:
                 print(tail, file=sys.stderr, flush=True)
         return err.code
     finally:
+        # Order matters: the server must be dead before the backups go back,
+        # so it cannot rewrite state.json after the restore. kill_tree does
+        # not block, so reap briefly (no-op if it already exited cleanly).
         if server is not None:
             server.kill_tree()
+            server.wait(timeout=5.0)
+        if env is not None:
+            env.teardown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

PR 3 of 4 in the cross-platform CI hardening effort (follows #479, #480). The `mcp-boot` matrix job now proves the core state workflow end-to-end on ubuntu, windows, and macos — not just a JSON-RPC handshake.

### e2e state-workflow scenario (`tests/e2e/mcp_boot_check.py --scenario state-workflow`)
- Seeds a temp album tree (README + 2 tracks, one title with an em dash), writes a scenario `config.yaml`, boots the real server through the real launcher, then drives `rebuild_state` (asserts exactly 1 album / 2 tracks), `list_albums`, fuzzy `find_album`, `get_config` (artist + content_root round-trip via pathlib comparison), and `list_tracks` (UTF-8 title round-trips intact — cp1252 regression guard).
- Safe on developer machines: the runner backs up any real `~/.bitwize-music/config.yaml` + `cache/state.json` first and restores them in a finally that only runs after the server is provably dead — verified byte-identical (sha256) across positive, negative, and crash paths. A stale-backup guard refuses to run over a previous crash's backups.
- Negative path verified: a corrupted seed exits 1 with a legible `[FAIL] scenario:` diagnosis.
- Windows mcp-boot timeout bumped 180 → 240 for the extra round-trips.

### Test-isolation bug found and fixed along the way
Several test flows (master_album Stage 7, rename, streaming, status, core) call `write_state` with the state location unpatched — **every full-suite run overwrote the developer's real `~/.bitwize-music/cache/state.json`** with fixture data. Some tests had fake protection (`patch.object(server, "write_state")` patches the wrong module — the handlers import lazily). Fixed with an autouse conftest fixture redirecting `tools.state.indexer.{CACHE_DIR,STATE_FILE,LOCK_FILE}` — plus every loaded server-module copy of `STATE_FILE`/`CONFIG_FILE` (imported by value) — to `tmp_path` for every test, present and future. Reproduce/prevent both proven by checksum.

### Verification
- Local: positive scenario exit 0 (config checksums byte-identical before/after), negative exit 1, full suite 4,282 passed, ruff both gates + mypy (bare/win32/darwin) clean.
- CI on all 3 OSes is the merge gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)