### PR TITLE
docs: make core-workflow venv commands Windows-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ At the beginning of a fresh session:
 5. _(Removed — skills use tier aliases (`opus`/`sonnet`/`haiku`) that auto-track the frontier model, and the test suite (`/bitwize-music:test`) enforces model/effort hygiene, so no action is needed on new releases.)_
 6. **Report from MCP state**:
    - Health warnings (from step 1.5 — omit if ok):
-     - Venv stale: "⚠️ Venv has N outdated package(s): pkg1 (1.0.0 → 1.1.0), ... Run: `<venv check's fix field from health_check>`" (already the correct pip path for the user's OS — `venv/bin/pip` on macOS/Linux/WSL, `venv\Scripts\pip.exe` on Windows)
+     - Venv stale: "⚠️ Venv has N outdated package(s): pkg1 (1.0.0 → 1.1.0), ... Run: `<venv check's fix field from health_check>`" (already the correct command for the user's OS)
      - Skills stale: "⚠️ N skill(s) missing from Claude Code, N ghost — run: `claude plugin update bitwize-music`"
    - Album ideas (from `get_ideas`)
    - In-progress albums (status: "In Progress", "Research Complete", "Complete")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ At the beginning of a fresh session:
 
 1. **Verify setup** — Quick dependency check:
    ```bash
-   ~/.bitwize-music/venv/bin/python3 -c "import mcp" 2>&1 >/dev/null && echo "✅ MCP ready" || echo "❌ MCP missing"
+   ~/.bitwize-music/venv/bin/python3 -c "import mcp" 2>&1 >/dev/null && echo "✅ MCP ready" || echo "❌ MCP missing"        # macOS/Linux/WSL
+   ~/.bitwize-music/venv/Scripts/python.exe -c "import mcp" 2>&1 >/dev/null && echo "✅ MCP ready" || echo "❌ MCP missing" # Windows (Git Bash; cmd/PowerShell: %USERPROFILE%\.bitwize-music\venv\Scripts\python.exe)
    ```
    - If MCP missing → **Stop immediately** and suggest: `/bitwize-music:setup mcp`
    - If config missing → suggest: `/bitwize-music:configure`
@@ -104,7 +105,7 @@ At the beginning of a fresh session:
 5. _(Removed — skills use tier aliases (`opus`/`sonnet`/`haiku`) that auto-track the frontier model, and the test suite (`/bitwize-music:test`) enforces model/effort hygiene, so no action is needed on new releases.)_
 6. **Report from MCP state**:
    - Health warnings (from step 1.5 — omit if ok):
-     - Venv stale: "⚠️ Venv has N outdated package(s): pkg1 (1.0.0 → 1.1.0), ... Run: `~/.bitwize-music/venv/bin/pip install -r .../requirements.txt`"
+     - Venv stale: "⚠️ Venv has N outdated package(s): pkg1 (1.0.0 → 1.1.0), ... Run: `<venv check's fix field from health_check>`" (already the correct pip path for the user's OS — `venv/bin/pip` on macOS/Linux/WSL, `venv\Scripts\pip.exe` on Windows)
      - Skills stale: "⚠️ N skill(s) missing from Claude Code, N ghost — run: `claude plugin update bitwize-music`"
    - Album ideas (from `get_ideas`)
    - In-progress albums (status: "In Progress", "Research Complete", "Complete")

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,8 +43,11 @@ Or use the interactive config tool:
 
 **Solution:**
 ```bash
-python3 -m venv ~/.bitwize-music/venv
-~/.bitwize-music/venv/bin/pip install -r requirements.txt
+python3 -m venv ~/.bitwize-music/venv                              # macOS/Linux/WSL
+~/.bitwize-music/venv/bin/pip install -r requirements.txt          # macOS/Linux/WSL
+
+py -3 -m venv ~/.bitwize-music/venv                                 # Windows
+~/.bitwize-music/venv/Scripts/pip.exe install -r requirements.txt   # Windows
 ```
 
 ## Playwright Setup (Document Hunter)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,8 +46,8 @@ Or use the interactive config tool:
 python3 -m venv ~/.bitwize-music/venv                              # macOS/Linux/WSL
 ~/.bitwize-music/venv/bin/pip install -r requirements.txt          # macOS/Linux/WSL
 
-py -3 -m venv ~/.bitwize-music/venv                                 # Windows
-~/.bitwize-music/venv/Scripts/pip.exe install -r requirements.txt   # Windows
+py -3 -m venv ~/.bitwize-music/venv                                          # Windows
+~/.bitwize-music/venv/Scripts/python.exe -m pip install -r requirements.txt  # Windows
 ```
 
 ## Playwright Setup (Document Hunter)

--- a/reference/workflows/error-recovery.md
+++ b/reference/workflows/error-recovery.md
@@ -316,7 +316,7 @@ This document covers edge cases and recovery procedures for common workflow issu
 **Prevention**: Install and upgrade via the marketplace (`claude plugin update bitwize-music`) rather than editing the cached plugin. Keep the venv in sync (session-start venv check / `check_venv_health`).
 
 **Recovery Steps**:
-1. If MCP tools are entirely unavailable, the server didn't start — run `/bitwize-music:setup` (or `/bitwize-music:setup mcp`) to detect the Python environment and reinstall dependencies. Quick check: `~/.bitwize-music/venv/bin/python3 -c "import mcp"`
+1. If MCP tools are entirely unavailable, the server didn't start — run `/bitwize-music:setup` (or `/bitwize-music:setup mcp`) to detect the Python environment and reinstall dependencies. Quick check: `~/.bitwize-music/venv/bin/python3 -c "import mcp"` (macOS/Linux/WSL) or `~/.bitwize-music/venv/Scripts/python.exe -c "import mcp"` (Windows; cmd/PowerShell: `%USERPROFILE%\.bitwize-music\venv\Scripts\python.exe`)
 2. If the server runs but skills are missing/ghost, `health_check` will say so — run `claude plugin update bitwize-music` to refresh the plugin cache, then restart the session
 3. If `health_check` reports skills `no_cache`, the plugin isn't installed via the marketplace — reinstall it (or use `--plugin-dir` for local development)
 4. If the venv is stale or missing (`check_venv_health` → `stale`/`no_venv`), run the reported `pip install -r requirements.txt` fix, or `/bitwize-music:setup` to rebuild the venv

--- a/servers/bitwize-music-server/README.md
+++ b/servers/bitwize-music-server/README.md
@@ -18,6 +18,7 @@ The server is registered as `bitwize-music-mcp` in Claude Code. Future MCP tools
 
 **Recommended: Virtual environment (all systems)**
 
+macOS/Linux/WSL:
 ```bash
 # Create shared venv for all plugin tools
 python3 -m venv ~/.bitwize-music/venv
@@ -32,7 +33,20 @@ python3 -m venv ~/.bitwize-music/venv
 ~/.bitwize-music/venv/bin/playwright install chromium
 ```
 
-The MCP server automatically detects and uses `~/.bitwize-music/venv` if it exists. No manual configuration needed.
+Windows (native):
+```bat
+:: Create shared venv for all plugin tools
+py -3 -m venv "%USERPROFILE%\.bitwize-music\venv"
+
+:: Install MCP server (required)
+"%USERPROFILE%\.bitwize-music\venv\Scripts\python.exe" -m pip install -r requirements.txt
+
+:: Optional: Install additional tools
+"%USERPROFILE%\.bitwize-music\venv\Scripts\python.exe" -m pip install playwright
+"%USERPROFILE%\.bitwize-music\venv\Scripts\playwright.exe" install chromium
+```
+
+The MCP server automatically detects and uses the platform venv (`~/.bitwize-music/venv` on macOS/Linux/WSL, `%USERPROFILE%\.bitwize-music\venv` on native Windows) if it exists. No manual configuration needed.
 
 **Alternative: User install (externally-managed Python)**
 

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -40,7 +40,7 @@ HEALTH CHECK: WARN
 VENV [warn]
   N outdated: pkg1 (1.0 -> 1.1), pkg2 (2.0 -> 2.1)
   N missing: pkg3, pkg4
-  Fix: ~/.bitwize-music/venv/bin/pip install -r .../requirements.txt
+  Fix: <the venv check's `fix` field from the health_check result> (already the correct pip path for the user's OS)
 
 SKILLS [warn]
   N missing from Claude Code: skill-a, skill-b

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -40,7 +40,7 @@ HEALTH CHECK: WARN
 VENV [warn]
   N outdated: pkg1 (1.0 -> 1.1), pkg2 (2.0 -> 2.1)
   N missing: pkg3, pkg4
-  Fix: <the venv check's `fix` field from the health_check result> (already the correct pip path for the user's OS)
+  Fix: <the venv check's `fix` field from the health_check result> (already the correct command for the user's OS)
 
 SKILLS [warn]
   N missing from Claude Code: skill-a, skill-b

--- a/skills/session-start/SKILL.md
+++ b/skills/session-start/SKILL.md
@@ -30,7 +30,8 @@ You perform the 8-step session startup procedure that initializes a working sess
 Quick dependency check:
 
 ```bash
-~/.bitwize-music/venv/bin/python3 -c "import mcp" 2>&1 >/dev/null && echo "MCP ready" || echo "MCP missing"
+~/.bitwize-music/venv/bin/python3 -c "import mcp" 2>&1 >/dev/null && echo "MCP ready" || echo "MCP missing"        # macOS/Linux/WSL
+~/.bitwize-music/venv/Scripts/python.exe -c "import mcp" 2>&1 >/dev/null && echo "MCP ready" || echo "MCP missing" # Windows (Git Bash; cmd/PowerShell: %USERPROFILE%\.bitwize-music\venv\Scripts\python.exe)
 ```
 
 - If MCP missing: **Stop immediately** and suggest: `/bitwize-music:setup mcp`

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -109,8 +109,8 @@ python3 -m venv ~/.bitwize-music/venv                                           
 py -3 -m venv ~/.bitwize-music/venv                                                       # Windows (native)
 
 # Install ALL plugin dependencies
-~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt           # macOS/Linux/WSL
-~/.bitwize-music/venv/Scripts/pip.exe install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt   # Windows (native)
+~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt                     # macOS/Linux/WSL
+~/.bitwize-music/venv/Scripts/python.exe -m pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt   # Windows (native)
 
 # Set up document hunter browser
 ~/.bitwize-music/venv/bin/playwright install chromium                                     # macOS/Linux/WSL
@@ -140,9 +140,9 @@ Present a clear, simple installation guide:
    ~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt         # macOS/Linux/WSL
    ~/.bitwize-music/venv/bin/playwright install chromium                                   # macOS/Linux/WSL
 
-   py -3 -m venv ~/.bitwize-music/venv                                                     # Windows (native)
-   ~/.bitwize-music/venv/Scripts/pip.exe install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt # Windows (native)
-   ~/.bitwize-music/venv/Scripts/playwright.exe install chromium                           # Windows (native)
+   py -3 -m venv ~/.bitwize-music/venv                                                               # Windows (native)
+   ~/.bitwize-music/venv/Scripts/python.exe -m pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt # Windows (native)
+   ~/.bitwize-music/venv/Scripts/playwright.exe install chromium                                     # Windows (native)
    ```
 4. **After installation**:
    - Restart Claude Code to reload the plugin

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -51,8 +51,9 @@ uname -s
 **CRITICAL:** Always check the venv, not system Python!
 
 ```bash
-# Set venv path
+# Set venv path (macOS/Linux/WSL uses bin/python3; native Windows uses Scripts/python.exe)
 VENV_PYTHON=~/.bitwize-music/venv/bin/python3
+[ -f "$VENV_PYTHON" ] || VENV_PYTHON=~/.bitwize-music/venv/Scripts/python.exe
 
 # Check if venv exists
 if [ -f "$VENV_PYTHON" ]; then
@@ -89,7 +90,8 @@ else:
 " 2>&1
 else
     echo "❌ Venv not found at ~/.bitwize-music/venv"
-    echo "   Run: python3 -m venv ~/.bitwize-music/venv"
+    echo "   Run: python3 -m venv ~/.bitwize-music/venv   # macOS/Linux/WSL"
+    echo "   Or:  py -3 -m venv ~/.bitwize-music/venv      # Windows"
 fi
 ```
 
@@ -103,20 +105,24 @@ All components are installed together in the venv via requirements.txt.
 
 ```bash
 # Create unified venv (if it doesn't exist)
-python3 -m venv ~/.bitwize-music/venv
+python3 -m venv ~/.bitwize-music/venv                                                    # macOS/Linux/WSL
+py -3 -m venv ~/.bitwize-music/venv                                                       # Windows (native)
 
 # Install ALL plugin dependencies
-~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt
+~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt           # macOS/Linux/WSL
+~/.bitwize-music/venv/Scripts/pip.exe install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt   # Windows (native)
 
 # Set up document hunter browser
-~/.bitwize-music/venv/bin/playwright install chromium
+~/.bitwize-music/venv/bin/playwright install chromium                                     # macOS/Linux/WSL
+~/.bitwize-music/venv/Scripts/playwright.exe install chromium                             # Windows (native)
 ```
 
-**That's it!** The plugin automatically detects and uses `~/.bitwize-music/venv`. No configuration needed.
+**That's it!** The plugin automatically detects and uses the platform venv (`~/.bitwize-music/venv` on macOS/Linux/WSL, `%USERPROFILE%\.bitwize-music\venv` on native Windows). No configuration needed.
 
 **Works on:**
 - ✅ Linux (externally-managed Python)
 - ✅ macOS
+- ✅ Windows (native — Core tier, best-effort; audio tooling needs WSL2)
 - ✅ Windows (WSL)
 - ✅ All other systems
 
@@ -130,9 +136,13 @@ Present a clear, simple installation guide:
 2. **Missing components**: [list what needs to be installed]
 3. **Installation commands**:
    ```bash
-   python3 -m venv ~/.bitwize-music/venv
-   ~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt
-   ~/.bitwize-music/venv/bin/playwright install chromium
+   python3 -m venv ~/.bitwize-music/venv                                                  # macOS/Linux/WSL
+   ~/.bitwize-music/venv/bin/pip install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt         # macOS/Linux/WSL
+   ~/.bitwize-music/venv/bin/playwright install chromium                                   # macOS/Linux/WSL
+
+   py -3 -m venv ~/.bitwize-music/venv                                                     # Windows (native)
+   ~/.bitwize-music/venv/Scripts/pip.exe install -r ${CLAUDE_PLUGIN_ROOT}/requirements.txt # Windows (native)
+   ~/.bitwize-music/venv/Scripts/playwright.exe install chromium                           # Windows (native)
    ```
 4. **After installation**:
    - Restart Claude Code to reload the plugin
@@ -173,7 +183,7 @@ Use clear sections with checkboxes for status:
 
 ### Installation
 
-Run these commands to install all plugin dependencies:
+Run these commands to install all plugin dependencies (macOS/Linux/WSL shown; see Step 3 for the Windows native `py -3` / `Scripts\` equivalents):
 
 ```bash
 # Create unified venv

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -27,10 +27,10 @@ You are the plugin's automated test runner. Execute each test, track pass/fail, 
 
 ## Quick Automated Tests (`/test quick`)
 
-For fast automated validation, run the pytest suite:
+For fast automated validation, run the pytest suite. Call `get_python_command()` first to get `$PYTHON` (the venv interpreter path — correct on every OS, including native Windows):
 
 ```bash
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -v
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -v
 ```
 
 This covers:
@@ -39,10 +39,10 @@ This covers:
 
 Run specific categories:
 ```bash
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/plugin/test_skills.py -v       # Skills only
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/plugin/ -v                      # All plugin tests
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/unit/ -v                        # All unit tests
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -m "not slow" -v               # Skip slow tests
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/plugin/test_skills.py -v       # Skills only
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/plugin/ -v                      # All plugin tests
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/unit/ -v                        # All unit tests
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -m "not slow" -v               # Skip slow tests
 ```
 
 Pytest catches common issues fast. For deep behavioral tests, use the full test suite below.
@@ -117,20 +117,20 @@ Read that file before running tests to understand what each test checks.
 
 ## Quick Tests via Pytest
 
-For rapid validation during development, use pytest directly:
+For rapid validation during development, use pytest directly. Call `get_python_command()` first to get `$PYTHON` (the venv interpreter path — correct on every OS):
 
 ```bash
 # Run all tests
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -v
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -v
 
 # Run specific test modules
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/plugin/test_skills.py ${CLAUDE_PLUGIN_ROOT}/tests/plugin/test_templates.py -v
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/plugin/test_skills.py ${CLAUDE_PLUGIN_ROOT}/tests/plugin/test_templates.py -v
 
 # Verbose with short tracebacks
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -v --tb=short
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -v --tb=short
 
 # Quiet mode (for CI/logs)
-~/.bitwize-music/venv/bin/python3 -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -q --tb=line
+$PYTHON -m pytest ${CLAUDE_PLUGIN_ROOT}/tests/ -q --tb=line
 ```
 
 Test modules in `tests/plugin/`:

--- a/skills/test/test-definitions.md
+++ b/skills/test/test-definitions.md
@@ -10,8 +10,9 @@ Glob: config/config.example.yaml
 ```
 
 ### TEST: config.example.yaml is valid YAML
+Call `get_python_command()` first for `$PYTHON` (the venv interpreter — correct on every OS), then:
 ```bash
-~/.bitwize-music/venv/bin/python3 -c "import yaml; yaml.safe_load(open('${CLAUDE_PLUGIN_ROOT}/config/config.example.yaml'))"
+$PYTHON -c "import yaml; yaml.safe_load(open('${CLAUDE_PLUGIN_ROOT}/config/config.example.yaml'))"
 ```
 
 ### TEST: config.example.yaml has all required sections

--- a/tools/database/README.md
+++ b/tools/database/README.md
@@ -6,8 +6,10 @@ PostgreSQL integration for social media post management. The database complement
 
 ### 1. Install dependencies
 
+Get the venv interpreter via the `get_python_command` MCP tool, then:
+
 ```bash
-~/.bitwize-music/venv/bin/pip install psycopg2-binary
+$PYTHON -m pip install psycopg2-binary
 ```
 
 ### 2. Create the database


### PR DESCRIPTION
## Summary

Follow-up to #479–#482: the compat matrix now declares native Windows a "Core (best-effort)" tier, but core-workflow skill/doc markdown still embedded POSIX-only commands (`venv/bin/python3`, `venv/bin/pip`) that dead-end on Windows. This sweep brings the instructions in line with what the product already does.

- **10 core-tier files fixed**: CLAUDE.md, setup / session-start / health-check / test skills, test-definitions, server README, database README, troubleshooting, error-recovery.
- **Patterns**: where the MCP server is available, commands now route through the `get_python_command` tool (returns the correct interpreter on every OS); where it isn't (setup, boot probes), dual-form commands show macOS/Linux/WSL and Windows variants. Windows forms match the product's own shipped hints exactly (`py -3 -m venv`, `Scripts\python.exe -m pip install`).
- **8 files deliberately left**: CHANGELOG (history), WSL guide (POSIX is correct there), and the audio-tier docs (mastering/promo/sheet-music/cloud — WSL2-recommended on Windows per the support tier).

## Verification

CLAUDE.md at 19,028 chars (CI limit 40k); plugin doc validators 275 passed; full suite green (known xdist flake passes solo); repo-wide grep confirms every remaining `venv/bin` markdown hit is in a deliberately-left file or the labeled POSIX half of a dual-form block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)