### PR TITLE
test: e2e write-path round-trip + multi-process state-lock stress

### DIFF
--- a/tests/e2e/mcp_boot_check.py
+++ b/tests/e2e/mcp_boot_check.py
@@ -9,9 +9,13 @@ and asserts the server shuts down cleanly on EOF.
 With ``--scenario state-workflow`` it additionally proves the core state
 workflow end-to-end: it seeds a temp content tree (1 album / 2 tracks, one
 track title carrying a non-ASCII em dash for UTF-8 regression coverage),
-points ``~/.bitwize-music/config.yaml`` at it, then drives ``rebuild_state``
--> ``list_albums`` -> ``find_album`` -> ``get_config`` -> ``list_tracks``
-and asserts the real payloads. Any pre-existing ``config.yaml`` and
+points ``~/.bitwize-music/config.yaml`` at it, then drives the READ path
+(``rebuild_state`` -> ``list_albums`` -> ``find_album`` -> ``get_config`` ->
+``list_tracks``) and the WRITE path (``create_track`` a 3rd track ->
+``rebuild_state`` -> ``update_track_field`` status -> ``get_track`` ->
+``rebuild_state``, then reads the new file off disk) — the write path is where
+the cross-platform atomic ``os.replace`` + fcntl/msvcrt locking actually run.
+It asserts the real payloads throughout. Any pre-existing ``config.yaml`` and
 ``cache/state.json`` are renamed aside first and restored in a ``finally``
 no matter how the run ends, so the scenario is safe on a developer machine.
 
@@ -98,6 +102,12 @@ SCENARIO_TRACK1_SLUG = "01-first-track"
 SCENARIO_TRACK1_TITLE = "First Track — Reprise"
 SCENARIO_TRACK2_SLUG = "02-second-track"
 SCENARIO_TRACK2_TITLE = "Second Track"
+# Created at runtime through the WRITE path (create_track). The em dash again
+# exercises UTF-8 on the way *out* (atomic_write_text body + the json.dumps'd
+# YAML title scalar), and — being NTFS-legal, unlike <>:"|?* — normalizes to an
+# identical slug/filename on all three OSes, so the assertions stay uniform.
+SCENARIO_TRACK3_NUMBER = 3
+SCENARIO_TRACK3_TITLE = "Third Track — Bonus"
 
 
 class BootError(Exception):
@@ -554,7 +564,15 @@ class StateWorkflowEnv:
 
 
 def run_state_workflow(server: ServerProc, deadline: float, env: StateWorkflowEnv) -> None:
-    """Drive config -> rebuild_state -> queries -> UTF-8 round-trip."""
+    """Drive config -> rebuild_state -> read queries -> write round-trip.
+
+    First proves the read path (rebuild/list/find/get_config/list_tracks with a
+    UTF-8 title), then the write path where the cross-platform atomic-replace +
+    file locking live: create_track -> re-index -> update_track_field ->
+    get_track -> re-index, and finally reads the new file straight off the temp
+    content tree. Every write lands in the scenario's temp tree, never in the
+    real ~/.bitwize-music.
+    """
     # 1. rebuild_state must index exactly the seeded tree: 1 album / 2 tracks.
     payload = call_tool_json(server, 4, "rebuild_state", {}, deadline, phase="scenario")
     if payload.get("success") is not True:
@@ -654,6 +672,171 @@ def run_state_workflow(server: ServerProc, deadline: float, env: StateWorkflowEn
         )
     # !a (ascii) keeps this line safe on non-UTF-8 Windows consoles.
     _ok("scenario", f"UTF-8 track title round-tripped intact ({got_title!a})")
