### PR TITLE
ci: give the skipped Python Floor Check job a readable name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -290,7 +290,10 @@ jobs:
         /tmp/wsl-venv/bin/python -m pytest tests/ --tb=short -n auto
 
   floor-check:
-    name: Python Floor Check (${{ inputs.check-python-floor }})
+    # Falls back to a label when no version is given: the job is skipped in that
+    # case (see `if` below), and GitHub does not expand an empty template on a
+    # skipped job — so without this the run page shows the raw ${{ ... }} string.
+    name: Python Floor Check (${{ inputs.check-python-floor || 'not requested' }})
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.check-python-floor != '' }}
     timeout-minutes: 30


### PR DESCRIPTION
Cosmetic follow-up from the nightly confirmation run. When nightly runs without a `check-python-floor` input (cron, or plain dispatch), the floor-check job is skipped, and GitHub doesn't expand the empty `${{ inputs.check-python-floor }}` template on a skipped job — so the run page showed the raw template string as the job name.

Falls back to `not requested` so the skipped job reads cleanly. No behaviour change — the job still only runs when a version is supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)