### PR TITLE
docs: remove broken star history chart from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,6 @@ If you make something with this, I'd genuinely love to hear it — [@bitwizemusi
 
 ---
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=bitwize-music-studio/claude-ai-music-skills&type=Date)](https://star-history.com/#bitwize-music-studio/claude-ai-music-skills&Date)
-
----
-
 ## License
 
 CC0 — Public Domain. Do whatever you want with it.


### PR DESCRIPTION
## Summary

GitHub restricted the stargazers API on June 30, 2026, so the official star-history.com badge in the README now renders an error card ("GitHub restricted access to star data") instead of a chart.

This removes the Star History section rather than pointing the README at a third-party mirror. Per [star-history's blog](https://www.star-history.com/blog/github-stargazer-api-restriction), the GitHub team is actively working on restoring access — the official badge can be re-added once it works again.

Replaces #550, which proposed redirecting the badge to an unofficial mirror domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)