### PR TITLE
docs: add the 0.102.0 migration note

### DIFF
--- a/migrations/0.102.0.md
+++ b/migrations/0.102.0.md
@@ -1,0 +1,71 @@
+---
+version: "0.102.0"
+summary: "Suno v6: pre-v6 models retired, Generation Settings table on tracks, Exclude Styles values are bare elements, cut-EQ zero now disables"
+categories:
+  - templates
+  - workflow
+actions:
+  - type: info
+    description: "Suno retired every model before v6 on 2026-09-09. The plugin now targets the v6 family only (v6, v6-wild, v6-mini, Custom Models — catalog in reference/suno/models.md). Generation Log rows naming any other model refer to a retired model. Prompts written for older models should be re-prompted rather than rerun; saved Voices offer a one-click 'Upgrade Voice to v6'; Custom Models were upgraded automatically; older songs can be Remastered or Covered on v6."
+  - type: info
+    description: "templates/track.md gained a '### Generation Settings' table (Model, Variety, Max Mode, Vocal Gender, Duration, Weirdness, Style Influence; defaults v6 / Off / On / — / Auto / 50 / 50). Existing tracks do not have it, and the new advisory 'Generation Settings' pre-generation gate SKIPs when the section is missing. Copy the table from the template into any track you still plan to generate. Variety must be Off, or Suno rewrites the engineered Style Box."
+  - type: info
+    description: "Exclude Styles values are bare elements ('drums, autotune'), never 'no drums'. The clipboard 'style' type now returns the Style Box alone; use the 'exclude' type, or the 'suno' JSON's exclude_styles key, for Suno's Exclude Styles field. Both paste the track's section verbatim, so a leftover 'no ' prefix goes into the field as written."
+  - type: manual
+    instruction: |
+      Strip 'no ' prefixes from existing Exclude Styles sections in your catalog.
+      Replace {content_root} with paths.content_root from ~/.bitwize-music/config.yaml.
+
+      Preview which track files are affected:
+
+        grep -rl -A4 '^### Exclude Styles' {content_root}/artists --include=*.md | xargs grep -l -E '^(no |No |.*, *(no|No) )'
+
+      Rewrite them (touches only the code block directly under '### Exclude Styles'):
+
+        python3 - <<'PY'
+        import pathlib, re
+        root = pathlib.Path('{content_root}').expanduser() / 'artists'
+        block = re.compile(r'(### Exclude Styles\n(?:[^\n]*\n)*?```\n)(.*?)(\n```)', re.S)
+        def fix(m):
+            body = re.sub(r'(^|,\s*)[Nn]o ', r'\1', m.group(2), flags=re.M)
+            return m.group(1) + body + m.group(3)
+        n = 0
+        for p in root.rglob('tracks/*.md'):
+            t = p.read_text(encoding='utf-8')
+            new = block.sub(fix, t, count=1)
+            if new != t:
+                p.write_text(new, encoding='utf-8'); n += 1
+        print(n, 'track files updated')
+        PY
+
+      Review the diff in the content repo and commit it.
+  - type: info
+    description: "master_album, album_coherence_correct and polish_and_master_album: an explicit 0 for cut_highmid or cut_highs now DISABLES that EQ cut (it used to mean 'use the genre preset'). Omit the parameter to keep preset behaviour. No in-repo caller passed 0; only external callers that did are affected. (#556)"
+  - type: info
+    description: "Suno downloads and rights under the Terms effective 2026-09-03: Free accounts get 7 lifetime trial downloads for personal use only; Pro 20 and Premier 60 per month, stems included in a song's download; commercial use requires a permitted download on a paid plan; Remixes of other people's songs are never commercial; never remove the in-audio watermark. reference/suno/best-practices.md § Ownership and the release-director docs carry the details."
+---
+
+## Suno v6 and the retired model line
+
+Suno shipped the v6 family (v6, v6-wild, v6-mini) on 2026-09-09 and retired every earlier model the same day. Issue [#562](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/562), PRs [#563](https://github.com/bitwize-music-studio/claude-ai-music-skills/pull/563), [#566](https://github.com/bitwize-music-studio/claude-ai-music-skills/pull/566) and [#567](https://github.com/bitwize-music-studio/claude-ai-music-skills/pull/567).
+
+### What changed for me as a user?
+
+**Prompting mechanics did not change.** The Style Box (1,000 characters), Lyrics Box (5,000), Exclude Styles (1,000), structure tags and the Weirdness / Style Influence sliders all still work the same way. What changed is two controls that decide whether your prompt is used as written:
+
+- **Variety** (More Options; default Normal on v6 and v6-mini, Off on v6-wild) rewrites and expands the Style Box at any setting above Off. The plugin's rule is **Off** for an engineered Style Box; the new gate warns when a track's Generation Settings say otherwise.
+- **Max Mode** doubles the credit cost (20 per generation) for consistency across the song. The template defaults it On; Suno recommends it over about two minutes, on Covers and with Voices.
+
+**Existing tracks keep working.** A track without a `### Generation Settings` section passes the new gate with a SKIP. Add the table only to tracks you still intend to generate. `update_track_field` accepts `model`, `variety` and `max-mode` if you want to fill it from the MCP side.
+
+**Generation Logs that name v5.5, v5 or v4.5** are history, not errors. Those models cannot be selected any more; regenerating such a track runs on v6 and will sound different. Treat any re-run as a new attempt with a new log row.
+
+**Exclude Styles.** The documented format has always been the bare element (`drums`, `autotune`), but the suno-engineer skill, the genre tables and the track template drifted to `no drums`. That is fixed everywhere in this release, and the clipboard `style` type no longer appends the Exclude Styles section to the Style Box (which would have asked *for* the excluded things). Older track files in your catalog still carry the `no ` prefixes; the manual action above rewrites them in one pass. Until then, the `exclude` clipboard type pastes them as written.
+
+**Pre-v6 guidance is gone, not archived.** `reference/suno/v5-best-practices.md` and `reference/suno/version-history/` were removed; git history keeps them. `reference/suno/models.md § Made before v6` holds the one operational note about older songs, Voices and Custom Models.
+
+**Verification status.** Several v6 claims in the docs carry an **(unverified)** tag: they come from Suno's documentation and launch-week reports and have not yet been confirmed on a maintainer account. The list is in `reference/suno/CHANGELOG.md § Open verification`. Nothing tagged changes a default.
+
+### Mastering: the cut-EQ sentinel
+
+From [#556](https://github.com/bitwize-music-studio/claude-ai-music-skills/issues/556): `master_album`, `album_coherence_correct` and `polish_and_master_album` treated an explicit `0` for `cut_highmid` / `cut_highs` as "use the genre preset", so a preset's cut could not be disabled through them, and the same parameter meant the opposite thing on `master_audio`. All four now agree: omit the parameter for the preset, pass `0` to disable the cut. Only callers that deliberately passed `0` to mean "preset" are affected, and none exist in the plugin.


### PR DESCRIPTION
Migration note for the 0.102.0 release, per migrations/README.md (template and workflow changes need one).

- Suno retired every pre-v6 model; Generation Logs naming older models refer to retired models; Voices upgrade, Custom Models auto-upgraded, Remaster/Cover for older songs.
- templates/track.md gained the Generation Settings table; existing tracks pass the new advisory gate with SKIP; copy the table into tracks still to be generated.
- Exclude Styles values are bare elements and the clipboard style type no longer appends them (#567). A manual action carries a one-pass script that strips 'no ' prefixes from existing tracks. Dry-run on copies of the maintainer catalog: 121 files would change, edits confined to the Exclude Styles code block, second pass a no-op.
- #556 (via #558): an explicit 0 for cut_highmid / cut_highs now disables the cut.
- Sep 3 download and rights rules.

tests/plugin/test_migrations.py: 86 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)