+
+    # ---- WRITE PATH round-trip ---------------------------------------------
+    # Everything above proved the read path. The write path is where atomic
+    # os.replace + fcntl/msvcrt locking actually run cross-platform. Config
+    # points at the temp tree, so every write below lands there, never in
+    # ~/.bitwize-music.
+
+    # 6. create_track writes a new markdown file via atomic_write_text. Capture
+    #    the server-computed slug/filename instead of hardcoding it, so the
+    #    later steps assert identically on every OS (NTFS-forbidden-char slug
+    #    divergence is unit-tested; this title carries none).
+    payload = call_tool_json(
+        server,
+        9,
+        "create_track",
+        {
+            "album_slug": SCENARIO_ALBUM,
+            "track_number": SCENARIO_TRACK3_NUMBER,
+            "title": SCENARIO_TRACK3_TITLE,
+        },
+        deadline,
+        phase="scenario",
+    )
+    if payload.get("created") is not True:
+        raise BootError(
+            "scenario",
+            f"create_track did not report created=true: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    created_slug = payload.get("track_slug")
+    created_filename = payload.get("filename")
+    if not isinstance(created_slug, str) or not created_slug:
+        raise BootError(
+            "scenario", f"create_track returned no track_slug: {payload!r}", EXIT_PROTOCOL
+        )
+    if not isinstance(created_filename, str) or not created_filename:
+        raise BootError(
+            "scenario", f"create_track returned no filename: {payload!r}", EXIT_PROTOCOL
+        )
+    _ok("scenario", f"create_track wrote {created_filename!a} (slug {created_slug!a})")
+
+    # 7. Re-index so the on-disk file enters the server's state cache.
+    #    create_track writes markdown but does not refresh the cache, and
+    #    staleness is tracked off state.json's mtime (not the content tree), so
+    #    update_track_field/get_track only see the new track after a rebuild.
+    #    This also proves the created file indexes cleanly: 1 album / 3 tracks.
+    payload = call_tool_json(server, 10, "rebuild_state", {}, deadline, phase="scenario")
+    if (
+        payload.get("success") is not True
+        or payload.get("albums") != 1
+        or payload.get("tracks") != 3
+    ):
+        raise BootError(
+            "scenario",
+            f"rebuild_state after create_track expected 1 album / 3 tracks, "
+            f"got {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", "rebuild_state re-indexed the created track (1 album / 3 tracks)")
+
+    # 8. update_track_field flips status Not Started -> In Progress (a valid
+    #    transition), writing via atomic_write_text then rebuilding under lock.
+    payload = call_tool_json(
+        server,
+        11,
+        "update_track_field",
+        {
+            "album_slug": SCENARIO_ALBUM,
+            "track_slug": created_slug,
+            "field": "status",
+            "value": "In Progress",
+        },
+        deadline,
+        phase="scenario",
+    )
+    if payload.get("success") is not True:
+        raise BootError(
+            "scenario",
+            f"update_track_field did not report success: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", "update_track_field set status -> In Progress")
+
+    # 9. get_track: the updated field round-trips AND the UTF-8 title is exact.
+    payload = call_tool_json(
+        server,
+        12,
+        "get_track",
+        {"album_slug": SCENARIO_ALBUM, "track_slug": created_slug},
+        deadline,
+        phase="scenario",
+    )
+    track = payload.get("track")
+    if payload.get("found") is not True or not isinstance(track, dict):
+        raise BootError(
+            "scenario", f"get_track did not find the created track: {payload!r}", EXIT_PROTOCOL
+        )
+    if track.get("status") != "In Progress":
+        raise BootError(
+            "scenario",
+            f"get_track status={track.get('status')!r}, expected 'In Progress'",
+            EXIT_PROTOCOL,
+        )
+    if track.get("title") != SCENARIO_TRACK3_TITLE:
+        raise BootError(
+            "scenario",
+            f"get_track title did not round-trip: got {track.get('title')!a}, "
+            f"expected {SCENARIO_TRACK3_TITLE!a}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", f"get_track round-trips status + UTF-8 title ({track.get('title')!a})")
+
+    # 10. Rebuild once more and re-read: proves both on-disk writes (the created
+    #     file and the status edit) survive a full re-index from scratch, not
+    #     just the in-memory cache update from step 8.
+    payload = call_tool_json(server, 13, "rebuild_state", {}, deadline, phase="scenario")
+    if payload.get("albums") != 1 or payload.get("tracks") != 3:
+        raise BootError(
+            "scenario",
+            f"final rebuild_state expected 1 album / 3 tracks, got {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    payload = call_tool_json(
+        server,
+        14,
+        "get_track",
+        {"album_slug": SCENARIO_ALBUM, "track_slug": created_slug},
+        deadline,
+        phase="scenario",
+    )
+    track = payload.get("track")
+    track = track if isinstance(track, dict) else {}
+    if track.get("status") != "In Progress" or track.get("title") != SCENARIO_TRACK3_TITLE:
+        raise BootError(
+            "scenario",
+            f"created track did not survive a full re-index: {payload!r}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", "created track + status survived a full re-index")
+
+    # 11. Read the created file straight off the temp content tree: pins that
+    #     the atomic write actually landed on disk where expected (UTF-8 body).
+    assert env.content_root is not None  # set by setup()
+    track_file = (
+        env.content_root / "artists" / SCENARIO_ARTIST / "albums"
+        / SCENARIO_GENRE / SCENARIO_ALBUM / "tracks" / created_filename
+    )
+    if not track_file.is_file():
+        raise BootError(
+            "scenario", f"created track file not found on disk: {track_file}", EXIT_PROTOCOL
+        )
+    on_disk = track_file.read_text(encoding="utf-8")
+    if SCENARIO_TRACK3_TITLE not in on_disk:
+        raise BootError(
+            "scenario",
+            f"created track file on disk is missing the title: {track_file}",
+            EXIT_PROTOCOL,
+        )
+    if "In Progress" not in on_disk:
+        raise BootError(
+            "scenario",
+            f"created track file on disk is missing the updated status: {track_file}",
+            EXIT_PROTOCOL,
+        )
+    _ok("scenario", f"created file landed on disk with title + status ({created_filename!a})")
 
 
 def shutdown(server: ServerProc, grace: float) -> None:

--- a/tests/unit/state/test_lock_stress.py
+++ b/tests/unit/state/test_lock_stress.py
@@ -1,0 +1,266 @@
+"""Multi-process stress test for the state lock and atomic write path.
+
+The other lock tests (``test_lock_backoff.py``) are single-process: they take a
+lock in one file descriptor and contend from another in the *same* interpreter.
+That never exercises the real cross-platform failure mode — several independent
+OS processes (fcntl advisory locks on POSIX, ``msvcrt`` byte locks on Windows)
+racing on ``write_state``'s lock + atomic ``os.replace``, plus a reader watching
+for torn/interleaved content.
+
+So this test spawns real ``sys.executable`` subprocesses (works uniformly under
+pytest-xdist and on all three OSes — no ``multiprocessing`` start-method quirks)
+that point ``tools.state.indexer``'s cache constants at a SHARED tmp location and
+hammer it concurrently:
+
+* N writer processes each ``write_state`` a distinct payload in a loop; every
+  payload embeds ``writer``-id + ``seq`` so the final file can be matched to one
+  writer's last write.
+* One reader process ``read_state``s in a loop while the writers run and asserts
+  it never observes a torn/empty read.
+
+The autouse ``_isolate_state_cache`` fixture in ``tests/conftest.py`` only
+redirects the constants for *this* pytest process; fresh subprocesses inherit
+nothing, so each worker re-points the constants explicitly from an env var. The
+real ``~/.bitwize-music`` is never touched.
+
+read_state() contract (pinned from tools/state/indexer.py, do not invent one):
+    * missing file            -> returns ``None``
+    * corrupt / partial JSON,
+      or a JSON non-object    -> copies the file to ``state.<ts>.corrupt`` and
+                                 returns ``{}`` (it never raises)
+    * a valid JSON object     -> returns it
+Because ``write_state`` publishes via an atomic ``os.replace``, a reader can only
+ever see the *previous* whole file or the *next* whole file — never a partial
+one. So after the seed, every read here must return a non-empty dict carrying our
+marker; a ``None``/``{}``/marker-less result means a torn read, and any
+``state.*.corrupt`` file left behind is on-disk proof that read_state had to
+quarantine one. Both are asserted as failures.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+# Tuned so the whole thing runs in a couple of seconds locally while still
+# forcing real lock contention. Bump WRITER_ITERS / N_WRITERS to stress harder;
+# drop them if a slow CI box brushes the hard cap.
+N_WRITERS = 4
+WRITER_ITERS = 15
+READER_ITERS = 400
+# Generous hard cap — the *only* wall-clock assertion. Never tune this to be
+# tight; process spawn + fsync-per-write on a loaded CI box is unpredictable.
+HARD_CAP_SECONDS = 60.0
+SCHEMA_VERSION = "1.4.0"
+
+# Worker body. Kept as a module written to tmp (rather than ``-c``) so tracebacks
+# from a failing worker point at real line numbers. It re-points the indexer
+# constants from env BEFORE any write/read, so it can never touch the developer's
+# real ~/.bitwize-music cache.
+_WORKER_SRC = '''\
+import json
+import os
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.environ["STRESS_PROJECT_ROOT"])
+
+import tools.state.indexer as indexer
+
+cache_dir = Path(os.environ["STRESS_CACHE_DIR"])
+indexer.CACHE_DIR = cache_dir
+indexer.STATE_FILE = cache_dir / "state.json"
+indexer.LOCK_FILE = cache_dir / "state.lock"
+
+MODE = sys.argv[1]
+WORKER_ID = int(sys.argv[2])
+ITERS = int(sys.argv[3])
+FINAL_SEQ = int(sys.argv[4])
+SCHEMA_VERSION = sys.argv[5]
+
+# Distinct RNG per worker/mode so they jitter out of lockstep.
+rng = random.Random((hash(MODE) & 0xFFFF) * 1000 + WORKER_ID)
+
+
+def _sleep_jitter(hi):
+    t = rng.uniform(0.0, hi)
+    if t:
+        import time
+        time.sleep(t)
+
+
+if MODE == "writer":
+    for seq in range(ITERS):
+        state = {
+            "version": SCHEMA_VERSION,
+            "writer": WORKER_ID,
+            "seq": seq,
+            "marker": "w%d-s%d" % (WORKER_ID, seq),
+            "albums": {},
+        }
+        indexer.write_state(state)
+        _sleep_jitter(0.006)
+    sys.exit(0)
+
+elif MODE == "reader":
+    for _ in range(ITERS):
+        state = indexer.read_state()
+        if state is None:
+            sys.stderr.write("READER_SAW_NONE (missing file mid-run)\\n")
+            sys.exit(11)
+        if not isinstance(state, dict):
+            sys.stderr.write("READER_SAW_NON_DICT: %r\\n" % (state,))
+            sys.exit(12)
+        if "marker" not in state:
+            # An empty dict is read_state's quarantine sentinel: it only returns
+            # {} after backing up a corrupt/partial file -> a torn read happened.
+            sys.stderr.write("READER_SAW_TORN: %r\\n" % (state,))
+            sys.exit(13)
+        _sleep_jitter(0.002)
+    sys.exit(0)
+
+sys.stderr.write("UNKNOWN_MODE: %r\\n" % (MODE,))
+sys.exit(99)
+'''
+
+
+def _write_seed(state_file: Path) -> None:
+    """Seed a valid state so the reader never legitimately observes ``None``."""
+    seed = {
+        "version": SCHEMA_VERSION,
+        "writer": -1,
+        "seq": -1,
+        "marker": "seed",
+        "albums": {},
+    }
+    state_file.write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
+
+
+def _expected_final(writer_id: int) -> dict[str, object]:
+    """The exact payload a writer publishes on its last iteration."""
+    last = WRITER_ITERS - 1
+    return {
+        "version": SCHEMA_VERSION,
+        "writer": writer_id,
+        "seq": last,
+        "marker": f"w{writer_id}-s{last}",
+        "albums": {},
+    }
+
+
+def test_multiprocess_lock_stress(tmp_path: Path) -> None:
+    """N writers + 1 reader race on the shared state file; no torn state."""
+    cache_dir = tmp_path / "stress_cache"
+    cache_dir.mkdir()
+    state_file = cache_dir / "state.json"
+    _write_seed(state_file)
+
+    worker_py = tmp_path / "_lock_stress_worker.py"
+    worker_py.write_text(_WORKER_SRC, encoding="utf-8")
+
+    env = {
+        **_base_env(),
+        "STRESS_PROJECT_ROOT": str(PROJECT_ROOT),
+        "STRESS_CACHE_DIR": str(cache_dir),
+    }
+
+    # Spawn everyone up front so writers and the reader genuinely overlap.
+    procs: list[tuple[str, subprocess.Popen[str]]] = []
+    procs.append((
+        "reader",
+        _spawn(worker_py, "reader", 0, READER_ITERS, WRITER_ITERS - 1, env),
+    ))
+    for wid in range(N_WRITERS):
+        procs.append((
+            f"writer-{wid}",
+            _spawn(worker_py, "writer", wid, WRITER_ITERS, WRITER_ITERS - 1, env),
+        ))
+
+    start = time.monotonic()
+    deadline = start + HARD_CAP_SECONDS
+    failures: list[str] = []
+    for name, proc in procs:
+        remaining = deadline - time.monotonic()
+        try:
+            _out, err = proc.communicate(timeout=max(remaining, 0.001))
+        except subprocess.TimeoutExpired:
+            for _n, p in procs:
+                p.kill()
+            pytest.fail(
+                f"lock stress exceeded hard cap of {HARD_CAP_SECONDS}s "
+                f"(worker {name} still running) — a lock deadlock or lost wakeup?"
+            )
+        if proc.returncode != 0:
+            failures.append(f"{name} exited {proc.returncode}: {err.strip()!r}")
+    elapsed = time.monotonic() - start
+
+    assert not failures, "worker process failure(s):\n" + "\n".join(failures)
+
+    # Final file must be intact JSON equal to *some* writer's last write — proof
+    # that atomic replace never left torn/interleaved content behind.
+    final_text = state_file.read_text(encoding="utf-8")
+    final = json.loads(final_text)  # raises -> test fails if not valid JSON
+    assert isinstance(final, dict), f"final state is not a JSON object: {final!r}"
+    expected_finals = [_expected_final(wid) for wid in range(N_WRITERS)]
+    assert final in expected_finals, (
+        "final state.json is not any writer's last write (torn/interleaved?): "
+        f"{final!r}"
+    )
+    # It must be a *final* write specifically (seq == last), never a stale seed
+    # or mid-loop payload — the globally-last os.replace is a writer's seq N-1.
+    assert final["seq"] == WRITER_ITERS - 1
+
+    # No temp files may survive: write_state os.replace's its NamedTemporaryFile
+    # (.state_*.tmp) into place on success and unlinks it on error.
+    leftover_tmp = list(cache_dir.glob("*.tmp"))
+    assert not leftover_tmp, f"leftover temp files after stress: {leftover_tmp}"
+
+    # No quarantine backups: read_state only writes state.*.corrupt when it had
+    # to recover a torn/partial read. None here == the reader never saw one.
+    corrupt = list(cache_dir.glob("state.*.corrupt"))
+    assert not corrupt, f"read_state quarantined a torn read: {corrupt}"
+
+    # Hard cap is the only timing assertion; keep it loose. (Local runs land in
+    # a few seconds; this just documents the bound and fails loudly if a future
+    # regression makes the lock path pathologically slow.)
+    assert elapsed < HARD_CAP_SECONDS
+
+
+def _base_env() -> dict[str, str]:
+    # Inherit the parent env (PATH, venv, SystemRoot on Windows) so the child
+    # interpreter starts cleanly; the STRESS_* keys are layered on by the caller.
+    return dict(os.environ)
+
+
+def _spawn(
+    worker_py: Path,
+    mode: str,
+    worker_id: int,
+    iters: int,
+    final_seq: int,
+    env: dict[str, str],
+) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [
+            sys.executable,
+            str(worker_py),
+            mode,
+            str(worker_id),
+            str(iters),
+            str(final_seq),
+            SCHEMA_VERSION,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )

--- a/tests/unit/state/test_lock_stress.py
+++ b/tests/unit/state/test_lock_stress.py
@@ -1,22 +1,35 @@
-"""Multi-process stress test for the state lock and atomic write path.
+"""Multi-process contention test for the state lock + atomic write path.
 
 The other lock tests (``test_lock_backoff.py``) are single-process: they take a
 lock in one file descriptor and contend from another in the *same* interpreter.
-That never exercises the real cross-platform failure mode — several independent
-OS processes (fcntl advisory locks on POSIX, ``msvcrt`` byte locks on Windows)
-racing on ``write_state``'s lock + atomic ``os.replace``, plus a reader watching
-for torn/interleaved content.
+This one spawns real ``sys.executable`` subprocesses (uniform under pytest-xdist
+and on all three OSes — no ``multiprocessing`` start-method quirks) that point
+``tools.state.indexer``'s cache constants at a SHARED tmp location and hammer it:
 
-So this test spawns real ``sys.executable`` subprocesses (works uniformly under
-pytest-xdist and on all three OSes — no ``multiprocessing`` start-method quirks)
-that point ``tools.state.indexer``'s cache constants at a SHARED tmp location and
-hammer it concurrently:
+* N writer processes each ``write_state`` a distinct ``{writer, seq}`` payload in
+  a loop.
+* One reader process ``read_state``s in a loop while the writers run.
 
-* N writer processes each ``write_state`` a distinct payload in a loop; every
-  payload embeds ``writer``-id + ``seq`` so the final file can be matched to one
-  writer's last write.
-* One reader process ``read_state``s in a loop while the writers run and asserts
-  it never observes a torn/empty read.
+What this test actually pins (be honest about scope):
+
+1. The real cross-process lock primitive runs — ``fcntl.flock`` on POSIX,
+   ``msvcrt.locking`` on Windows — under genuine multi-process contention (not
+   two fds in one interpreter). It proves that primitive does not deadlock,
+   livelock, or crash a worker when N processes fight for the lock: every worker
+   exits 0 within a hard cap.
+2. ``os.replace`` is atomic on the host OS — the reader never observes a partial
+   file, and the final ``state.json`` is exactly one writer's last write (no
+   interleaved bytes).
+3. No temp-file leaks: ``write_state``'s ``.state_*.tmp`` files are all consumed
+   by ``os.replace`` (or unlinked on error), so none survive.
+
+What this test does NOT prove: that the *lock* is what prevents torn writes. It
+is not — ``write_state`` publishes each state through a UNIQUE ``NamedTemporaryFile``
++ atomic ``os.replace``, so torn/interleaved reads are structurally impossible
+whether or not the lock is held (disabling the lock and re-running keeps this
+green). The lock serializes writers so they don't clobber each other's *temp
+files* or churn the same rename target, and it is exercised here for contention
+safety — but atomicity is owned by the unique-tempfile design, not the lock.
 
 The autouse ``_isolate_state_cache`` fixture in ``tests/conftest.py`` only
 redirects the constants for *this* pytest process; fresh subprocesses inherit
@@ -29,16 +42,18 @@ read_state() contract (pinned from tools/state/indexer.py, do not invent one):
       or a JSON non-object    -> copies the file to ``state.<ts>.corrupt`` and
                                  returns ``{}`` (it never raises)
     * a valid JSON object     -> returns it
-Because ``write_state`` publishes via an atomic ``os.replace``, a reader can only
-ever see the *previous* whole file or the *next* whole file — never a partial
-one. So after the seed, every read here must return a non-empty dict carrying our
-marker; a ``None``/``{}``/marker-less result means a torn read, and any
-``state.*.corrupt`` file left behind is on-disk proof that read_state had to
-quarantine one. Both are asserted as failures.
+The reader's ``None`` / ``{}`` / marker-less branches assert this contract as
+live documentation, but they are UNREACHABLE-BY-DESIGN while the atomic-replace
+guarantee holds: after the seed, no read can ever legitimately see a partial
+file. They exist to fail loudly if a future refactor breaks atomicity (e.g.
+switches ``write_state`` to an in-place truncating write) — not because the
+current code can hit them. The ``state.*.corrupt`` check is the same: on-disk
+proof read_state never had to quarantine a torn read.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import subprocess
@@ -158,7 +173,15 @@ def _expected_final(writer_id: int) -> dict[str, object]:
 
 
 def test_multiprocess_lock_stress(tmp_path: Path) -> None:
-    """N writers + 1 reader race on the shared state file; no torn state."""
+    """N writers + 1 reader contend on the shared state file.
+
+    Asserts the cross-process lock primitive survives real contention (no
+    deadlock/hang/crash — every worker exits 0 within the hard cap), that
+    ``os.replace`` is atomic (final file is one writer's whole last write, reader
+    never sees a partial one), and that no ``.tmp`` files leak. See the module
+    docstring for why atomicity here is owned by the unique-tempfile design, not
+    the lock.
+    """
     cache_dir = tmp_path / "stress_cache"
     cache_dir.mkdir()
     state_file = cache_dir / "state.json"
@@ -193,8 +216,13 @@ def test_multiprocess_lock_stress(tmp_path: Path) -> None:
         try:
             _out, err = proc.communicate(timeout=max(remaining, 0.001))
         except subprocess.TimeoutExpired:
+            # Kill AND reap every worker before failing so no zombies survive the
+            # test (CI hygiene, especially under -n auto where the xdist worker
+            # keeps running further tests).
             for _n, p in procs:
                 p.kill()
+                with contextlib.suppress(Exception):
+                    p.wait(timeout=5)
             pytest.fail(
                 f"lock stress exceeded hard cap of {HARD_CAP_SECONDS}s "
                 f"(worker {name} still running) — a lock deadlock or lost wakeup?"


### PR DESCRIPTION
## Summary

CI-expansion items C (follows #484, #485):

- **e2e write path on all 3 OSes**: the mcp-boot state-workflow scenario now also drives `create_track` (em-dash title), `rebuild_state` (cache-refresh requirement discovered and documented), `update_track_field`, `get_track`, asserts the field and title round-trip exactly, re-indexes to 3 tracks, and reads the created file straight off disk (UTF-8) — proving the atomic write landed where expected. Slug/filename asserted from the payload (identical on all OSes; no NTFS-divergent characters used).
- **Multi-process lock stress** (`tests/unit/state/test_lock_stress.py`): real OS processes (not threads) hammer `write_state`/`read_state` on a shared tmp state location — exercising fcntl on POSIX and msvcrt byte-range locking on Windows for the first time under genuine cross-process contention. Asserts: all workers exit clean, final state is valid JSON equal to some worker's last write (no torn writes), readers never observe invalid JSON, no leftover temp files. Runs in ~0.5s solo / ~2s under xdist.

## Verification
Local: e2e scenario exit 0 (config/state sha256 byte-identical before/after), stress green solo + under -n auto, full suite 4,283 passed, ruff/PLW1514/mypy gates clean, no product code touched. 3-OS CI on this PR is the cross-platform proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)