### PR TITLE
fix(hooks): make validate_track.py run under Python 3.9

### DIFF
--- a/hooks/validate_track.py
+++ b/hooks/validate_track.py
@@ -4,6 +4,8 @@
 Only activates for files matching */tracks/*.md pattern.
 Checks required frontmatter fields and valid status values.
 """
+from __future__ import annotations
+
 import json
 import sys
 import re


### PR DESCRIPTION
`hooks/hooks.json` runs this hook with bare `python3`, which on stock macOS
(Xcode CLT) is Python 3.9.6. The PEP 604 `dict | None` annotations on
`extract_frontmatter()` / `get_file_content()` are evaluated at definition
time and raise `TypeError` on 3.9, so the hook crashed at import on **every**
Write/Edit (noisy non-blocking error) and the track-frontmatter validation
never actually ran.

Fix: `from __future__ import annotations` — annotations become lazy strings,
the modern syntax stays, and the script runs on 3.9+.

Verified under Python 3.9.6:

- non-track file → exit 0, silent
- `tracks/*.md` missing `track_number` + invalid `status` → exit 2 with the
  intended validation message
- valid track file → exit 0

Fixes #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3qBjDEpxk5hqFzYm5vmsi
