### PR TITLE
docs: add @MrReasonable to Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ config/              Example config and setup docs
 <a href="https://github.com/DaveMatNat"><img src="https://images.weserv.nl/?url=github.com/DaveMatNat.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@DaveMatNat"></a>
 <a href="https://github.com/thejesh23"><img src="https://images.weserv.nl/?url=github.com/thejesh23.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@thejesh23"></a>
 <a href="https://github.com/tgh612"><img src="https://images.weserv.nl/?url=github.com/tgh612.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@tgh612"></a>
+<a href="https://github.com/MrReasonable"><img src="https://images.weserv.nl/?url=github.com/MrReasonable.png&h=60&w=60&fit=cover&mask=circle" width="60" height="60" alt="@MrReasonable"></a>
 
 If you make something with this, I'd genuinely love to hear it — [@bitwizemusic](https://x.com/bitwizemusic) on X, [join the Discord](https://discord.gg/dMURByGF), or [open a discussion](https://github.com/bitwize-music-studio/claude-ai-music-skills/discussions).
 


### PR DESCRIPTION
Adds @MrReasonable to the Contributors section following their first two merged contributions:

- #534 — `fix:` extracted the guarded album-path core into `handlers/_shared._album_dir`, replacing fifteen hand-built album paths across six handler modules and closing an unguarded escape at the fourteen sites that had no confinement check.
- #535 — `feat:` per-track lyrics word-count target resolution (track genre → album genre → default).

Same `<a href>` avatar block format as the existing entries, appended after @tgh612. Single-line change, no other edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)