### PR TITLE
fix: derive tracks_completed from track files, not the README table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project uses [Conventional Commits](https://conventionalcommits.org/) and [
 
 ## [Unreleased]
 
+### Fixed
+- **`tracks_completed` no longer flips between two different numbers depending on which code path last ran** ([#523](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/523)) — `reference/state-schema.md` defines the field as "Number of tracks with completed status", but only the incremental track-change path counted the track files. A full rebuild (`scan_albums`) and the incremental README-changed branch both counted the album README's `## Tracklist` table instead. Since `update_track_field` rewrites a track file without touching that table, the two drifted the moment a track's status changed: `rebuild_state()` — the documented remedy for a stale cache — discarded the correct count and reinstated the README's stale one, and editing only the README silently reset it. This also made `list_albums` and `get_album_progress` disagree about the same album, and made the CLI print a README-derived numerator over an actual-file denominator (a finished album could render as `[0/12 tracks]`). All three sites now derive the count from the track files through a single `_count_completed_tracks` helper. `parse_album_readme` still reports what the README table claims, but nothing feeds it into state.
+
 ## [0.101.0] - 2026-07-21
 
 ### Fixed

--- a/tests/unit/state/test_indexer.py
+++ b/tests/unit/state/test_indexer.py
@@ -133,7 +133,7 @@ def _make_skill_content(name="test-skill", description="A test skill.",
 
 
 def _make_album_tree(content_root, artist, genre, album_slug,
-                     readme_text=None, tracks=None):
+                     readme_text=None, tracks=None, tracklist=None):
     """Create an album directory tree with optional tracks.
 
     Args:
@@ -143,6 +143,12 @@ def _make_album_tree(content_root, artist, genre, album_slug,
         album_slug: Album slug.
         readme_text: README.md content. Uses a default if None.
         tracks: Dict of {filename: content}. None means no tracks dir.
+        tracklist: Optional list of ``(number, title, status)`` tuples used to
+            emit a populated ``## Tracklist`` table, mirroring what
+            ``templates/album.md`` produces. The default README deliberately
+            omits the section entirely, which is what real albums look like
+            only before any track is added — pass this whenever a test needs
+            the README's tracklist statuses to differ from the track files'.
 
     Returns:
         Path to the album directory.
@@ -165,6 +171,19 @@ explicit: false
 |-----------|--------|
 | **Status** | Concept |
 | **Tracks** | 0 |
+"""
+        if tracklist is not None:
+            rows = "\n".join(
+                f"| {num} | [{title}](tracks/{num}-{title.lower().replace(' ', '-')}.md) "
+                f"| {status} |"
+                for num, title, status in tracklist
+            )
+            readme_text += f"""
+## Tracklist
+
+| # | Title | Status |
+|---|-------|--------|
+{rows}
 """
     (album_dir / "README.md").write_text(readme_text)
 
@@ -3881,14 +3900,25 @@ class TestIncrementalUpdateTracksCompleted:
     """Tests for tracks_completed recomputation during incremental updates."""
 
     def test_tracks_completed_recomputed_on_readme_change(self, tmp_path, monkeypatch):
-        """When README changes, tracks_completed is recomputed from actual track data."""
+        """When README changes, tracks_completed is recomputed from actual track data.
+
+        Rewrites README.md so the README-changed branch of incremental_update
+        actually runs. The README's tracklist table is deliberately left stale
+        (all 'Not Started') while the track files say otherwise — the count must
+        follow the track files, which are the authoritative per-track status.
+        """
         content_root = tmp_path / "content"
-        _make_album_tree(content_root, "testartist", "rock", "my-album",
-                         tracks={
-                             "01-track.md": _make_track_content("Track One", "Final"),
-                             "02-track.md": _make_track_content("Track Two", "Generated"),
-                             "03-track.md": _make_track_content("Track Three", "Not Started"),
-                         })
+        album_dir = _make_album_tree(
+            content_root, "testartist", "rock", "my-album",
+            tracks={
+                "01-track.md": _make_track_content("Track One", "Final"),
+                "02-track.md": _make_track_content("Track Two", "Generated"),
+                "03-track.md": _make_track_content("Track Three", "Not Started"),
+            },
+            tracklist=[("01", "Track One", "Not Started"),
+                       ("02", "Track Two", "Not Started"),
+                       ("03", "Track Three", "Not Started")],
+        )
 
         config = {
             'artist': {'name': 'testartist'},
@@ -3900,17 +3930,84 @@ class TestIncrementalUpdateTracksCompleted:
         existing = build_state(config)
         existing['config']['config_mtime'] = 100.0
 
-        # Modify a track to become Final
+        # Modify a track to become Final AND touch the README, so the
+        # README-changed branch is the one under test.
         time.sleep(0.05)
-        track_path = (content_root / "artists" / "testartist" / "albums" /
-                      "rock" / "my-album" / "tracks" / "03-track.md")
+        track_path = album_dir / "tracks" / "03-track.md"
         track_path.write_text(_make_track_content("Track Three", "Final"))
+        readme = album_dir / "README.md"
+        readme.write_text(readme.read_text() + "\nEdited.\n")
 
         updated = incremental_update(existing, config)
         album = updated['albums']['my-album']
-        # tracks_completed should include Final (2) + Generated (1) = 3
-        # _update_tracks_incremental counts Final+Generated+Complete
+        # Final (3) + Generated (0) = 3 from the track files. The README's
+        # stale table would say 0.
         assert album['tracks_completed'] == 3
+
+    def test_full_rebuild_counts_track_files_not_readme_table(self, tmp_path):
+        """A full rebuild derives tracks_completed from track files.
+
+        reference/state-schema.md defines the field as "Number of tracks with
+        completed status", so the README's hand-maintained tracklist table must
+        not be able to override the actual per-track statuses.
+        """
+        content_root = tmp_path / "content"
+        _make_album_tree(
+            content_root, "testartist", "rock", "my-album",
+            tracks={
+                "01-one.md": _make_track_content("One", "Final"),
+                "02-two.md": _make_track_content("Two", "Final"),
+            },
+            tracklist=[("01", "One", "Not Started"),
+                       ("02", "Two", "Not Started")],
+        )
+
+        albums = scan_albums(content_root, "testartist")
+        assert albums["my-album"]["tracks_completed"] == 2
+
+    def test_rebuild_and_incremental_agree(self, tmp_path, monkeypatch):
+        """rebuild_state must never regress the count an incremental produced.
+
+        A rebuild is the documented remedy for a stale cache, so it has to be
+        at least as accurate as the incremental path, not less.
+        """
+        content_root = tmp_path / "content"
+        album_dir = _make_album_tree(
+            content_root, "testartist", "rock", "agree-album",
+            tracks={
+                "01-one.md": _make_track_content("One", "Not Started"),
+                "02-two.md": _make_track_content("Two", "Not Started"),
+            },
+            tracklist=[("01", "One", "Not Started"),
+                       ("02", "Two", "Not Started")],
+        )
+
+        config = {
+            'artist': {'name': 'testartist'},
+            'paths': {'content_root': str(content_root)},
+        }
+        import tools.state.indexer as indexer
+        monkeypatch.setattr(indexer, 'get_config_mtime', lambda: 100.0)
+
+        existing = build_state(config)
+        existing['config']['config_mtime'] = 100.0
+
+        # Promote both tracks the way update_track_field does: the track file
+        # changes, the README's tracklist table does not.
+        time.sleep(0.05)
+        (album_dir / "tracks" / "01-one.md").write_text(
+            _make_track_content("One", "Final"))
+        (album_dir / "tracks" / "02-two.md").write_text(
+            _make_track_content("Two", "Final"))
+
+        incremental = incremental_update(existing, config)
+        from_incremental = incremental['albums']['agree-album']['tracks_completed']
+
+        rebuilt = build_state(config)
+        from_rebuild = rebuilt['albums']['agree-album']['tracks_completed']
+
+        assert from_incremental == 2
+        assert from_rebuild == from_incremental
 
     def test_tracks_completed_recomputed_on_track_change(self, tmp_path, monkeypatch):
         """Track status change triggers tracks_completed recount."""

--- a/tools/state/indexer.py
+++ b/tools/state/indexer.py
@@ -108,6 +108,29 @@ LOCK_FILE = CACHE_DIR / "state.lock"
 
 CONFIG_FILE = CONFIG_PATH
 
+# Track statuses that count toward an album's tracks_completed.
+_COMPLETED_TRACK_STATUSES = frozenset({'Final', 'Generated'})
+
+
+def _count_completed_tracks(tracks: dict[str, dict[str, Any]]) -> int:
+    """Count tracks whose status counts as completed.
+
+    Single source of truth for ``tracks_completed``, which
+    reference/state-schema.md defines as "Number of tracks with completed
+    status". It is always derived from the track files, never from the album
+    README's ``## Tracklist`` table: that table is a hand-maintained summary,
+    and ``update_track_field`` rewrites a track file without touching it, so
+    the two drift the moment a track's status changes. Deriving the count in
+    one place keeps the full-rebuild and incremental paths from disagreeing —
+    previously a rebuild reinstated the README's stale number and silently
+    regressed a count the incremental path had gotten right (#523).
+    """
+    return sum(
+        1 for t in tracks.values()
+        if t.get('status') in _COMPLETED_TRACK_STATUSES
+    )
+
+
 def _read_plugin_version(plugin_root: Path) -> str | None:
     """Read plugin version from .claude-plugin/plugin.json.
 
@@ -418,7 +441,7 @@ def scan_albums(
                 'mastering': album_data.get('mastering') or {},
                 'release_date': album_data.get('release_date'),
                 'track_count': album_data.get('track_count', len(tracks)),
-                'tracks_completed': album_data.get('tracks_completed', 0),
+                'tracks_completed': _count_completed_tracks(tracks),
                 'streaming_urls': album_data.get('streaming_urls', {}),
                 'readme_mtime': readme_mtime,
                 'tracks': tracks,
@@ -799,7 +822,7 @@ def incremental_update(
                     'mastering': album_data.get('mastering') or {},
                     'release_date': album_data.get('release_date'),
                     'track_count': album_data.get('track_count', len(tracks)),
-                    'tracks_completed': album_data.get('tracks_completed', 0),
+                    'tracks_completed': _count_completed_tracks(tracks),
                     'streaming_urls': album_data.get('streaming_urls', {}),
                     'readme_mtime': readme_mtime,
                     'tracks': tracks,
@@ -916,11 +939,7 @@ def _update_tracks_incremental(album: dict[str, Any], album_dir: Path) -> None:
     album['tracks'] = existing_tracks
 
     # Recompute completed count
-    completed_statuses = {'Final', 'Generated'}
-    album['tracks_completed'] = sum(
-        1 for t in existing_tracks.values()
-        if t.get('status') in completed_statuses
-    )
+    album['tracks_completed'] = _count_completed_tracks(existing_tracks)
 
 
 def _acquire_lock_with_timeout(lock_fd: Any, timeout: int | float = LOCK_TIMEOUT_SECONDS) -> None:

--- a/tools/state/parsers.py
+++ b/tools/state/parsers.py
@@ -251,6 +251,12 @@ def parse_album_readme(path: Path) -> dict[str, Any]:
     tracklist = _parse_tracklist_table(text)
     result['tracklist'] = tracklist
 
+    # What the README's hand-maintained tracklist table CLAIMS is complete.
+    # This is not the album's tracks_completed and must not be used as it:
+    # the table lags the track files (update_track_field rewrites a track file
+    # without touching it), so feeding this into state made a full rebuild
+    # regress a count the incremental path had right. The state field is
+    # derived from the track files by indexer._count_completed_tracks (#523).
     completed_statuses = {'Final', 'Generated'}
     result['tracks_completed'] = sum(
         1 for t in tracklist if t.get('status') in completed_statuses


### PR DESCRIPTION
Closes #523.

`tracks_completed` was computed from two different data sources depending on which code path last ran, so the same album reported different completion numbers at different times.

`reference/state-schema.md:56` defines the field as "Number of tracks with completed status". Only the incremental track-change path implemented that. `scan_albums` (full rebuild) and the README-changed branch of `incremental_update` both counted the album README's `## Tracklist` table instead — and `update_track_field` rewrites a track file without ever touching that table, so the two drifted as soon as a track's status changed.

## What was breaking

- **`rebuild_state()` made the number worse.** It is the documented remedy for a stale cache, but it discarded the track-file-derived count and reinstated the README table's.
- **Editing only the README silently reset it**, even when no track changed.
- **Two MCP tools disagreed** — `list_albums` returned the cached field, `get_album_progress` recomputed from track files.
- **The CLI mixed both models** (`indexer.py:1745`), printing a README-derived numerator over a `len(tracks)` denominator, so a finished album could render as `[0/12 tracks]`.

## The fix

All three sites now derive the count through one `_count_completed_tracks` helper, so they cannot drift again:

| Site | Before | After |
|---|---|---|
| `scan_albums` | README table | track files |
| `incremental_update`, README-changed branch | README table | track files |
| `_update_tracks_incremental` | track files (inline) | track files (shared helper) |

`parse_album_readme` still reports what the README table claims — that value is legitimately "what the README says" — but nothing feeds it into state, and it now carries a comment saying so.

## Why the tests missed it

Two independent gaps, both fixed here:

1. `test_tracks_completed_recomputed_on_readme_change` — docstring *"When README changes..."* — **never rewrote `README.md`**. The README mtime stayed unchanged, so it took the cache-valid branch and exercised exactly the same path as its sibling test. The branch holding the bug was untested. It now actually rewrites the README.
2. The shared fixture `_make_album_tree` emitted a README with **no `## Tracklist` section at all**, so `parse_album_readme` always returned `0` and the full-rebuild path could never diverge in tests. It now takes an optional `tracklist=` argument that emits a populated table mirroring `templates/album.md`.

Plus a new `test_rebuild_and_incremental_agree` pinning both paths to the same number, and `test_full_rebuild_counts_track_files_not_readme_table` covering the rebuild path directly.

Each new test was confirmed to fail against the old code for the right reason (`assert 0 == 2` / `assert 0 == 3`) before the fix landed.

## Verification

Full local gate, matching CI:

```
ruff check tools/ servers/ hooks/                      All checks passed!
ruff check ... --select PLW1514 --preview              All checks passed!
bandit -r tools/ servers/ -ll -q -s B108,B608          clean
mypy                                                   Success: no issues found in 73 source files
pytest tests/ -n auto --cov                            4451 passed, 13 skipped
                                                       coverage 90.02% (gate 75%)
```

Test count is 4449 → 4451 (two new tests; one existing test corrected in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
