### PR TITLE
docs: refresh README platform support and stale counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Concept to released album. You generate on Suno, everything else happens in the 
 
 Then run `/bitwize-music:setup` to detect your environment and install dependencies. Run `/bitwize-music:configure` to set your artist name and workspace paths.
 
-**Platform**: Linux or macOS (Windows users: use WSL). Python 3.11+ for the MCP server and audio tools.
+**Platform**: macOS, Linux, and WSL2 are fully supported. Native Windows is core (best-effort) — the MCP server, state cache, non-audio workflow, and the ffmpeg audio pipeline are CI-tested on windows-latest; sheet-music tools (AnthemScore/MuseScore) still need WSL2. Python 3.11+ for the MCP server and audio tools. See the [compatibility matrix](reference/cross-platform/tool-compatibility-matrix.md) for details.
 
 ---
 
@@ -108,7 +108,7 @@ Nothing ships without passing gates:
 
 ### CI/CD
 
-5 GitHub Actions workflows: test suite (3,773 tests), security scanning (bandit + pip-audit), static validation, auto-release from changelog, and PR target enforcement. Dependabot watches pip and Actions versions weekly.
+6 GitHub Actions workflows: tests (4,308 across ubuntu/macOS/Windows, plus lint, security scanning with bandit + pip-audit, and static validation), real-service integration (Postgres, SeaweedFS/S3, MuseScore), nightly deep tests, auto-release from changelog, PR target enforcement, and version sync. Dependabot watches pip and Actions versions weekly.
 
 ---
 
@@ -121,7 +121,7 @@ tools/               Audio mastering, promo videos, sheet music, cloud uploads
 reference/           46+ docs — Suno guides, mastering workflows, genre references
 genres/              72 genre directories with production guides
 templates/           Album, track, artist, research templates
-tests/               3,773 tests across 14 categories
+tests/               4,308 tests across 14 categories
 config/              Example config and setup docs
 ```
 


### PR DESCRIPTION
Three staleness fixes in the most-read file, each verified against the repo rather than estimated.

### 1. Platform support contradicted the shipped Windows tier
The line read *"Linux or macOS (Windows users: use WSL)"* — but native Windows has been **Core (best-effort)** since #476/#477 and the #479–#494 cross-platform arc: full suite on windows-latest, native `mcp-launch.cmd`, ffmpeg on the Windows runner. The README was still telling Windows users they need WSL.

Now mirrors the authoritative `reference/cross-platform/tool-compatibility-matrix.md` — including the real caveat that AnthemScore/MuseScore (sheet music) still need WSL2 — and links to it.

### 2. Test count: 3,773 → 4,308
Measured: `pytest tests/ --collect-only -q` → `4308 tests collected`.

### 3. Workflow count: 5 → 6, and the list was miscategorised
The old list conflated **jobs** with **workflows** — "security scanning" and "static validation" are jobs *inside* `test.yml`, not separate workflows. `integration.yml`, `nightly.yml` and `version-sync.yml` were missing entirely. Actual files: `auto-release`, `integration`, `nightly`, `pr-target-check`, `test`, `version-sync`.

### Verification
- No other stale `3,773` or "use WSL" references anywhere in the repo
- New link target confirmed present
- `tests/plugin/` (README/consistency checks): 275 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)