### PR TITLE
docs: add @tgh612 to Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ config/              Example config and setup docs
 <a href="https://github.com/alijahak"><img src="https://images.weserv.nl/?url=github.com/alijahak.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@alijahak"></a>
 <a href="https://github.com/DaveMatNat"><img src="https://images.weserv.nl/?url=github.com/DaveMatNat.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@DaveMatNat"></a>
 <a href="https://github.com/thejesh23"><img src="https://images.weserv.nl/?url=github.com/thejesh23.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@thejesh23"></a>
+<a href="https://github.com/tgh612"><img src="https://images.weserv.nl/?url=github.com/tgh612.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@tgh612"></a>
 
 If you make something with this, I'd genuinely love to hear it — [@bitwizemusic](https://x.com/bitwizemusic) on X, [join the Discord](https://discord.gg/dMURByGF), or [open a discussion](https://github.com/bitwize-music-studio/claude-ai-music-skills/discussions).
 


### PR DESCRIPTION
Credits @tgh612 for #492, which fixed `hooks/validate_track.py` under Python 3.9.

`hooks/hooks.json` invokes the hook with bare `python3` — the **system** interpreter, not the 3.11+ plugin venv — so on stock macOS (Xcode CLT ships 3.9.6) the PEP 604 `dict | None` annotations were evaluated at definition time, raised `TypeError` at import, and the track-frontmatter validation silently never ran on every Write/Edit.

Same `<a href>` avatar block format as the existing entries; `tests/plugin/test_consistency.py` passes (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)